### PR TITLE
chore: Update swift-tools and visionOS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -117,5 +117,6 @@ let package = Package(
     platforms: [.iOS(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v8), .visionOS(.v1)],
     products: products,
     targets: targets,
+    swiftLanguageModes: [.v5],
     cxxLanguageStandard: .cxx14
 )


### PR DESCRIPTION
Update to the swift-tools version in Xcode 16, the minimum required for the App Store as of 6 months ago. This versions allows specifying visionOS min supported version

Closes #6765