### PR TITLE
chore: Add fast workflow for in progress PRs

### DIFF
--- a/.github/workflows/fast-pr-checks.yml
+++ b/.github/workflows/fast-pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
       name: iOS 18 Sentry
       runs-on: macos-15
       timeout: 20
-      should_skip: ${{needs.files-changed.outputs.run_unit_tests_for_prs != 'true'}}
+      should_skip: false
       xcode: "16.4"
       test-destination-os: "18.4"
       platform: iOS


### PR DESCRIPTION
This PR adds a new workflow that will run on PRs while the PR is in progress

#skip-changelog

Closes #6683