### PR TITLE
chore: Bump deprecated Xcode version on macOS 26 runners

### DIFF
--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Select Xcode
-        run: ./scripts/ci-select-xcode.sh 16.4
+        run: ./scripts/ci-select-xcode.sh 26.1.1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@d697be2f83c6234b20877c3b5eac7a7f342f0d0c # v1.269.0


### PR DESCRIPTION
GitHub deprecated and removed Xcode 16 from the macOS 26 image on [Dec 8th](https://github.com/actions/runner-images/issues/13345)

Bump to the newest xcode version.

#skip-changelog

Closes #7040