### PR TITLE
Update changelog for minimum OS version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- Bumped minimum OS versions to iOS 15.0, macOS 12.0, tvOS 15.0, visionOS 1.0, and watchOS 8.0
 - Moves `SentryEventDecoder` to SPI (#6365)
 - Makes `PreviewRedactOptions`, `SentryProfileOptions`, `SentryRedactViewHelper`, `SentryViewScreenshotOptions`, `SentryReplayOptions`, `SentryUserFeedbackConfiguration`, `SentryUserFeedbackFormConfiguration`, `SentryUserFeedbackThemeConfiguration`, `SentryUserFeedbackWidgetConfiguration`, `SentryFeedback`, and `SentryExperimentalOptions` `final` (#6365)
 - Removes Decodable conformances from the public API of model classes (#5691)


### PR DESCRIPTION
## :scroll: Description

Updates the `CHANGELOG.md` to document the minimum OS version bump in the "Unreleased" section.

#skip-changelog

## :bulb: Motivation and Context

This change is required to clearly communicate a breaking change regarding the minimum supported OS versions for `sentry-cocoa` v9. This is crucial for hybrid SDKs that depend on `sentry-cocoa` to understand the new minimum deployment targets.

## :green_heart: How did you test it?

Verified the `CHANGELOG.md` file content after the update.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
[Slack Thread](https://sentry.slack.com/archives/C040TTUKQT1/p1762790949305039?thread_ts=1762790949.305039&cid=C040TTUKQT1)

<a href="https://cursor.com/background-agent?bcId=bc-141644eb-8975-429c-a793-af6e3357dba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-141644eb-8975-429c-a793-af6e3357dba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

