### PR TITLE
docs: Add documentation regarding HybridSDK target removal

### DIFF
--- a/develop-docs/DECISIONS.md
+++ b/develop-docs/DECISIONS.md
@@ -575,7 +575,12 @@ Needs a POC to confirm this is possible
 Date: December 10, 2025
 Contributors: @itaybre, @philprime, @philipphofmann
 
-Until v9.1.0, we maintained a separate variant of the SDK with additional public headers and APIs intended for downstream SDKs (React Native, Flutter, .NET, and our SwiftUI variant). This meant any change that affected our distribution system required maintaining at least one extra variant of the SDK, which increased the team's workload significantly.
+Until v9.1.0, we maintained a separate variant of the SDK with additional public headers and APIs intended for downstream SDKs (React Native, Flutter, .NET, and our SwiftUI variant). This meant any change that affected our distribution system required maintaining at least one extra variant of the SDK, which increased the team's workload significantly:
+
+- Extra linting jobs
+- Additional integration tests
+- More complex header management (Public, HybridPublic, modulemap)
+- Additional SDK variants if we want to migrate CocoaPods to XCFrameworks
 
 However, there is nothing stopping users from using these APIs. They could simply change their dependency to the HybridSDK variant and access any of the "internal" APIs, so the separation provided no real protection.
 


### PR DESCRIPTION
This decision documents the removal of the `HybridSDK` subspec and module, consolidating all hybrid APIs into the main Sentry target.

### Background

Until v9.1.0, we maintained a separate SDK variant with additional public headers/APIs for downstream SDKs (React Native, Flutter, .NET, SwiftUI). This separation:

- Required maintaining multiple distribution variants
- Increased CI complexity and team workload
- Provided no real protection (users could still access "internal" APIs by switching dependencies)

### Decision

Remove the HybridSDK submodule and subspec, treating hybrid SDK consumers as first-class citizens by:

- Exposing required APIs in a documented manner
- Avoiding breaking changes to these APIs in minor versions  
- Using naming conventions to distinguish internal APIs from user-facing ones

### Next Steps

1. Consolidate headers into the main target and remove `HybridSDK` subspec, done in #7019 
2. Update downstream SDKs
3. Align on an API naming convention (gather input from other SDK maintainers)