### PR TITLE
chore: SentrySwiftLog xcconfig versions

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,7 +5,6 @@ on:
       - main
       - v8.x
       - release/**
-      - fix/swift-log-versions
 
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
* Include Versioning.xcconfig for version management
* Change CURRENT_PROJECT_VERSION to use

To fix build errors when uploading the sample app to TestFlight like these https://github.com/getsentry/sentry-cocoa/actions/runs/19161843087/job/54773586843?pr=6702

```
[07:57:08]: [altool]     NSLocalizedFailureReason = "The bundle 'Payload/iOS-Swift.app/Frameworks/SentrySwiftLog.framework' is missing plist key. The Info.plist file is missing the required key: CFBundleShortVersionString. Please find more information about CFBundleShortVersionString at https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring (ID: 80c2e6ae-150a-4f4c-bde8-adc1c70b9de1)";
```

#skip-changelog 

The build worked here https://github.com/getsentry/sentry-cocoa/actions/runs/19162516115/job/54775665188?pr=6704

I don't want to change this to run also for changes in Sources because we only want to upload TestFlight builds on main. https://github.com/getsentry/sentry-cocoa/blob/5c05f837af42f4319e8b9d7897d7398b98da84b3/.github/file-filters.yml#L368-L370