### PR TITLE
chore: Fix SwiftLint script warning

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -4780,6 +4780,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		D480390A2F19316E00FA1619 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
## :scroll: Description

Updates swiftlint script to always run, skipping dependency analysis step so no warning is shown in Xcode

## :bulb: Motivation and Context

Fixes warning when building Sentry on Xcode:
```
Run script build phase 'SwiftLint' will be run during every build because it does not specify any outputs. To address this issue, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
```

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7268