### PR TITLE
fix: Outdated app launch comment

### DIFF
--- a/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
+++ b/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
@@ -49,8 +49,7 @@ SENTRY_NO_INIT
 
 /**
  * How long the app start took. From appStartTimestamp to when the SDK creates the
- * AppStartMeasurement, which is done when the OS posts UIWindowDidBecomeVisibleNotification and
- * when `enablePerformanceV2` is enabled when the app draws it's first frame.
+ * AppStartMeasurement, which is done when the first CADisplayLink callback is received.
  */
 @property (readonly, nonatomic, assign) NSTimeInterval duration;
 


### PR DESCRIPTION
Looks like I forgot to change this comment when I removed the UIWindow notification approach in V9 here: https://github.com/getsentry/sentry-cocoa/pull/6008

#skip-changelog

Closes #7035