### PR TITLE
fix: Mark dark theme deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Rename log attribute `sentry.trace.parent_span_id` to `span_id` (#7055)
 - Fixes stacktraces for MetricKit events (#6908)
 - Fix `raw_description` in `runtime` context on Mac Catalyst (#7082)
+- Deprecates `configureDarkTheme` for user feedback (#7114)
 
 ## 9.1.0
 

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
@@ -88,8 +88,6 @@ public final class SentryUserFeedbackConfiguration: NSObject {
     
     /**
      * Builder for default/light theme overrides.
-     * - note: On iOS versions predating dark mode (≤12) this is the only theme override used. Apps
-     * running on later versions that include dark mode should also consider `configureDarkTheme`.
      * - note: Default: `nil`
      */
     public var configureTheme: ((SentryUserFeedbackThemeConfiguration) -> Void)?
@@ -101,9 +99,19 @@ public final class SentryUserFeedbackConfiguration: NSObject {
      * mode, but you still want to override some theme settings, assign the same builder to this
      * property as you do for `configureTheme`.
      * - note: Default: `nil`
-     * - note: Only applies to iOS ≤12.
      */
-    public var configureDarkTheme: ((SentryUserFeedbackThemeConfiguration) -> Void)?
+    public var configureDarkTheme: ((SentryUserFeedbackThemeConfiguration) -> Void)? {
+        // Only the setter is deprecated to avoid warnings when compiling the SDK. The getter is
+        // used from SentrySDK.init
+        @available(*, deprecated, message: "Use dynamic UIColor instead of the dark theme.")
+        set {
+            _configureDarkTheme = newValue
+        }
+        get {
+            _configureDarkTheme
+        }
+    }
+    var _configureDarkTheme: ((SentryUserFeedbackThemeConfiguration) -> Void)?
     
     lazy var darkTheme = SentryUserFeedbackThemeConfiguration()
     

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -42573,12 +42573,9 @@
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC18configureDarkThemeyAA0abcgD0CcSgvp",
             "moduleName": "Sentry",
             "declAttributes": [
-              "HasInitialValue",
               "Final",
-              "ObjC",
-              "HasStorage"
+              "ObjC"
             ],
-            "hasStorage": true,
             "accessors": [
               {
                 "kind": "Accessor",
@@ -42623,7 +42620,6 @@
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(im)configureDarkTheme",
                 "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC18configureDarkThemeyAA0abcgD0CcSgvg",
                 "moduleName": "Sentry",
-                "implicit": true,
                 "declAttributes": [
                   "Final",
                   "ObjC"
@@ -42678,9 +42674,11 @@
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration(im)setConfigureDarkTheme:",
                 "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC18configureDarkThemeyAA0abcgD0CcSgvs",
                 "moduleName": "Sentry",
-                "implicit": true,
+                "deprecated": true,
+                "objc_name": "setConfigureDarkTheme:",
                 "declAttributes": [
                   "Final",
+                  "Available",
                   "ObjC"
                 ],
                 "accessorKind": "set"


### PR DESCRIPTION
Mark dark theme deprecated because UIColor's built in dark mode support ([dynamic provider](https://developer.apple.com/documentation/uikit/uicolor/init(dynamicprovider:))) should be used instead

Resolves https://github.com/getsentry/sentry-cocoa/issues/7112