### PR TITLE
Remove extra log check

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -208,10 +208,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     SentryClientInternal *client = self.client;
-    if (client.options.diagnosticLevel == kSentryLevelDebug) {
-        SENTRY_LOG_DEBUG(@"Capturing session with status: %@",
-            [self createSessionDebugString:SENTRY_UNWRAP_NULLABLE(SentrySession, session)]);
-    }
+    SENTRY_LOG_DEBUG(@"Capturing session with status: %@",
+        [self createSessionDebugString:SENTRY_UNWRAP_NULLABLE(SentrySession, session)]);
     [client captureSession:SENTRY_UNWRAP_NULLABLE(SentrySession, session)];
 }
 
@@ -737,10 +735,8 @@ NS_ASSUME_NONNULL_BEGIN
                 [currentSession
                     endSessionCrashedWithTimestamp:[SentryDependencyContainer.sharedInstance
                                                            .dateProvider date]];
-                if (self.client.options.diagnosticLevel == kSentryLevelDebug) {
-                    SENTRY_LOG_DEBUG(@"Ending session with status: %@",
-                        [self createSessionDebugString:currentSession]);
-                }
+                SENTRY_LOG_DEBUG(@"Ending session with status: %@",
+                    [self createSessionDebugString:currentSession]);
                 if (startNewSession) {
                     // Setting _session to nil so startSession doesn't capture it again
                     _session = nil;


### PR DESCRIPTION
I happened to notice these redundant log level checks, not necessary since it already calls `SENTRY_LOG_DEBUG` which checks the log level

#skip-changelog

Closes #7028