### PR TITLE
fix(ci): Use CirrusLabs for collecting app metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
 
   app-metrics:
     name: Collect App Metrics
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:tahoe", "runner_group_id:10"]
+    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
     needs: [files-changed, assemble-xcframework-variant]
     # Run the job only for PRs with related changes (from contributors) or non-PR events.
     if: github.event_name != 'pull_request' || (needs.files-changed.outputs.run_release_for_prs == 'true' && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association))


### PR DESCRIPTION
The workflow job "Collect App Metrics" is constantly timing out:

- https://github.com/getsentry/sentry-cocoa/actions/runs/21240958581/job/61119402883
- https://github.com/getsentry/sentry-cocoa/actions/runs/21240958581/job/61119402883

I assume it might be caused by slow runners, therefore this is an attempt to use the faster CirrusLabs runners.

#skip-changelog

Closes #7250