### PR TITLE
test: add tests for custom type array conversion

### DIFF
--- a/Tests/SentryTests/Protocol/SentryAttributeValuableTests.swift
+++ b/Tests/SentryTests/Protocol/SentryAttributeValuableTests.swift
@@ -368,6 +368,125 @@ final class SentryAttributeValueTests: XCTestCase {
         XCTAssertEqual(result, .booleanArray([true, true]))
     }
     
+    func testAsSentryAttributeContent_whenHomogenousIntegerArrayWithSingleCustomType_shouldReturnIntegerArrayCase() {
+        // -- Arrange --
+        struct CustomType: SentryAttributeValue {
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .integer(42)
+            }
+        }
+        
+        let array: [CustomType] = [CustomType(), CustomType()]
+        
+        // -- Act --
+        let result = array.asSentryAttributeContent
+        
+        // -- Assert --
+        guard case .integerArray(let value) = result else {
+            return XCTFail("Expected .integerArray case")
+        }
+        XCTAssertEqual(value, [42, 42])
+    }
+    
+    func testAsSentryAttributeContent_whenHomogenousIntegerArrayWithDifferentCustomTypes_shouldReturnIntegerArrayCase() {
+        // -- Arrange --
+        struct CustomIntegerType1: SentryAttributeValue {
+            let value: Int
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .integer(value)
+            }
+        }
+        
+        struct CustomIntegerType2: SentryAttributeValue {
+            let value: Int
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .integer(value)
+            }
+        }
+        
+        let array: [SentryAttributeValue] = [
+            CustomIntegerType1(value: 10),
+            CustomIntegerType2(value: 20),
+            CustomIntegerType1(value: 30)
+        ]
+        
+        // -- Act --
+        let result = array.asSentryAttributeContent
+        
+        // -- Assert --
+        guard case .integerArray(let value) = result else {
+            return XCTFail("Expected .integerArray case when different custom types return .integer")
+        }
+        XCTAssertEqual(value, [10, 20, 30])
+    }
+    
+    func testAsSentryAttributeContent_whenHomogenousDoubleArrayWithDifferentCustomTypes_shouldReturnDoubleArrayCase() {
+        // -- Arrange --
+        struct CustomDoubleType1: SentryAttributeValue {
+            let value: Double
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .double(value)
+            }
+        }
+        
+        struct CustomDoubleType2: SentryAttributeValue {
+            let value: Double
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .double(value)
+            }
+        }
+        
+        let array: [SentryAttributeValue] = [
+            CustomDoubleType1(value: 1.1),
+            CustomDoubleType2(value: 2.2),
+            CustomDoubleType1(value: 3.3)
+        ]
+        
+        // -- Act --
+        let result = array.asSentryAttributeContent
+        
+        // -- Assert --
+        guard case .doubleArray(let value) = result else {
+            return XCTFail("Expected .doubleArray case when different custom types return .double")
+        }
+        XCTAssertEqual(value.count, 3)
+        XCTAssertEqual(value[0], 1.1, accuracy: 0.00001)
+        XCTAssertEqual(value[1], 2.2, accuracy: 0.00001)
+        XCTAssertEqual(value[2], 3.3, accuracy: 0.00001)
+    }
+    
+    func testAsSentryAttributeContent_whenHomogenousStringArrayWithDifferentCustomTypes_shouldReturnStringArrayCase() {
+        // -- Arrange --
+        struct CustomStringType1: SentryAttributeValue {
+            let value: String
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .string(value)
+            }
+        }
+        
+        struct CustomStringType2: SentryAttributeValue {
+            let value: String
+            var asSentryAttributeContent: SentryAttributeContent {
+                return .string(value)
+            }
+        }
+        
+        let array: [SentryAttributeValue] = [
+            CustomStringType1(value: "first"),
+            CustomStringType2(value: "second"),
+            CustomStringType1(value: "third")
+        ]
+        
+        // -- Act --
+        let result = array.asSentryAttributeContent
+        
+        // -- Assert --
+        guard case .stringArray(let value) = result else {
+            return XCTFail("Expected .stringArray case when different custom types return .string")
+        }
+        XCTAssertEqual(value, ["first", "second", "third"])
+    }
+    
     func testAsSentryAttributeContent_whenHeterogeneousArrayWithDifferentTypes_shouldReturnStringArrayCase() {
         // -- Arrange --
         struct CustomBoolType: SentryAttributeValue {


### PR DESCRIPTION
Add tests to verify that arrays containing different custom types adopting SentryAttributeValue are correctly converted to typed arrays (integer[], double[], string[]) when all elements return the same SentryAttributeContent case, rather than falling back to string[].

#skip-changelog

Closes #7338