### PR TITLE
ci: skip integration unit tests on release branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,10 +155,8 @@ jobs:
           # with communicating with the test server in CI.
           # We are going to add these back in https://github.com/getsentry/sentry-cocoa/issues/6361
           - name: macOS 15
-            runs-on: [
-              "ghcr.io/cirruslabs/macos-runner:sequoia",
-              "runner_group_id:10",
-            ]
+            runs-on:
+              ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
             platform: "macOS"
             xcode: "16.4"
             test-destination-os: "15.0"
@@ -386,7 +384,7 @@ jobs:
   # This will be replaced once #6945 is merged.
   swiftlog-integration-unit-tests:
     name: SentrySwiftLog Unit Tests
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true')
     needs: files-changed
     runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
     steps:
@@ -418,7 +416,7 @@ jobs:
   # This will be replaced once #6945 is merged.
   swiftybeaver-integration-unit-tests:
     name: SentrySwiftyBeaver Unit Tests
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true')
     needs: files-changed
     runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
     steps:
@@ -450,7 +448,7 @@ jobs:
   # This will be replaced once #6945 is merged.
   cocoalumberjack-integration-unit-tests:
     name: SentryCocoaLumberjack Unit Tests
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true')
     needs: files-changed
     runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
     steps:
@@ -482,7 +480,7 @@ jobs:
   # This will be replaced once #6945 is merged.
   pulse-integration-unit-tests:
     name: SentryPulse Unit Tests
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true')
     needs: files-changed
     runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
     steps:


### PR DESCRIPTION
Skip the following integration unit tests on release branches:

- SentrySwiftLog Unit Tests
- SentrySwiftyBeaver Unit Tests
- SentryCocoaLumberjack Unit Tests
- SentryPulse Unit Tests

This matches the pattern used by the distribution-tests job to avoid running these tests on release branches.

#skip-changelog

Closes #7238