### PR TITLE
chore: Exclude 3rd-party-integrations build/packages from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,8 @@ excluded:
   - .build/**
   - .git/**
   - XCFrameworkBuildPath/**
+  - 3rd-party-integrations/**/Packages/sentry-cocoa
+  - 3rd-party-integrations/**/.build
 
 only_rules:
   - class_delegate_protocol


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

Exclude 3rd-party-integrations build/packages from SwiftLint

- sentry-cocoa package
- .build

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

swiftlint was hanging because of a circular dependency.

<img width="464" height="304" alt="image" src="https://github.com/user-attachments/assets/9bbd50d7-f952-4c5b-bc3b-4e726f60c45a" />

## :green_heart: How did you test it?

Running `make lint` without issues again.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
