### PR TITLE
fix: Move file manager URL constructing to Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fixes a possible crash from ObjC to Swift nullability conversion in SentryFileManager (#6899)
+
 ## 9.0.0-rc.1
 
 ### Breaking Changes

--- a/Sources/Sentry/SentryFileManagerHelper.m
+++ b/Sources/Sentry/SentryFileManagerHelper.m
@@ -191,9 +191,9 @@ _non_thread_safe_removeFileAtPath(NSString *path)
 
 #pragma mark - Convenience Accessors
 
-- (NSURL *)getSentryPathAsURL
+- (NSString *)getSentryPath
 {
-    return [NSURL fileURLWithPath:self.sentryPath];
+    return self.sentryPath;
 }
 
 #pragma mark - Envelope

--- a/Sources/Sentry/include/SentryFileManagerHelper.h
+++ b/Sources/Sentry/include/SentryFileManagerHelper.h
@@ -58,7 +58,7 @@ SENTRY_NO_INIT
 - (void)deleteAllEnvelopes;
 
 #pragma mark - Convenience Accessors
-- (NSURL *)getSentryPathAsURL;
+- (NSString *)getSentryPath;
 
 #pragma mark - State
 - (void)moveState:(NSString *)stateFilePath toPreviousState:(NSString *)previousStateFilePath;

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -88,7 +88,7 @@
     }
     
     @objc public func getSentryPathAsURL() -> URL {
-        helper.getSentryPathAsURL()
+        URL(fileURLWithPath: helper.getSentryPath())
     }
 
     @objc public func moveState(_ stateFilePath: String, toPreviousState previousStateFilePath: String) {


### PR DESCRIPTION
The ObjC version of this URL constructing can return nil if the string provided is an empty string in which case our code would crash. To protect against this we can migrate a bit more of this file manager code to Swift and guarantee it won't crash

Closes #6900