### PR TITLE
fix: prevent workflow_dispatch runs from canceling each other

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,10 @@ on:
 #   only the latest version needs validation before merging.
 # - For main branch pushes (actual releases), we never cancel runs to ensure every release
 #   process completes fully, as partial releases could corrupt our distribution pipeline.
+# - For workflow_dispatch events (manual releases), each run gets a unique group using run_id
+#   to prevent manual releases from canceling each other, allowing multiple concurrent releases.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}', github.ref, github.run_id) || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

This PR fixes an issue where manual `workflow_dispatch` events in the release workflow were sharing the same concurrency group, causing them to cancel each other when multiple releases were triggered.

## Changes

- Modified the concurrency group configuration to include `github.run_id` for `workflow_dispatch` events, ensuring each manual release gets a unique group
- Updated documentation comments to explain the behavior for manual releases

## Impact

Manual SDK releases can now run concurrently without interfering with each other, while maintaining the existing behavior for pull requests and push events.

## Testing

The change follows the existing concurrency pattern and maintains backward compatibility for all other event types.

#skip-changelog

Closes #7230