### PR TITLE
ref: Cleanup SentryOptions implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Makes `SentryEventDecodable` internal (#5808)
 - The `span` property on `SentryScope` is now readonly (#5866)
 - Removes deprecated SentryDebugImageProvider class (#5598)
+- Properties on SentryOptions that had no effect on the WithoutUIKit variant are now removed from the API (#6644)
 - Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
 - Removes deprecated TraceContext initializers (#6348)
 - Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -305,7 +305,7 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic) SentryScope * (^initialScope)(SentryScope *);
 
-#if SENTRY_UIKIT_AVAILABLE
+#if SENTRY_HAS_UIKIT
 /**
  * When enabled, the SDK tracks performance for UIViewController subclasses.
  * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
@@ -313,6 +313,14 @@ NS_SWIFT_NAME(Options)
  * @note The default is @c YES .
  */
 @property (nonatomic, assign) BOOL enableUIViewControllerTracing;
+
+/**
+ * When enabled the SDK reports non-fully-blocking app hangs. A non-fully-blocking app hang is when
+ * the app appears stuck to the user but can still render a few frames.
+ *
+ * @note The default is @c YES.
+ */
+@property (nonatomic, assign) BOOL enableReportNonFullyBlockingAppHangs;
 
 /**
  * Automatically attaches a screenshot when capturing an error or exception.
@@ -380,7 +388,7 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) BOOL enablePreWarmedAppStartTracing;
 
-#endif // SENTRY_UIKIT_AVAILABLE
+#endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
@@ -571,18 +579,6 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @note App Hang tracking is automatically disabled if a debugger is attached.
  */
 @property (nonatomic, assign) BOOL enableAppHangTracking;
-
-#if SENTRY_UIKIT_AVAILABLE
-
-/**
- * When enabled the SDK reports non-fully-blocking app hangs. A non-fully-blocking app hang is when
- * the app appears stuck to the user but can still render a few frames.
- *
- * @note The default is @c YES.
- */
-@property (nonatomic, assign) BOOL enableReportNonFullyBlockingAppHangs;
-
-#endif // SENTRY_UIKIT_AVAILABLE
 
 /**
  * The minimum amount of time an app should be unresponsive to be classified as an App Hanging.

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -263,11 +263,6 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
     }
 }
 
-- (void)setTracesSampler:(SentryTracesSamplerCallback)tracesSampler
-{
-    _tracesSampler = tracesSampler;
-}
-
 - (BOOL)isTracingEnabled
 {
     return (_tracesSampleRate != nil && [_tracesSampleRate doubleValue] > 0)
@@ -289,39 +284,6 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
 
 #if SENTRY_UIKIT_AVAILABLE
 
-- (void)setEnableUIViewControllerTracing:(BOOL)enableUIViewControllerTracing
-{
-#    if SENTRY_HAS_UIKIT
-    _enableUIViewControllerTracing = enableUIViewControllerTracing;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"enableUIViewControllerTracing only works with UIKit enabled. Ensure you're "
-        @"using the right configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
-
-- (void)setAttachScreenshot:(BOOL)attachScreenshot
-{
-#    if SENTRY_HAS_UIKIT
-    _attachScreenshot = attachScreenshot;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"attachScreenshot only works with UIKit enabled. Ensure you're using the "
-        @"right configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
-
-- (void)setAttachViewHierarchy:(BOOL)attachViewHierarchy
-{
-#    if SENTRY_HAS_UIKIT
-    _attachViewHierarchy = attachViewHierarchy;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"attachViewHierarchy only works with UIKit enabled. Ensure you're using the "
-        @"right configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
-
 #    if SENTRY_TARGET_REPLAY_SUPPORTED
 
 - (BOOL)enableViewRendererV2
@@ -335,39 +297,6 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
 }
 
 #    endif // SENTRY_TARGET_REPLAY_SUPPORTED
-
-- (void)setEnableUserInteractionTracing:(BOOL)enableUserInteractionTracing
-{
-#    if SENTRY_HAS_UIKIT
-    _enableUserInteractionTracing = enableUserInteractionTracing;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"enableUserInteractionTracing only works with UIKit enabled. Ensure you're "
-        @"using the right configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
-
-- (void)setIdleTimeout:(NSTimeInterval)idleTimeout
-{
-#    if SENTRY_HAS_UIKIT
-    _idleTimeout = idleTimeout;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"idleTimeout only works with UIKit enabled. Ensure you're using the right "
-        @"configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
-
-- (void)setEnablePreWarmedAppStartTracing:(BOOL)enablePreWarmedAppStartTracing
-{
-#    if SENTRY_HAS_UIKIT
-    _enablePreWarmedAppStartTracing = enablePreWarmedAppStartTracing;
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"enablePreWarmedAppStartTracing only works with UIKit enabled. Ensure you're "
-        @"using the right configuration of Sentry that links UIKit.");
-#    endif // SENTRY_HAS_UIKIT
-}
 
 #endif // SENTRY_UIKIT_AVAILABLE
 

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -17947,6 +17947,89 @@
           },
           {
             "kind": "Var",
+            "name": "enableReportNonFullyBlockingAppHangs",
+            "printedName": "enableReportNonFullyBlockingAppHangs",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "c:objc(cs)SentryOptions(py)enableReportNonFullyBlockingAppHangs",
+            "moduleName": "Sentry",
+            "isOpen": true,
+            "objc_name": "enableReportNonFullyBlockingAppHangs",
+            "declAttributes": [
+              "ObjC",
+              "Dynamic"
+            ],
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "c:objc(cs)SentryOptions(im)enableReportNonFullyBlockingAppHangs",
+                "moduleName": "Sentry",
+                "isOpen": true,
+                "objc_name": "enableReportNonFullyBlockingAppHangs",
+                "declAttributes": [
+                  "DiscardableResult",
+                  "ObjC",
+                  "Dynamic"
+                ],
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "Void",
+                    "printedName": "Swift.Void",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Void",
+                        "printedName": "()"
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "c:objc(cs)SentryOptions(im)setEnableReportNonFullyBlockingAppHangs:",
+                "moduleName": "Sentry",
+                "isOpen": true,
+                "objc_name": "setEnableReportNonFullyBlockingAppHangs:",
+                "declAttributes": [
+                  "ObjC",
+                  "Dynamic"
+                ],
+                "accessorKind": "set"
+              }
+            ]
+          },
+          {
+            "kind": "Var",
             "name": "attachScreenshot",
             "printedName": "attachScreenshot",
             "children": [
@@ -20308,89 +20391,6 @@
                 "moduleName": "Sentry",
                 "isOpen": true,
                 "objc_name": "setEnableAppHangTracking:",
-                "declAttributes": [
-                  "ObjC",
-                  "Dynamic"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "enableReportNonFullyBlockingAppHangs",
-            "printedName": "enableReportNonFullyBlockingAppHangs",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:objc(cs)SentryOptions(py)enableReportNonFullyBlockingAppHangs",
-            "moduleName": "Sentry",
-            "isOpen": true,
-            "objc_name": "enableReportNonFullyBlockingAppHangs",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryOptions(im)enableReportNonFullyBlockingAppHangs",
-                "moduleName": "Sentry",
-                "isOpen": true,
-                "objc_name": "enableReportNonFullyBlockingAppHangs",
-                "declAttributes": [
-                  "DiscardableResult",
-                  "ObjC",
-                  "Dynamic"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNameAlias",
-                    "name": "Void",
-                    "printedName": "Swift.Void",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Void",
-                        "printedName": "()"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryOptions(im)setEnableReportNonFullyBlockingAppHangs:",
-                "moduleName": "Sentry",
-                "isOpen": true,
-                "objc_name": "setEnableReportNonFullyBlockingAppHangs:",
                 "declAttributes": [
                   "ObjC",
                   "Dynamic"


### PR DESCRIPTION
I'm refactoring SentryOptions to be in Swift and figured we could take the opportunity to cleanup this implementation.

Closes #6645