### PR TITLE
fix: Resolve broken pipes in make generate-public-api

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Source CI utility functions
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/ci-utils.sh"
+# Disable SC1091 because it won't work with pre-commit
+# shellcheck source=./scripts/ci-utils.sh disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
 begin_group "Check Xcode Version"
 # Check if Xcode 16 is selected


### PR DESCRIPTION
Fixes error 141 (SIGPIPE) that occurred when parsing xcodebuild version output with `set -euo pipefail` enabled. The issue happened because piping xcodebuild output directly to awk caused a broken pipe when awk exited early:

```
$ make generate-public-api
./scripts/update-api.sh
make: *** [generate-public-api] Error 141

$ make generate-public-api
./scripts/update-api.sh
Xcode 26.1.1 is currently selected, but found Xcode 16 at /Applications/Xcode-16.4.0.app
Using Xcode 16 for this script execution...
make: *** [generate-public-api] Error 141
```

Changes:
- Read full xcodebuild output into a variable before parsing to avoid broken pipe
- Remove verbose tracing flag (`-x`) from set command
- Add progress echo statements for better visibility during script execution

This ensures the script runs successfully when Xcode 26 is selected and automatically switches to Xcode 16 for API generation.

#skip-changelog

Closes #7060