### PR TITLE
docs: Move v9 changelog changes from v8.57.2 to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@
   If you need a precompiled XCFramework built with Xcode 15, continue using Sentry SDK 8.x.x.
 - Set `SentryException.type` to `nil` when `NSException` has no `reason` (#6653). The backend then can provide a proper message when there is no reason.
 - Rename `SentryLog.Level` and `SentryLog.Attribute` for ObjC (#6666)
-- Rename `SentryMechanismMeta` to `SentryMechanismContext` to resolve Kotlin Multi-Platform build errors (#6607)
 
 ### Fixes
 


### PR DESCRIPTION
During the back-merge of the v8 changes into `main` it merged the v8.57.2 changes with the unreleased v9 changes. This PR separates the two changes.

Closes #6710