### PR TITLE
docs: Add options to ignore views from subtree traversal to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- Encode SwiftUI internal class names in session replay redaction to avoid false-positive App Store review rejections (#7123)
 - The transport now correctly discard envelopes on 4xx and 5xx responses and records client reports `send_error` (#6618) This also fixes edge cases in which the SDK kept retrying sending a faulty envelope until the offline cache overflowed.
 - Change default attributes of Logs to only include user attributes when `options.sendDefaultPii = true` (#7055)
 - Rename log attribute `sentry.trace.parent_span_id` to `span_id` (#7055)


### PR DESCRIPTION
Adds missing changelog after merging v8.x into main

#skip-changelog

Closes #7201