### PR TITLE
chore(ci): Update SDK Size analysis workflow to trigger on label updates

### DIFF
--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
I forgot to add the labeled trigger for PRs for this workflow which caused this workflow only to trigger when opening a PR, but not when adding the label.

This should fix this.

#skip-changelog

Closes #6833