### PR TITLE
fix(tests): Remove fatal error logging in SentryFileManager

### DIFF
--- a/Sources/Sentry/SentryFileManagerHelper.m
+++ b/Sources/Sentry/SentryFileManagerHelper.m
@@ -120,12 +120,18 @@ _non_thread_safe_removeFileAtPath(NSString *path)
         [self removeFileAtPath:self.eventsPath];
 
         if (!createDirectoryIfNotExists(self.sentryPath, error)) {
+// Disabled fatal error logging in tests to reduce noise in test logs
+#if !SENTRY_TEST && !SENTRY_TEST_CI
             SENTRY_LOG_FATAL(@"Failed to create Sentry SDK working directory: %@", self.sentryPath);
+#endif
             return nil;
         }
         if (!createDirectoryIfNotExists(self.envelopesPath, error)) {
+// Disabled fatal error logging in tests to reduce noise in test logs
+#if !SENTRY_TEST && !SENTRY_TEST_CI
             SENTRY_LOG_FATAL(
                 @"Failed to create Sentry SDK envelopes directory: %@", self.envelopesPath);
+#endif
             return nil;
         }
 


### PR DESCRIPTION
## :scroll: Description

This change prevents fatal error logs from cluttering test outputs when the Sentry SDK working directory or envelopes directory cannot be created during tests. The logging is conditionally compiled to exclude test environments.

**Matches of `Failed to create Sentry SDK working directory`:**

- Before: 5636 matches
- After: 0 matches 

## :bulb: Motivation and Context

Closes #5317 

## :green_heart: How did you test it?

The created Xcode Results bundle contains the test logs, where I counted the occurences of the spam text.

#skip-changelog