### PR TITLE
ref: Simplify integrations setup

### DIFF
--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -44,19 +44,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
 #endif // SWIFT_PACKAGE || SENTRY_TEST
 
-+ (NSArray<NSString *> *)defaultIntegrations
-{
-    NSArray<Class> *defaultIntegrationClasses = [SentryOptionsInternal defaultIntegrationClasses];
-    NSMutableArray<NSString *> *defaultIntegrationNames =
-        [[NSMutableArray alloc] initWithCapacity:defaultIntegrationClasses.count];
-
-    for (Class class in defaultIntegrationClasses) {
-        [defaultIntegrationNames addObject:NSStringFromClass(class)];
-    }
-
-    return defaultIntegrationNames;
-}
-
 - (instancetype)init
 {
     if (self = [super init]) {

--- a/Sources/Sentry/SentryOptionsInternal.m
+++ b/Sources/Sentry/SentryOptionsInternal.m
@@ -1,71 +1,12 @@
 #import "SentryOptionsInternal.h"
-#import "SentryANRTrackingIntegration.h"
-#import "SentryAutoBreadcrumbTrackingIntegration.h"
-#import "SentryAutoSessionTrackingIntegration.h"
-#import "SentryCoreDataTrackingIntegration.h"
-#import "SentryCrashIntegration.h"
 #import "SentryDsn.h"
-#import "SentryFileIOTrackingIntegration.h"
 #import "SentryInternalDefines.h"
 #import "SentryLevelMapper.h"
-#import "SentryNetworkTrackingIntegration.h"
 #import "SentryOptions+Private.h"
 #import "SentryOptions.h"
-#import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"
-#import "SentrySwiftAsyncIntegration.h"
-
-#if SENTRY_HAS_UIKIT
-#    import "SentryAppStartTrackingIntegration.h"
-#    import "SentryFramesTrackingIntegration.h"
-#    import "SentryPerformanceTrackingIntegration.h"
-#    import "SentryScreenshotIntegration.h"
-#    import "SentryUIEventTrackingIntegration.h"
-#    import "SentryUserFeedbackIntegration.h"
-#    import "SentryViewHierarchyIntegration.h"
-#    import "SentryWatchdogTerminationTrackingIntegration.h"
-#endif // SENTRY_HAS_UIKIT
-
-#if SENTRY_HAS_METRIC_KIT
-#    import "SentryMetricKitIntegration.h"
-#endif // SENTRY_HAS_METRIC_KIT
 
 @implementation SentryOptionsInternal
-
-+ (NSArray<Class> *)defaultIntegrationClasses
-{
-    // The order of integrations here is important.
-    // SentryCrashIntegration needs to be initialized before SentryAutoSessionTrackingIntegration.
-    // And SentrySessionReplayIntegration before SentryCrashIntegration.
-    NSMutableArray<Class> *defaultIntegrations = [NSMutableArray<Class> arrayWithObjects:
-#if SENTRY_TARGET_REPLAY_SUPPORTED
-            [SentrySessionReplayIntegration class],
-#endif // SENTRY_TARGET_REPLAY_SUPPORTED
-        [SentryCrashIntegration class],
-#if SENTRY_HAS_UIKIT
-        [SentryAppStartTrackingIntegration class], [SentryFramesTrackingIntegration class],
-        [SentryPerformanceTrackingIntegration class], [SentryUIEventTrackingIntegration class],
-        [SentryViewHierarchyIntegration class],
-        [SentryWatchdogTerminationTrackingIntegration class],
-#endif // SENTRY_HAS_UIKIT
-#if SENTRY_TARGET_REPLAY_SUPPORTED
-        [SentryScreenshotIntegration class],
-#endif // SENTRY_TARGET_REPLAY_SUPPORTED
-        [SentryANRTrackingIntegration class], [SentryAutoBreadcrumbTrackingIntegration class],
-        [SentryAutoSessionTrackingIntegration class], [SentryCoreDataTrackingIntegration class],
-        [SentryFileIOTrackingIntegration class], [SentryNetworkTrackingIntegration class],
-        [SentrySwiftAsyncIntegration class], nil];
-
-#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
-    [defaultIntegrations addObject:[SentryUserFeedbackIntegration class]];
-#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
-
-#if SENTRY_HAS_METRIC_KIT
-    [defaultIntegrations addObject:[SentryMetricKitIntegration class]];
-#endif // SENTRY_HAS_METRIC_KIT
-
-    return defaultIntegrations;
-}
 
 + (nullable SentryOptions *)initWithDict:(NSDictionary<NSString *, id> *)options
                         didFailWithError:(NSError *_Nullable *_Nullable)error

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -2,13 +2,19 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryANRTrackingIntegration.h"
 #import "SentryAppStartMeasurement.h"
+#import "SentryAutoBreadcrumbTrackingIntegration.h"
+#import "SentryAutoSessionTrackingIntegration.h"
 #import "SentryBreadcrumb.h"
 #import "SentryClient+Private.h"
+#import "SentryCoreDataTrackingIntegration.h"
 #import "SentryCrash.h"
+#import "SentryCrashIntegration.h"
+#import "SentryFileIOTrackingIntegration.h"
 #import "SentryHub+Private.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"
 #import "SentryMeta.h"
+#import "SentryNetworkTrackingIntegration.h"
 #import "SentryOptions+Private.h"
 #import "SentryOptionsInternal.h"
 #import "SentryProfilingConditionals.h"
@@ -17,10 +23,27 @@
 #import "SentrySamplingContext.h"
 #import "SentryScope.h"
 #import "SentrySerialization.h"
+#import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"
+#import "SentrySwiftAsyncIntegration.h"
 #import "SentryTransactionContext.h"
 #import "SentryUseNSExceptionCallstackWrapper.h"
 #import "SentryUserFeedbackIntegration.h"
+
+#if SENTRY_HAS_UIKIT
+#    import "SentryAppStartTrackingIntegration.h"
+#    import "SentryFramesTrackingIntegration.h"
+#    import "SentryPerformanceTrackingIntegration.h"
+#    import "SentryScreenshotIntegration.h"
+#    import "SentryUIEventTrackingIntegration.h"
+#    import "SentryUserFeedbackIntegration.h"
+#    import "SentryViewHierarchyIntegration.h"
+#    import "SentryWatchdogTerminationTrackingIntegration.h"
+#endif // SENTRY_HAS_UIKIT
+
+#if SENTRY_HAS_METRIC_KIT
+#    import "SentryMetricKitIntegration.h"
+#endif // SENTRY_HAS_METRIC_KIT
 
 #if TARGET_OS_OSX
 #    import "SentryCrashExceptionApplication.h"
@@ -520,6 +543,41 @@ static NSDate *_Nullable startTimestamp = nil;
     [SentrySDKInternal.currentHub endSession];
 }
 
++ (NSArray<Class> *)defaultIntegrationClasses
+{
+    // The order of integrations here is important.
+    // SentryCrashIntegration needs to be initialized before SentryAutoSessionTrackingIntegration.
+    // And SentrySessionReplayIntegration before SentryCrashIntegration.
+    NSMutableArray<Class> *defaultIntegrations = [NSMutableArray<Class> arrayWithObjects:
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+            [SentrySessionReplayIntegration class],
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
+        [SentryCrashIntegration class],
+#if SENTRY_HAS_UIKIT
+        [SentryAppStartTrackingIntegration class], [SentryFramesTrackingIntegration class],
+        [SentryPerformanceTrackingIntegration class], [SentryUIEventTrackingIntegration class],
+        [SentryViewHierarchyIntegration class],
+        [SentryWatchdogTerminationTrackingIntegration class],
+#endif // SENTRY_HAS_UIKIT
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+        [SentryScreenshotIntegration class],
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
+        [SentryANRTrackingIntegration class], [SentryAutoBreadcrumbTrackingIntegration class],
+        [SentryAutoSessionTrackingIntegration class], [SentryCoreDataTrackingIntegration class],
+        [SentryFileIOTrackingIntegration class], [SentryNetworkTrackingIntegration class],
+        [SentrySwiftAsyncIntegration class], nil];
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+    [defaultIntegrations addObject:[SentryUserFeedbackIntegration class]];
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+#if SENTRY_HAS_METRIC_KIT
+    [defaultIntegrations addObject:[SentryMetricKitIntegration class]];
+#endif // SENTRY_HAS_METRIC_KIT
+
+    return defaultIntegrations;
+}
+
 /**
  * Install integrations and keeps ref in @c SentryHub.integrations
  */
@@ -530,48 +588,24 @@ static NSDate *_Nullable startTimestamp = nil;
         return;
     }
     SentryOptions *options = [SentrySDKInternal.currentHub getClient].options;
-    NSMutableArray<NSString *> *integrationNames = [SentryOptions defaultIntegrations].mutableCopy;
 
-    NSArray<Class> *defaultIntegrations = SentryOptionsInternal.defaultIntegrationClasses;
+    NSArray<Class> *integrationClasses = [SentrySDKInternal defaultIntegrationClasses];
 
-    // Since 8.22.0, we use a precompiled XCFramework for SPM, which can lead to Sentry's
-    // definition getting duplicated in the app with a warning “SentrySDK is defined in both
-    // ModuleA and ModuleB”. This doesn't happen when users use Sentry-Dynamic and
-    // when compiling Sentry from source via SPM. Due to the duplication, some users didn't
-    // see any crashes reported to Sentry cause the SentryCrashReportSink couldn't find
-    // a hub bound to the SentrySDK, and it dropped the crash events. This problem
-    // is fixed now by using a dictionary that links the classes with their names
-    // so we can quickly check whether that class is in the option integrations collection.
-    // We cannot load the class itself with NSClassFromString because doing so may load a class
-    // that was duplicated in another module, leading to undefined behavior.
-    NSMutableDictionary<NSString *, Class> *integrationDictionary =
-        [[NSMutableDictionary alloc] init];
-
-    for (Class integrationClass in defaultIntegrations) {
-        integrationDictionary[NSStringFromClass(integrationClass)] = integrationClass;
-    }
-
-    for (NSString *integrationName in integrationNames) {
-        Class integrationClass
-            = integrationDictionary[integrationName] ?: NSClassFromString(integrationName);
-        if (nil == integrationClass) {
-            SENTRY_LOG_ERROR(@"[SentryHub doInstallIntegrations] "
-                             @"couldn't find \"%@\" -> skipping.",
-                integrationName);
-            continue;
-        } else if ([SentrySDKInternal.currentHub isIntegrationInstalled:integrationClass]) {
+    for (Class integrationClass in integrationClasses) {
+        if ([SentrySDKInternal.currentHub isIntegrationInstalled:integrationClass]) {
             SENTRY_LOG_ERROR(
                 @"[SentryHub doInstallIntegrations] already installed \"%@\" -> skipping.",
-                integrationName);
+                NSStringFromClass(integrationClass));
             continue;
         }
+
         id<SentryIntegrationProtocol> integrationInstance = [[integrationClass alloc] init];
         BOOL shouldInstall = [integrationInstance installWithOptions:options];
-
         if (shouldInstall) {
-            SENTRY_LOG_DEBUG(@"Integration installed: %@", integrationName);
-            [SentrySDKInternal.currentHub addInstalledIntegration:integrationInstance
-                                                             name:integrationName];
+            SENTRY_LOG_DEBUG(@"Integration installed: %@", NSStringFromClass(integrationClass));
+            [SentrySDKInternal.currentHub
+                addInstalledIntegration:integrationInstance
+                                   name:NSStringFromClass(integrationClass)];
         }
     }
 }

--- a/Sources/Sentry/include/HybridPublic/SentryOptionsInternal.h
+++ b/Sources/Sentry/include/HybridPublic/SentryOptionsInternal.h
@@ -6,8 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryOptionsInternal : NSObject
 
-@property (nonatomic, readonly, class) NSArray<Class> *defaultIntegrationClasses;
-
 + (nullable SentryOptions *)initWithDict:(NSDictionary<NSString *, id> *)options
                         didFailWithError:(NSError *_Nullable *_Nullable)error;
 

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -32,11 +32,6 @@ FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 @property (nonatomic, nullable, strong) SentryProfileOptions *profiling;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-/**
- * Array of default integrations. Will be used if @c integrations is @c nil .
- */
-+ (NSArray<NSString *> *)defaultIntegrations;
-
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
 - (BOOL)enableViewRendererV2;


### PR DESCRIPTION
This was overly complicated due to the previous API letting you specify an array of the class names as strings. Now that is gone so we don't need all this

#skip-changelog

Closes #6669