### PR TITLE
ci: update TestFlight builds to use Xcode 26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
     # Don't run this on release branches, cause the SPM Package.swift points to the unreleased versions.
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       # As the DistributionSample project uses local SPM, xcodebuild resolves SPM dependencies for all
@@ -61,7 +61,7 @@ jobs:
       - name: Only keep distribution lib and target in Package.swift
         run: ./scripts/prepare-package.sh --remove-binary-targets true
 
-      - run: ./scripts/ci-select-xcode.sh 16.4
+      - run: ./scripts/ci-select-xcode.sh 26.2
       - name: Setup Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -51,10 +51,10 @@ jobs:
     if: (github.event_name != 'pull_request' && needs.files-changed.outputs.run_testflight_for_pushes == 'true' ) || ( github.event_name == 'pull_request' && needs.files-changed.outputs.run_testflight_for_prs == 'true' && needs.files-changed.outputs.is_contributor == 'true' )
     needs: files-changed
     name: Build and Upload iOS-Swift to Testflight
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - run: ./scripts/ci-select-xcode.sh 16.4
+      - run: ./scripts/ci-select-xcode.sh 26.2
       - name: Setup Ruby
         uses: ruby/setup-ruby@675dd7ba1b06c8786a1480d89c384f5620a42647 # v1.281.0
         with:
@@ -115,11 +115,12 @@ jobs:
   # to make testflight a required check with only running the upload_to_testflight when required.
   # So, we don't have to run upload_to_testflight, for example, for unrelated changes.
   testflight-required-check:
-    needs: [
-      files-changed,
-      upload_to_testflight,
-      skip-testflight-for-non-contributors,
-    ]
+    needs:
+      [
+        files-changed,
+        upload_to_testflight,
+        skip-testflight-for-non-contributors,
+      ]
     name: Testflight
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()


### PR DESCRIPTION
## Summary

Updates workflows to use Xcode 26.2 (iOS 26 SDK) instead of Xcode 16.4 (iOS 18.5 SDK) to resolve Apple's ITMS-90725 warning requiring apps to be built with iOS 26 SDK or later by April 2026.

## Changes

- Updated `.github/workflows/testflight.yml` to use Xcode 26.2 and macos-26 runner
- Updated `.github/workflows/build.yml` (ios-swift-release job) to use Xcode 26.2 and macos-26 runner

## Testing

The next TestFlight build will use iOS 26 SDK, which should resolve the Apple warning.

#skip-changelog