### PR TITLE
chore: Allow URLs as issue

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-pr.yml
+++ b/.github/workflows/create-issue-for-unreferenced-pr.yml
@@ -55,7 +55,8 @@ jobs:
             const prNumber = pr.number;
 
             // Regex for GitHub issue references (e.g., #123, fixes #456)
-            const issueRegexGitHub = /(?:(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*)?#\d+/i;
+            // https://regex101.com/r/eDiGrQ/1
+            const issueRegexGitHub = /(?:(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s*)?(#\d+|https:\/\/github\.com\/getsentry\/[\w-]+\/issues\/\d+)/i;
 
             // Regex for Linear issue references (e.g., ENG-123, resolves ENG-456)
             const issueRegexLinear = /(?:(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*)?[A-Z]+-\d+/i;


### PR DESCRIPTION
## :scroll: Description

We had an issue in https://github.com/getsentry/sentry-javascript/pull/18372 that it created an issue, even though an issue has added. 

<img width="525" height="173" alt="Screenshot 2025-12-02 at 12 00 56" src="https://github.com/user-attachments/assets/55ac1b8e-06f8-43d6-8910-c6e4a4eaeee5" />

The issue was that the URL was given instead of the short link such as `#100` (btw, I think this example will also be taken as false positive)

## :bulb: Motivation and Context

Since we don't have a shared action right now, this is the only option.

## :green_heart: How did you test it?

We tested it in our repo :+1:, also there is a regex101.com link as reference

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
