### PR TITLE
chore: Move `testRemoveImageFromTail` to flaky plan

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -34,6 +34,7 @@
         "SentryCoreDataTrackerTests\/testSaveBackgroundThread()",
         "SentryCrashBinaryImageCacheTests\/testRemoveImageAddAgain",
         "SentryCrashBinaryImageCacheTests\/testRemoveImageFromBeginning",
+        "SentryCrashBinaryImageCacheTests\/testRemoveImageFromTail",
         "SentryCrashIntegrationTests\/testStartUpCrash_CallsFlush()",
         "SentryCrashReportStore_Tests\/testCrashReportCount1",
         "SentryCrashReportStore_Tests\/testDeleteAllReports",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -19,6 +19,7 @@
         "PrivateSentrySDKOnlyTests\/testProfilingStartAndCollect()",
         "SentryCrashBinaryImageCacheTests\/testRemoveImageAddAgain",
         "SentryCrashBinaryImageCacheTests\/testRemoveImageFromBeginning",
+        "SentryCrashBinaryImageCacheTests\/testRemoveImageFromTail",
         "SentryCrashReportStore_Tests\/testCrashReportCount1",
         "SentryCrashReportStore_Tests\/testDeleteAllReports",
         "SentryCrashReportStore_Tests\/testPruneReports",


### PR DESCRIPTION
Saw this [test fail](https://github.com/getsentry/sentry-cocoa/actions/runs/20148728914/job/57837021971), so until we fix it definitely, let's move it to the flaky plan

Closes #7042