### PR TITLE
chore: Update CHANGELOG to include fix for incorrect variable assignment of 'sampled' key (#7120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixes stacktraces for MetricKit events (#6908)
 - Fix `raw_description` in `runtime` context on Mac Catalyst (#7082)
 - Deprecates `configureDarkTheme` for user feedback (#7114)
+- Fix incorrect variable assignment for 'sampled' key (#7120)
 
 ## 9.1.0
 


### PR DESCRIPTION
## :scroll: Description

Adds changelog entry for PR #7120 

This PR should not be included in the changelog #skip-changelog

## :bulb: Motivation and Context

I did not want to ask the user to add a changelog entry after already asking for some tests.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
