### PR TITLE
ref: Refactor SentryClient init

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1037,6 +1037,7 @@
 		FA1841832E4B457F005DEDC7 /* SentryApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA18417D2E4B457B005DEDC7 /* SentryApplication.swift */; };
 		FA21A2EF2E60E9CB00E7EADB /* EnvelopeComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA21A2E92E60E9C700E7EADB /* EnvelopeComparison.swift */; };
 		FA21F0B42E4A2A80008B4E5A /* SentryAppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C32972DF7513F001D7B01 /* SentryAppState.swift */; };
+		FA27EBF52EB82FAD00F2ECF7 /* FileIOTrackerTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA27EBEF2EB82FA800F2ECF7 /* FileIOTrackerTestHelpers.swift */; };
 		FA34C1A32E692A5000BC52AA /* SentryEnvelopeItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA34C1A22E692A5000BC52AA /* SentryEnvelopeItem.swift */; };
 		FA3734842E0F086C0091EF24 /* SentryDependencyContainerSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3734832E0F07A20091EF24 /* SentryDependencyContainerSwiftHelper.h */; };
 		FA3734862E0F09320091EF24 /* SentryDependencyContainerSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FA3734852E0F092F0091EF24 /* SentryDependencyContainerSwiftHelper.m */; };
@@ -2415,6 +2416,7 @@
 		FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		FA18417D2E4B457B005DEDC7 /* SentryApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryApplication.swift; sourceTree = "<group>"; };
 		FA21A2E92E60E9C700E7EADB /* EnvelopeComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvelopeComparison.swift; sourceTree = "<group>"; };
+		FA27EBEF2EB82FA800F2ECF7 /* FileIOTrackerTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIOTrackerTestHelpers.swift; sourceTree = "<group>"; };
 		FA34C1A22E692A5000BC52AA /* SentryEnvelopeItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeItem.swift; sourceTree = "<group>"; };
 		FA3734832E0F07A20091EF24 /* SentryDependencyContainerSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDependencyContainerSwiftHelper.h; path = include/SentryDependencyContainerSwiftHelper.h; sourceTree = "<group>"; };
 		FA3734852E0F092F0091EF24 /* SentryDependencyContainerSwiftHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDependencyContainerSwiftHelper.m; sourceTree = "<group>"; };
@@ -4621,6 +4623,7 @@
 				D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */,
 				D885266327739D01001269FC /* SentryFileIOTrackingIntegrationTests.swift */,
 				7B82722A27A3220A00F4BFF4 /* SentryFileIoTrackingUnitTests.swift */,
+				FA27EBEF2EB82FA800F2ECF7 /* FileIOTrackerTestHelpers.swift */,
 				D4AF00242D2E93C400F5F3D7 /* SentryNSFileManagerSwizzlingTests.m */,
 			);
 			path = IO;
@@ -6163,6 +6166,7 @@
 				7B5B94352657AD21002E474B /* SentryFramesTrackingIntegrationTests.swift in Sources */,
 				D43A2A142DD4816500114724 /* SentryWeakMapTests.swift in Sources */,
 				8431EE5B29ADB8EA00D8DC56 /* SentryTimeTests.m in Sources */,
+				FA27EBF52EB82FAD00F2ECF7 /* FileIOTrackerTestHelpers.swift in Sources */,
 				7B0A54562523178700A71716 /* SentryScopeSwiftTests.swift in Sources */,
 				7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */,
 				62278CA82E30B21A0022ABC6 /* SentryHttpTransportFlushIntegrationTests.swift in Sources */,

--- a/SentryTestUtils/TestClient.swift
+++ b/SentryTestUtils/TestClient.swift
@@ -6,32 +6,27 @@ public class TestClient: SentryClient {
     public override init?(options: Options) {
         super.init(
             options: options,
+            transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options),
             fileManager: try! TestFileManager(
                 options: options,
                 dateProvider: TestCurrentDateProvider(),
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             ),
-            deleteOldEnvelopeItems: false,
-            transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options)
+            threadInspector: SentryDefaultThreadInspector(options: options),
+            debugImageProvider: SentryDependencyContainer.sharedInstance().debugImageProvider,
+            random: SentryDependencyContainer.sharedInstance().random,
+            locale: NSLocale.autoupdatingCurrent,
+            timezone: NSCalendar.autoupdatingCurrent.timeZone
         )
-    }
-
-    @_spi(Private) public override init?(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool) {
-        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options))
-    }
-    
-    @_spi(Private) public override init(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, transportAdapter: SentryTransportAdapter) {
-        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: transportAdapter)
     }
     
     // Without this override we get a fatal error: use of unimplemented initializer
     // see https://stackoverflow.com/questions/28187261/ios-swift-fatal-error-use-of-unimplemented-initializer-init
-    @_spi(Private) public override init(options: Options, transportAdapter: SentryTransportAdapter, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, threadInspector: SentryDefaultThreadInspector, debugImageProvider: SentryDebugImageProvider, random: SentryRandomProtocol, locale: Locale, timezone: TimeZone) {
+    @_spi(Private) public override init(options: Options, transportAdapter: SentryTransportAdapter, fileManager: SentryFileManager, threadInspector: SentryDefaultThreadInspector, debugImageProvider: SentryDebugImageProvider, random: SentryRandomProtocol, locale: Locale, timezone: TimeZone) {
         super.init(
             options: options,
             transportAdapter: transportAdapter,
             fileManager: fileManager,
-            deleteOldEnvelopeItems: false,
             threadInspector: threadInspector,
             debugImageProvider: debugImageProvider,
             random: random,

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -1,10 +1,10 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-@objcMembers @_spi(Private) public class SentryEnabledFeaturesBuilder: NSObject {
+final class SentryEnabledFeaturesBuilder: NSObject {
 
     // swiftlint:disable cyclomatic_complexity function_body_length
-    public static func getEnabledFeatures(options: Options?) -> [String] {
+    static func getEnabledFeatures(options: Options?) -> [String] {
         guard let options = options else {
             return []
         }

--- a/Sources/Swift/SentryCrash/SentryThreadInspector.swift
+++ b/Sources/Swift/SentryCrash/SentryThreadInspector.swift
@@ -7,7 +7,7 @@
         internalHelper = SentryDefaultThreadInspector(options: SentrySDKInternal.options)
     }
 
-    @objc public init(options: Options) {
+    init(options: Options) {
         internalHelper = SentryDefaultThreadInspector(options: options)
     }
 

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -207,7 +207,6 @@ class SentryFeedbackTests: XCTestCase {
                 dateProvider: TestCurrentDateProvider(),
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
-            deleteOldEnvelopeItems: false,
             threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),
@@ -250,7 +249,6 @@ class SentryFeedbackTests: XCTestCase {
                 dateProvider: TestCurrentDateProvider(),
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
-            deleteOldEnvelopeItems: false,
             threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),
@@ -293,7 +291,6 @@ class SentryFeedbackTests: XCTestCase {
                 dateProvider: TestCurrentDateProvider(),
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
-            deleteOldEnvelopeItems: false,
             threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),

--- a/Tests/SentryTests/Integrations/Performance/IO/FileIOTrackerTestHelpers.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileIOTrackerTestHelpers.swift
@@ -1,0 +1,9 @@
+@_spi(Private) @testable import Sentry
+
+@objc public class FileIOTrackerTestHelpers: NSObject {
+    @objc static func makeTracker(options: Options) -> SentryFileIOTracker {
+        let threadInspector = SentryThreadInspector(options: options)
+        let processInfoWrapper = SentryDependencyContainer.sharedInstance().processInfoWrapper
+        return SentryFileIOTracker(threadInspector: threadInspector, processInfoWrapper: processInfoWrapper)
+    }
+}

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingTests.m
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingTests.m
@@ -56,12 +56,7 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     options.enableFileManagerSwizzling = enableFileManagerSwizzling;
 
-    SentryThreadInspector *threadInspector =
-        [[SentryThreadInspector alloc] initWithOptions:options];
-    id<SentryProcessInfoSource> processInfoWrapper =
-        [SentryDependencyContainer.sharedInstance processInfoWrapper];
-    self->tracker = [[SentryFileIOTracker alloc] initWithThreadInspector:threadInspector
-                                                      processInfoWrapper:processInfoWrapper];
+    self->tracker = [FileIOTrackerTestHelpers makeTrackerWithOptions:options];
     [tracker enable];
 
     [[SentryNSFileManagerSwizzling shared] startWithOptions:options tracker:self->tracker];

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -39,7 +39,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
                 dispatchQueueWrapper: dispatchQueue
             )
 
-            let hub = TestHub(client: SentryClient(options: options, fileManager: fileManager, deleteOldEnvelopeItems: false), andScope: nil)
+            let hub = TestHub(client: SentryClient(options: options, fileManager: fileManager), andScope: nil)
             return SentryTracer(transactionContext: TransactionContext(operation: "ui.load"), hub: hub, configuration: SentryTracerConfiguration(block: {
                 $0.waitForChildren = true
             }))

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -30,7 +30,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
                 options: options,
                 dateProvider: dateProvider,
                 dispatchQueueWrapper: dispatchQueueWrapper
-            ), deleteOldEnvelopeItems: false)
+            ))
             hub = TestHub(client: client, andScope: nil)
 
             fileManager = try TestFileManager(
@@ -398,7 +398,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         api?.pointee.setEnabled(true)
         
         let transport = TestTransport()
-        let client = SentryClient(options: fixture.options, fileManager: fixture.fileManager, deleteOldEnvelopeItems: false)
+        let client = SentryClient(options: fixture.options, fileManager: fixture.fileManager)
         Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         hub.bindClient(client)
         

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -13,24 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryClient ()
 
-- (_Nullable instancetype)initWithOptions:(SentryOptions *)options
-                             dateProvider:(id<SentryCurrentDateProvider>)dateProvider
-                            dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
-                   deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems;
-
-- (_Nullable instancetype)initWithOptions:(SentryOptions *)options
-                              fileManager:(SentryFileManager *)fileManager
-                   deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems;
-
-- (instancetype)initWithOptions:(SentryOptions *)options
-                    fileManager:(SentryFileManager *)fileManager
-         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
-               transportAdapter:(SentryTransportAdapter *)transportAdapter;
-
 - (instancetype)initWithOptions:(SentryOptions *)options
                transportAdapter:(SentryTransportAdapter *)transportAdapter
                     fileManager:(SentryFileManager *)fileManager
-         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
                 threadInspector:(SentryDefaultThreadInspector *)threadInspector
              debugImageProvider:(SentryDebugImageProvider *)debugImageProvider
                          random:(id<SentryRandomProtocol>)random

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -277,8 +277,7 @@ class SentryHubTests: XCTestCase {
     func testAddUserToTheScope() throws {
         let client = SentryClient(
             options: fixture.options,
-            fileManager: fixture.fileManager,
-            deleteOldEnvelopeItems: false
+            fileManager: fixture.fileManager
         )
         let hub = SentryHub(client: client, andScope: Scope())
         

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -608,7 +608,7 @@ class SentrySDKInternalTests: XCTestCase {
 
         let transport = TestTransport()
         let fileManager = try TestFileManager(options: fixture.options, dateProvider: fixture.currentDate, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
-        let client = SentryClient(options: fixture.options, fileManager: fileManager, deleteOldEnvelopeItems: false)
+        let client = SentryClient(options: fixture.options, fileManager: fileManager)
         Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         SentrySDKInternal.currentHub().bindClient(client)
         SentrySDK.close()
@@ -693,7 +693,7 @@ class SentrySDKInternalTests: XCTestCase {
 
         let transport = TestTransport()
         let fileManager = try TestFileManager(options: fixture.options, dateProvider: fixture.currentDate, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
-        let client = SentryClient(options: fixture.options, fileManager: fileManager, deleteOldEnvelopeItems: false)
+        let client = SentryClient(options: fixture.options, fileManager: fileManager)
         Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         SentrySDKInternal.currentHub().bindClient(client)
 


### PR DESCRIPTION
The many paths through this logic confused me, but it wasn't actually confusing, it was just written confusingly so I cleaned it up.

For example this allowed me to delete `deleteOldEnvelopeItems` which was only ever `YES`

I removed a few @objc annotations that weren't needed anymore also

#skip-changelog

Closes #6626