### PR TITLE
test: Fix SentryDestinationTests to handle array type for tags

### DIFF
--- a/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
@@ -194,11 +194,7 @@ final class SentryDestinationTests: XCTestCase {
         }
         
         XCTAssertEqual(log.attributes["swiftybeaver.context.tags"]?.type, "string[]")
-        if let tagsValue = log.attributes["swiftybeaver.context.tags"]?.value as? [String] {
-            XCTAssertEqual(tagsValue, ["production", "api", "v2"])
-        } else {
-            XCTFail("Tags value should be a [String]")
-        }
+        XCTAssertEqual(log.attributes["swiftybeaver.context.tags"]?.value as? [String], ["production", "api", "v2"])
         
         XCTAssertNil(result)
     }


### PR DESCRIPTION
## :scroll: Description

Fixes a broken test in main branch

## :bulb: Motivation and Context

Our testing structure seems broken because we are not using swift from source but the latest release.
This needs to be fixed

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7241