### PR TITLE
fix(ci): skip code signing for dependabot PRs in size analysis and app metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
     needs: ready-to-merge-gate
     outputs:
       run_release_for_prs: ${{ steps.changes.outputs.run_release_for_prs }}
+      is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Get changed files
@@ -265,8 +266,16 @@ jobs:
     name: Collect App Metrics
     runs-on: macos-15
     needs: [files-changed, assemble-xcframework-variant]
-    # Run the job only for PRs with related changes (from contributors) or non-PR events.
-    if: github.event_name != 'pull_request' || (needs.files-changed.outputs.run_release_for_prs == 'true' && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association))
+    # Run for PRs with related changes (including dependabot) or non-PR events.
+    if: |
+      github.event_name != 'pull_request' || (
+        needs.files-changed.outputs.run_release_for_prs == 'true' && (
+          contains(
+          fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+          github.event.pull_request.author_association
+        ) ||
+        needs.files-changed.outputs.is_dependabot == 'true')
+      )
     timeout-minutes: 20
     steps:
       - name: Git checkout
@@ -281,9 +290,13 @@ jobs:
         with:
           path: Tests/Perf/test-app-plain.ipa
           key: ${{ github.workflow }}-${{ github.job }}-appplain-${{ hashFiles('fastlane/Fastfile', 'Tests/Perf/test-app-plain/**') }}
+      # When running the workflows for dependabot PRs, we need to skip code signing, because the code signing secrets are not available for dependabot PRs.
+      # We still want to run as much of the full workflow as possible, to verify the behaviour.
       - name: Build test app plain
         if: steps.app-plain-cache.outputs['cache-hit'] != 'true'
-        run: bundle exec fastlane build_perf_test_app_plain
+        run: |
+          bundle exec fastlane build_perf_test_app_plain \
+            skip_codesigning:${{ needs.files-changed.outputs.is_dependabot == 'true' }}
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -298,7 +311,9 @@ jobs:
           path: XCFrameworkBuildPath/
       - run: find XCFrameworkBuildPath -name "Sentry-Dynamic.xcframework.zip" -print0 | xargs -t0I @ unzip @ -d XCFrameworkBuildPath
       - name: Build test app with sentry
-        run: bundle exec fastlane build_perf_test_app_sentry
+        run: |
+          bundle exec fastlane build_perf_test_app_sentry \
+            skip_codesigning:${{ needs.files-changed.outputs.is_dependabot == 'true' }}
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -308,11 +323,16 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect app metrics
+        if: needs.files-changed.outputs.is_dependabot != 'true'
         uses: getsentry/action-app-sdk-overhead-metrics@5f2d99b8e5a7b833386524924d24320501099a44
         with:
           config: Tests/Perf/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}
           sauce-key: ${{ secrets.SAUCE_ACCESS_KEY }}
+      - name: App metrics collection skipped
+        if: needs.files-changed.outputs.is_dependabot == 'true'
+        run: |
+          echo "::warning::App metrics collection was SKIPPED ON PURPOSE for dependabot PR. Code signing secrets are not available for dependabot PRs."
       - name: Debug Xcode environment
         if: ${{ failure() || cancelled() }}
         run: ./scripts/ci-diagnostics.sh

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -22,6 +22,7 @@ jobs:
     needs: ready-to-merge-gate
     outputs:
       run_size_analysis_for_prs: ${{ steps.changes.outputs.run_size_analysis_for_prs }}
+      is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - name: Get changed files
@@ -35,7 +36,8 @@ jobs:
     name: Skip Size Analysis for Non-Contributors
     runs-on: ubuntu-latest
     needs: files-changed
-    if: github.event_name == 'pull_request' && needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association)
+    # Skip for non-contributors, but not for dependabot (handled in build)
+    if: github.event_name == 'pull_request' && needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) && needs.files-changed.outputs.is_dependabot == 'false'
     steps:
       - name: Skip Size Analysis for Non-Contributors
         run: |
@@ -45,8 +47,16 @@ jobs:
   build:
     name: Build and Analyze SDK Size
     runs-on: macos-26
-    # Run the job only for PRs with related changes (from contributors) or non-PR events.
-    if: github.event_name != 'pull_request' || (needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association))
+    # Run for PRs with related changes (including dependabot) or non-PR events.
+    if: |
+      github.event_name != 'pull_request' || (
+        needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && (
+          contains(
+          fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
+          github.event.pull_request.author_association
+        ) ||
+        needs.files-changed.outputs.is_dependabot == 'true')
+      )
     needs: files-changed
     timeout-minutes: 20
     steps:
@@ -70,8 +80,12 @@ jobs:
 
       - run: make xcode-ci
 
+      # When running the workflows for dependabot PRs, we need to skip code signing, because the code signing secrets are not available for dependabot PRs.
+      # We still want to run as much of the full workflow as possible, to verify the behaviour.
       - name: Build and Upload for Size Analysis
-        run: bundle exec fastlane build_ios_for_size_analysis
+        run: |
+          bundle exec fastlane build_ios_for_size_analysis \
+            skip_codesigning:${{ needs.files-changed.outputs.is_dependabot == 'true' }}
         env:
           FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -360,17 +360,21 @@ platform :ios do
   end
 
   desc "Build Perf-test app without Sentry"
-  lane :build_perf_test_app_plain do
+  lane :build_perf_test_app_plain do |options|
+    skip_codesigning = options[:skip_codesigning] || false
+
     setup_ci(
       force: true
     ) if is_ci
 
-    sync_code_signing(
-      type: "development",
-      app_identifier: [
-        "io.sentry.cocoa.perf-test-app-plain"
-      ]
-    )
+    unless skip_codesigning
+      sync_code_signing(
+        type: "development",
+        app_identifier: [
+          "io.sentry.cocoa.perf-test-app-plain"
+        ]
+      )
+    end
 
     build_app(
       project: "Tests/Perf/test-app-plain/test-app-plain.xcodeproj",
@@ -380,24 +384,30 @@ platform :ios do
       export_method: "development",
       output_directory: "Tests/Perf/",
       output_name: "test-app-plain.ipa",
-      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
+      skip_package_dependencies_resolution: true, # See SKIP_SPM_RESOLUTION_NOTE
+      xcargs: skip_codesigning ? "CODE_SIGNING_ALLOWED=NO" : nil,
+      skip_package_ipa: skip_codesigning
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
   end
 
   desc "Build Perf-test app with Sentry"
-  lane :build_perf_test_app_sentry do
+  lane :build_perf_test_app_sentry do |options|
+    skip_codesigning = options[:skip_codesigning] || false
+
     setup_ci(
       force: true
     ) if is_ci
 
-    sync_code_signing(
-      type: "development",
-      app_identifier: [
-        "io.sentry.cocoa.perf-test-app-sentry"
-      ],
-    )
+    unless skip_codesigning
+      sync_code_signing(
+        type: "development",
+        app_identifier: [
+          "io.sentry.cocoa.perf-test-app-sentry"
+        ],
+      )
+    end
 
     build_app(
       project: "Tests/Perf/test-app-sentry/test-app-sentry.xcodeproj",
@@ -407,7 +417,9 @@ platform :ios do
       export_method: "development",
       output_directory: "Tests/Perf/",
       output_name: "test-app-sentry.ipa",
-      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
+      skip_package_dependencies_resolution: true, # See SKIP_SPM_RESOLUTION_NOTE
+      xcargs: skip_codesigning ? "CODE_SIGNING_ALLOWED=NO" : nil,
+      skip_package_ipa: skip_codesigning
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
@@ -440,15 +452,19 @@ platform :ios do
 end
 
 desc "Build and Upload for Size Analysis"
-lane :build_ios_for_size_analysis do
-  setup_ci if is_ci
+lane :build_ios_for_size_analysis do |options|
+  skip_codesigning = options[:skip_codesigning] || false
 
-  sync_code_signing(
+  setup_ci if is_ci && !skip_codesigning
+
+  unless skip_codesigning
+    sync_code_signing(
       type: "appstore",
       app_identifier: [
         "io.sentry.sample.SDK-Size"
       ],
-  )
+    )
+  end
 
   build_ios_app(
     workspace: "Sentry.xcworkspace",
@@ -457,18 +473,21 @@ lane :build_ios_for_size_analysis do
     configuration: 'Release',
     skip_package_ipa: true,
     archive_path: './build/SDK-Size.xcarchive',
+    xcargs: skip_codesigning ? "CODE_SIGNING_ALLOWED=NO" : nil,
   )
 
-  sentry_upload_build(
-    xcarchive_path: './build/SDK-Size.xcarchive',
-    auth_token: ENV['SENTRY_AUTH_TOKEN'],
-    org_slug: 'sentry-sdks',
-    project_slug: 'sentry-cocoa',
-    build_configuration: 'Release',
-    log_level: 'debug'
-  )
+  unless skip_codesigning
+    sentry_upload_build(
+      xcarchive_path: './build/SDK-Size.xcarchive',
+      auth_token: ENV['SENTRY_AUTH_TOKEN'],
+      org_slug: 'sentry-sdks',
+      project_slug: 'sentry-cocoa',
+      build_configuration: 'Release',
+      log_level: 'debug'
+    )
+  end
 
-  delete_keychain(name: "fastlane_tmp_keychain") if is_ci
+  delete_keychain(name: "fastlane_tmp_keychain") if is_ci && !skip_codesigning
 end
 
 # SKIP_SPM_RESOLUTION_NOTE:


### PR DESCRIPTION
This PR extends the dependabot code signing skip functionality to two additional workflow jobs:

- **Build and Analyze SDK Size** (size-analysis.yml)
- **Collect App Metrics** (release.yml)

## Changes

- Add `skip_codesigning` option to `build_ios_for_size_analysis` Fastlane lane
- Add `skip_codesigning` option to `build_perf_test_app_plain` and `build_perf_test_app_sentry` Fastlane lanes
- Update size-analysis.yml to build without signing for dependabot PRs and skip Sentry upload
- Update release.yml to build without signing for dependabot PRs and skip SauceLabs metrics collection

## Behavior

For dependabot PRs:
- ✅ Build jobs still run (without code signing)
- ✅ As many jobs as possible are kept running
- ❌ Only jobs requiring code signing artifacts are skipped (Sentry upload, SauceLabs metrics)

This allows dependabot PRs to pass CI checks without requiring code signing secrets, keeping as many jobs as possible while skipping only those requiring code signing artifacts.

#skip-changelog

Closes #7366