### PR TITLE
chore: DistributionSample uses local SPM package

### DIFF
--- a/Samples/DistributionSample/DistributionSample.yml
+++ b/Samples/DistributionSample/DistributionSample.yml
@@ -7,8 +7,11 @@ configs:
 options:
   bundleIdPrefix: io.sentry.sample.
 packages:
+  # Use the local SentryDistribution package instead of the repo root manifest so the sample
+  # depends only on the checked-in sources and does not try to fetch unreleased binary artifacts
+  # during release builds.
   Sentry:
-    path: ../../
+    path: ../../Sources/SentryDistribution
 targets:
   DistributionSample:
     type: application

--- a/Sources/SentryDistribution/Package.swift
+++ b/Sources/SentryDistribution/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.5
+
+// NOTE:
+// The distribution sample used to reference the repository’s root `Package.swift`, whose binary
+// targets point at release artifacts that may not exist yet when we run CI before publishing. This
+// trimmed-down manifest mirrors the relevant parts of the root package but only exposes the local
+// `Sources/SentryDistribution` target so the sample can build against it without fetching unreleased
+// binaries.
+
+import PackageDescription
+
+var products: [Product] = [
+    .library(name: "SentryDistribution", targets: ["SentryDistribution"])
+]
+
+var targets: [Target] = [
+    .target(name: "SentryDistribution", path: "./")
+]
+
+let package = Package(
+    name: "Sentry",
+    platforms: [.iOS(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v8)],
+    products: products,
+    targets: targets
+)


### PR DESCRIPTION
- Changed the path in DistributionSample.yml to reference the local SentryDistribution package instead of the repo root manifest.
- Added a new Package.swift file for SentryDistribution to avoid fetching unreleased binaries during CI builds.

This fixes sample build errors in build.yml for https://github.com/getsentry/publish/issues/6576.

#skip-changelog

Closes #6676