### PR TITLE
chore(ci): Change benchmarking.yml to use iOS 26

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/download-artifact@v6
         with:
           name: DerivedData-Xcode
-      - run: npm install -g saucectl@0.186.0
+      - run: npm install -g saucectl@0.197.2
       - name: Run Benchmarks in SauceLab
         id: run-benchmarks-in-sauce-lab
         env:


### PR DESCRIPTION
Swift 6 is not available on older macOS runner versions, so we should bump it to the latest one.

#skip-changelog

Closes #6786