### PR TITLE
ref: Remove unused session.user

### DIFF
--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -526,11 +526,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)applyToSession:(SentrySession *)session
 {
-    SentryUser *userObject = self.userObject;
-    if (userObject != nil) {
-        session.user = userObject.copy;
-    }
-
     NSString *environment = self.environmentString;
     if (environment != nil) {
         // TODO: Make sure environment set on options is applied to the

--- a/Sources/Sentry/SentrySessionInternal.m
+++ b/Sources/Sentry/SentrySessionInternal.m
@@ -265,7 +265,6 @@ nameForSentrySessionStatus(SentrySessionStatus status)
         copy->_duration = _duration;
         copy->_releaseName = _releaseName;
         copy.environment = self.environment;
-        copy.user = self.user;
         copy->_abnormalMechanism = _abnormalMechanism;
         copy->_init = _init;
     }

--- a/Sources/Sentry/include/SentrySessionInternal.h
+++ b/Sources/Sentry/include/SentrySessionInternal.h
@@ -51,7 +51,6 @@ SENTRY_NO_INIT
 
 @property (nonatomic, readonly, copy) NSString *_Nullable releaseName;
 @property (nonatomic, copy) NSString *_Nullable environment;
-@property (nonatomic, copy) SentryUser *_Nullable user;
 
 /**
  * The reason for session to become abnormal, for example an app hang.

--- a/Sources/Swift/SentrySession.swift
+++ b/Sources/Swift/SentrySession.swift
@@ -115,10 +115,6 @@ import Foundation
         get { session.environment }
         set { session.environment = newValue }
     }
-    @objc public var user: User? {
-        get { session.user }
-        set { session.user = newValue }
-    }
     @objc public var abnormalMechanism: String? {
         get { session.abnormalMechanism }
         set { session.abnormalMechanism = newValue }

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -812,7 +812,6 @@ class SentrySessionTrackerTests: XCTestCase {
         XCTAssertNotNil(session.sessionId)
         XCTAssertNotNil(session.distinctId)
         XCTAssertEqual(fixture.options.environment, session.environment)
-        XCTAssertNil(session.user)
     }
     
     private func assertNoInitSessionSent(file: StaticString = #file, line: UInt = #line) {

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.m
@@ -42,8 +42,6 @@
     if (self.environment != session.environment
         && ![self.environment isEqualToString:session.environment])
         return NO;
-    if (self.user != session.user && ![self.user isEqual:session.user])
-        return NO;
     if (self.flagInit != session.flagInit && ![self.flagInit isEqualToNumber:session.flagInit])
         return NO;
     return YES;
@@ -63,7 +61,6 @@
     hash = hash * 23 + [self.timestamp hash];
     hash = hash * 23 + [self.releaseName hash];
     hash = hash * 23 + [self.environment hash];
-    hash = hash * 23 + [self.user hash];
 
     return hash;
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -45,20 +45,12 @@ class SentrySessionTestsSwift: XCTestCase {
     }
 
     func testCopySession() throws {
-        let user = User()
-        user.email = "someone@sentry.io"
-
         let session = SentrySession(releaseName: "1.0.0", distinctId: "some-id")
-        session.user = user
         session.abnormalMechanism = "app hang"
         let copiedSession = try XCTUnwrap(session.copy() as? SentrySession)
 
         XCTAssertEqual(session, copiedSession)
         XCTAssertEqual(session.abnormalMechanism, copiedSession.abnormalMechanism)
-
-        // The user is copied as well
-        session.user?.email = "someone_else@sentry.io"
-        XCTAssertNotEqual(session, copiedSession)
     }
     
     func testInitWithJson_Status_MapsToCorrectStatus() {


### PR DESCRIPTION
The session.user isn't really used anywhere in the code. While the scope applied the user to the session, the session doesn't do anything with the user property. Therefore, we can remove it. Also, the [develop docs](https://develop.sentry.dev/sdk/telemetry/sessions/) don't mention a user property. Only the distinctID that should be the userID.

#skip-changelog 

Closes #6898