### PR TITLE
chore: Remove swift5.9 checks

### DIFF
--- a/SentryTestUtils/Sources/TestOptions.swift
+++ b/SentryTestUtils/Sources/TestOptions.swift
@@ -16,7 +16,7 @@ public extension Options {
         enableAutoBreadcrumbTracking = false
         enableCoreDataTracing = false
         enableFileIOTracing = false
-        #if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+        #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
         enableUserInteractionTracing = false
         attachViewHierarchy = false
         enableUIViewControllerTracing = false

--- a/Sources/Swift/AppState/SentryAppStateManager.swift
+++ b/Sources/Swift/AppState/SentryAppStateManager.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 #endif
 
@@ -9,7 +9,7 @@ import UIKit
     private let releaseName: String?
     private let crashWrapper: SentryCrashWrapper
     private let fileManager: SentryFileManager?
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
     private let _updateAppState: (@escaping (SentryAppState) -> Void) -> Void
     private let _buildCurrentAppState: () -> SentryAppState
     private let helper: SentryDefaultAppStateManager
@@ -19,7 +19,7 @@ import UIKit
         self.releaseName = releaseName
         self.crashWrapper = crashWrapper
         self.fileManager = fileManager
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
         let lock = NSRecursiveLock()
         let buildCurrentAppState = {
             // Is the current process being traced or not? If it is a debugger is attached.
@@ -53,7 +53,7 @@ import UIKit
 #endif
     }
     
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
     var startCount: Int {
         helper.startCount
     }

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length type_body_length
 @_implementationOnly import _SentryPrivate
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 private typealias CrossPlatformApplication = UIApplication
 #elseif (os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT
@@ -9,7 +9,7 @@ import AppKit
 private typealias CrossPlatformApplication = NSApplication
 #endif
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 
 @_spi(Private) @objc
 public protocol SentryFramesTrackerListener: NSObjectProtocol {

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryScreenFrames.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryScreenFrames.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+#if (os(iOS) || os(tvOS) || os(visionOS))
 
 #if os(iOS)
 /// An array of dictionaries that each contain a start and end timestamp for a rendered frame.
@@ -73,7 +73,7 @@ public final class SentryScreenFrames: NSObject, NSCopying {
         self.total = total
         self.frozen = frozen
         self.slow = slow
-    #endif // !(os(watchOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+    #endif // !(os(watchOS) || os(tvOS) || os(visionOS))
 
         super.init()
     }
@@ -184,4 +184,4 @@ public final class SentryScreenFrames: NSObject, NSCopying {
     }
 }
 
-#endif // (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+#endif // (os(iOS) || os(tvOS) || os(visionOS))

--- a/Sources/Swift/Core/Integrations/Integrations.swift
+++ b/Sources/Swift/Core/Integrations/Integrations.swift
@@ -44,7 +44,7 @@ private struct AnyIntegration {
         integrations.append(.init(UserFeedbackIntegration.self))
         #endif
         
-        #if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || os(macOS)
+        #if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || os(macOS)
         integrations.append(.init(FlushLogsIntegration.self))
         #endif
 

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -367,7 +367,7 @@ import Foundation
         SentrySDKInternal.close()
     }
     
-#if !(os(watchOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+#if !(os(watchOS) || os(tvOS) || os(visionOS))
     /// Start a new continuous profiling session if one is not already running.
     /// - warning: Continuous profiling mode is experimental and may still contain bugs.
     /// - note: Unlike transaction-based profiling, continuous profiling does not take into account

--- a/Sources/Swift/Helper/SentrySwizzleWrapper.swift
+++ b/Sources/Swift/Helper/SentrySwizzleWrapper.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 
 @_spi(Private) public typealias SentrySwizzleSendActionCallback = (String, Any?, Any?, UIEvent?) -> Void

--- a/Sources/Swift/Integrations/Log/FlushLogsIntegration.swift
+++ b/Sources/Swift/Integrations/Log/FlushLogsIntegration.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 private typealias CrossPlatformApplication = UIApplication
 #elseif os(macOS)
@@ -8,7 +8,7 @@ import AppKit
 private typealias CrossPlatformApplication = NSApplication
 #endif
 
-#if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || os(macOS)
+#if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || os(macOS)
 
 protocol NotificationCenterProvider {
     var notificationCenterWrapper: SentryNSNotificationCenterWrapper { get }

--- a/Sources/Swift/Integrations/Performance/SentryDisplayLinkWrapper.swift
+++ b/Sources/Swift/Integrations/Performance/SentryDisplayLinkWrapper.swift
@@ -1,4 +1,4 @@
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 
 import UIKit
 

--- a/Sources/Swift/Integrations/Performance/SentryUIViewControllerPerformanceTracker.swift
+++ b/Sources/Swift/Integrations/Performance/SentryUIViewControllerPerformanceTracker.swift
@@ -1,4 +1,4 @@
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 
 @_implementationOnly import _SentryPrivate
 import UIKit

--- a/Sources/Swift/Integrations/Session/SessionTracker.swift
+++ b/Sources/Swift/Integrations/Session/SessionTracker.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 typealias Application = UIApplication
 #elseif (os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT
@@ -50,7 +50,7 @@ final class SessionTracker {
         // WillTerminate is called no matter if started from the background or launched into the
         // foreground.
 
-    #if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || ((os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT)
+    #if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || ((os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT)
         
         // Call before subscribing to the notifications to avoid that didBecomeActive gets called before
         // ending the cached session.
@@ -84,7 +84,7 @@ final class SessionTracker {
     }
     
     func removeObservers() {
-#if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || ((os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT)
+#if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || ((os(macOS) || targetEnvironment(macCatalyst)) && !SENTRY_NO_UIKIT)
         // Remove the observers with the most specific detail possible, see
         // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
         notificationCenter.removeObserver(self, name: Application.didBecomeActiveNotification, object: nil)
@@ -173,7 +173,7 @@ final class SessionTracker {
             self.lastInForeground = nil
         }
 
-    #if !(os(watchOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+    #if !(os(watchOS) || os(tvOS) || os(visionOS))
         if SentryDependencyContainerSwiftHelper.hasProfilingOptions() {
             sentry_reevaluateSessionSampleRate()
         }

--- a/Sources/Swift/SentryCrash/SentryCrashWrapper.swift
+++ b/Sources/Swift/SentryCrash/SentryCrashWrapper.swift
@@ -2,9 +2,9 @@
 import Darwin
 import Foundation
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
-#endif // (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 
 /**
  * A wrapper around SentryCrash for testability.
@@ -228,7 +228,7 @@ public final class SentryCrashWrapper: NSObject {
         return "tvOS"
 #elseif os(watchOS)
         return "watchOS"
-#elseif (swift(>=5.9) && os(visionOS))
+#elseif os(visionOS)
         return "visionOS"
 #endif
     }
@@ -236,12 +236,12 @@ public final class SentryCrashWrapper: NSObject {
     private func getOSVersion() -> String {
         // For MacCatalyst the UIDevice returns the current version of MacCatalyst and not the
         // macOSVersion. Therefore we have to use NSProcessInfo.
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT && !targetEnvironment(macCatalyst)
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT && !targetEnvironment(macCatalyst)
         return Dependencies.uiDeviceWrapper.getSystemVersion()
 #else
         let version = ProcessInfo.processInfo.operatingSystemVersion
         return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
-#endif // (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT && !targetEnvironment(macCatalyst)
+#endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT && !targetEnvironment(macCatalyst)
     }
     
     private func isSimulator() -> Bool {

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -1,12 +1,12 @@
 @_implementationOnly import _SentryPrivate
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 import UIKit
 #endif
 
 // Declare the application provider block at the top level to prevent capturing 'self'
 // from the dependency container, which would create cyclic dependencies and memory leaks.
 let defaultApplicationProvider: () -> SentryApplication? = {
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
     return UIApplication.shared
 #elseif os(macOS)
     return NSApplication.shared
@@ -22,7 +22,7 @@ let SENTRY_AUTO_TRANSACTION_MAX_DURATION = 500.0
 extension SentryFileManager: SentryFileManagerProtocol { }
 @_spi(Private) extension SentryANRTrackerV1: SentryANRTrackerInternalProtocol { }
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 @_spi(Private) extension SentryANRTrackerV2: SentryANRTrackerInternalProtocol { }
 
 @_spi(Private) extension SentryDelayedFramesTracker: SentryDelayedFramesTrackerWrapper {
@@ -78,7 +78,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
     @objc public static func reset() {
         instanceLock.synchronized {
             instance.reachability.removeAllObservers()
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
             instance._framesTracker?.stop()
 #endif
             instance = SentryDependencyContainer()
@@ -130,7 +130,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
     @objc public var extraContextProvider = SentryExtraContextProvider(crashWrapper: Dependencies.crashWrapper, processInfoWrapper: Dependencies.processInfoWrapper)
 #endif
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
     @objc public var uiDeviceWrapper: SentryUIDeviceWrapper = Dependencies.uiDeviceWrapper
     @objc public var threadsafeApplication = SentryThreadsafeApplication(applicationProvider: defaultApplicationProvider, notificationCenter: Dependencies.notificationCenterWrapper)
     @objc public var swizzleWrapper = SentrySwizzleWrapper()
@@ -227,7 +227,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
     private var anrTracker: SentryANRTracker?
     @objc public func getANRTracker(_ timeout: TimeInterval) -> SentryANRTracker {
         getLazyVar(\.anrTracker) {
-        #if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+        #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
             SentryANRTracker(helper: SentryANRTrackerV2(timeoutInterval: timeout))
         #else
             SentryANRTracker(helper: SentryANRTrackerV1(timeoutInterval: timeout))
@@ -242,7 +242,7 @@ extension SentryDependencyContainer: ScreenshotSourceProvider { }
 
 extension SentryDependencyContainer: AutoSessionTrackingProvider { }
 
-#if ((os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT) || os(macOS)
+#if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || os(macOS)
 extension SentryDependencyContainer: NotificationCenterProvider { }
 #endif
 

--- a/Sources/Swift/Tools/SentryViewHierarchyProvider.swift
+++ b/Sources/Swift/Tools/SentryViewHierarchyProvider.swift
@@ -1,4 +1,4 @@
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT
 
 @_implementationOnly import _SentryPrivate
 import UIKit

--- a/Tests/SentryTests/Networking/TestSentryReachability.swift
+++ b/Tests/SentryTests/Networking/TestSentryReachability.swift
@@ -1,4 +1,4 @@
-#if !os(watchOS) && !((swift(>=5.9) && os(visionOS)) && !canImport(UIKit))
+#if !os(watchOS) && !(os(visionOS) && !canImport(UIKit))
 
 @_spi(Private) @testable import Sentry
 import SentryTestUtils
@@ -30,4 +30,4 @@ import SentryTestUtils
     }
 }
 
-#endif // !os(watchOS) && !((swift(>=5.9) && os(visionOS)) && !canImport(UIKit))
+#endif // !os(watchOS) && !(os(visionOS) && !canImport(UIKit))

--- a/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
@@ -31,7 +31,7 @@ final class SentryCrashWrapperTests: XCTestCase {
         ])
         scope = Scope()
         
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !targetEnvironment(macCatalyst)
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !targetEnvironment(macCatalyst)
         // Ensure DeviceWrapper info is initialized
         // This is done at SentrySDKInteral, but during tests that might not be the case
         Dependencies.uiDeviceWrapper.start()

--- a/Tests/SentryTests/Swift/Profiling/SentryScreenFramesTests.swift
+++ b/Tests/SentryTests/Swift/Profiling/SentryScreenFramesTests.swift
@@ -1,7 +1,7 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
-#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS)))
+#if (os(iOS) || os(tvOS) || os(visionOS))
 
 class SentryScreenFramesTests: XCTestCase {
     
@@ -378,4 +378,4 @@ class SentryScreenFramesTests: XCTestCase {
     #endif // os(iOS)
 }
 
-#endif // (os(iOS) || os(tvOS) || os(swift(>=5.9) && os(visionOS)))
+#endif // (os(iOS) || os(tvOS) || os(visionOS))


### PR DESCRIPTION
## :scroll: Description

Remove Swift 5.9 checks since we are building with Xcode 16 now.

## :bulb: Motivation and Context

The motivation is removing unnecessary code in our codebase.

## :green_heart: How did you test it?

Make sure the library builds on Xcode locally

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7099