### PR TITLE
ref: Save startOptions on SentrySDK

### DIFF
--- a/SentryTestUtils/Sources/ClearTestState.swift
+++ b/SentryTestUtils/Sources/ClearTestState.swift
@@ -27,7 +27,7 @@ class TestCleanup: NSObject {
         SentrySDKInternal.crashedLastRunCalled = false
         SentrySDKInternal.startInvocations = 0
         SentrySDKInternal.setDetectedStartUpCrash(false)
-        SentrySDKInternal.setStart(with: nil)
+        SentrySDK.setStart(with: nil)
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false
         SentryNetworkTracker.sharedInstance.disable()
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -163,7 +163,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
     // we would lose the scope. Furthermore, we want to know in which state the app was when the
     // app hang started.
     SentryScope *scope = [SentrySDKInternal currentHub].scope;
-    SentryOptions *options = SentrySDKInternal.options;
+    SentryOptions *options = SentrySDK.startOption;
     if (scope != nil && options != nil) {
         [scope applyToEvent:event maxBreadcrumb:options.maxBreadcrumbs];
     }

--- a/Sources/Sentry/SentryDefaultUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryDefaultUIViewControllerPerformanceTracker.m
@@ -119,7 +119,7 @@
         return;
     }
 
-    SentryOptions *options = [SentrySDKInternal options];
+    SentryOptions *options = SentrySDK.startOption;
 
     if ([SentrySwizzleClassNameExclude
             shouldExcludeClassWithClassName:NSStringFromClass([controller class])

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -4,24 +4,6 @@
 #import "SentrySDK+Private.h"
 #import "SentrySwift.h"
 
-@implementation SentryDefaultRedactOptions
-- (instancetype)initWithMaskAllText:(BOOL)maskAllText
-                      maskAllImages:(BOOL)maskAllImages
-                  maskedViewClasses:(NSArray<Class> *)maskedViewClasses
-                unmaskedViewClasses:(NSArray<Class> *)unmaskedViewClasses
-{
-    if (self = [super init]) {
-        _maskAllText = maskAllText;
-        _maskAllImages = maskAllImages;
-        _maskedViewClasses = maskedViewClasses;
-        _unmaskedViewClasses = unmaskedViewClasses;
-        return self;
-    }
-    return nil;
-}
-
-@end
-
 @implementation SentryDependencyContainerSwiftHelper
 
 #if SENTRY_HAS_UIKIT
@@ -29,25 +11,6 @@
 + (NSArray<UIWindow *> *)windows
 {
     return [SentryDependencyContainer.sharedInstance.application getWindows];
-}
-
-+ (BOOL)fastViewRenderingEnabled:(SentryOptions *)options
-{
-    return options.screenshot.enableFastViewRendering;
-}
-
-+ (BOOL)viewRendererV2Enabled:(SentryOptions *)options
-{
-    return options.screenshot.enableViewRendererV2;
-}
-
-+ (SentryDefaultRedactOptions *)redactOptions:(SentryOptions *)options
-{
-    return [[SentryDefaultRedactOptions alloc]
-        initWithMaskAllText:options.screenshot.maskAllText
-              maskAllImages:options.screenshot.maskAllImages
-          maskedViewClasses:options.screenshot.maskedViewClasses
-        unmaskedViewClasses:options.screenshot.unmaskedViewClasses];
 }
 
 #endif // SENTRY_HAS_UIKIT
@@ -70,11 +33,6 @@
     return options.environment;
 }
 
-+ (NSString *)cacheDirectoryPath:(SentryOptions *)options
-{
-    return options.cacheDirectoryPath;
-}
-
 + (BOOL)enableLogs:(SentryOptions *)options
 {
     return options.enableLogs;
@@ -88,11 +46,6 @@
 + (BOOL)sendDefaultPii:(SentryOptions *)options
 {
     return options.sendDefaultPii;
-}
-
-+ (NSArray<NSString *> *)inAppIncludes:(SentryOptions *)options
-{
-    return options.inAppIncludes;
 }
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper

--- a/Sources/Sentry/SentryFileManagerHelper.m
+++ b/Sources/Sentry/SentryFileManagerHelper.m
@@ -105,7 +105,7 @@ _non_thread_safe_removeFileAtPath(NSString *path)
 - (nullable instancetype)initWithPlaceholder:(NSObject *)objc
                                        error:(NSError *_Nullable *_Nullable)error
 {
-    SentryOptions *options = [SentrySDKInternal options];
+    SentryOptions *options = SentrySDK.startOption;
     return [self initWithOptions:options error:error];
 }
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -121,7 +121,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         return;
 
     // SDK not enabled no need to continue
-    if (SentrySDKInternal.options == nil) {
+    if (SentrySDK.startOption == nil) {
         return;
     }
 
@@ -132,7 +132,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     }
 
     // Don't measure requests to Sentry's backend
-    NSURL *_Nullable apiUrl = SentrySDKInternal.options.parsedDsn.url;
+    NSURL *_Nullable apiUrl = SentrySDK.startOption.parsedDsn.url;
     if (apiUrl && apiUrl.host && apiUrl.path.length > 0 &&
         [url.host isEqualToString:SENTRY_UNWRAP_NULLABLE(NSString, apiUrl.host)] &&
         [url.path containsString:SENTRY_UNWRAP_NULLABLE(NSString, apiUrl.path)]) {
@@ -192,13 +192,12 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         }
 
         SentryBaggage *baggage = [[[SentryTracer getTracer:span] traceContext] toBaggage];
-        [SentryTracePropagation
-                   addBaggageHeader:baggage
-                        traceHeader:SENTRY_UNWRAP_NULLABLE(
-                                        SentryTraceHeader, [netSpan toTraceHeader])
-               propagateTraceparent:SentrySDKInternal.options.enablePropagateTraceparent
-            tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
-                          toRequest:sessionTask];
+        [SentryTracePropagation addBaggageHeader:baggage
+                                     traceHeader:SENTRY_UNWRAP_NULLABLE(
+                                                     SentryTraceHeader, [netSpan toTraceHeader])
+                            propagateTraceparent:SentrySDK.startOption.enablePropagateTraceparent
+                         tracePropagationTargets:SentrySDK.startOption.tracePropagationTargets
+                                       toRequest:sessionTask];
 
         SENTRY_LOG_DEBUG(
             @"SentryNetworkTracker automatically started HTTP span for sessionTask: %@",
@@ -222,8 +221,8 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 
     [SentryTracePropagation addBaggageHeader:[traceContext toBaggage]
                                  traceHeader:[propagationContext traceHeader]
-                        propagateTraceparent:SentrySDKInternal.options.enablePropagateTraceparent
-                     tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
+                        propagateTraceparent:SentrySDK.startOption.enablePropagateTraceparent
+                     tracePropagationTargets:SentrySDK.startOption.tracePropagationTargets
                                    toRequest:sessionTask];
 }
 
@@ -249,7 +248,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     }
 
     // Don't measure requests to Sentry's backend
-    NSURL *apiUrl = SentrySDKInternal.options.parsedDsn.url;
+    NSURL *apiUrl = SentrySDK.startOption.parsedDsn.url;
     if ([url.host isEqualToString:SENTRY_UNWRAP_NULLABLE(NSString, apiUrl.host)] &&
         [url.path containsString:SENTRY_UNWRAP_NULLABLE(NSString, apiUrl.path)]) {
         return;
@@ -318,9 +317,8 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         return;
     }
 
-    if (![SentryTracePropagation
-            isTargetMatch:SENTRY_UNWRAP_NULLABLE(NSURL, myRequest.URL)
-              withTargets:SentrySDKInternal.options.failedRequestTargets ?: @[]]) {
+    if (![SentryTracePropagation isTargetMatch:SENTRY_UNWRAP_NULLABLE(NSURL, myRequest.URL)
+                                   withTargets:SentrySDK.startOption.failedRequestTargets ?: @[]]) {
         SENTRY_LOG_DEBUG(
             @"Request url isn't within the request targets, not capturing HTTP Client errors.");
         return;
@@ -400,7 +398,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 
 - (BOOL)containsStatusCode:(NSInteger)statusCode
 {
-    for (SentryHttpStatusCodeRange *range in SentrySDKInternal.options.failedRequestStatusCodes) {
+    for (SentryHttpStatusCodeRange *range in SentrySDK.startOption.failedRequestStatusCodes) {
         if ([range isInRange:statusCode]) {
             return YES;
         }

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -59,8 +59,6 @@
 #    import "SentryProfiler+Private.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-NSString *const SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY = @"XCODE_RUNNING_FOR_PREVIEWS";
-
 @interface SentrySDKInternal ()
 
 @property (class) SentryHubInternal *currentHub;
@@ -75,8 +73,6 @@ static BOOL crashedLastRunCalled;
 static SentryAppStartMeasurement *_Nullable sentrySDKappStartMeasurement;
 static NSObject *sentrySDKappStartMeasurementLock;
 static BOOL _detectedStartUpCrash;
-static SentryOptions *_Nullable startOption;
-static NSObject *startOptionsLock;
 
 /**
  * @brief We need to keep track of the number of times @c +[startWith...] is called, because our
@@ -94,7 +90,6 @@ static NSDate *_Nullable startTimestamp = nil;
     if (self == [SentrySDKInternal class]) {
         sentrySDKappStartMeasurementLock = [[NSObject alloc] init];
         currentHubLock = [[NSObject alloc] init];
-        startOptionsLock = [[NSObject alloc] init];
         startInvocations = 0;
         _detectedStartUpCrash = NO;
     }
@@ -112,14 +107,9 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (nullable SentryOptions *)options
 {
-    @synchronized(startOptionsLock) {
-        return startOption;
-    }
+    return SentrySDK.startOption;
 }
-+ (nullable SentryOptionsObjC *)optionsInternal
-{
-    return [SentrySDKInternal options];
-}
+
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 + (SentryReplayApi *)replay
 {
@@ -137,12 +127,11 @@ static NSDate *_Nullable startTimestamp = nil;
         currentHub = hub;
     }
 }
+
 /** Internal, only needed for testing. */
 + (void)setStartOptions:(nullable SentryOptions *)options
 {
-    @synchronized(startOptionsLock) {
-        startOption = options;
-    }
+    [SentrySDK setStartWith:options];
 }
 
 + (nullable id<SentrySpan>)span
@@ -222,16 +211,6 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startWithOptions:(SentryOptions *)options
 {
-    // We save the options before checking for Xcode preview because
-    // we will use this options in the preview
-    startOption = options;
-    if ([SentryDependencyContainer.sharedInstance.processInfoWrapper
-                .environment[SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY] isEqualToString:@"1"]) {
-        // Using NSLog because SentryLog was not initialized yet.
-        NSLog(@"[SENTRY] [WARNING] SentrySDK not started. Running from Xcode preview.");
-        return;
-    }
-
     [SentrySDKLogSupport configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
         _origin = context.origin;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-        _isContinuousProfiling = SentrySDKInternal.options != nil;
+        _isContinuousProfiling = SentrySDK.startOption != nil;
         if (_isContinuousProfiling) {
             _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;
             if (_profileSessionID == nil) {

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -428,8 +428,8 @@ static BOOL appStartMeasurementRead;
                 _traceContext = [[SentryTraceContext alloc] initWithTracer:self
                                                                      scope:_hub.scope
                                                                    options:_hub.client.options
-                        ?: SentrySDKInternal.options]; // We should remove static classes and always
-                                                       // inject dependencies.
+                        ?: SentrySDK.startOption]; // We should remove static classes and always
+                                                   // inject dependencies.
             }
         }
     }

--- a/Sources/Sentry/SentryUseNSExceptionCallstackWrapper.m
+++ b/Sources/Sentry/SentryUseNSExceptionCallstackWrapper.m
@@ -57,7 +57,7 @@
 
 - (SentryCrashStackEntryMapper *)buildCrashStackToEntryMapper
 {
-    SentryOptions *options = SentrySDKInternal.options;
+    SentryOptions *options = SentrySDK.startOption;
 
     SentryInAppLogic *inAppLogic =
         [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes];

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -31,21 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSArray<UIWindow *> *)windows;
 
-// Since SentryOptions is in ObjC, Swift code can't see the SentryViewScreenshotOptions property
-+ (BOOL)fastViewRenderingEnabled:(SentryOptionsObjC *)options;
-+ (BOOL)viewRendererV2Enabled:(SentryOptionsObjC *)options;
-+ (SentryDefaultRedactOptions *)redactOptions:(SentryOptionsObjC *)options;
-
 #endif // SENTRY_HAS_UIKIT
 
 + (NSString *_Nullable)release:(SentryOptionsObjC *)options;
 + (NSString *)environment:(SentryOptionsObjC *)options;
 + (NSObject *_Nullable)beforeSendLog:(NSObject *)beforeSendLog options:(SentryOptionsObjC *)options;
-+ (NSString *)cacheDirectoryPath:(SentryOptionsObjC *)options;
 + (BOOL)enableLogs:(SentryOptionsObjC *)options;
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptionsObjC *)options;
 + (BOOL)sendDefaultPii:(SentryOptionsObjC *)options;
-+ (NSArray<NSString *> *)inAppIncludes:(SentryOptionsObjC *)options;
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block;

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -49,7 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
  * The option used to start the SDK
  */
 @property (nonatomic, nullable, readonly, class) SentryOptions *options;
-@property (nonatomic, nullable, readonly, class) SentryOptionsObjC *optionsInternal;
 
 /**
  * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -29,8 +29,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY;
-
 typedef NS_ENUM(NSInteger, SentryTransactionNameSource);
 
 @class SentrySpanId;

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -56,6 +56,15 @@ import Foundation
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
     @objc public static func start(options: Options) {
+        // We save the options before checking for Xcode preview because
+        // we will use this options in the preview
+        setStart(with: options)
+        guard SentryDependencyContainer.sharedInstance().processInfoWrapper
+                    .environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else {
+            // Using NSLog because SentryLog was not initialized yet.
+            NSLog("[SENTRY] [WARNING] SentrySDK not started. Running from Xcode preview.")
+            return
+        }
         SentrySDKInternal.start(options: options)
     }
     
@@ -66,7 +75,7 @@ import Foundation
     @objc public static func start(configureOptions: @escaping (Options) -> Void) {
         let options = Options()
         configureOptions(options)
-        SentrySDKInternal.start(options: options)
+        start(options: options)
     }
     
     // MARK: - Event Capture
@@ -422,6 +431,20 @@ import Foundation
         _loggerLock.synchronized {
             _logger = nil
             _loggerConfigured = false
+        }
+    }
+
+    /// The option used to start the SDK
+    private static var _startOption: Options?
+    private static let startOptionLock = NSRecursiveLock()
+    @_spi(Private) @objc public static var startOption: Options? {
+        startOptionLock.synchronized {
+            return _startOption
+        }
+    }
+    @_spi(Private) @objc public static func setStart(with option: Options?) {
+        startOptionLock.synchronized {
+            _startOption = option
         }
     }
 

--- a/Sources/Swift/Integrations/Performance/SentryUIViewControllerPerformanceTracker.swift
+++ b/Sources/Swift/Integrations/Performance/SentryUIViewControllerPerformanceTracker.swift
@@ -26,8 +26,7 @@ import UIKit
     @objc private let helper: SentryDefaultUIViewControllerPerformanceTracker
     
     override init() {
-        let options = SentrySDKInternal.optionsInternal
-        let inAppIncludes = options.map { SentryDependencyContainerSwiftHelper.inAppIncludes($0) } ?? []
+        let inAppIncludes = SentrySDK.startOption?.inAppIncludes ?? []
         inAppLogic = SentryInAppLogic(inAppIncludes: inAppIncludes)
         helper = SentryDefaultUIViewControllerPerformanceTracker(tracker: SentryPerformanceTracker.shared)
     }

--- a/Sources/Swift/SentryCrash/SentryThreadInspector.swift
+++ b/Sources/Swift/SentryCrash/SentryThreadInspector.swift
@@ -4,7 +4,7 @@
     private let internalHelper: SentryDefaultThreadInspector
     
     override init() {
-        internalHelper = SentryDefaultThreadInspector(options: SentrySDKInternal.optionsInternal)
+        internalHelper = SentryDefaultThreadInspector(options: SentrySDK.startOption)
     }
 
     init(options: Options) {

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -478,13 +478,13 @@ extension SentryProfilingPublicAPITests {
 private extension SentryProfilingPublicAPITests {
     func givenSdkWithHub() {
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         sentry_sdkInitProfilerTasks(fixture.options, fixture.hub)
     }
 
     func givenSdkWithHubButNoClient() {
         SentrySDKInternal.setCurrentHub(SentryHubInternal(client: nil, andScope: nil))
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
 
     func stopProfiler() throws {

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -48,7 +48,7 @@ final class SentryDependencyContainerTests: XCTestCase {
 
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
 
         let iterations = 100
 
@@ -136,7 +136,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -153,7 +153,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -173,7 +173,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
         let dispatchFactory = TestDispatchFactory()
@@ -202,7 +202,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         options2.dsn = SentryDependencyContainerTests.dsn
         options2.sessionTrackingIntervalMillis = 5_000
         
-        SentrySDKInternal.setStart(with: options1)
+        SentrySDK.setStart(with: options1)
         
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -226,7 +226,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         options2.sessionTrackingIntervalMillis = 5_000
         options2.environment = "test2"
         
-        SentrySDKInternal.setStart(with: options1)
+        SentrySDK.setStart(with: options1)
         
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -248,7 +248,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
         
         let container = SentryDependencyContainer.sharedInstance()
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -63,7 +63,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         fixture = Fixture()
 
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         SentryDependencyContainer.sharedInstance().dateProvider = fixture.dateProvider
     }
 

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -76,7 +76,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         fixture.client.fileManager.deleteAppState()
         fixture.client.fileManager.deleteAppHangEvent()
         
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
     
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -208,7 +208,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDKInternal.options))
+        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDK.startOption))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
         SentrySDKInternal.setCurrentHub(hub)
@@ -236,7 +236,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDKInternal.options))
+        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDK.startOption))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
         SentrySDKInternal.setCurrentHub(hub)
@@ -273,7 +273,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         // capture all error replays if this were not a buffer replay from previous session
         startSDK(sessionSampleRate: 0, errorSampleRate: 1)
         
-        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDKInternal.options))
+        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDK.startOption))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
         SentrySDKInternal.setCurrentHub(hub)
@@ -313,7 +313,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             }
         })
         
-        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDKInternal.options))
+        let client = SentryClientInternal(options: try XCTUnwrap(SentrySDK.startOption))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
         SentrySDKInternal.setCurrentHub(hub)

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -30,7 +30,7 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         let client = TestClient(options: options ?? self.options)
         let hub = SentryHubInternal(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper(processInfoWrapper: ProcessInfo.processInfo), andDispatchQueue: SentryDispatchQueueWrapper())
         
-        SentrySDKInternal.setStart(with: self.options)
+        SentrySDK.setStart(with: self.options)
         SentrySDKInternal.setCurrentHub(hub)
     }
     

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -985,12 +985,12 @@ private extension SentrySDKInternalTests {
 
     func givenSdkWithHub() {
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
 
     func givenSdkWithHubButNoClient() {
         SentrySDKInternal.setCurrentHub(SentryHubInternal(client: nil, andScope: nil))
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
 
     func assertIntegrationsInstalled(integrations: [String]) {
@@ -1019,7 +1019,7 @@ class SentrySDKWithSetupTests: XCTestCase {
         let expectation = expectation(description: "no deadlock")
         expectation.expectedFulfillmentCount = 20
 
-        SentrySDKInternal.setStart(with: Options())
+        SentrySDK.setStart(with: Options())
 
         for _ in 0..<10 {
             concurrentQueue.async {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -248,14 +248,14 @@ class SentrySDKTests: XCTestCase {
 
     func testGlobalOptions() {
         SentrySDK.start(options: fixture.options)
-        XCTAssertEqual(SentrySDKInternal.options, fixture.options)
+        XCTAssertEqual(SentrySDK.startOption, fixture.options)
     }
 
     func testGlobalOptionsForPreview() {
         startprocessInfoWrapperForPreview()
 
         SentrySDK.start(options: fixture.options)
-        XCTAssertEqual(SentrySDKInternal.options, fixture.options)
+        XCTAssertEqual(SentrySDK.startOption, fixture.options)
     }
 
     func testCaptureEvent() {
@@ -422,7 +422,7 @@ class SentrySDKTests: XCTestCase {
     func testFlush_CallsLoggerCaptureLogs() {
         fixture.client.options.enableLogs = true
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.client.options)
+        SentrySDK.setStart(with: fixture.client.options)
         
         // Add a log to ensure there's something to flush
         SentrySDK.logger.info("Test log message")
@@ -440,7 +440,7 @@ class SentrySDKTests: XCTestCase {
     func testClose_CallsLoggerCaptureLogs() {
         fixture.client.options.enableLogs = true
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.client.options)
+        SentrySDK.setStart(with: fixture.client.options)
         
         // Add a log to ensure there's something to flush
         SentrySDK.logger.info("Test log message")
@@ -462,7 +462,7 @@ class SentrySDKTests: XCTestCase {
         // Now properly start the SDK using internal APIs  
         fixture.client.options.enableLogs = true
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.client.options)
+        SentrySDK.setStart(with: fixture.client.options)
         
         // Access logger again after SDK is started
         let loggerAfterStart = SentrySDK.logger
@@ -484,7 +484,7 @@ class SentrySDKTests: XCTestCase {
         // Start SDK with logs disabled
         fixture.client.options.enableLogs = false
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.client.options)
+        SentrySDK.setStart(with: fixture.client.options)
         
         // Access logger
         let logger = SentrySDK.logger
@@ -557,11 +557,11 @@ extension SentrySDKTests {
 
     private func givenSdkWithHubButNoClient() {
         SentrySDKInternal.setCurrentHub(SentryHubInternal(client: nil, andScope: nil))
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
 
     private func givenSdkWithHub() {
         SentrySDKInternal.setCurrentHub(fixture.hub)
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
     }
 }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -68,7 +68,7 @@ class SentrySpanTests: XCTestCase {
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func testSpanDoesNotSubscribeToNotificationsIfAlreadyCapturedContinuousProfileID() {
         SentryContinuousProfiler.start()
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         let _ = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -77,7 +77,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testSpanDoesSubscribeToNotificationsIfNotAlreadyCapturedContinuousProfileID() {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         let _ = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -92,7 +92,7 @@ class SentrySpanTests: XCTestCase {
     ///     +----profile----+
     /// ```
     func test_spanStart_profileStart_spanEnd_profileEnd_spanIncludesProfileID() throws {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         let span = fixture.getSut()
         XCTAssertEqual(fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -113,7 +113,7 @@ class SentrySpanTests: XCTestCase {
     ///     +----profile----+
     /// ```
     func test_spanStart_profileStart_profileEnd_spanEnd_spanIncludesProfileID() throws {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
@@ -132,7 +132,7 @@ class SentrySpanTests: XCTestCase {
     ///         +-------span-------+
     /// ```
     func test_profileStart_spanStart_profileEnd_spanEnd_spanIncludesProfileID() throws {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
@@ -151,7 +151,7 @@ class SentrySpanTests: XCTestCase {
     ///         +-------span-------+
     /// ```
     func test_profileStart_spanStart_spanEnd_profileEnd_spanIncludesProfileID() throws {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
@@ -169,7 +169,7 @@ class SentrySpanTests: XCTestCase {
     ///     +--profile1--+    +--profile2--+
     /// ```
     func test_spanStart_profileStart_profileEnd_profileStart_profileEnd_spanEnd_spanIncludesSameProfileID() throws {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
         let profileId1 = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
@@ -191,7 +191,7 @@ class SentrySpanTests: XCTestCase {
     ///                          +----profile----+
     /// ```
     func test_spanStart_spanEnd_profileStart_profileEnd_spanDoesNotIncludeProfileID() {
-        SentrySDKInternal.setStart(with: fixture.options)
+        SentrySDK.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         SentryContinuousProfiler.stop()
         let span = fixture.getSut()

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -1,4 +1,4 @@
-@testable import Sentry
+@_spi(Private) @testable import Sentry
 import SentryTestUtils
 import XCTest
 
@@ -210,7 +210,7 @@ class SentryTransactionTests: XCTestCase {
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func testTransactionWithContinuousProfile() throws {
         let options = Options()
-        SentrySDKInternal.setStart(with: options)
+        SentrySDK.setStart(with: options)
         let transaction = fixture.getTransaction()
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)


### PR DESCRIPTION
By storing this on SentrySDK.swift instead of the ObjC version, we can save some Swift-ObjC interop

#skip-changelog

Closes #6749