### PR TITLE
chore: Skip SPM resolution for all lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -141,7 +141,8 @@ platform :ios do
       include_bitcode: false,
       include_symbols: true,
       export_method: "app-store",
-      archive_path: "iOS-Swift"
+      archive_path: "iOS-Swift",
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -166,7 +167,7 @@ platform :ios do
       scheme: "iOS-Swift",
       derived_data_path: "DerivedData",
       skip_archive: true,
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -214,7 +215,7 @@ platform :ios do
       xcargs: "build-for-testing",
       derived_data_path: "DerivedData",
       skip_archive: true,
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -332,7 +333,7 @@ platform :ios do
       export_method: "development",
       output_directory: "Tests/Perf/",
       output_name: "test-app-plain.ipa",
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -359,7 +360,7 @@ platform :ios do
       export_method: "development",
       output_directory: "Tests/Perf/",
       output_name: "test-app-sentry.ipa",
-      skip_package_dependencies_resolution: true
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -387,3 +388,9 @@ platform :ios do
     )
   end
 end
+
+# SKIP_SPM_RESOLUTION_NOTE:
+# We skip Swift Package resolution in these lanes because the samples embed the locally built
+# Sentry.framework. When `Package.swift` points to upcoming release artefacts the resolver would
+# fail before the build starts. Skipping resolution keeps CI green while release assets are still
+# being published.


### PR DESCRIPTION
skip_package_dependencies_resolution for all lanes in the Fastfile to avoid chicken egg problems when releasing.

The build.yml for the release https://github.com/getsentry/publish/issues/6576 failed with 

```
[14:26:41]: Resolving Swift Package Manager dependencies...
[14:26:41]: $ xcodebuild -resolvePackageDependencies -workspace Sentry.xcworkspace -scheme iOS-Swift
[14:26:42]: ▸ Command line invocation:
[14:26:42]: ▸     /Applications/Xcode_16.4.app/Contents/Developer/usr/bin/xcodebuild -resolvePackageDependencies -workspace Sentry.xcworkspace -scheme iOS-Swift
[14:26:45]: ▸ Resolve Package Graph
[14:26:54]: ▸ failed downloading 'https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-alpha.0/Sentry-Dynamic.xcframework.zip' which is required by binary target 'Sentry-Dynamic': badResponseStatusCode(404)failed downloading 'https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-alpha.0/Sentry.xcframework.zip' which is required by binary target 'Sentry': badResponseStatusCode(404)failed downloading 'https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-alpha.0/Sentry-Dynamic-WithARM64e.xcframework.zip' which is required by binary target 'Sentry-Dynamic-WithARM64e': badResponseStatusCode(404)failed downloading 'https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-alpha.0/Sentry-WithoutUIKitOrAppKit.xcframework.zip' which is required by binary target 'Sentry-WithoutUIKitOrAppKit': badResponseStatusCode(404)failed downloading 'https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-alpha.0/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip' which is required by binary target 'Sentry-WithoutUIKitOrAppKit-WithARM64e': badResponseStatusCode(404)fatalError
```

We don't need to resolve the package in Fastlane. 

Closes #6674