### PR TITLE
chore: Allow whitespaces on Xcode path when executing `make init`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ init-local:
 	rbenv exec gem update bundler
 	rbenv exec bundle install
 	# Install the tools needed to update tooling versions locally
-	$(MAKE) init-ci-format
+	"$(MAKE)" init-ci-format
 	./scripts/update-tooling-versions.sh
 
 ## Install CI build dependencies
@@ -612,7 +612,7 @@ endef
 .PHONY: help
 help:
 	@if [ -n "$(name)" ]; then \
-		$(MAKE) --no-print-directory help-target name="$(name)"; \
+		"$(MAKE)" --no-print-directory help-target name="$(name)"; \
 	else \
 		echo "=============================================="; \
 		echo "🚀 SENTRY COCOA SDK DEVELOPMENT COMMANDS"; \


### PR DESCRIPTION
## :scroll: Description

Adds `""` to allow whitespaces in the path

## :bulb: Motivation and Context

Executing `make init` fails if there are whitespaces:
```
# Install the tools needed to update tooling versions locally
/Applications/Xcode 16.app/Contents/Developer/usr/bin/make init-ci-format
make: /Applications/Xcode: No such file or directory
make: *** [init-local] Error 1
```

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7194