### PR TITLE
chore: Clarify app hang V2 platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This changelog lists every breaking change. For a high-level overview and upgrad
 - Removes deprecated getStoreEndpoint (#5591)
 - Remove legacy profiling, the only supported profiling is now what was known as continuous V2 (#6386)
 - Removes deprecated useSpan function (#5591)
-- Makes app hang tracking V2 the default and removes the option to enable/disable it (#5615)
+- Makes app hang tracking V2 the default only on **iOS and tvOS** and removes the option to enable/disable it (#5615). macOS still uses V1.
 - Removes initializers for SentryTraceContext from the public API (#6662)
 - Removes `integrations` property from `SentryOptions` (#5749)
 - Removes `defaultIntegrations` function from `SentryOptions` (#6664)

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -462,7 +462,9 @@
     /// time defined by the @c appHangTimeoutInterval option.
     ///
     /// On iOS, tvOS and visionOS, the SDK can differentiate between fully-blocking and non-fully
-    /// blocking app hangs.
+    /// blocking app hangs. Important: this feature can't differentiate between fully-blocking and
+    /// non-fully-blocking app hangs on macOS.
+    ///
     /// A fully-blocking app hang is when the main thread is stuck completely, and the app can't render a
     /// single frame. A non-fully-blocking app hang is when the app appears stuck to the user but can still
     /// render a few frames. Fully-blocking app hangs are more actionable because the stacktrace shows the


### PR DESCRIPTION
Came up here https://github.com/getsentry/sentry-cocoa/issues/4950#issuecomment-3667411535

#skip-changelog 