### PR TITLE
chore: Improve Carthage support with a json file for versions

### DIFF
--- a/Sentry-Dynamic-WithARM64e.json
+++ b/Sentry-Dynamic-WithARM64e.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/Sentry-Dynamic-WithARM64e.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/Sentry-Dynamic-WithARM64e.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/Sentry-Dynamic-WithARM64e.xcframework.zip"
+}

--- a/Sentry-Dynamic.json
+++ b/Sentry-Dynamic.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/Sentry-Dynamic.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/Sentry-Dynamic.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/Sentry-Dynamic.xcframework.zip"
+}

--- a/Sentry-WithoutUIKitOrAppKit-WithARM64e.json
+++ b/Sentry-WithoutUIKitOrAppKit-WithARM64e.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip"
+}

--- a/Sentry-WithoutUIKitOrAppKit.json
+++ b/Sentry-WithoutUIKitOrAppKit.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/Sentry-WithoutUIKitOrAppKit.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/Sentry-WithoutUIKitOrAppKit.xcframework.zip"
+}

--- a/Sentry.json
+++ b/Sentry.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/Sentry.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/Sentry.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/Sentry.xcframework.zip"
+}

--- a/SentrySwiftUI.json
+++ b/SentrySwiftUI.json
@@ -1,0 +1,5 @@
+{
+  "8.57.3": "https://github.com/getsentry/sentry-cocoa/releases/download/8.57.3/SentrySwiftUI.xcframework.zip",
+  "9.0.0-rc.0": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.0/SentrySwiftUI.xcframework.zip",
+  "9.0.0-rc.1": "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0-rc.1/SentrySwiftUI.xcframework.zip"
+}

--- a/Utils/VersionBump/Package.swift
+++ b/Utils/VersionBump/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "VersionBump",
+    platforms: [.macOS(.v11)],
     products: [
         .executable(name: "VersionBump", targets: ["VersionBump"])
     ],


### PR DESCRIPTION
When using Carthage to download xcframework files, the downloaded zip [is random](https://github.com/Carthage/Carthage/issues/3207).
This makes using Sentry with prebuilt binaries unreliable.

We can provide a json file per package to allow users to manually define which version they want to download, for example if they intend to use `Sentry-Dynamic` only, they just need to add this to their Cartfile
```
binary "https://raw.githubusercontent.com/getsentry/sentry-cocoa/refs/heads/main/Sentry-Dynamic.json"
```

i also updated `VersionBump` util to create the new entries on each release