### PR TITLE
fix: Delete unused SentrySDKInfo init and cleanup code

### DIFF
--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -6,7 +6,7 @@ import Foundation
  * @note Both name and version are required.
  * @see https://develop.sentry.dev/sdk/event-payloads/sdk/
  */
-final class SentrySdkInfo {
+struct SentrySdkInfo {
     
     static func global() -> Self {
         if let options = SentrySDKInternal.currentHub().getClient()?.getOptions() {
@@ -56,12 +56,12 @@ final class SentrySdkInfo {
      */
     let settings: SentrySDKSettings
     
-    convenience init(withOptions options: Options?) {
+    init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
         self.init(withEnabledFeatures: features, sendDefaultPii: options?.sendDefaultPii ?? false)
     }
 
-    convenience init(withEnabledFeatures features: [String], sendDefaultPii: Bool) {
+    init(withEnabledFeatures features: [String], sendDefaultPii: Bool) {
         let integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()
         var packages = SentryExtraPackages.getPackages()
         let sdkPackage = SentrySdkPackage.global()
@@ -87,7 +87,7 @@ final class SentrySdkInfo {
     }
     
     // swiftlint:disable cyclomatic_complexity
-    convenience init(dict: [AnyHashable: Any]?) {
+    init(dict: [AnyHashable: Any]?) {
         var name = ""
         var version = ""
         var integrations = Set<String>()

--- a/Sources/Swift/Helper/SentrySerializationSwift.swift
+++ b/Sources/Swift/Helper/SentrySerializationSwift.swift
@@ -110,20 +110,9 @@
                 #endif
                 do {
                     let headerDictionary = try JSONSerialization.jsonObject(with: headerData) as? [String: Any]
-                    var eventId: SentryId?
-                    if let eventIdAsString = headerDictionary?["event_id"] as? String {
-                        eventId = SentryId(uuidString: eventIdAsString)
-                    }
-                    
-                    var sdkInfo: SentrySdkInfo?
-                    if let sdkDict = headerDictionary?["sdk"] as? [String: Any] {
-                        sdkInfo = SentrySdkInfo(dict: sdkDict)
-                    }
-
-                    var traceContext: TraceContext?
-                    if let traceDict = headerDictionary?["trace"] as? [String: Any] {
-                        traceContext = TraceContext(dict: traceDict)
-                    }
+                    let eventId = (headerDictionary?["event_id"] as? String).map { SentryId(uuidString: $0) }
+                    let sdkInfo = (headerDictionary?["sdk"] as? [String: Any]).map { SentrySdkInfo(dict: $0) }
+                    let traceContext = (headerDictionary?["trace"] as? [String: Any]).map { TraceContext(dict: $0) } ?? .none
                     
                     envelopeHeader = SentryEnvelopeHeader(id: eventId,
                                                       sdkInfo: sdkInfo,

--- a/Sources/Swift/Protocol/SentrySDKSettings.swift
+++ b/Sources/Swift/Protocol/SentrySDKSettings.swift
@@ -2,14 +2,10 @@
  * Describes the settings for the Sentry SDK
  * @see https://develop.sentry.dev/sdk/event-payloads/sdk/
  */
-final class SentrySDKSettings {
+struct SentrySDKSettings {
     
     init() {
         autoInferIP = false
-    }
-    
-    convenience init(options: Options?) {
-        self.init(sendDefaultPii: options?.sendDefaultPii ?? false)
     }
 
     init(sendDefaultPii: Bool) {
@@ -24,7 +20,7 @@ final class SentrySDKSettings {
         }
     }
     
-    var autoInferIP: Bool
+    let autoInferIP: Bool
     
     func serialize() -> NSDictionary {
         [

--- a/Sources/Swift/Tools/SentryEnvelopeHeader.swift
+++ b/Sources/Swift/Tools/SentryEnvelopeHeader.swift
@@ -51,9 +51,9 @@
      * An event id exist if the envelope contains an event of items within it are related. i.e
      * Attachments
      */
-    @objc public var eventId: SentryId?
-    var sdkInfo: SentrySdkInfo?
-    @objc public var traceContext: TraceContext?
+    @objc public let eventId: SentryId?
+    let sdkInfo: SentrySdkInfo?
+    @objc public let traceContext: TraceContext?
     
     /**
      * The timestamp when the event was sent from the SDK as string in RFC 3339 format. Used

--- a/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
@@ -3,43 +3,6 @@ import XCTest
 
 class SentrySDKSettingsTests: XCTestCase {
     
-    // MARK: - initWithOptions tests
-    
-    func testInitWithOptions_WhenOptionsNil_ReturnsDefaultSettings() {
-        let settings = SentrySDKSettings(options: nil)
-        
-        XCTAssertNotNil(settings)
-        XCTAssertFalse(settings.autoInferIP)
-    }
-    
-    func testInitWithOptions_WhenSendDefaultPiiTrue_SetsAutoInferIPToTrue() throws {
-        let options = try XCTUnwrap(SentryOptionsInternal.initWithDict([
-            "dsn": "https://username:password@app.getsentry.com/12345",
-            "sendDefaultPii": true
-        ]))
-
-        XCTAssertNotNil(options)
-        
-        let settings = SentrySDKSettings(options: options)
-        
-        XCTAssertNotNil(settings)
-        XCTAssertTrue(settings.autoInferIP)
-    }
-    
-    func testInitWithOptions_WhenSendDefaultPiiFalse_SetsAutoInferIPToFalse() throws {
-        let options = try XCTUnwrap(SentryOptionsInternal.initWithDict([
-            "dsn": "https://username:password@app.getsentry.com/12345",
-            "sendDefaultPii": false
-        ]))
-
-        XCTAssertNotNil(options)
-        
-        let settings = SentrySDKSettings(options: options)
-        
-        XCTAssertNotNil(settings)
-        XCTAssertFalse(settings.autoInferIP)
-    }
-    
     // MARK: - initWithDict tests
     
     func testInitWithDict_WhenInferIpIsAuto_SetsAutoInferIPToTrue() {
@@ -119,8 +82,7 @@ class SentrySDKSettingsTests: XCTestCase {
     }
     
     func testSerialize_WhenAutoInferIPIsSetDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings()
-        settings.autoInferIP = true
+        let settings = SentrySDKSettings(sendDefaultPii: true)
         
         let serialized = settings.serialize()
         
@@ -129,8 +91,7 @@ class SentrySDKSettingsTests: XCTestCase {
     }
     
     func testSerialize_WhenAutoInferIPIsSetToFalseDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings()
-        settings.autoInferIP = false
+        let settings = SentrySDKSettings(sendDefaultPii: false)
         
         let serialized = settings.serialize()
         
@@ -141,17 +102,17 @@ class SentrySDKSettingsTests: XCTestCase {
     // MARK: - autoInferIP property tests
     
     func testAutoInferIPProperty_CanBeSetAndRetrieved() {
-        let settings = SentrySDKSettings()
+        var settings = SentrySDKSettings()
         
         // Test default value
         XCTAssertFalse(settings.autoInferIP)
         
         // Test setting to true
-        settings.autoInferIP = true
+        settings = SentrySDKSettings(sendDefaultPii: true)
         XCTAssertTrue(settings.autoInferIP)
         
         // Test setting to false
-        settings.autoInferIP = false
+        settings = SentrySDKSettings(sendDefaultPii: false)
         XCTAssertFalse(settings.autoInferIP)
     }
     

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -171,8 +171,7 @@ class SentrySdkInfoTests: XCTestCase {
     
     func testInitWithDict_SdkInfo() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings()
-        settings.autoInferIP = true
+        let settings = SentrySDKSettings(sendDefaultPii: true)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,
@@ -292,8 +291,7 @@ class SentrySdkInfoTests: XCTestCase {
 
     func testInitWithDict_WrongTypesInArrays() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings(dict: [:])
-        settings.autoInferIP = false
+        let settings = SentrySDKSettings(sendDefaultPii: false)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,


### PR DESCRIPTION
The `init(options: Options?)` in SentrySDKSettings was unused so I delete it, also changed a handful of `var` to `let` and made some data types into structs now that they aren't used from ObjC

#skip-changelog

Closes #7002