### PR TITLE
chore: Disable spotlight feature in feature-flags.yml

### DIFF
--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -77,7 +77,7 @@ schemeTemplates:
         # other
         "--io.sentry.other.base64-attachment-data": false
         "--io.sentry.other.disable-http-transport": false
-        "--io.sentry.other.disable-spotlight": false
+        "--io.sentry.other.disable-spotlight": true
         "--io.sentry.other.reject-screenshots-in-before-capture-screenshot": false
         "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy": false
         "--io.sentry.other.reject-all-spans": false


### PR DESCRIPTION
I noticed while working on the watchOS sample that spotlight is enabled by default. Not sure if we we want this and why nobody noticed it yet for the other samples.

#skip-changelog

Closes #7068