### PR TITLE
fix: Crash when user feedback block is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 - Fixes warnings about minimum OS version being lower than Xcode supported version (#5591)
 - Fix rendering method for fast view rendering (#6360)
+- Fixes a crash when setting configureUserFeedback to nil (#6642)
 - Fix issue where the thread that generated an event could be missing when more than 100 threads are running (#6377)
 - Fix wrong Frame Delay when becoming active, which lead to false reported app hangs when the app moves to the foreground after being in the background (#6381)
 - Session Replay masking improvements (#6292)

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -395,7 +395,9 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
     SentryUserFeedbackConfiguration *userFeedbackConfiguration =
         [[SentryUserFeedbackConfiguration alloc] init];
     self.userFeedbackConfiguration = userFeedbackConfiguration;
-    configureUserFeedback(userFeedbackConfiguration);
+    if (configureUserFeedback) {
+        configureUserFeedback(userFeedbackConfiguration);
+    }
 }
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 


### PR DESCRIPTION
If you had done `options.configureUserFeedback = nil` the app would crash, this fixes it

Closes #6643