### PR TITLE
ref: rename MetricsBatcher to MetricsBuffer

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -768,12 +768,12 @@
 		D46B041D2EDF168400AF4A0A /* SentryMetricsIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B041C2EDF167D00AF4A0A /* SentryMetricsIntegration.swift */; };
 		D46B04202EDF175C00AF4A0A /* SentryMetricsIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B041F2EDF175600AF4A0A /* SentryMetricsIntegrationTests.swift */; };
 		D46B04482EDF25E100AF4A0A /* SentryMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B04472EDF25E100AF4A0A /* SentryMetric.swift */; };
-		D46B044F2EDF260A00AF4A0A /* SentryMetricsBatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B044E2EDF260A00AF4A0A /* SentryMetricsBatcher.swift */; };
+		D46B044F2EDF260A00AF4A0A /* SentryMetricsBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B044E2EDF260A00AF4A0A /* SentryMetricsBuffer.swift */; };
 		D46B05042EDF374000AF4A0A /* SentryMetricsApiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B05032EDF374000AF4A0A /* SentryMetricsApiTests.swift */; };
 		D46B050B2EDF375300AF4A0A /* SentryMetricsApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B050A2EDF375300AF4A0A /* SentryMetricsApi.swift */; };
 		D473ACD72D8090FC000F1CC6 /* FileManager+SentryTracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D473ACD62D8090FC000F1CC6 /* FileManager+SentryTracing.swift */; };
 		D4749EF02EF042C1000F9AE7 /* SentryMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4749EEF2EF042C1000F9AE7 /* SentryMetricTests.swift */; };
-		D4749F482EF062FD000F9AE7 /* SentryMetricsBatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4749F472EF062FD000F9AE7 /* SentryMetricsBatcherTests.swift */; };
+		D4749F482EF062FD000F9AE7 /* SentryMetricsBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4749F472EF062FD000F9AE7 /* SentryMetricsBufferTests.swift */; };
 		D48039522F1942EC00FA1619 /* FlushableIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48039512F1942EC00FA1619 /* FlushableIntegration.swift */; };
 		D480F9D92DE47A50009A0594 /* TestSentryScopePersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D480F9D82DE47A48009A0594 /* TestSentryScopePersistentStore.swift */; };
 		D480F9DB2DE47AF2009A0594 /* SentryScopePersistentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D480F9DA2DE47AEB009A0594 /* SentryScopePersistentStoreTests.swift */; };
@@ -2160,14 +2160,14 @@
 		D46B041C2EDF167D00AF4A0A /* SentryMetricsIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsIntegration.swift; sourceTree = "<group>"; };
 		D46B041F2EDF175600AF4A0A /* SentryMetricsIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsIntegrationTests.swift; sourceTree = "<group>"; };
 		D46B04472EDF25E100AF4A0A /* SentryMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetric.swift; sourceTree = "<group>"; };
-		D46B044E2EDF260A00AF4A0A /* SentryMetricsBatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsBatcher.swift; sourceTree = "<group>"; };
+		D46B044E2EDF260A00AF4A0A /* SentryMetricsBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsBuffer.swift; sourceTree = "<group>"; };
 		D46B05032EDF374000AF4A0A /* SentryMetricsApiTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsApiTests.swift; sourceTree = "<group>"; };
 		D46B050A2EDF375300AF4A0A /* SentryMetricsApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsApi.swift; sourceTree = "<group>"; };
 		D46D45E12D5F3FD600A1CB35 /* Sentry_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sentry_Base.xctestplan; sourceTree = "<group>"; };
 		D46D45E92D5F411700A1CB35 /* SentrySwiftUI_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = SentrySwiftUI_Base.xctestplan; path = Plans/SentrySwiftUI_Base.xctestplan; sourceTree = SOURCE_ROOT; };
 		D473ACD62D8090FC000F1CC6 /* FileManager+SentryTracing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+SentryTracing.swift"; sourceTree = "<group>"; };
 		D4749EEF2EF042C1000F9AE7 /* SentryMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricTests.swift; sourceTree = "<group>"; };
-		D4749F472EF062FD000F9AE7 /* SentryMetricsBatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsBatcherTests.swift; sourceTree = "<group>"; };
+		D4749F472EF062FD000F9AE7 /* SentryMetricsBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsBufferTests.swift; sourceTree = "<group>"; };
 		D48039512F1942EC00FA1619 /* FlushableIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlushableIntegration.swift; sourceTree = "<group>"; };
 		D480F9D82DE47A48009A0594 /* TestSentryScopePersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryScopePersistentStore.swift; sourceTree = "<group>"; };
 		D480F9DA2DE47AEB009A0594 /* SentryScopePersistentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopePersistentStoreTests.swift; sourceTree = "<group>"; };
@@ -4450,7 +4450,7 @@
 			children = (
 				D46B050A2EDF375300AF4A0A /* SentryMetricsApi.swift */,
 				D489542E2EF5878C0086F240 /* SentryMetricsApiProtocol.swift */,
-				D46B044E2EDF260A00AF4A0A /* SentryMetricsBatcher.swift */,
+				D46B044E2EDF260A00AF4A0A /* SentryMetricsBuffer.swift */,
 				D46B041C2EDF167D00AF4A0A /* SentryMetricsIntegration.swift */,
 			);
 			path = Metrics;
@@ -4461,7 +4461,7 @@
 			children = (
 				D489542C2EF583EB0086F240 /* SentryMetricsApiE2ETests.swift */,
 				D46B05032EDF374000AF4A0A /* SentryMetricsApiTests.swift */,
-				D4749F472EF062FD000F9AE7 /* SentryMetricsBatcherTests.swift */,
+				D4749F472EF062FD000F9AE7 /* SentryMetricsBufferTests.swift */,
 				D46B041F2EDF175600AF4A0A /* SentryMetricsIntegrationTests.swift */,
 			);
 			path = Metrics;
@@ -5928,7 +5928,7 @@
 				D8ACE3C82762187200F5A213 /* SentryFileIOTrackerHelper.m in Sources */,
 				D8B088B729C9E3FF00213258 /* SentryTracerConfiguration.m in Sources */,
 				FA7206E12E0B37C80072FDD4 /* SentryProfileCollector.mm in Sources */,
-				D46B044F2EDF260A00AF4A0A /* SentryMetricsBatcher.swift in Sources */,
+				D46B044F2EDF260A00AF4A0A /* SentryMetricsBuffer.swift in Sources */,
 				9264E1EB2E2E385E00B077CF /* SentryLogMessage.swift in Sources */,
 				8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.m in Sources */,
 				D46B04482EDF25E100AF4A0A /* SentryMetric.swift in Sources */,
@@ -6524,7 +6524,7 @@
 				7B16FD022654F86B008177D3 /* SentrySysctlTests.swift in Sources */,
 				7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */,
 				D8F67AF12BE0D33F00C9197B /* UIImageHelperTests.swift in Sources */,
-				D4749F482EF062FD000F9AE7 /* SentryMetricsBatcherTests.swift in Sources */,
+				D4749F482EF062FD000F9AE7 /* SentryMetricsBufferTests.swift in Sources */,
 				8EAE8E5E2681768000D6958B /* URLSessionTaskMock.m in Sources */,
 				62CB191E2E77F8B500AF5DA2 /* SentryDispatchSourceWrapperTests.swift in Sources */,
 				D8CE69BC277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m in Sources */,

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
@@ -49,17 +49,17 @@ struct SentryMetricsApi<Dependencies: SentryMetricsApiDependencies>: SentryMetri
         }
 
         // Capture the traceId at metric creation time to ensure it reflects the active trace
-        // when the metric was captured, not when it gets flushed by the batcher.
+        // when the metric was captured, not when it gets flushed by the buffer.
         //
         // This logic is intentionally duplicated from BatcherScope.applyToItem (used by Logs)
         // for the following reasons:
-        // 1. Safety: If batcher enrichment is skipped or fails, metrics still have valid traceIds
+        // 1. Safety: If buffer enrichment is skipped or fails, metrics still have valid traceIds
         //    rather than empty ones, which would break trace correlation entirely.
         // 2. Semantic correctness: A metric captured during a network request should correlate
         //    with that request's trace, matching how we capture timestamp at creation time.
-        // 3. Fail-safe redundancy: The batchers scope enrichment will overwrite this value, producing
+        // 3. Fail-safe redundancy: The buffer's scope enrichment will overwrite this value, producing
         //    the same result but with a safety net for edge cases. We can not remove the duplication from
-        //    the batcher scope because it is used by Logs and other integrations.
+        //    the buffer scope because it is used by Logs and other integrations.
         //
         // When a span is active, use its traceId to ensure consistency with span_id.
         // Otherwise, fall back to propagationContext traceId.

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -19,7 +19,7 @@ typealias SentryMetricsIntegrationDependencies = DateProviderProvider & Dispatch
 #endif
 
 final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDependencies>: NSObject, SwiftIntegration, SentryMetricsIntegrationProtocol, FlushableIntegration {
-    private let metricBatcher: SentryMetricsBatcherProtocol
+    private let metricsBuffer: SentryMetricsBufferProtocol
     #if ((os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UIKIT) || os(macOS)
     private let notificationCenter: SentryNSNotificationCenterWrapper
     #endif
@@ -27,7 +27,7 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     init?(with options: Options, dependencies: Dependencies) {
         guard options.experimental.enableMetrics else { return nil }
 
-        self.metricBatcher = SentryMetricsBatcher(
+        self.metricsBuffer = SentryMetricsBuffer(
             options: options,
             dateProvider: dependencies.dateProvider,
             dispatchQueue: dependencies.dispatchQueueWrapper,
@@ -55,8 +55,8 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
         //
         // Note: This calls captureMetrics() synchronously, which uses dispatchSync internally.
         // This is safe because uninstall() is typically called from the main thread during
-        // app lifecycle events, and the batcher's dispatch queue is a separate serial queue.
-        metricBatcher.captureMetrics()
+        // app lifecycle events, and the buffer's dispatch queue is a separate serial queue.
+        metricsBuffer.captureMetrics()
 
         removeLifecycleObservers()
     }
@@ -66,7 +66,7 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     /// This defensive pattern guarantees that notification observers are removed, preventing crashes from dangling references.
     ///
     /// Note: We do NOT flush metrics in deinit because:
-    /// - Flushing uses dispatchSync which can deadlock if deinit is called from the batcher's queue
+    /// - Flushing uses dispatchSync which can deadlock if deinit is called from the buffer's queue
     /// - uninstall() should be called explicitly before deallocation to ensure metrics are flushed
     /// - This prevents deadlocks during hub deallocation when integrations are released
     deinit {
@@ -80,16 +80,16 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     // MARK: - Public API for Metrics
 
     func addMetric(_ metric: SentryMetric, scope: Scope) {
-        metricBatcher.addMetric(metric, scope: scope)
+        metricsBuffer.addMetric(metric, scope: scope)
     }
 
     /// Captures batched metrics synchronously and returns the duration.
     /// - Returns: The time taken to capture metrics in seconds
     ///
-    /// - Note: This method calls captureMetrics() on the internal batcher synchronously.
+    /// - Note: This method calls captureMetrics() on the internal buffer synchronously.
     ///         This is safe to call from any thread, but be aware that it uses dispatchSync internally.
     @discardableResult func captureMetrics() -> TimeInterval {
-        return metricBatcher.captureMetrics()
+        return metricsBuffer.captureMetrics()
     }
 
     // MARK: - FlushableIntegration

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -531,7 +531,7 @@ class SentryMetricsApiE2ETests: XCTestCase {
     }
     
     // Helper to get captured metrics
-    // Note: The batcher produces JSON in the format {"items":[...]} as verified by InMemoryBatchBuffer.batchedData
+    // Note: The buffer produces JSON in the format {"items":[...]} as verified by InMemoryBatchBuffer.batchedData
     //
     // Design decision: We use JSONSerialization instead of:
     // 1. Decodable: Would introduce decoding logic in tests that could be wrong, creating a risk that tests pass
@@ -540,7 +540,7 @@ class SentryMetricsApiE2ETests: XCTestCase {
     //
     // JSONSerialization provides a good middle ground: it parses the JSON structure without duplicating
     // the encoding/decoding logic, and it's order-agnostic, making tests stable while still verifying
-    // the actual data structure produced by the batcher.
+    // the actual data structure produced by the buffer.
     private func getCapturedMetrics(from client: TestClient) -> [[String: Any]] {
         var allMetrics: [[String: Any]] = []
         

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -34,7 +34,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().first, "Metrics")
     }
     
-    func testAddMetric_whenMetricAdded_shouldAddToBatcher() throws {
+    func testAddMetric_whenMetricAdded_shouldAddToBuffer() throws {
         // -- Arrange --
         try givenSdkWithHub()
         let client = try XCTUnwrap(SentrySDKInternal.currentHub().getClient() as? TestClient, "Hub Client is not a `TestClient`")


### PR DESCRIPTION
## Summary
- Renamed `SentryMetricsBatcher` → `SentryMetricsBuffer`
- Renamed `SentryMetricsBatcherProtocol` → `SentryMetricsBufferProtocol`
- Renamed `SentryMetricsBatcherOptionsProtocol` → `SentryMetricsBufferOptionsProtocol`
- Updated all variable names and comments from "batcher" to "buffer" terminology
- All tests passing (81 metrics-related tests)

## Context
First step for #7210. More class renames coming in follow-up PRs.

#skip-changelog