### PR TITLE
test: Add SentryFileManagerTest to flaky plans

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -38,6 +38,7 @@
         "SentryCrashReportStore_Tests\/testDeleteAllReports",
         "SentryCrashReportStore_Tests\/testPruneReports",
         "SentryCrashReportStore_Tests\/testStoresLoadsMultipleReports",
+        "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
         "SentryHttpTransportTests\/testFlush_WhenNoInternet_BlocksAndFinishes()",
         "SentryNetworkTrackerIntegrationTestServerTests",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -19,6 +19,7 @@
         "PrivateSentrySDKOnlyTests\/testProfilingStartAndCollect()",
         "SentryCrashBinaryImageCacheTests\/testRemoveImageFromBeginning",
         "SentryCrashReportStore_Tests\/testPruneReports",
+        "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
         "SentryWatchdogTerminationTrackerTests\/testTerminateApp_RunsOnMainThread()"
       ],


### PR DESCRIPTION
Add testCreateDirectoryIfNotExists_successful_shouldNotLogError to the flaky plan.

Failed here: https://github.com/getsentry/sentry-cocoa/actions/runs/19233074305/job/54976002030

#skip-changelog

Closes #6736