### PR TITLE
chore: Bumps macOS-14 runner to macOS-15

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -67,7 +67,7 @@ jobs:
   assemble-xcframework-variant:
     name: ${{ inputs.override-name || format('{0}{1}', inputs.scheme, inputs.suffix) }}
 
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -38,7 +38,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_swiftlint_for_prs == 'true'
     needs: files-changed
     name: Lint
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v6
       - name: Install tooling


### PR DESCRIPTION
I noticed some jobs where using macOS 14 when it wasn't needed (not testing iOS 17 or macOS 14 specifically).

Using macOS 15 should provide more runners availability.