### PR TITLE
chore: Add platform for iOS in Swift6 and other UI test

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -58,11 +58,13 @@ jobs:
             target: ios_objc
             test_destination_os: "18.6"
             device: iPhone 16 Pro
+            platform: iOS
           - job_id: tvos_swift
             name: tvOS Swift
             target: tvos_swift
             test_destination_os: "18.5"
             device: "Apple TV"
+            platform: tvOS
     with:
       fastlane_command: ui_tests_${{matrix.target}}
       xcode_version: 16.4
@@ -73,6 +75,7 @@ jobs:
       test-destination-os: ${{matrix.test_destination_os}}
       device: ${{matrix.device}}
       files_suffix: _${{matrix.target}}_${{matrix.runner}}
+      platform: ${{matrix.platform}}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -91,6 +94,7 @@ jobs:
       test-destination-os: "18.6"
       device: iPhone 16 Pro
       files_suffix: _swiftui_-${{matrix.runner}}
+      platform: "iOS"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
@@ -173,7 +177,7 @@ jobs:
       codecov_test_analytics: true
       device: iPhone 16 Pro
       test-destination-os: "18.4"
-      platform: "iOS"
+      platform: iOS
       files_suffix: _swift6_-${{matrix.runner}}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Adds iOS platform field to enable step process which reloads runtimes

#skip-changelog

Closes #6919