### PR TITLE
chore(deps): Update ruby/setup-ruby to v1.267.0

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -71,7 +71,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         if: ${{ inputs.signed }}
         with:
           bundler-cache: true

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -42,7 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: ./scripts/ci-select-xcode.sh 15.4
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
       - name: Install old xcodegen
@@ -107,11 +108,7 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_benchmarking_for_prs == 'true'
     runs-on: ubuntu-latest
-    needs:
-      [
-        files-changed,
-        build-benchmark-test-target,
-      ]
+    needs: [files-changed, build-benchmark-test-target]
     strategy:
       fail-fast: false
       matrix:
@@ -203,12 +200,7 @@ jobs:
         run: ./scripts/ci-diagnostics.sh
 
   benchmarking-required-check:
-    needs:
-      [
-        files-changed,
-        build-benchmark-test-target,
-        run-ui-tests-with-sauce,
-      ]
+    needs: [files-changed, build-benchmark-test-target, run-ui-tests-with-sauce]
     name: Benchmarking
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,8 @@ jobs:
         run: ./scripts/prepare-package.sh --only-keep-distribution true
 
       - run: ./scripts/ci-select-xcode.sh 16.4
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
       - run: make init-ci-build

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,7 +46,7 @@ jobs:
         run: ./scripts/ci-select-xcode.sh 16.4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
 
@@ -70,11 +70,7 @@ jobs:
   # to make integration tests a required check with only running the integration tests when required.
   # So, we don't have to run integration tests, for example, for Changelog or ReadMe changes.
   integration_test-required-check:
-    needs:
-      [
-        files-changed,
-        test,
-      ]
+    needs: [files-changed, test]
     name: Integration Test
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/.github/workflows/objc-conversion-analysis.yml
+++ b/.github/workflows/objc-conversion-analysis.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # pin@v5.4.3
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           ruby-version: "3.2"
           bundler-cache: true
@@ -89,11 +89,7 @@ jobs:
   # So, we don't have to run analysis, for example, for Changelog or ReadMe changes.
 
   objc_conversion_analysis-required-check:
-    needs:
-      [
-        files-changed,
-        analyze-objc-conversion,
-      ]
+    needs: [files-changed, analyze-objc-conversion]
     name: Objective-C Conversion Analysis
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v5
       - run: ./scripts/ci-select-xcode.sh 16.4
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
       - uses: actions/cache@v4

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -42,7 +42,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: ./scripts/ci-select-xcode.sh 16.4
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
 
@@ -101,11 +102,7 @@ jobs:
   # to make testflight a required check with only running the upload_to_testflight when required.
   # So, we don't have to run upload_to_testflight, for example, for unrelated changes.
   testflight-required-check:
-    needs:
-      [
-        files-changed,
-        upload_to_testflight,
-      ]
+    needs: [files-changed, upload_to_testflight]
     name: Testflight
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
+        uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
Dependabot didn't update the ruby/setup-ruby action to the latest version, so this PR does it.
Unblocks the CI in #3327

#skip-changelog