### PR TITLE
chore: Remove cache on release job to avoid conflicts between different build types

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -113,24 +113,6 @@ jobs:
             echo "XCFRAMEWORK_NAME=$SCHEME$SUFFIX" >> $GITHUB_ENV
           fi
 
-      - name: Compute cache key
-        env:
-          SDKS: ${{ inputs.sdks }}
-          VARIANT_ID: ${{ inputs.variant-id }}
-          SIGNED: ${{ inputs.signed }}
-          VERSION: ${{ env.VERSION }}
-        run: |
-          sdks_string="$SDKS"
-          sdks_string_slugified="${sdks_string//,/_}"
-          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${{runner.os}}-xcframework-$VARIANT_ID-$sdks_string_slugified-$SIGNED-$VERSION-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
-
-      - name: Restore XCFramework cache
-        id: cache-xcframework
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{env.XCFRAMEWORK_NAME}}.xcframework.zip
-
       - name: Download ${{inputs.variant-id}} Slices
         if: steps.cache-xcframework.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v5
@@ -193,12 +175,6 @@ jobs:
             ./scripts/compress-xcframework.sh --not-signed "${{env.XCFRAMEWORK_NAME}}"
           fi
         shell: bash
-
-      - name: Cache XCFramework
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{env.XCFRAMEWORK_NAME}}.xcframework.zip
 
       - name: Upload XCFramework
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## :scroll: Description

Some jobs seem to be using the same cache key thus causing issues: https://github.com/getsentry/sentry-cocoa/actions/runs/20848932689/job/59899886232
We already removed this on main, removing this on `v8.x`, just in case we run into this again

## :bulb: Motivation and Context

Make releases easier

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog