### PR TITLE
ref: Remove unnecessary @objcMembers and @objc annotations

### DIFF
--- a/Sources/Swift/Core/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Core/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -9,13 +9,12 @@ import Foundation
     func anrStopped(result: SentryANRStoppedResult?)
 }
 
-@objcMembers
-@_spi(Private) public final class SentryANRStoppedResult: NSObject {
+@objc @_spi(Private) public final class SentryANRStoppedResult: NSObject {
     
-    public let minDuration: TimeInterval
-    public let maxDuration: TimeInterval
+    let minDuration: TimeInterval
+    let maxDuration: TimeInterval
     
-    public init(minDuration: TimeInterval, maxDuration: TimeInterval) {
+    init(minDuration: TimeInterval, maxDuration: TimeInterval) {
         self.minDuration = minDuration
         self.maxDuration = maxDuration
     }

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryDefaultViewRenderer.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryDefaultViewRenderer.swift
@@ -4,9 +4,8 @@
 
 import UIKit
 
-@objcMembers
-@_spi(Private) public final class SentryDefaultViewRenderer: NSObject, SentryViewRenderer {
-    public func render(view: UIView) -> UIImage {
+final class SentryDefaultViewRenderer: NSObject, SentryViewRenderer {
+    func render(view: UIView) -> UIImage {
         let image = UIGraphicsImageRenderer(size: view.bounds.size).image { _ in
             view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
         }

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryViewRendererV2.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryViewRendererV2.swift
@@ -4,15 +4,14 @@
 
 import UIKit
 
-@objcMembers
-@_spi(Private) public final class SentryViewRendererV2: NSObject, SentryViewRenderer {
+final class SentryViewRendererV2: NSObject, SentryViewRenderer {
     let enableFastViewRendering: Bool
 
-    public init(enableFastViewRendering: Bool) {
+    init(enableFastViewRendering: Bool) {
         self.enableFastViewRendering = enableFastViewRendering
     }
 
-    public func render(view: UIView) -> UIImage {
+    func render(view: UIView) -> UIImage {
         let scale = (view as? UIWindow ?? view.window)?.screen.scale ?? 1
         let image = SentryGraphicsImageRenderer(size: view.bounds.size, scale: scale).image { context in
             if enableFastViewRendering {

--- a/Sources/Swift/Protocol/SentryLog.swift
+++ b/Sources/Swift/Protocol/SentryLog.swift
@@ -1,7 +1,6 @@
 /// A structured log entry that captures log data with associated attribute metadata.
 ///
 /// Use the `options.beforeSendLog` callback to modify or filter log data.
-@objc
 @objcMembers
 public final class SentryLog: NSObject {
     /// Alias for `SentryAttribute` to maintain backward compatibility after `SentryLog.Attribute` was renamed to `SentryAttribute`.


### PR DESCRIPTION
- Remove @objcMembers from SentryViewRendererV2 and SentryDefaultViewRenderer as they are not used from Objective-C code (only conform to @objc protocol)
- Make SentryViewRendererV2 and SentryDefaultViewRenderer internal since they are implementation details not exposed in the public API
- Remove @objcMembers from SentryANRStoppedResult as it is only used from Swift
- Remove redundant @objc from SentryLog since @objcMembers already exposes the class to Objective-C

#skip-changelog


Closes #7306