### PR TITLE
ref: Convert SentryFeedbackAPI to Swift

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -605,8 +605,8 @@
 		845C16D52A622A5B00EC9519 /* SentryTracer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 845C16D42A622A5B00EC9519 /* SentryTracer+Private.h */; };
 		845CEAEF2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */; };
 		845CEB172D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEB162D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift */; };
-		8482FA9B2DD7C397000E9283 /* SentryFeedbackAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8482FA9C2DD7C397000E9283 /* SentryFeedbackAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */; };
+		8482FA9B2DD7C397000E9283 /* SentryFeedbackAPIHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 8482FA992DD7C397000E9283 /* SentryFeedbackAPIHelper.h */; };
+		8482FA9C2DD7C397000E9283 /* SentryFeedbackAPIHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 8482FA9A2DD7C397000E9283 /* SentryFeedbackAPIHelper.m */; };
 		848A45192BBF8D33006AAAEC /* SentryContinuousProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.mm */; };
 		848A451A2BBF8D33006AAAEC /* SentryContinuousProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */; };
 		848A451D2BBF9504006AAAEC /* SentryProfilerTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */; };
@@ -1101,6 +1101,7 @@
 		FA8E58F12E0AD4270049F69D /* SentryDispatchQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E58F02E0AD4220049F69D /* SentryDispatchQueueWrapper.swift */; };
 		FA90FAA82E06614E008CAAE8 /* SentryExtraPackages.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90FAA72E06614B008CAAE8 /* SentryExtraPackages.swift */; };
 		FA90FAFD2E070A3B008CAAE8 /* SentryURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */; };
+		FA914E6D2ECFD7D800C54BDD /* SentryFeedbackAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA914E6C2ECFD7D800C54BDD /* SentryFeedbackAPI.swift */; };
 		FA94E6912E6B92C100576666 /* SentryClientReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA94E68B2E6B92BE00576666 /* SentryClientReport.swift */; };
 		FA94E6B22E6D265800576666 /* SentryEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA94E6B12E6D265500576666 /* SentryEnvelope.swift */; };
 		FA94E7242E6F339400576666 /* SentryEnvelopeItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA94E7232E6F32FA00576666 /* SentryEnvelopeItemType.swift */; };
@@ -1963,8 +1964,8 @@
 		846F90332D56F59D009E86C1 /* Brewfile-ci-deploy */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = "Brewfile-ci-deploy"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		848214B42E32B10900DF6998 /* SwiftUITestSample_Crash.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUITestSample_Crash.xctestplan; sourceTree = "<group>"; };
 		848214B52E32B10900DF6998 /* SwiftUITestSample_Envelope.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftUITestSample_Envelope.xctestplan; sourceTree = "<group>"; };
-		8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryFeedbackAPI.h; path = ../../../Sentry/Public/SentryFeedbackAPI.h; sourceTree = "<group>"; };
-		8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryFeedbackAPI.m; path = ../../../Sentry/SentryFeedbackAPI.m; sourceTree = "<group>"; };
+		8482FA992DD7C397000E9283 /* SentryFeedbackAPIHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryFeedbackAPIHelper.h; path = ../../../Sentry/include/SentryFeedbackAPIHelper.h; sourceTree = "<group>"; };
+		8482FA9A2DD7C397000E9283 /* SentryFeedbackAPIHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryFeedbackAPIHelper.m; path = ../../../Sentry/SentryFeedbackAPIHelper.m; sourceTree = "<group>"; };
 		848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryContinuousProfiler.h; path = ../include/SentryContinuousProfiler.h; sourceTree = "<group>"; };
 		848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryContinuousProfiler.mm; sourceTree = "<group>"; };
 		848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilerTestHelpers.h; path = ../include/SentryProfilerTestHelpers.h; sourceTree = "<group>"; };
@@ -2483,6 +2484,7 @@
 		FA8E58F02E0AD4220049F69D /* SentryDispatchQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDispatchQueueWrapper.swift; sourceTree = "<group>"; };
 		FA90FAA72E06614B008CAAE8 /* SentryExtraPackages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExtraPackages.swift; sourceTree = "<group>"; };
 		FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryURLRequestFactory.swift; sourceTree = "<group>"; };
+		FA914E6C2ECFD7D800C54BDD /* SentryFeedbackAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFeedbackAPI.swift; sourceTree = "<group>"; };
 		FA94E68B2E6B92BE00576666 /* SentryClientReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryClientReport.swift; sourceTree = "<group>"; };
 		FA94E6B12E6D265500576666 /* SentryEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelope.swift; sourceTree = "<group>"; };
 		FA94E7232E6F32FA00576666 /* SentryEnvelopeItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeItemType.swift; sourceTree = "<group>"; };
@@ -4097,8 +4099,9 @@
 			children = (
 				849B8F9E2C70091A00148E1F /* Configuration */,
 				849B8F962C6E906900148E1F /* SentryUserFeedbackIntegrationDriver.swift */,
-				8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */,
-				8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */,
+				8482FA992DD7C397000E9283 /* SentryFeedbackAPIHelper.h */,
+				8482FA9A2DD7C397000E9283 /* SentryFeedbackAPIHelper.m */,
+				FA914E6C2ECFD7D800C54BDD /* SentryFeedbackAPI.swift */,
 				84DBC62B2CE82F0E000C4904 /* SentryFeedback.swift */,
 				84CFA4CB2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.h */,
 				84CFA4CC2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.m */,
@@ -5098,7 +5101,7 @@
 				0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */,
 				D8BBD32728FD9FC00011F850 /* SentrySwift.h in Headers */,
 				84CFA4CE2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.h in Headers */,
-				8482FA9B2DD7C397000E9283 /* SentryFeedbackAPI.h in Headers */,
+				8482FA9B2DD7C397000E9283 /* SentryFeedbackAPIHelper.h in Headers */,
 				8E4E7C7425DAAB49006AB9E2 /* SentrySpanProtocol.h in Headers */,
 				8EC4CF4A25C38DAA0093DEE9 /* SentrySpanStatus.h in Headers */,
 				8ECC673D25C23996000E2BF6 /* SentrySpanId.h in Headers */,
@@ -5886,6 +5889,7 @@
 				63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m in Sources */,
 				63FE711120DA4C1000CDBAE8 /* SentryCrashDebug.c in Sources */,
 				7B883F49253D714C00879E62 /* SentryCrashUUIDConversion.c in Sources */,
+				FA914E6D2ECFD7D800C54BDD /* SentryFeedbackAPI.swift in Sources */,
 				62F70E932D4234B800634054 /* SentryMechanismContextCodable.swift in Sources */,
 				843FB3232D0CD04D00558F18 /* SentryUserAccess.m in Sources */,
 				63FE716720DA4C1100CDBAE8 /* SentryCrashCPU.c in Sources */,
@@ -6133,7 +6137,7 @@
 				FACEED132E3179A10007B4AC /* SentryOptionsInternal.m in Sources */,
 				FAAB95C02EA163590030A2DB /* SentryScopeObserver.swift in Sources */,
 				D48891D02E98F2E700212823 /* SentryInfoPlistError.swift in Sources */,
-				8482FA9C2DD7C397000E9283 /* SentryFeedbackAPI.m in Sources */,
+				8482FA9C2DD7C397000E9283 /* SentryFeedbackAPIHelper.m in Sources */,
 				7BC9A20628F41781001E7C4C /* SentryMeasurementUnit.m in Sources */,
 				F429D3AA2E8562EF00DBF387 /* RateLimitParser.swift in Sources */,
 				F4E1E9812E8C2B150007B080 /* SentryDateUtil.swift in Sources */,

--- a/Sources/Sentry/Public/Sentry.h
+++ b/Sources/Sentry/Public/Sentry.h
@@ -18,7 +18,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #    import <Sentry/SentryError.h>
 #    import <Sentry/SentryEvent.h>
 #    import <Sentry/SentryException.h>
-#    import <Sentry/SentryFeedbackAPI.h>
 #    import <Sentry/SentryFrame.h>
 #    import <Sentry/SentryGeo.h>
 #    import <Sentry/SentryHttpStatusCodeRange.h>

--- a/Sources/Sentry/Public/SentryWithoutUIKit.h
+++ b/Sources/Sentry/Public/SentryWithoutUIKit.h
@@ -19,7 +19,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #    import <SentryWithoutUIKit/SentryError.h>
 #    import <SentryWithoutUIKit/SentryEvent.h>
 #    import <SentryWithoutUIKit/SentryException.h>
-#    import <SentryWithoutUIKit/SentryFeedbackAPI.h>
 #    import <SentryWithoutUIKit/SentryFrame.h>
 #    import <SentryWithoutUIKit/SentryGeo.h>
 #    import <SentryWithoutUIKit/SentryHttpStatusCodeRange.h>

--- a/Sources/Sentry/SentryFeedbackAPIHelper.m
+++ b/Sources/Sentry/SentryFeedbackAPIHelper.m
@@ -8,22 +8,22 @@
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-#    import "SentryFeedbackAPI.h"
+#    import "SentryFeedbackAPIHelper.h"
 #    import "SentryHub+Private.h"
 #    import "SentryLogC.h"
 #    import "SentrySDK+Private.h"
 #    import "SentryUserFeedbackIntegration.h"
 
-@implementation SentryFeedbackAPI
+@implementation SentryFeedbackAPIHelper
 
-- (void)showWidget
++ (void)showWidget
 {
     SentryUserFeedbackIntegration *feedback = [[SentrySDKInternal currentHub]
         getInstalledIntegration:[SentryUserFeedbackIntegration class]];
     [feedback showWidget];
 }
 
-- (void)hideWidget
++ (void)hideWidget
 {
     SentryUserFeedbackIntegration *feedback = [SentrySDKInternal.currentHub
         getInstalledIntegration:[SentryUserFeedbackIntegration class]];

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -47,12 +47,6 @@
 #    import "SentryCrashExceptionApplication.h"
 #endif // TARGET_OS_MAC
 
-#if SENTRY_HAS_UIKIT
-#    if TARGET_OS_IOS
-#        import "SentryFeedbackAPI.h"
-#    endif // TARGET_OS_IOS
-#endif // SENTRY_HAS_UIKIT
-
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryContinuousProfiler.h"
 #    import "SentryProfileConfiguration.h"

--- a/Sources/Sentry/include/SentryFeedbackAPIHelper.h
+++ b/Sources/Sentry/include/SentryFeedbackAPIHelper.h
@@ -12,22 +12,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryFeedbackAPI : NSObject
+// Needed to access SentryFeedbackIntegration until that class is written in Swift
+@interface SentryFeedbackAPIHelper : NSObject
 
-/**
- * Show the feedback widget button.
- * @warning This is an experimental feature and may still have bugs.
- * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
- */
-- (void)showWidget NS_EXTENSION_UNAVAILABLE(
++ (void)showWidget NS_EXTENSION_UNAVAILABLE(
     "Sentry User Feedback UI cannot be used from app extensions.");
 
-/**
- * Hide the feedback widget button.
- * @warning This is an experimental feature and may still have bugs.
- * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
- */
-- (void)hideWidget NS_EXTENSION_UNAVAILABLE(
++ (void)hideWidget NS_EXTENSION_UNAVAILABLE(
     "Sentry User Feedback UI cannot be used from app extensions.");
 
 @end

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -41,6 +41,7 @@
 #import "SentryDelayedFramesTracker.h"
 #import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryDeviceContextKeys.h"
+#import "SentryFeedbackAPIHelper.h"
 #import "SentryFileIOTrackerHelper.h"
 #import "SentryFileManagerHelper.h"
 #import "SentryMeta.h"

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
@@ -1,0 +1,24 @@
+@_implementationOnly import _SentryPrivate
+
+#if os(iOS) && !SENTRY_NO_UIKIT
+
+@objc
+public final class SentryFeedbackAPI: NSObject {
+    
+    /// Show the feedback widget button.
+    /// - warning: This is an experimental feature and may still have bugs.
+    /// - seealso: See `SentryOptions.configureUserFeedback` to configure the widget.
+    @available(iOSApplicationExtension, unavailable)
+    @objc public func showWidget() {
+        SentryFeedbackAPIHelper.showWidget()
+    }
+    
+    /// Hide the feedback widget button.
+    /// - warning: This is an experimental feature and may still have bugs.
+    /// - seealso: See `SentryOptions.configureUserFeedback` to configure the widget.
+    @available(iOSApplicationExtension, unavailable)
+    @objc public func hideWidget() {
+        SentryFeedbackAPIHelper.hideWidget()
+    }
+}
+#endif

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -126,16 +126,6 @@
       },
       {
         "kind": "Import",
-        "name": "Sentry.SentryFeedbackAPI",
-        "printedName": "Sentry.SentryFeedbackAPI",
-        "declKind": "Import",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "Exported"
-        ]
-      },
-      {
-        "kind": "Import",
         "name": "Sentry.SentryFrame",
         "printedName": "Sentry.SentryFrame",
         "declKind": "Import",
@@ -18713,167 +18703,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryFeedbackAPI",
-        "printedName": "SentryFeedbackAPI",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "showWidget",
-            "printedName": "showWidget()",
-            "children": [
-              {
-                "kind": "TypeNameAlias",
-                "name": "Void",
-                "printedName": "Swift.Void",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ]
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:objc(cs)SentryFeedbackAPI(im)showWidget",
-            "moduleName": "Sentry",
-            "isOpen": true,
-            "objc_name": "showWidget",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "hideWidget",
-            "printedName": "hideWidget()",
-            "children": [
-              {
-                "kind": "TypeNameAlias",
-                "name": "Void",
-                "printedName": "Swift.Void",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ]
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:objc(cs)SentryFeedbackAPI(im)hideWidget",
-            "moduleName": "Sentry",
-            "isOpen": true,
-            "objc_name": "hideWidget",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryFeedbackAPI",
-                "printedName": "Sentry.SentryFeedbackAPI",
-                "usr": "c:objc(cs)SentryFeedbackAPI"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)NSObject(im)init",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "implicit": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "Override",
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:objc(cs)SentryFeedbackAPI",
-        "moduleName": "Sentry",
-        "isOpen": true,
-        "objc_name": "SentryFeedbackAPI",
-        "declAttributes": [
-          "ObjC",
-          "Dynamic"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryFeedbackSource",
         "printedName": "SentryFeedbackSource",
         "children": [
@@ -36630,6 +36459,152 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "SentryFeedbackAPI",
+        "printedName": "SentryFeedbackAPI",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "showWidget",
+            "printedName": "showWidget()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI(im)showWidget",
+            "mangledName": "$s6Sentry0A11FeedbackAPIC10showWidgetyyF",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "Final",
+              "ObjC",
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "hideWidget",
+            "printedName": "hideWidget()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI(im)hideWidget",
+            "mangledName": "$s6Sentry0A11FeedbackAPIC10hideWidgetyyF",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "Final",
+              "ObjC",
+              "Available"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryFeedbackAPI",
+                "printedName": "Sentry.SentryFeedbackAPI",
+                "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI(im)init",
+            "mangledName": "$s6Sentry0A11FeedbackAPICACycfc",
+            "moduleName": "Sentry",
+            "overriding": true,
+            "objc_name": "init",
+            "declAttributes": [
+              "ObjC",
+              "Dynamic",
+              "Override"
+            ],
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI",
+        "mangledName": "$s6Sentry0A11FeedbackAPIC",
+        "moduleName": "Sentry",
+        "declAttributes": [
+          "Final",
+          "ObjC"
+        ],
+        "superclassUsr": "c:objc(cs)NSObject",
+        "inheritsConvenienceInitializers": true,
+        "superclassNames": [
+          "ObjectiveC.NSObject"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "NSObjectProtocol",
+            "printedName": "NSObjectProtocol",
+            "usr": "c:objc(pl)NSObject"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "SentryReplayOptions",
         "printedName": "SentryReplayOptions",
         "children": [
@@ -42155,12 +42130,12 @@
                 "kind": "TypeNominal",
                 "name": "SentryFeedbackAPI",
                 "printedName": "Sentry.SentryFeedbackAPI",
-                "usr": "c:objc(cs)SentryFeedbackAPI"
+                "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI"
               }
             ],
             "declKind": "Var",
             "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)feedback",
-            "mangledName": "$s6Sentry0A3SDKC8feedbackSo0A11FeedbackAPICvpZ",
+            "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvpZ",
             "moduleName": "Sentry",
             "static": true,
             "declAttributes": [
@@ -42180,12 +42155,12 @@
                     "kind": "TypeNominal",
                     "name": "SentryFeedbackAPI",
                     "printedName": "Sentry.SentryFeedbackAPI",
-                    "usr": "c:objc(cs)SentryFeedbackAPI"
+                    "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI"
                   }
                 ],
                 "declKind": "Accessor",
                 "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)feedback",
-                "mangledName": "$s6Sentry0A3SDKC8feedbackSo0A11FeedbackAPICvgZ",
+                "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvgZ",
                 "moduleName": "Sentry",
                 "static": true,
                 "implicit": true,


### PR DESCRIPTION
Just converts this class to Swift. I'll get rid of the wrapper in a follow up PR after converting the Integration class to Swift

#skip-changelog

Closes #6865