### PR TITLE
docs: simplify file renaming guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,24 +268,6 @@ git add new-name.swift
 git commit -m "ref: rename old-name to new-name"
 ```
 
-**Multi-step Renames:**
-
-If a rename requires multiple steps (e.g., moving and renaming, or updating imports before renaming), perform each step in a separate commit:
-
-```bash
-# Step 1: Move file to new location (preserving name initially)
-git mv Sources/Old/File.swift Sources/New/File.swift
-git commit -m "ref: move File.swift to new location"
-
-# Step 2: Update all imports/references
-# ... make changes ...
-git commit -m "ref: update imports for File.swift"
-
-# Step 3: Rename file (if needed)
-git mv Sources/New/File.swift Sources/New/NewName.swift
-git commit -m "ref: rename File.swift to NewName.swift"
-```
-
 **Benefits:**
 
 - Git can track file history across renames (`git log --follow`)
@@ -293,10 +275,6 @@ git commit -m "ref: rename File.swift to NewName.swift"
 - Bisect operations remain accurate
 - Code archaeology and debugging are easier
 - Refactoring history is preserved
-
-**Note on Squash Merges:**
-
-These benefits apply even when PRs are squash-merged. Git's rename detection works on the final diff of the squashed commit, so using `git mv` in feature branches ensures the squashed commit is recognized as a rename (shown as `R` in git log) rather than a delete + add. This preserves `git log --follow` and other history-tracking features after merging.
 
 **Verification:**
 


### PR DESCRIPTION
This is a follow-up PR to #7211, accepting the feedback that the multi-step renames section and note on squash merges don't provide value. My reasoning about squash merges was incorrect.

Thanks to @philprime for testing and surfacing this in https://github.com/getsentry/sentry-cocoa/pull/7211#issuecomment-3772803157 - his testing showed that `git mv` doesn't have a special impact on squash commits, as rename detection is purely based on similarity diff.

## Changes

- Removed "Multi-step Renames" section
- Removed "Note on Squash Merges" section

## Rationale

With squash merges, intermediate commits in a feature branch are lost when merging to main. The multi-step approach (separate commits for move, update imports, rename) doesn't provide value since only the final diff matters after squashing.

As demonstrated in the testing, Git's rename detection in squashed commits works based on content similarity, regardless of whether `git mv` or `mv` + `git add` was used in the feature branch.

The simplified guidance now focuses on the core message: **use `git mv` to preserve history** in your local workflow.

Addresses feedback from https://github.com/getsentry/sentry-cocoa/pull/7211#discussion_r2708189526

#skip-changelog