### PR TITLE
chore(ci): Replace cache-based slice caching with artifact upload/download

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -114,46 +114,25 @@ jobs:
             echo "XCFRAMEWORK_NAME=$SCHEME$SUFFIX" >> $GITHUB_ENV
           fi
 
-      - name: Compute cache key
-        env:
-          SDKS: ${{ inputs.sdks }}
-          VARIANT_ID: ${{ inputs.variant-id }}
-          SIGNED: ${{ inputs.signed }}
-          VERSION: ${{ env.VERSION }}
-        run: |
-          sdks_string="$SDKS"
-          sdks_string_slugified="${sdks_string//,/_}"
-          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${{runner.os}}-xcframework-$VARIANT_ID-$sdks_string_slugified-$SIGNED-$VERSION-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
-
-      - name: Restore XCFramework cache
-        id: cache-xcframework
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{env.XCFRAMEWORK_NAME}}.xcframework.zip
-
       - name: Download ${{inputs.variant-id}} Slices
-        if: steps.cache-xcframework.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v6
         with:
           pattern: xcframework-${{inputs.variant-id}}-slice-*
           path: xcframework-slices
 
       - name: Unzip slice artifact ZIP archives
-        if: steps.cache-xcframework.outputs.cache-hit != 'true'
         run: |
           find xcframework-slices -type f -print0 | xargs -t0I @ unzip @ -d xcframework-slices
         shell: bash
 
       - name: Remove excluded archs
-        if: ${{ steps.cache-xcframework.outputs.cache-hit != 'true' && inputs.excluded-archs != '' }}
+        if: ${{ inputs.excluded-archs != '' }}
         env:
           EXCLUDED_ARCHS: ${{ inputs.excluded-archs }}
         run: ./scripts/remove-architectures.sh xcframework-slices/ "$EXCLUDED_ARCHS"
         shell: bash
 
       - name: Assemble XCFramework
-        if: steps.cache-xcframework.outputs.cache-hit != 'true'
         env:
           SCHEME: ${{ inputs.scheme }}
           SUFFIX: ${{ inputs.suffix }}
@@ -174,40 +153,34 @@ jobs:
         shell: bash
 
       - name: Validate XCFramework structure
-        # only validate if the xcframework was not cached
-        if: steps.cache-xcframework.outputs.cache-hit != 'true'
         run: ./scripts/validate-xcframework-format.sh "${{env.XCFRAMEWORK_NAME}}.xcframework"
         shell: bash
         env:
           XCFRAMEWORK_NAME: ${{ env.XCFRAMEWORK_NAME }}
 
       - name: Zip XCFramework
-        if: steps.cache-xcframework.outputs.cache-hit != 'true'
         env:
           SIGNED: ${{ inputs.signed }}
           SCHEME: ${{ inputs.scheme }}
           SUFFIX: ${{ inputs.suffix }}
+          XCFRAMEWORK_NAME: ${{ env.XCFRAMEWORK_NAME }}
         run: |
           if [ "$SIGNED" = "true" ]; then
-            ./scripts/compress-xcframework.sh --sign "${{env.XCFRAMEWORK_NAME}}"
+            ./scripts/compress-xcframework.sh --sign "$XCFRAMEWORK_NAME"
           else
-            ./scripts/compress-xcframework.sh --not-signed "${{env.XCFRAMEWORK_NAME}}"
+            ./scripts/compress-xcframework.sh --not-signed "$XCFRAMEWORK_NAME"
           fi
         shell: bash
 
-      - name: Cache XCFramework
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{env.XCFRAMEWORK_NAME}}.xcframework.zip
-
       - name: Upload XCFramework
         uses: actions/upload-artifact@v5
+        env:
+          XCFRAMEWORK_NAME: ${{ env.XCFRAMEWORK_NAME }}
         with:
           overwrite: true
           name: xcframework-${{github.sha}}-${{inputs.override-name || inputs.variant-id}}
           if-no-files-found: error
-          path: ${{env.XCFRAMEWORK_NAME}}.xcframework.zip
+          path: ${{ env.XCFRAMEWORK_NAME }}.xcframework.zip
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -84,24 +84,7 @@ jobs:
           fi
         shell: sh
 
-      - name: Compute cache key
-        env:
-          RUNNER_OS: ${{ runner.os }}
-          VARIANT_ID: ${{ inputs.variant-id }}
-          MATRIX_SDK: ${{ matrix.sdk }}
-          VERSION: ${{ env.VERSION }}
-        run: |
-          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${RUNNER_OS}-xcframework-${VARIANT_ID}-slice-${MATRIX_SDK}-${VERSION}-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
-
-      - name: Restore xcarchive cache
-        id: cache-xcarchive
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{inputs.name}}${{inputs.suffix}}.xcarchive.zip
-
       - name: Bump version
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true'
         env:
           VERSION: ${{ env.VERSION }}
         run: |
@@ -109,7 +92,6 @@ jobs:
           make bump-version TO=$VERSION
 
       - name: Build ${{inputs.name}}${{inputs.suffix}} XCFramework slice for ${{matrix.sdk}}
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true'
         env:
           MATRIX_SDK: ${{ matrix.sdk }}
           INPUT_NAME: ${{ inputs.name }}
@@ -121,7 +103,7 @@ jobs:
 
       # The SentrySwiftUI archive build also builds Sentry.framework as a byproduct of the dependency. We need to remove that to avoid downstream assembly tasks from tripping on these extra files. In the future we could investigate using this byproduct instead of running a separate task for Sentry.framework, or use the one already built by that other task instead of rebuilding it here.
       - name: Remove Sentry.framework from SentrySwiftUI build
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true' && inputs.name == 'SentrySwiftUI'
+        if: inputs.name == 'SentrySwiftUI'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
@@ -131,7 +113,6 @@ jobs:
 
       # the upload action broke symlinks in the mac sdk slice's xcarchive
       - name: Zip xcarchive
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
           INPUT_NAME: ${{ inputs.name }}
@@ -140,13 +121,6 @@ jobs:
         run: |
           ditto -c -k -X --rsrc --keepParent ${GITHUB_WORKSPACE}/Carthage/archive/${INPUT_NAME}${INPUT_SUFFIX}/${MATRIX_SDK}.xcarchive ${INPUT_NAME}${INPUT_SUFFIX}.xcarchive.zip
         shell: bash
-
-      - name: Cache xcarchive
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{inputs.name}}${{inputs.suffix}}.xcarchive.zip
 
       - name: Upload xcarchive
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
Replace actions/cache usage for xcframework slices with artifact upload/download to prevent cross-branch cache contamination. Artifacts are scoped to workflow runs and commit SHAs, ensuring proper isolation between branches.

Changes:
- Remove cache restore/save steps from build-xcframework-variant-slices.yml
- Remove cache restore/save steps from assemble-xcframework-variant.yml
- Remove all cache-hit conditional logic
- Rely entirely on artifact upload/download for inter-job communication

This solves the issue where slices from other branches could be used if files were missing in the hash sum calculation used for cache key generation.

#skip-changelog

Closes #6796