### PR TITLE
chore: Allow alpha releases on RNSentry.podspec for Cross Platform Test

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -86,7 +86,7 @@ jobs:
         run: yarn install
 
       - name: Remove fixed version of Sentry Dependency from RNSentry.podspec
-        run: sed -E -i '' "s/s.dependency 'Sentry', '9.1.1(-[a-z]+\.[0-9]+)?'/s.dependency 'Sentry'/" sentry-react-native/packages/core/RNSentry.podspec
+        run: sed -E -i '' "s/s.dependency 'Sentry', '[0-9]*\.[0-9]*\.[0-9]*(-[a-z]+\.[0-9]+)?'/s.dependency 'Sentry'/" sentry-react-native/packages/core/RNSentry.podspec
 
       - name: Add Sentry Dependency with path to Sentry Cocoa SDK to RNSentryCocoaTester/Podfile
         run: sed -i '' -e "s/RNSentry.podspec'/RNSentry.podspec'\\n  pod 'Sentry', :path => '..\/..\/..\/..\/sentry-cocoa'/" sentry-react-native/packages/core/RNSentryCocoaTester/Podfile


### PR DESCRIPTION
## :scroll: Description

Fixes RN cross platform test when RNSentry.podspec uses alpha releases

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7131