### PR TITLE
chore: Use Cirrus Runners for running unit tests on iOS 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,7 @@ jobs:
 
           # iOS 18 - Use pre-installed iOS 18.4 runtime on macOS-15
           - name: iOS 18 Sentry
-            runs-on: macos-15
+            runs-on: sequoia
             xcode: "16.4"
             test-destination-os: "18.4"
             platform: "iOS"


### PR DESCRIPTION
Similar to #6820, this enables Cirrus Runners on iOS18 unit tests which are timing out.

Example: https://github.com/getsentry/sentry-cocoa/actions/runs/19471609958/attempts/1?pr=6818