### PR TITLE
chore: Update GA workflow to use reat native branch with v9

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           repository: getsentry/sentry-react-native
           path: sentry-react-native
-          ref: itay/use_regular_podspec
+          ref: antonis/cocoa-9.1.1
 
       - name: Enable Corepack
         working-directory: sentry-react-native


### PR DESCRIPTION
## :scroll: Description

Updates the remote reference in React Native repo, to the new one with the latest changes for v9.

## :bulb: Motivation and Context

Previous branch was merged to `antonis/cocoa-9.1.1` so CI fails on our repo.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
