### PR TITLE
fix: Cleanup issues from SentryCrashIntegration conversion to Swift

### DIFF
--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -135,11 +135,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 #endif
-    if ((integrationOptions & kIntegrationOptionEnableCrashHandler)
-        && !options.enableCrashHandler) {
-        [self logWithOptionName:@"enableCrashHandler"];
-        return NO;
-    }
 
 #if SENTRY_HAS_METRIC_KIT
     if ((integrationOptions & kIntegrationOptionEnableMetricKit) && !options.enableMetricKit) {

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -24,7 +24,6 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionIsTracingEnabled = 1 << 13,
     kIntegrationOptionDebuggerNotAttached = 1 << 14,
     kIntegrationOptionAttachViewHierarchy = 1 << 15,
-    kIntegrationOptionEnableCrashHandler = 1 << 16,
     kIntegrationOptionEnableMetricKit = 1 << 17,
     kIntegrationOptionEnableReplay = 1 << 18,
 };

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -19,13 +19,9 @@ class SentryCrashInstallationReporterTests: XCTestCase {
 
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-1")
 
-        let expectation = expectation(description: "sendAllReports completion")
         sut.sendAllReports { filteredReports, _, _ in
             XCTAssertEqual(filteredReports?.count, 1)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1.0)
 
         XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
@@ -39,13 +35,9 @@ class SentryCrashInstallationReporterTests: XCTestCase {
 
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-legacy-storage-info")
 
-        let expectation = expectation(description: "sendAllReports completion")
         sut.sendAllReports { filteredReports, _, _ in
             XCTAssertEqual(filteredReports?.count, 1)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1.0)
 
         XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
@@ -61,13 +53,9 @@ class SentryCrashInstallationReporterTests: XCTestCase {
 
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-without-device-context")
 
-        let expectation = expectation(description: "sendAllReports completion")
         sut.sendAllReports { filteredReports, _, _ in
             XCTAssertEqual(filteredReports?.count, 1)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1.0)
 
         XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
@@ -82,13 +70,9 @@ class SentryCrashInstallationReporterTests: XCTestCase {
 
         try givenStoredSentryCrashReport(resource: "Resources/Crash-faulty-report")
 
-        let expectation = expectation(description: "sendAllReports completion")
         sut.sendAllReports { filteredReports, _, _ in
             XCTAssertEqual(filteredReports?.count, 0)
-            expectation.fulfill()
         }
-
-        waitForExpectations(timeout: 1.0)
 
         XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 0)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
@@ -97,6 +81,8 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     private func givenSutWithStartedSDK() {
         let options = Options()
         options.dsn = TestConstants.dsnAsString(username: "SentryCrashInstallationReporterTests")
+        // Disable crash handler so only
+        options.enableCrashHandler = false
         SentrySDK.start(options: options)
         
         testClient = TestClient(options: options)


### PR DESCRIPTION
## :scroll: Description

Looks like some things were missing since the migration:
- Cleanup old conditions on SentryBaseIntegration.m
- Fix for flaky test: disable CrashIntegration installation on CreashInstallationReporter Tests
  - Having 2 installation reporters caused issues, since now the SDK creates a new one on each SDK start, the flakiness became more noticeable.
 

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

Closes #7232