### PR TITLE
fix: Development builds with prebuilt binary

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -469,8 +469,11 @@ getBuildType(void)
         return "debug";
     }
     SentryMobileProvisionParser *parser = [[SentryMobileProvisionParser alloc] init];
+    if ([[parser apsEnvironment] isEqualToString:@"development"] && [parser getTaskAllow]) {
+        return "debug";
+    }
     if ([parser hasEmbeddedMobileProvisionProfile]) {
-        return [parser mobileProvisionProfileProvisionsAllDevices] ? "enterprise" : "adhoc";
+        return [parser provisionsAllDevices] ? "enterprise" : "adhoc";
     }
     if (isTestBuild()) {
         return "test";

--- a/Sources/Swift/Helper/SentryMobileProvisionParser.swift
+++ b/Sources/Swift/Helper/SentryMobileProvisionParser.swift
@@ -1,13 +1,11 @@
 @objc @_spi(Private)
-public class SentryMobileProvisionParser: NSObject {
-    private var provisionsAllDevices: Bool = false
-    private var embeddedProfilePath: String?
-    
+
+public final class SentryMobileProvisionParser: NSObject {
     // If the profile provisions all devices, it indicates Enterprise distribution
-    @objc 
-    public var mobileProvisionProfileProvisionsAllDevices: Bool {
-        return provisionsAllDevices
-    }
+    @objc public private(set) var provisionsAllDevices: Bool = false
+    private var embeddedProfilePath: String?
+    @objc public private(set) var apsEnvironment: String?
+    @objc public private(set) var getTaskAllow: Bool = false
     
     // This convenience initializer exists so we can use it from ObjC.
     // Functions with Optional parameters (used for testing) are not available to ObjC
@@ -58,6 +56,9 @@ public class SentryMobileProvisionParser: NSObject {
               let dict = obj as? [String: Any] else {
             return
         }
+        let entitlements = (dict["Entitlements"] as? Dictionary<AnyHashable, Any>)
+        getTaskAllow = entitlements?["get-task-allow"] as? Int == 1
+        apsEnvironment = entitlements?["aps-environment"] as? String
         provisionsAllDevices = dict["ProvisionsAllDevices"] as? Bool ?? false
     }
 }


### PR DESCRIPTION
The only way this would ever report debug is if the code was built with the DEBUG preprocessor flag. But we support building from a pre-built binary which is pre-built in release mode (I hope) so this would not work. A more reliable way is to check the entitlements to see if it's a debug build.

#skip-changelog

Closes #6990