### PR TITLE
chore: Replace macOS runners with xcode image

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -79,7 +79,7 @@ jobs:
   common-ui-tests:
     if: ${{ !inputs.should_skip }}
     name: UI Tests Common
-    runs-on: ${{ inputs.run_on_cirrus_labs && fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0}", "runner_group_id:10"]', inputs.macos_version)) || inputs.macos_version }}
+    runs-on: ${{ inputs.run_on_cirrus_labs && fromJSON(format('["ghcr.io/cirruslabs/macos-{0}-xcode:{1}", "runner_group_id:10"]', inputs.macos_version, inputs.xcode_version)) || inputs.macos_version }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Test using Cirrus Runners images with xcode version set