### PR TITLE
fix: New API for feedback

### DIFF
--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -255,6 +255,7 @@ import Foundation
     }
     
     #if os(iOS) && !SENTRY_NO_UIKIT
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     @objc public static let feedback = {
       return SentryFeedbackAPI()
     }()

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
@@ -18,8 +18,10 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * Configuration settings specific to the managed widget that displays the UI form.
      * - note: Default: `nil` to use the default widget settings.
      */
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     public var configureWidget: ((SentryUserFeedbackWidgetConfiguration) -> Void)?
     
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     lazy var widgetConfig = SentryUserFeedbackWidgetConfiguration()
     
     /**
@@ -27,6 +29,7 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * - note: Default: `false`
      * - note: Setting this to true does not disable the widget. In order to do so, you must set `SentryUserFeedbackWidgetConfiguration.autoInject` to `false` using the `SentryUserFeedbackConfiguration.configureWidget` config builder.
      */
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     public var useShakeGesture: Bool = false
     
     /**
@@ -34,6 +37,7 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * - note: Default: `false`
      * - note: Setting this to true does not disable the widget. In order to do so, you must set `SentryUserFeedbackWidgetConfiguration.autoInject` to `false` using the `SentryUserFeedbackConfiguration.configureWidget` config builder.
      */
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     public var showFormForScreenshots: Bool = false
 
     /**
@@ -41,6 +45,7 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * - note: If this is set, `configureWidget` is ignored.
      * - note: Default: `nil`
      */
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     public var customButton: UIButton?
 
     /**
@@ -62,6 +67,7 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * Called when the managed feedback form is opened.
      * - note: Default: `nil`
      */
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     public var onFormOpen: (() -> Void)?
     
     /**

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
@@ -9,6 +9,7 @@ public final class SentryFeedbackAPI: NSObject {
     /// - warning: This is an experimental feature and may still have bugs.
     /// - seealso: See `SentryOptions.configureUserFeedback` to configure the widget.
     @available(iOSApplicationExtension, unavailable)
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     @objc public func showWidget() {
         getIntegration()?.driver.showWidget()
     }
@@ -17,10 +18,12 @@ public final class SentryFeedbackAPI: NSObject {
     /// - warning: This is an experimental feature and may still have bugs.
     /// - seealso: See `SentryOptions.configureUserFeedback` to configure the widget.
     @available(iOSApplicationExtension, unavailable)
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     @objc public func hideWidget() {
         getIntegration()?.driver.hideWidget()
     }
     
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     private func getIntegration() -> UserFeedbackIntegration<SentryDependencyContainer>? {
         SentrySDKInternal.currentHub().getInstalledIntegration(UserFeedbackIntegration<SentryDependencyContainer>.self) as? UserFeedbackIntegration<SentryDependencyContainer>
     }

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -8,16 +8,20 @@ protocol SentryUserFeedbackFormDelegate: NSObjectProtocol {
     func finished(with feedback: SentryFeedback?)
 }
 
-final class SentryUserFeedbackFormController: UIViewController {
+public final class SentryUserFeedbackFormController: UIViewController {
     let config: SentryUserFeedbackConfiguration
     weak var delegate: SentryUserFeedbackFormDelegate?
     let screenshot: UIImage?
     lazy var viewModel = SentryUserFeedbackFormViewModel(config: config, controller: self, screenshot: screenshot)
     
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         config.theme.updateDefaultFonts()
         config.recalculateScaleFactors()
         viewModel.updateLayout()
+    }
+    
+    public convenience init(config: SentryUserFeedbackConfiguration, screenshot: UIImage?) {
+        self.init(config: config, delegate: nil, screenshot: screenshot)
     }
     
     init(config: SentryUserFeedbackConfiguration, delegate: SentryUserFeedbackFormDelegate?, screenshot: UIImage?) {
@@ -104,19 +108,19 @@ extension SentryUserFeedbackFormController: SentryUserFeedbackFormViewModelDeleg
 
 // MARK: UITextFieldDelegate
 extension SentryUserFeedbackFormController: UITextFieldDelegate {
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
     }
     
-    func textFieldDidChangeSelection(_ textField: UITextField) {
+    public func textFieldDidChangeSelection(_ textField: UITextField) {
         viewModel.updateSubmitButtonAccessibilityHint()
     }
 }
 
 // MARK: UITextViewDelegate
 extension SentryUserFeedbackFormController: UITextViewDelegate {
-    func textViewDidChange(_ textView: UITextView) {
+    public func textViewDidChange(_ textView: UITextView) {
         viewModel.messageTextViewPlaceholder.isHidden = textView.text != ""
         viewModel.updateSubmitButtonAccessibilityHint()
     }

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -8,6 +8,7 @@ import UIKit
  * - note: The default method to show the feedback form is via a floating widget placed in the bottom trailing corner of the screen. See the configuration classes for alternative options.
  */
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 final class SentryUserFeedbackIntegrationDriver: NSObject {
     let configuration: SentryUserFeedbackConfiguration
     private var widget: SentryUserFeedbackWidget?
@@ -79,6 +80,7 @@ final class SentryUserFeedbackIntegrationDriver: NSObject {
 
 // MARK: SentryUserFeedbackFormDelegate
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
     func finished(with feedback: SentryFeedback?) {
         if let feedback = feedback {
@@ -94,6 +96,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
 
 // MARK: SentryUserFeedbackWidgetDelegate
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate {
     func showForm() {
         showForm(screenshot: nil)
@@ -102,6 +105,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate 
 
 // MARK: UIAdaptivePresentationControllerDelegate
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
@@ -112,6 +116,7 @@ extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerD
 
 // MARK: Private
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 private extension SentryUserFeedbackIntegrationDriver {
     func showForm(screenshot: UIImage?) {
         let form = SentryUserFeedbackFormController(config: configuration, delegate: self, screenshot: screenshot)

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
@@ -11,6 +11,7 @@ protocol SentryUserFeedbackWidgetDelegate: NSObjectProtocol {
 }
 
 @available(iOSApplicationExtension, unavailable)
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 final class SentryUserFeedbackWidget {
     private lazy var button = {
         let button = SentryUserFeedbackWidgetButtonView(config: config, target: self, selector: #selector(showForm))

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonView.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonView.swift
@@ -3,6 +3,7 @@ import Foundation
 @_implementationOnly import _SentryPrivate
 import UIKit
 
+@available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
 final class SentryUserFeedbackWidgetButtonView: UIView {
     // MARK: Measurements
     let svgSize: CGFloat = 16

--- a/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
@@ -8,8 +8,10 @@ protocol ScreenshotSourceProvider {
 
 final class UserFeedbackIntegration<Dependencies: ScreenshotSourceProvider>: NSObject, SwiftIntegration {
 
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     let driver: SentryUserFeedbackIntegrationDriver
 
+    @available(*, deprecated, message: "Create an instance of SentryUserFeedbackFormController directly.")
     init?(with options: Options, dependencies: Dependencies) {
         guard let configuration = options.userFeedbackConfiguration else {
             return nil

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -38777,9 +38777,11 @@
             "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI(im)showWidget",
             "mangledName": "$s6Sentry0A11FeedbackAPIC10showWidgetyyF",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "Final",
               "ObjC",
+              "Available",
               "Available"
             ],
             "funcSelfKind": "NonMutating"
@@ -38799,9 +38801,11 @@
             "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI(im)hideWidget",
             "mangledName": "$s6Sentry0A11FeedbackAPIC10hideWidgetyyF",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "Final",
               "ObjC",
+              "Available",
               "Available"
             ],
             "funcSelfKind": "NonMutating"
@@ -41040,9 +41044,11 @@
             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(py)configureWidget",
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC15configureWidgetyAA0abcfD0CcSgvp",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "HasInitialValue",
               "Final",
+              "Available",
               "ObjC",
               "HasStorage"
             ],
@@ -41171,8 +41177,10 @@
             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(py)useShakeGesture",
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC15useShakeGestureSbvp",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "Final",
+              "Available",
               "ObjC",
               "HasStorage"
             ],
@@ -41247,8 +41255,10 @@
             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(py)showFormForScreenshots",
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC22showFormForScreenshotsSbvp",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "Final",
+              "Available",
               "ObjC",
               "HasStorage"
             ],
@@ -41331,9 +41341,11 @@
             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(py)customButton",
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC12customButtonSo8UIButtonCSgvp",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "HasInitialValue",
               "Final",
+              "Available",
               "ObjC",
               "HasStorage"
             ],
@@ -41748,9 +41760,11 @@
             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(py)onFormOpen",
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC10onFormOpenyycSgvp",
             "moduleName": "Sentry",
+            "deprecated": true,
             "declAttributes": [
               "HasInitialValue",
               "Final",
+              "Available",
               "ObjC",
               "HasStorage"
             ],
@@ -44438,9 +44452,11 @@
             "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvpZ",
             "moduleName": "Sentry",
             "static": true,
+            "deprecated": true,
             "declAttributes": [
               "Final",
               "ObjC",
+              "Available",
               "HasStorage"
             ],
             "isLet": true,
@@ -47406,6 +47422,362 @@
             "printedName": "CustomDebugStringConvertible",
             "usr": "s:s28CustomDebugStringConvertibleP",
             "mangledName": "$ss28CustomDebugStringConvertibleP"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SentryUserFeedbackFormController",
+        "printedName": "SentryUserFeedbackFormController",
+        "children": [
+          {
+            "kind": "Function",
+            "name": "traitCollectionDidChange",
+            "printedName": "traitCollectionDidChange(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "UIKit.UITraitCollection?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UITraitCollection",
+                    "printedName": "UIKit.UITraitCollection",
+                    "usr": "c:objc(cs)UITraitCollection"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormController(im)traitCollectionDidChange:",
+            "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC24traitCollectionDidChangeyySo07UITraitG0CSgF",
+            "moduleName": "Sentry",
+            "overriding": true,
+            "objc_name": "traitCollectionDidChange:",
+            "declAttributes": [
+              "ObjC",
+              "Final",
+              "Preconcurrency",
+              "Override",
+              "Custom"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(config:screenshot:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryUserFeedbackFormController",
+                "printedName": "Sentry.SentryUserFeedbackFormController",
+                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormController"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "UIKit.UIImage?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "UIImage",
+                    "printedName": "UIKit.UIImage",
+                    "usr": "c:objc(cs)UIImage"
+                  }
+                ],
+                "usr": "s:Sq"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:6Sentry0A26UserFeedbackFormControllerC6config10screenshotAcA0abC13ConfigurationC_So7UIImageCSgtcfc",
+            "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC6config10screenshotAcA0abC13ConfigurationC_So7UIImageCSgtcfc",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "Preconcurrency",
+              "Custom"
+            ],
+            "init_kind": "Convenience"
+          },
+          {
+            "kind": "Function",
+            "name": "textFieldShouldReturn",
+            "printedName": "textFieldShouldReturn(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "UITextField",
+                "printedName": "UIKit.UITextField",
+                "usr": "c:objc(cs)UITextField"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@CM@Sentry@objc(cs)SentryUserFeedbackFormController(im)textFieldShouldReturn:",
+            "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC21textFieldShouldReturnySbSo06UITextG0CF",
+            "moduleName": "Sentry",
+            "objc_name": "textFieldShouldReturn:",
+            "declAttributes": [
+              "ObjC",
+              "Final",
+              "Preconcurrency",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "textFieldDidChangeSelection",
+            "printedName": "textFieldDidChangeSelection(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "UITextField",
+                "printedName": "UIKit.UITextField",
+                "usr": "c:objc(cs)UITextField"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@CM@Sentry@objc(cs)SentryUserFeedbackFormController(im)textFieldDidChangeSelection:",
+            "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC27textFieldDidChangeSelectionyySo06UITextG0CF",
+            "moduleName": "Sentry",
+            "objc_name": "textFieldDidChangeSelection:",
+            "declAttributes": [
+              "ObjC",
+              "Final",
+              "Preconcurrency",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
+            "name": "textViewDidChange",
+            "printedName": "textViewDidChange(_:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Void",
+                "printedName": "()"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "UITextView",
+                "printedName": "UIKit.UITextView",
+                "usr": "c:objc(cs)UITextView"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:@CM@Sentry@objc(cs)SentryUserFeedbackFormController(im)textViewDidChange:",
+            "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC17textViewDidChangeyySo06UITextG0CF",
+            "moduleName": "Sentry",
+            "objc_name": "textViewDidChange:",
+            "declAttributes": [
+              "ObjC",
+              "Final",
+              "Preconcurrency",
+              "Custom"
+            ],
+            "isFromExtension": true,
+            "funcSelfKind": "NonMutating"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormController",
+        "mangledName": "$s6Sentry0A26UserFeedbackFormControllerC",
+        "moduleName": "Sentry",
+        "declAttributes": [
+          "Final",
+          "Preconcurrency",
+          "ObjC",
+          "Custom"
+        ],
+        "superclassUsr": "c:objc(cs)UIViewController",
+        "hasMissingDesignatedInitializers": true,
+        "inheritsConvenienceInitializers": true,
+        "superclassNames": [
+          "UIKit.UIViewController",
+          "UIKit.UIResponder",
+          "ObjectiveC.NSObject"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "NSCoding",
+            "printedName": "NSCoding",
+            "usr": "c:objc(pl)NSCoding"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIAppearanceContainer",
+            "printedName": "UIAppearanceContainer",
+            "usr": "c:objc(pl)UIAppearanceContainer"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UITraitEnvironment",
+            "printedName": "UITraitEnvironment",
+            "usr": "c:objc(pl)UITraitEnvironment"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIContentContainer",
+            "printedName": "UIContentContainer",
+            "usr": "c:objc(pl)UIContentContainer"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIFocusEnvironment",
+            "printedName": "UIFocusEnvironment",
+            "usr": "c:objc(pl)UIFocusEnvironment"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIResponderStandardEditActions",
+            "printedName": "UIResponderStandardEditActions",
+            "usr": "c:objc(pl)UIResponderStandardEditActions"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "NSObjectProtocol",
+            "printedName": "NSObjectProtocol",
+            "usr": "c:objc(pl)NSObject"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIActivityItemsConfigurationProviding",
+            "printedName": "UIActivityItemsConfigurationProviding",
+            "usr": "c:objc(pl)UIActivityItemsConfigurationProviding"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIPasteConfigurationSupporting",
+            "printedName": "UIPasteConfigurationSupporting",
+            "usr": "c:objc(pl)UIPasteConfigurationSupporting"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIUserActivityRestoring",
+            "printedName": "UIUserActivityRestoring",
+            "usr": "c:objc(pl)UIUserActivityRestoring"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UITraitChangeObservable",
+            "printedName": "UITraitChangeObservable",
+            "usr": "s:5UIKit23UITraitChangeObservableP",
+            "mangledName": "$s5UIKit23UITraitChangeObservableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "NSExtensionRequestHandling",
+            "printedName": "NSExtensionRequestHandling",
+            "usr": "c:objc(pl)NSExtensionRequestHandling"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIStateRestoring",
+            "printedName": "UIStateRestoring",
+            "usr": "c:objc(pl)UIStateRestoring"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UITextFieldDelegate",
+            "printedName": "UITextFieldDelegate",
+            "usr": "c:objc(pl)UITextFieldDelegate"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UITextViewDelegate",
+            "printedName": "UITextViewDelegate",
+            "usr": "c:objc(pl)UITextViewDelegate"
+          },
+          {
+            "kind": "Conformance",
+            "name": "UIScrollViewDelegate",
+            "printedName": "UIScrollViewDelegate",
+            "usr": "c:objc(pl)UIScrollViewDelegate"
           }
         ]
       },


### PR DESCRIPTION
This is just an example of what is being proposed in https://github.com/getsentry/sentry-cocoa/issues/7110 I'm not planning to merge it. The tests would probably need some work and the various callbacks like `onFormClose` would need to be updated to work with the new API.

#skip-changelog (chagelog should be updated before merging)