### PR TITLE
chore: Fixes broken tests on main

### DIFF
--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -17,6 +17,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.dsn = TestConstants.dsnAsString(username: "SentrySwiftIntegrationInstallerTests")
         options.debug = true
         options.swiftAsyncStacktraces = true
+        options.enableAutoSessionTracking = false
         
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)
@@ -36,6 +37,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.dsn = TestConstants.dsnAsString(username: "SentrySwiftIntegrationInstallerTests")
         options.debug = true
         options.swiftAsyncStacktraces = false
+        options.enableAutoSessionTracking = false
         
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)


### PR DESCRIPTION
Fixes broken tests `SentrySwiftIntegrationInstallerTests` due to a new merged PR which includes new swift integrations.

#skip-changelog