### PR TITLE
ci: Update react native branch in cross-platform test workflow to cocoa-v9

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: getsentry/sentry-react-native
           path: sentry-react-native
-          ref: itay/frames_tracker_swift
+          ref: cocoa-v9
 
       - name: Enable Corepack
         working-directory: sentry-react-native


### PR DESCRIPTION
Updates react native branch in cross-platform test workflow to cocoa-v9 since that the branch used for the migration

cc @antonis 

Closes #6751