### PR TITLE
ci: Use preinstalled device for iOS 26 unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,14 +270,12 @@ jobs:
             device: "iPhone 16 Pro"
             scheme: "Sentry"
 
-          # iOS 26 - Download iOS 26.1 beta runtime on macOS-26
+          # iOS 26 - Use pre-installed iOS 26.1 runtime on macOS-26
           - name: iOS 26 Sentry
             runs-on: macos-26
             xcode: "26.1"
             test-destination-os: "26.1"
-            install_platforms: true
             platform: "iOS"
-            create_device: true
             device: "iPhone 17 Pro"
             scheme: "Sentry"
             # This runner seems to be slower than the others, so we give it more time because otherwise it frequently times out. The build step often alone takes 20 minutes and also booting the simulator takes a while.


### PR DESCRIPTION
The macos-26 runner image has iOS 26 preinstalled. No need to download and install a simulator.

Fixes failing iOS 26 unit tests https://github.com/getsentry/sentry-cocoa/actions/runs/19307906940/job/55279562388

```
Command line invocation:
2025-11-13 09:30:33.989 xcodebuild[3380:19620] Writing error result bundle to /var/folders/2h/ld7l40j52ld3xm5md0h0md740000gn/T/ResultBundle_2025-13-11_09-30-0033.xcresult
Error: xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:26.1, name:iPhone 17 Pro }
	Available destinations for the "Sentry" scheme:
		{ platform:macOS, arch:arm64e, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, arch:arm64, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, arch:x86_64, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, arch:arm64e, variant:Mac Catalyst, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, arch:x86_64, variant:Mac Catalyst, id:1a4af81f4d48bad9af033bf53296c5da237bbb74, name:My Mac }
		{ platform:macOS, name:Any Mac }
		{ platform:macOS, variant:Mac Catalyst, name:Any Mac }
		{ platform:tvOS, id:dvtdevice-DVTiOSDevicePlaceholder-appletvos:placeholder, name:Any tvOS Device }
		{ platform:tvOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-appletvsimulator:placeholder, name:Any tvOS Simulator Device }
		{ platform:visionOS, id:dvtdevice-DVTiOSDevicePlaceholder-xros:placeholder, name:Any visionOS Device }
		{ platform:visionOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-xrsimulator:placeholder, name:Any visionOS Simulator Device }
		{ platform:watchOS, id:dvtdevice-DVTiOSDevicePlaceholder-watchos:placeholder, name:Any watchOS Device }
		{ platform:watchOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-watchsimulator:placeholder, name:Any watchOS Simulator Device }
		{ platform:tvOS Simulator, arch:arm64, id:17B1742E-EEE9-44A2-AEEB-ADD6D1C23A83, OS:18.5, name:Apple TV }
		{ platform:tvOS Simulator, arch:x86_64, id:17B1742E-EEE9-44A2-AEEB-ADD6D1C23A83, OS:18.5, name:Apple TV }
		{ platform:tvOS Simulator, arch:arm64, id:912567C8-F837-4D5E-952F-769872D71799, OS:26.0, name:Apple TV }
		{ platform:tvOS Simulator, arch:arm64, id:8B604CB3-C37E-48F8-A142-0E87E50FCFD6, OS:26.1, name:Apple TV }
		{ platform:tvOS Simulator, arch:arm64, id:35CCE02C-6F17-406C-B6E5-6F9DABA7BEEF, OS:18.5, name:Apple TV 4K (3rd generation) }
		{ platform:tvOS Simulator, arch:x86_64, id:35CCE02C-6F17-406C-B6E5-6F9DABA7BEEF, OS:18.5, name:Apple TV 4K (3rd generation) }
		{ platform:tvOS Simulator, arch:arm64, id:3D9089FE-96E9-4D68-8381-F3B455091548, OS:26.0, name:Apple TV 4K (3rd generation) }
		{ platform:tvOS Simulator, arch:arm64, id:EE3D23AE-85BA-4D19-9E9E-731C6DE192D0, OS:26.1, name:Apple TV 4K (3rd generation) }
		{ platform:tvOS Simulator, arch:arm64, id:5B19D52C-924B-4FEA-A6C3-F36462C33BF6, OS:18.5, name:Apple TV 4K (3rd generation) (at 1080p) }
		{ platform:tvOS Simulator, arch:x86_64, id:5B19D52C-924B-4FEA-A6C3-F36462C33BF6, OS:18.5, name:Apple TV 4K (3rd generation) (at 1080p) }
		{ platform:tvOS Simulator, arch:arm64, id:9295961E-83BE-4E8F-839F-9EA7E5003427, OS:26.0, name:Apple TV 4K (3rd generation) (at 1080p) }
		{ platform:tvOS Simulator, arch:arm64, id:0F96005A-9FA9-42EF-A835-995978A18D3E, OS:26.1, name:Apple TV 4K (3rd generation) (at 1080p) }
		{ platform:visionOS Simulator, arch:arm64, id:33BB0D17-91F3-403D-AA76-4B5A697FC50A, OS:2.5, name:Apple Vision Pro }
		{ platform:visionOS Simulator, arch:arm64, id:CE1FFEE0-F1B5-4F9A-91AC-CA536662E49B, OS:26.0, name:Apple Vision Pro }
		{ platform:visionOS Simulator, arch:arm64, id:09F0EBF3-CF66-4002-A799-2AAC9A0E65F0, OS:26.1, name:Apple Vision Pro }
		{ platform:watchOS Simulator, arch:arm64, id:189CCB6F-63A2-4023-A9EE-ABE100AA26B1, OS:11.5, name:Apple Watch SE (40mm) (2nd generation) }
		{ platform:watchOS Simulator, arch:x86_64, id:189CCB6F-63A2-4023-A9EE-ABE100AA26B1, OS:11.5, name:Apple Watch SE (40mm) (2nd generation) }
		{ platform:watchOS Simulator, arch:arm64, id:0F74D7F2-FA5A-4EDA-94D6-F1CA0D37603C, OS:11.5, name:Apple Watch SE (44mm) (2nd generation) }
		{ platform:watchOS Simulator, arch:x86_64, id:0F74D7F2-FA5A-4EDA-94D6-F1CA0D37603C, OS:11.5, name:Apple Watch SE (44mm) (2nd generation) }
		{ platform:watchOS Simulator, arch:arm64, id:C4FA35D5-D78A-42BF-A183-55A79A83A78C, OS:26.0, name:Apple Watch SE 3 (40mm) }
		{ platform:watchOS Simulator, arch:arm64, id:2862865A-3720-4E09-8F97-041E2127C9B9, OS:26.1, name:Apple Watch SE 3 (40mm) }
		{ platform:watchOS Simulator, arch:arm64, id:87B4CE40-F658-4059-AFBC-7B5EE2D39F68, OS:26.0, name:Apple Watch SE 3 (44mm) }
		{ platform:watchOS Simulator, arch:arm64, id:C4D5EE69-1876-42CA-8595-CC5EC3AD17D7, OS:26.1, name:Apple Watch SE 3 (44mm) }
		{ platform:watchOS Simulator, arch:arm64, id:765E75BB-A8C1-4EA9-8AFE-486196C3CE6F, OS:11.5, name:Apple Watch Series 10 (42mm) }
		{ platform:watchOS Simulator, arch:x86_64, id:765E75BB-A8C1-4EA9-8AFE-486196C3CE6F, OS:11.5, name:Apple Watch Series 10 (42mm) }
		{ platform:watchOS Simulator, arch:arm64, id:5E4C8538-8BEE-4342-87BF-6FE14A5987EA, OS:11.5, name:Apple Watch Series 10 (46mm) }
		{ platform:watchOS Simulator, arch:x86_64, id:5E4C8538-8BEE-4342-87BF-6FE14A5987EA, OS:11.5, name:Apple Watch Series 10 (46mm) }
		{ platform:watchOS Simulator, arch:arm64, id:808114F7-3E9A-4468-ABE6-2142784154C8, OS:26.0, name:Apple Watch Series 11 (42mm) }
		{ platform:watchOS Simulator, arch:arm64, id:AC0457F9-1F16-4B73-AC55-60D80B884751, OS:26.1, name:Apple Watch Series 11 (42mm) }
		{ platform:watchOS Simulator, arch:arm64, id:09345F6D-ACF2-49CE-89FB-FBB88F8264FA, OS:26.0, name:Apple Watch Series 11 (46mm) }
		{ platform:watchOS Simulator, arch:arm64, id:7C395F0F-88B0-4126-BA25-F7932A901DB0, OS:26.1, name:Apple Watch Series 11 (46mm) }
		{ platform:watchOS Simulator, arch:arm64, id:C2E6A648-2B98-40A0-A0B4-4E731D26202D, OS:11.5, name:Apple Watch Ultra 2 (49mm) }
		{ platform:watchOS Simulator, arch:x86_64, id:C2E6A648-2B98-40A0-A0B4-4E731D26202D, OS:11.5, name:Apple Watch Ultra 2 (49mm) }
		{ platform:watchOS Simulator, arch:arm64, id:68B5CB60-077C-4F5A-967E-BD058305AAC7, OS:26.0, name:Apple Watch Ultra 3 (49mm) }
		{ platform:watchOS Simulator, arch:arm64, id:7903551E-1593-4D92-A9EB-713B86514935, OS:26.1, name:Apple Watch Ultra 3 (49mm) }
	Ineligible destinations for the "Sentry" scheme:
		{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device, error:iOS 26.1 is not installed. Please download and install the platform from Xcode > Settings > Components. }
Error: Process completed with exit code 70.
```

#skip-changelog