### PR TITLE
Use Xcode 26.1.1 in benchmarking workflow

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
-      - run: ./scripts/ci-select-xcode.sh 26.1
+      - run: ./scripts/ci-select-xcode.sh 26.1.1
       - name: Setup Ruby
         uses: ruby/setup-ruby@8aeb6ff8030dd539317f8e1769a044873b56ea71 # v1.268.0
         with:


### PR DESCRIPTION

#skip-changelog

## :scroll: Description

Use Xcode 26.1.1 in benchmarking workflow

## :bulb: Motivation and Context

Fixes failing CI as Xcode select can't find 26.1 version.

The Runner was updated at some point to only include 26.1.1 and this was probably rolled out.

https://github.com/actions/runner-images/blob/db8d413376de785d0a00c118d31baa1d1821b627/images/macos/toolsets/toolset-26.json#L15

## :green_heart: How did you test it?

CI run
