### PR TITLE
docs: Add warning about absent user attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## 9.2.0
 
+> [!IMPORTANT]
+> This release contains a bug fix to only include user attributes in logs when `options.sendDefaultPii = true`.
+> Make sure to enable the option in case you rely on these attributes to be set.
+
 ### Features
 
 - Add options `options.sessionReplay.includedViewClasses` and `options.sessionReplay.excludedViewClasses` to ignore views from subtree traversal (#7063)


### PR DESCRIPTION
We received the feedback in #7316 that it was easy to miss that we fixed a bug which now requires `sendDefaultPii` to be set to `true` for user attributes to be set. This adds an alert to the changelog which I will also copy to the GitHub release notes

#skip-changelog