### PR TITLE
fix(ci): Add condition to run tests on push

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -24,7 +24,7 @@ jobs:
     name: Detect File Changes
     runs-on: ubuntu-latest
     outputs:
-      run_testflight_for_changes: ${{ github.event_name != 'pull_request' || steps.changes.outputs.run_testflight_for_prs == 'true' }}
+      run_testflight_for_changes: ${{ github.event_name == 'pull_request' && steps.changes.outputs.run_testflight_for_prs || steps.changes.outputs.run_testflight_for_pushes }}
     steps:
       - uses: actions/checkout@v6
       - name: Get changed files


### PR DESCRIPTION
## :scroll: Description

Adapted GitHub Actions workflow conditionals to ensure jobs run selectively for pull requests (only if relevant files change) and always for pushes to the `main` branch.

## :bulb: Motivation and Context

This change ensures that all CI/CD jobs are executed on every push to the `main` branch, providing comprehensive testing for releases, while maintaining efficient, selective testing for pull requests based on changed files.

## :green_heart: How did you test it?

Created a new branch, added the branch to the push triggers and created a commit with a file **not** in the list of file-filters.yml

This triggered the following workflow run, which is running all unit tests: https://github.com/getsentry/sentry-cocoa/actions/runs/20068753236

#skip-changelog

---
[Slack Thread](https://sentry.slack.com/archives/C09MQRJGBU2/p1765279778784709?thread_ts=1765279778.784709&cid=C09MQRJGBU2)

<a href="https://cursor.com/background-agent?bcId=bc-11be1426-f823-47a4-9fc4-f6b8dd3303b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11be1426-f823-47a4-9fc4-f6b8dd3303b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

