### PR TITLE
chore: Update cocoapods to use prebuild xcframework

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -19,19 +19,20 @@ Pod::Spec.new do |s|
       'CLANG_CXX_LIBRARY' => 'libc++'
   }
   s.preserve_paths = 'Sentry.xcframework'
+  s.static_framework = true
 
   # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec
   s.prepare_command = <<-CMD
-    curl -L "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0/Sentry.xcframework.zip" -o Sentry.xcframework.zip
+    curl -L "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0/Sentry-Dynamic.xcframework.zip" -o Sentry-Dynamic.xcframework.zip
     
-    export SENTRY_CHECKSUM="e54ed4597496468737e917e7826d90a40ee98f4985554651e32ddfcd82050f27"
-    shasum -a 256 Sentry.xcframework.zip | awk '{print $1}' | grep "$SENTRY_CHECKSUM"
+    export SENTRY_CHECKSUM="9e7571fc539a6e6850e3d792a0afc9abe63c75261774da6b99d66f426e0c52f7"
+    shasum -a 256 Sentry-Dynamic.xcframework.zip | awk '{print $1}' | grep "$SENTRY_CHECKSUM"
     if [ $? -ne 0 ]; then
-      echo "Error: Sentry.xcframework.zip checksum does not match"
+      echo "Error: Sentry-Dynamic.xcframework.zip checksum does not match"
       exit 1
     fi
 
-    unzip -o Sentry.xcframework.zip
+    unzip -o Sentry-Dynamic.xcframework.zip
   CMD
 
   s.default_subspecs = ['Core']

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -15,6 +15,10 @@ Pod::Spec.new do |s|
   s.visionos.deployment_target = "1.0"
   s.module_name  = "Sentry"
 
+  s.swift_versions = "5.5"
+  s.pod_target_xcconfig = {
+      'CLANG_CXX_LIBRARY' => 'libc++'
+  }
   s.preserve_paths = 'Sentry.xcframework'
 
   # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
       'CLANG_CXX_LIBRARY' => 'libc++'
   }
-  s.preserve_paths = 'Sentry.xcframework'
+  s.preserve_paths = 'Sentry-Dynamic.xcframework'
 
   # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec
   s.prepare_command = <<-CMD
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   s.default_subspecs = ['Core']
 
   s.subspec 'Core' do |sp|
-    sp.vendored_frameworks = 'Sentry.xcframework'
+    sp.vendored_frameworks = 'Sentry-Dynamic.xcframework'
   end
   
   s.subspec 'HybridSDK' do |sp|

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -14,38 +14,32 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "8.0"
   s.visionos.deployment_target = "1.0"
   s.module_name  = "Sentry"
-  s.requires_arc = true
-  s.frameworks = 'Foundation'
-  s.swift_versions = "5.5"
-  s.pod_target_xcconfig = {
-      'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
-      'APPLICATION_EXTENSION_API_ONLY' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
-      'CLANG_CXX_LIBRARY' => 'libc++',
-      'SWIFT_INCLUDE_PATHS' => '${PODS_TARGET_SRCROOT}/Sources/Sentry/include',
-      'OTHER_CFLAGS' => '$(inherited)'
-  }
-  s.watchos.pod_target_xcconfig = {
-      'OTHER_LDFLAGS' => '$(inherited) -framework WatchKit'
-  }
+
+  s.preserve_paths = 'Sentry.xcframework'
+
+  # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec
+  s.prepare_command = <<-CMD
+    curl -L "https://github.com/getsentry/sentry-cocoa/releases/download/9.0.0/Sentry.xcframework.zip" -o Sentry.xcframework.zip
+    
+    export SENTRY_CHECKSUM="e54ed4597496468737e917e7826d90a40ee98f4985554651e32ddfcd82050f27"
+    shasum -a 256 Sentry.xcframework.zip | awk '{print $1}' | grep "$SENTRY_CHECKSUM"
+    if [ $? -ne 0 ]; then
+      echo "Error: Sentry.xcframework.zip checksum does not match"
+      exit 1
+    fi
+
+    unzip -o Sentry.xcframework.zip
+  CMD
 
   s.default_subspecs = ['Core']
 
   s.subspec 'Core' do |sp|
-      sp.source_files = "Sources/Sentry/**/*.{h,hpp,m,mm,c,cpp}",
-        "Sources/SentryCrash/**/*.{h,hpp,m,mm,c,cpp}", "Sources/Swift/**/*.{swift,h,hpp,m,mm,c,cpp}"
-      sp.public_header_files =
-        "Sources/Sentry/Public/*.h"
-      sp.preserve_path = "Sources/Sentry/include/module.modulemap"
-      sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
+    sp.vendored_frameworks = 'Sentry.xcframework'
   end
   
   s.subspec 'HybridSDK' do |sp|
-      sp.source_files = "Sources/Sentry/**/*.{h,hpp,m,mm,c,cpp}",
-        "Sources/SentryCrash/**/*.{h,hpp,m,mm,c,cpp}", "Sources/Swift/**/*.{swift,h,hpp,m,mm,c,cpp}"
-      sp.public_header_files =
-        "Sources/Sentry/Public/*.h", "Sources/Sentry/include/HybridPublic/*.h"
-      sp.preserve_path = "Sources/Sentry/include/module.modulemap"
-      sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
+      sp.dependency 'Sentry/Core'
+      sp.source_files = "Sources/Sentry/Public/*.h", "Sources/Sentry/include/HybridPublic/*.h"
+      sp.public_header_files = "Sources/Sentry/Public/*.h", "Sources/Sentry/include/HybridPublic/*.h"
   end
 end

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -19,7 +19,6 @@ Pod::Spec.new do |s|
       'CLANG_CXX_LIBRARY' => 'libc++'
   }
   s.preserve_paths = 'Sentry.xcframework'
-  s.static_framework = true
 
   # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec
   s.prepare_command = <<-CMD

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
     fi
 
     unzip -o Sentry-Dynamic.xcframework.zip
+    rm -rf Sentry.xcframework
     mv Sentry-Dynamic.xcframework Sentry.xcframework
   CMD
 

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "8.0"
   s.visionos.deployment_target = "1.0"
   s.module_name  = "Sentry"
-
+  s.framework = true
   s.swift_versions = "5.5"
   s.pod_target_xcconfig = {
       'CLANG_CXX_LIBRARY' => 'libc++'

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
       'CLANG_CXX_LIBRARY' => 'libc++'
   }
-  s.preserve_paths = 'Sentry-Dynamic.xcframework'
+  s.preserve_paths = 'Sentry.xcframework'
 
   # Manually download the Sentry.xcframework and unzip it because we also need the headers for the HybridSDK subspec
   s.prepare_command = <<-CMD
@@ -32,12 +32,13 @@ Pod::Spec.new do |s|
     fi
 
     unzip -o Sentry-Dynamic.xcframework.zip
+    mv Sentry-Dynamic.xcframework Sentry.xcframework
   CMD
 
   s.default_subspecs = ['Core']
 
   s.subspec 'Core' do |sp|
-    sp.vendored_frameworks = 'Sentry-Dynamic.xcframework'
+    sp.vendored_frameworks = 'Sentry.xcframework'
   end
   
   s.subspec 'HybridSDK' do |sp|

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "8.0"
   s.visionos.deployment_target = "1.0"
   s.module_name  = "Sentry"
-  s.framework = true
   s.swift_versions = "5.5"
   s.pod_target_xcconfig = {
       'CLANG_CXX_LIBRARY' => 'libc++'


### PR DESCRIPTION
This PR attempts to update Cocoapods to use our prebuild xcframework.

Because we have some special headers for HybridSDK only, we cannot use the default http source option and have to manually download the built version.
This might change since this is just a draft.

For now this only applies to Sentry, it does not apply to SentrySwiftUI