### PR TITLE
fix: Remove extra @objc from SessionTracker

### DIFF
--- a/SentryTestUtils/Sources/TestNSNotificationCenterWrapper.swift
+++ b/SentryTestUtils/Sources/TestNSNotificationCenterWrapper.swift
@@ -11,7 +11,7 @@ public typealias CrossPlatformApplication = NSApplication
 
 @objcMembers public class TestNSNotificationCenterWrapper: NSObject {
     private enum Observer {
-        case observerWithObject(WeakReference<NSObject>, Selector, NSNotification.Name?, Any?)
+        case observerWithObject(WeakReference<AnyObject>, Selector, NSNotification.Name?, Any?)
         case observerForKeyPath(WeakReference<NSObject>, String, NSKeyValueObservingOptions, UnsafeMutableRawPointer?)
         case observerWithBlock(WeakReference<NSObject>, NSNotification.Name?, (Notification) -> Void)
     }
@@ -22,7 +22,7 @@ public typealias CrossPlatformApplication = NSApplication
     private var observers: [Observer] = []
 
     public var addObserverWithObjectInvocations = Invocations<(
-        observer: WeakReference<NSObject>,
+        observer: WeakReference<AnyObject>,
         selector: Selector,
         name: NSNotification.Name?,
         object: Any?
@@ -34,8 +34,8 @@ public typealias CrossPlatformApplication = NSApplication
         object anObject: Any? = nil
     ) {
         if ignoreAddObserver == false {
-            addObserverWithObjectInvocations.record((WeakReference(value: observer as! NSObject), aSelector, aName, anObject))
-            observers.append(.observerWithObject(WeakReference(value: observer as! NSObject), aSelector, aName, anObject))
+            addObserverWithObjectInvocations.record((WeakReference(value: observer as AnyObject), aSelector, aName, anObject))
+            observers.append(.observerWithObject(WeakReference(value: observer as AnyObject), aSelector, aName, anObject))
         }
     }
 

--- a/Sources/Swift/Integrations/Session/SessionTracker.swift
+++ b/Sources/Swift/Integrations/Session/SessionTracker.swift
@@ -10,7 +10,7 @@ typealias Application = NSApplication
 
 /// Tracks sessions for release health. For more info see:
 /// https://docs.sentry.io/workflow/releases/health/#session
-@_spi(Private) @objc(SentrySessionTracker) public final class SessionTracker: NSObject {
+final class SessionTracker {
     
     // MARK: Private
 
@@ -39,9 +39,9 @@ typealias Application = NSApplication
         self.notificationCenter.removeObserver(self, name: nil, object: nil)
     }
 
-    // MARK: Public
+    // MARK: Internal
     
-    @objc public func start() {
+    func start() {
         // We don't want to use WillEnterForeground because tvOS doesn't call it when it launches an app
         // the first time. It only calls it when the app was open and the user navigates back to it.
         // DidEnterBackground is called when the app launches a background task so we would need to
@@ -73,7 +73,7 @@ typealias Application = NSApplication
     #endif
     }
     
-    @objc public func stop() {
+    func stop() {
         SentrySDKInternal.currentHub().endSession()
 
         removeObservers()
@@ -83,7 +83,7 @@ typealias Application = NSApplication
         wasStartSessionCalled = false
     }
     
-    @objc public func removeObservers() {
+    func removeObservers() {
 #if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || ((os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT)
         // Remove the observers with the most specific detail possible, see
         // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
@@ -93,8 +93,6 @@ typealias Application = NSApplication
         notificationCenter.removeObserver(self, name: Application.willTerminateNotification, object: nil)
 #endif
     }
-    
-    // MARK: Internal
     
     let options: Options
     let dateProvider: SentryCurrentDateProvider

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -98,7 +98,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
         return defaultApplicationProvider()
     }
     
-    @objc(getSessionTrackerWithOptions:) public func getSessionTracker(with options: Options) -> SessionTracker {
+    func getSessionTracker(with options: Options) -> SessionTracker {
         return SessionTracker(options: options, applicationProvider: defaultApplicationProvider, dateProvider: dateProvider, notificationCenter: notificationCenterWrapper)
     }
     


### PR DESCRIPTION
Follow up from https://github.com/getsentry/sentry-cocoa/pull/6985

#skip-changelog

Closes #6994