### PR TITLE
docs: Update parameter description in SentryScope.h to include support for arrays

### DIFF
--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -147,7 +147,7 @@ NS_SWIFT_NAME(Scope)
  * message.
  * @note The SDK only applies attributes to Logs. The SDK doesn't apply the attributes to
  * Events, Transactions, Spans, Profiles, Session Replay.
- * @param value Supported values are string, integers, boolean and double
+ * @param value Supported values are string, integers, boolean, double and arrays of those types
  * @param key The key to store, cannot be an empty string
  */
 - (void)setAttributeValue:(id)value


### PR DESCRIPTION
## :scroll: Description

Updates the headers to reflect arrays being supported natively

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes: #7325

## :green_heart: How did you test it?

Just docs update

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
