### PR TITLE
chore: Cleanup file filter for required files modified

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -69,7 +69,7 @@ run_api_stability_for_prs: &run_api_stability_for_prs
   - "Sentry.xcodeproj/**"
   - "Package*.swift"
 
-  # Scripts  
+  # Scripts
   - "scripts/build-xcframework-slice.sh"
   - "scripts/assemble-xcframework.sh"
   - "scripts/update-api.sh"


### PR DESCRIPTION
In addition to #7030, found more files that shouldn't be in the filters since they aren't used in those jobs