### PR TITLE
fix: race condition in metric kit delegate

### DIFF
--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -4,29 +4,42 @@ import Foundation
 
 import MetricKit
 
+private let crashMechanism = "MXCrashDiagnostic"
+private let diskWriteMechanism = "mx_disk_write_exception"
+private let cpuExceptionMechanism = "mx_cpu_exception"
+private let hangDiagnosticMechanism = "mx_hang_diagnostic"
+
 @available(macOS 12.0, *)
-protocol SentryMXManagerDelegate: AnyObject {
-    
-    func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date)
-    
-    func didReceiveDiskWriteExceptionDiagnostic(_ diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date)
-    
-    func didReceiveCpuExceptionDiagnostic(_ diagnostic: MXCPUExceptionDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date)
-    
-    func didReceiveHangDiagnostic(_ diagnostic: MXHangDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date)
+protocol CallStackTreeProviding {
+    var callStackTree: MXCallStackTree { get }
 }
+
+@available(macOS 12.0, *)
+extension MXCrashDiagnostic: CallStackTreeProviding { }
+@available(macOS 12.0, *)
+extension MXDiskWriteExceptionDiagnostic: CallStackTreeProviding { }
+@available(macOS 12.0, *)
+extension MXCPUExceptionDiagnostic: CallStackTreeProviding { }
+@available(macOS 12.0, *)
+extension MXHangDiagnostic: CallStackTreeProviding { }
 
 @available(macOS 12.0, *)
 final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
     
     let disableCrashDiagnostics: Bool
+    let measurementFormatter: MeasurementFormatter
+    let inAppLogic: SentryInAppLogic
+    let attachDiagnosticAsAttachment: Bool
     
-    init(disableCrashDiagnostics: Bool = true) {
+    init(inAppLogic: SentryInAppLogic, attachDiagnosticAsAttachment: Bool, disableCrashDiagnostics: Bool = true) {
         self.disableCrashDiagnostics = disableCrashDiagnostics
+        self.inAppLogic = inAppLogic
+        self.attachDiagnosticAsAttachment = attachDiagnosticAsAttachment
+        measurementFormatter = MeasurementFormatter()
+        measurementFormatter.locale = Locale(identifier: "en_US")
+        measurementFormatter.unitOptions = .providedUnit
         super.init()
     }
-
-    weak var delegate: SentryMXManagerDelegate?
     
     func receiveReports() {
         let shared = MXMetricManager.shared
@@ -39,14 +52,6 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
     }
     
     func didReceive(_ payloads: [MXDiagnosticPayload]) {
-        func actOn(callStackTree: MXCallStackTree, action: (SentryMXCallStackTree) -> Void) {
-            guard let callStackTree = try? SentryMXCallStackTree.from(data: callStackTree.jsonRepresentation()) else {
-                return
-            }
-            
-            action(callStackTree)
-        }
-        
         payloads.forEach { payload in
             
             payload.crashDiagnostics?.forEach { diagnostic in
@@ -54,29 +59,72 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
                 if disableCrashDiagnostics {
                     return
                 }
-                actOn(callStackTree: diagnostic.callStackTree) { callStackTree in
-                    delegate?.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTree, timeStampBegin: payload.timeStampBegin)
-                }
+                let exceptionValue = "MachException Type:\(String(describing: diagnostic.exceptionType)) Code:\(String(describing: diagnostic.exceptionCode)) Signal:\(String(describing: diagnostic.signal))"
+                captureEvent(handled: false, exceptionValue: exceptionValue, exceptionType: "MXCrashDiagnostic", exceptionMechanism: crashMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
             }
             
             payload.diskWriteExceptionDiagnostics?.forEach { diagnostic in
-                actOn(callStackTree: diagnostic.callStackTree) { callStackTree in
-                    delegate?.didReceiveDiskWriteExceptionDiagnostic(diagnostic, callStackTree: callStackTree, timeStampBegin: payload.timeStampBegin)
-                }
+                let totalWritesCaused = measurementFormatter.string(from: diagnostic.totalWritesCaused)
+                let exceptionValue = "MXDiskWriteException totalWritesCaused:\(totalWritesCaused)"
+                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXDiskWriteException", exceptionMechanism: diskWriteMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
             }
             
             payload.cpuExceptionDiagnostics?.forEach { diagnostic in
-                actOn(callStackTree: diagnostic.callStackTree) { callStackTree in
-                    delegate?.didReceiveCpuExceptionDiagnostic(diagnostic, callStackTree: callStackTree, timeStampBegin: payload.timeStampBegin)
-                }
+                let totalCPUTime = measurementFormatter.string(from: diagnostic.totalCPUTime)
+                let totalSampledTime = measurementFormatter.string(from: diagnostic.totalSampledTime)
+
+                let exceptionValue = "MXCPUException totalCPUTime:\(totalCPUTime) totalSampledTime:\(totalSampledTime)"
+                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXCPUException", exceptionMechanism: cpuExceptionMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
             }
             
             payload.hangDiagnostics?.forEach { diagnostic in
-                actOn(callStackTree: diagnostic.callStackTree) { callStackTree in
-                    delegate?.didReceiveHangDiagnostic(diagnostic, callStackTree: callStackTree, timeStampBegin: payload.timeStampBegin)
-                }
+                let hangDuration = measurementFormatter.string(from: diagnostic.hangDuration)
+                let exceptionValue = "MXHangDiagnostic hangDuration:\(hangDuration)"
+                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXHangDiagnostic", exceptionMechanism: hangDiagnosticMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
             }
         }
+    }
+    
+    func captureEvent(handled: Bool, exceptionValue: String, exceptionType: String, exceptionMechanism: String, timeStampBegin: Date, diagnostic: MXDiagnostic & CallStackTreeProviding) {
+        if let callStackTree = try? SentryMXCallStackTree.from(data: diagnostic.callStackTree.jsonRepresentation()) {
+            let event = Event(level: handled ? .warning : .error)
+            event.timestamp = timeStampBegin
+            let exception = Exception(value: exceptionValue, type: exceptionType)
+            let mechanism = Mechanism(type: exceptionMechanism)
+            mechanism.handled = NSNumber(value: handled)
+            mechanism.synthetic = true
+            exception.mechanism = mechanism
+            event.exceptions = [exception]
+            capture(event: event, handled: handled, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation())
+        }
+    }
+    
+    func capture(event: Event, handled: Bool, callStackTree: SentryMXCallStackTree, diagnosticJSON: Data) {
+        callStackTree.prepare(event: event, inAppLogic: inAppLogic, handled: handled)
+        // The crash event can be way from the past. We don't want to impact the current session.
+        // Therefore we don't call captureFatalEvent.
+        capture(event: event, diagnosticJSON: diagnosticJSON)
+    }
+    
+    func capture(event: Event, diagnosticJSON: Data) {
+        if attachDiagnosticAsAttachment {
+            SentrySDK.capture(event: event) { scope in
+                scope.addAttachment(Attachment(data: diagnosticJSON, filename: "MXDiagnosticPayload.json"))
+            }
+        } else {
+            SentrySDK.capture(event: event)
+        }
+    }
+}
+
+extension Event {
+    @objc
+    @_spi(Private) public func isMetricKitEvent() -> Bool {
+        guard let mechanism = exceptions?.first?.mechanism, exceptions?.count == 1 else {
+            return false
+        }
+        
+        return [crashMechanism, diskWriteMechanism, cpuExceptionMechanism, hangDiagnosticMechanism].contains(mechanism.type)
     }
 }
 

--- a/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
@@ -5,24 +5,15 @@ import MetricKit
 final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration {
     
     let mxManager: SentryMXManager
-    let measurementFormatter: MeasurementFormatter
-    let attachDiagnosticAsAttachment: Bool
-    let inAppLogic: SentryInAppLogic
     
     init?(with options: Options, dependencies: Dependencies) {
         guard options.enableMetricKit else {
             return nil
         }
 
-        mxManager = SentryMXManager()
-        measurementFormatter = MeasurementFormatter()
-        measurementFormatter.locale = Locale(identifier: "en_US")
-        measurementFormatter.unitOptions = .providedUnit
-        attachDiagnosticAsAttachment = options.enableMetricKitRawPayload
-        inAppLogic = SentryInAppLogic(inAppIncludes: options.inAppIncludes)
+        mxManager = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: options.inAppIncludes), attachDiagnosticAsAttachment: options.enableMetricKitRawPayload)
         super.init()
-        
-        mxManager.delegate = self
+
         mxManager.receiveReports()
     }
     
@@ -32,84 +23,6 @@ final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration
     
     func uninstall() {
         mxManager.pauseReports()
-        mxManager.delegate = nil
-    }
-    
-    static func createEvent(handled: Bool, level: SentryLevel, exceptionValue: String, exceptionType: String, exceptionMechanism: String, timeStampBegin: Date) -> Event {
-        let event = Event(level: level)
-        event.timestamp = timeStampBegin
-        let exception = Exception(value: exceptionValue, type: exceptionType)
-        let mechanism = Mechanism(type: exceptionMechanism)
-        mechanism.handled = NSNumber(value: handled)
-        mechanism.synthetic = true
-        exception.mechanism = mechanism
-        event.exceptions = [exception]
-        return event
-    }
-    
-    func capture(event: Event, handled: Bool, callStackTree: SentryMXCallStackTree, diagnosticJSON: Data) {
-        callStackTree.prepare(event: event, inAppLogic: inAppLogic, handled: handled)
-        // The crash event can be way from the past. We don't want to impact the current session.
-        // Therefore we don't call captureFatalEvent.
-        capture(event: event, diagnosticJSON: diagnosticJSON)
-    }
-    
-    func capture(event: Event, diagnosticJSON: Data) {
-        if attachDiagnosticAsAttachment {
-            SentrySDK.capture(event: event) { scope in
-                scope.addAttachment(Attachment(data: diagnosticJSON, filename: "MXDiagnosticPayload.json"))
-            }
-        } else {
-            SentrySDK.capture(event: event)
-        }
-    }
-}
-
-private let crashMechanism = "MXCrashDiagnostic"
-private let diskWriteMechanism = "mx_disk_write_exception"
-private let cpuExceptionMechanism = "mx_cpu_exception"
-private let hangDiagnosticMechanism = "mx_hang_diagnostic"
-
-@available(macOS 12.0, *)
-extension SentryMetricKitIntegration: SentryMXManagerDelegate {
-    func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date) {
-        let exceptionValue = "MachException Type:\(String(describing: diagnostic.exceptionType)) Code:\(String(describing: diagnostic.exceptionCode)) Signal:\(String(describing: diagnostic.signal))"
-        let event = Self.createEvent(handled: false, level: .error, exceptionValue: exceptionValue, exceptionType: "MXCrashDiagnostic", exceptionMechanism: crashMechanism, timeStampBegin: timeStampBegin)
-        capture(event: event, handled: false, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation())
-    }
-    
-    func didReceiveDiskWriteExceptionDiagnostic(_ diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date) {
-        let totalWritesCaused = measurementFormatter.string(from: diagnostic.totalWritesCaused)
-        let exceptionValue = "MXDiskWriteException totalWritesCaused:\(totalWritesCaused)"
-        let event = Self.createEvent(handled: true, level: .warning, exceptionValue: exceptionValue, exceptionType: "MXDiskWriteException", exceptionMechanism: diskWriteMechanism, timeStampBegin: timeStampBegin)
-        capture(event: event, handled: true, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation())
-    }
-    
-    func didReceiveCpuExceptionDiagnostic(_ diagnostic: MXCPUExceptionDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date) {
-        let totalCPUTime = measurementFormatter.string(from: diagnostic.totalCPUTime)
-        let totalSampledTime = measurementFormatter.string(from: diagnostic.totalSampledTime)
-
-        let exceptionValue = "MXCPUException totalCPUTime:\(totalCPUTime) totalSampledTime:\(totalSampledTime)"
-        let event = Self.createEvent(handled: true, level: .warning, exceptionValue: exceptionValue, exceptionType: "MXCPUException", exceptionMechanism: cpuExceptionMechanism, timeStampBegin: timeStampBegin)
-        capture(event: event, handled: true, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation())
-    }
-    
-    func didReceiveHangDiagnostic(_ diagnostic: MXHangDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date) {
-        let hangDuration = measurementFormatter.string(from: diagnostic.hangDuration)
-        let exceptionValue = "MXHangDiagnostic hangDuration:\(hangDuration)"
-        let event = Self.createEvent(handled: true, level: .warning, exceptionValue: exceptionValue, exceptionType: "MXHangDiagnostic", exceptionMechanism: hangDiagnosticMechanism, timeStampBegin: timeStampBegin)
-        capture(event: event, handled: true, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation())
-    }
-}
-
-extension Event {
-    @objc
-    @_spi(Private) public func isMetricKitEvent() -> Bool {
-        guard let mechanism = exceptions?.first?.mechanism, exceptions?.count == 1 else {
-            return false
-        }
-        
-        return [crashMechanism, diskWriteMechanism, cpuExceptionMechanism, hangDiagnosticMechanism].contains(mechanism.type)
     }
 }
 

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
@@ -14,63 +14,11 @@ final class SentryMXManagerTests: XCTestCase {
         super.tearDown()
         clearTestState()
     }
-
-    func testReceiveNoPayloads() {
-            let (sut, delegate) = givenSut()
-            
-            sut.didReceive([])
-            
-            XCTAssertEqual(0, delegate.crashInvocations.count)
-            XCTAssertEqual(0, delegate.diskWriteExceptionInvocations.count)
-            XCTAssertEqual(0, delegate.cpuExceptionInvocations.count)
-            XCTAssertEqual(0, delegate.hangDiagnosticInvocations.count)
-    }
     
-    func testReceiveCrashPayload_DoesNothing() throws {
-            let (sut, delegate) = givenSut()
-            
-            let payload = try givenPayloads()
-            
-            sut.didReceive([payload])
-            
-            XCTAssertEqual(0, delegate.crashInvocations.count)
-            XCTAssertEqual(1, delegate.diskWriteExceptionInvocations.count)
-            XCTAssertEqual(1, delegate.cpuExceptionInvocations.count)
-            XCTAssertEqual(1, delegate.hangDiagnosticInvocations.count)
-    }
-    
-    func testReceivePayloadsWithFaultyJSON_DoesNothing() throws {
-            let (sut, delegate) = givenSut(disableCrashDiagnostics: false)
-            
-            let payload = try givenPayloads(withCallStackJSON: false)
-            
-            sut.didReceive([payload])
-            
-            XCTAssertEqual(0, delegate.crashInvocations.count)
-            XCTAssertEqual(0, delegate.diskWriteExceptionInvocations.count)
-            XCTAssertEqual(0, delegate.cpuExceptionInvocations.count)
-            XCTAssertEqual(0, delegate.hangDiagnosticInvocations.count)
-    }
-    
-    func testReceiveCrashPayloadEnabled_ForwardPayload() throws {
-            let (sut, delegate) = givenSut(disableCrashDiagnostics: false)
-            
-            let payload = try givenPayloads()
-            
-            sut.didReceive([payload])
-            
-            XCTAssertEqual(1, delegate.crashInvocations.count)
-            XCTAssertEqual(1, delegate.diskWriteExceptionInvocations.count)
-            XCTAssertEqual(1, delegate.cpuExceptionInvocations.count)
-            XCTAssertEqual(1, delegate.hangDiagnosticInvocations.count)
-    }
-    
-    private func givenSut(disableCrashDiagnostics: Bool = true) -> (SentryMXManager, SentryMXManagerTestDelegate) {
-        let sut = SentryMXManager(disableCrashDiagnostics: disableCrashDiagnostics)
-        let delegate = SentryMXManagerTestDelegate()
-        sut.delegate = delegate
+    private func givenSut(disableCrashDiagnostics: Bool = true) -> SentryMXManager {
+        let sut = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: []), attachDiagnosticAsAttachment: false, disableCrashDiagnostics: disableCrashDiagnostics)
         
-        return (sut, delegate)
+        return sut
     }
     
     private func givenPayloads(withCallStackJSON: Bool = true) throws -> TestMXDiagnosticPayload {
@@ -111,7 +59,6 @@ class TestMXDiagnosticPayload: MXDiagnosticPayload {
         var hangDiagnostic: [MXHangDiagnostic]?
         
         var timeStampBegin = SentryDependencyContainer.sharedInstance().dateProvider.date()
-        var timeStampEnd = SentryDependencyContainer.sharedInstance().dateProvider.date()
     }
     
     var overrides = Override()
@@ -134,34 +81,6 @@ class TestMXDiagnosticPayload: MXDiagnosticPayload {
     
     override var timeStampBegin: Date {
         return overrides.timeStampBegin
-    }
-    
-    override var timeStampEnd: Date {
-        return overrides.timeStampEnd
-    }
-}
-
-@available(macOS 12.0, *)
-class SentryMXManagerTestDelegate: SentryMXManagerDelegate {
-
-    var crashInvocations = Invocations<(diagnostic: MXCrashDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date)>()
-    func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date) {
-        crashInvocations.record((diagnostic, callStackTree, timeStampBegin))
-    }
-    
-    var diskWriteExceptionInvocations = Invocations<(diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date)>()
-    func didReceiveDiskWriteExceptionDiagnostic(_ diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date) {
-        diskWriteExceptionInvocations.record((diagnostic, callStackTree, timeStampBegin))
-    }
-    
-    var cpuExceptionInvocations = Invocations<(diagnostic: MXCPUExceptionDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date)>()
-    func didReceiveCpuExceptionDiagnostic(_ diagnostic: MXCPUExceptionDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date) {
-        cpuExceptionInvocations.record((diagnostic, callStackTree, timeStampBegin))
-    }
-    
-    var hangDiagnosticInvocations = Invocations<(diagnostic: MXHangDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date)>()
-    func didReceiveHangDiagnostic(_ diagnostic: MXHangDiagnostic, callStackTree: Sentry.SentryMXCallStackTree, timeStampBegin: Date) {
-        hangDiagnosticInvocations.record((diagnostic, callStackTree, timeStampBegin))
     }
 }
 


### PR DESCRIPTION
The delegate property was leading to race conditions where it could be set by one thread through the `uninstall()` function and simultaneously read from another thread handling a metric kit payload. Unlikely, but a data race. Fixed it by simplifying all this code and removing the delegate entirely - a pattern that was a holdover from when this was written in objc

#skip-changelog

Closes #7092