### PR TITLE
fix: Flush flaky test

### DIFF
--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -613,7 +613,7 @@ class SentrySDKInternalTests: XCTestCase {
         SentrySDKInternal.currentHub().bindClient(client)
         SentrySDK.close()
 
-        XCTAssertEqual(Options().shutdownTimeInterval, transport.flushInvocations.first ?? 0.0, accuracy: 0.003)
+        XCTAssertEqual(Options().shutdownTimeInterval, transport.flushInvocations.first ?? 0.0, accuracy: 0.03)
     }
 
     func testLogger_ReturnsSameInstanceOnMultipleCalls() {


### PR DESCRIPTION
This flaked with:

```
Error:     testClose_CallsFlushCorrectlyOnTransport, XCTAssertEqualWithAccuracy failed: ("2.0") is not equal to ("1.9969215") +/- ("0.003")
```

#skip-changelog

Closes #6767