### PR TITLE
chore(ci): Bump Xcode to 26.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
           # macOS 26
           - name: macOS 26 Sentry
             runs-on: macos-26
-            xcode: "26.1"
+            xcode: "26.1.1"
             test-destination-os: "26.1"
             platform: "macOS"
             scheme: "Sentry"
@@ -361,7 +361,7 @@ jobs:
           # tvOS 26
           - name: tvOS 26 Sentry
             runs-on: macos-26
-            xcode: "26.1"
+            xcode: "26.1.1"
             test-destination-os: "26.1"
             install_platforms: true
             platform: "tvOS"


### PR DESCRIPTION
GitHub Runner images updated to Xcode 26.1.1 and removed Xcode 26.1:

```
> Run ./scripts/ci-select-xcode.sh "$XCODE_VERSION"
  ./scripts/ci-select-xcode.sh "$XCODE_VERSION"
  shell: /bin/bash -e {0}
  env:
    XCODE_VERSION: 26.1
Available Xcode versions:
1) 16.4 (16F6)
2) 26.0.1 (17A400) (Selected)
3) 26.1.1 (17B100)
4) 26.2 Beta (17C5038g)
Enter the number of the Xcode to select: Not a valid number. Expecting a whole number between 1-4, but given nothing.
Error: Process completed with exit code 1.
```

First noticed in [this workflow run](https://github.com/getsentry/sentry-cocoa/actions/runs/19736269324/job/56548863349?pr=6817#step:3:1).

#skip-changelog

Closes #6915