### PR TITLE
chore(dx): Move feature flags other section

### DIFF
--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -53,34 +53,34 @@ schemeTemplates:
         "--io.sentry.performance.disable-app-hang-tracking-v2": false
         "--io.sentry.performance.disable-time-to-full-display-tracing": false
         "--io.sentry.performance.disable-performance-v2": false
-        "--io.sentry.other.disable-attach-view-hierarchy": false
-        "--io.sentry.other.disable-attach-screenshot": false
         "--io.sentry.performance.disable-file-io-tracing": false
         "--io.sentry.performance.disable-automatic-session-tracking": false
-        "--io.sentry.other.disable-metrickit-integration": false
-        "--io.sentry.other.disable-metrickit-raw-payloads": false
         "--io.sentry.performance.disable-watchdog-tracking": false
         "--io.sentry.tracing.disable-tracing": false
-        "--io.sentry.other.disable-crash-handler": false
-        "--io.sentry.other.disable-swizzling": false
         "--io.sentry.performance.disable-core-data-tracing": false
         "--io.sentry.performance.disable-uiviewcontroller-tracing": false
-        "--io.sentry.other.disable-automatic-breadcrumbs": false
         "--io.sentry.performance.disable-anr-tracking": false
         "--io.sentry.performance.disable-auto-performance-tracing": false
         "--io.sentry.performance.disable-ui-tracing": false
-        "--io.sentry.other.disable-filemanager-swizzling": false
 
         # events
         "--io.sentry.events.reject-all": false
 
         # other
         "--io.sentry.other.base64-attachment-data": false
+        "--io.sentry.other.disable-attach-view-hierarchy": false
+        "--io.sentry.other.disable-attach-screenshot": false
+        "--io.sentry.other.disable-automatic-breadcrumbs": false
+        "--io.sentry.other.disable-crash-handler": false
+        "--io.sentry.other.disable-filemanager-swizzling": false
         "--io.sentry.other.disable-http-transport": false
+        "--io.sentry.other.disable-metrickit-integration": false
+        "--io.sentry.other.disable-metrickit-raw-payloads": false
         "--io.sentry.other.disable-spotlight": true
+        "--io.sentry.other.disable-swizzling": false
+        "--io.sentry.other.reject-all-spans": false
         "--io.sentry.other.reject-screenshots-in-before-capture-screenshot": false
         "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy": false
-        "--io.sentry.other.reject-all-spans": false
 
       environmentVariables:
         # events


### PR DESCRIPTION
## :scroll: Description

Moved all `--io.sentry.other.*` flags from the `performance` section to the `other` section within `feature-flags.yml`.

## :bulb: Motivation and Context

This change addresses issue #5630 by correctly categorizing flags that are not performance-related into the `other` section, improving the clarity and organization of `feature-flags.yml`.

## :green_heart: How did you test it?

Verified by reading `feature-flags.yml` to ensure the flags were removed from the `performance` section and correctly added (and alphabetically sorted) within the `other` section.

#skip-changelog