### PR TITLE
chore: Run iOS18 unit tests on cirrus Runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -269,7 +269,7 @@ jobs:
 
           # iOS 18
           - name: iOS 18 Sentry
-            runs-on: macos-15
+            runs-on: sequoia
             xcode: "16.4"
             test-destination-os: "18.5"
             platform: "iOS"


### PR DESCRIPTION
Since iOS 18 tests have become flaky on GH, lets run them on Cirrus Runners

#skip-changelog

Closes #7065