### PR TITLE
chore: Remove assembly workflow files from UI test filter

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -445,8 +445,6 @@ run_ui_tests_for_prs: &run_ui_tests_for_prs
 
   # Scripts
   - "scripts/ci-select-xcode.sh"
-  - "scripts/build-xcframework-slice.sh"
-  - "scripts/assemble-xcframework.sh"
   - "scripts/ci-diagnostics.sh"
   - "scripts/ci-utils.sh"
   - "scripts/ci-ensure-runtime-loaded.sh"


### PR DESCRIPTION
I just found out that a modification to the asembly slice workflow triggered UI tests, which isn't needed.

This PR just removes that reference

Closes #7032