### PR TITLE
ref: Make integrations pure swift

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -785,7 +785,6 @@
 		D88817DA26D72AB800BF2251 /* SentryTraceContext.h in Headers */ = {isa = PBXBuildFile; fileRef = D88817D926D72AB800BF2251 /* SentryTraceContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D88817DD26D72BA500BF2251 /* SentryTraceContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88817DB26D72B7B00BF2251 /* SentryTraceContextTests.swift */; };
 		D8918B222849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8918B212849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift */; };
-		D8A3649C2C91AA3300AC569B /* SentryReplayApi.m in Sources */ = {isa = PBXBuildFile; fileRef = D8A3649B2C91AA3300AC569B /* SentryReplayApi.m */; };
 		D8A3649D2C91AA3300AC569B /* SentryReplayApi.h in Headers */ = {isa = PBXBuildFile; fileRef = D8A3649A2C91AA3300AC569B /* SentryReplayApi.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8A65B5D2C98656800974B74 /* SentryReplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A65B5C2C98656000974B74 /* SentryReplayView.swift */; };
 		D8ACE3C82762187200F5A213 /* SentryFileIOTrackerHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = D8ACE3C52762187200F5A213 /* SentryFileIOTrackerHelper.m */; };
@@ -894,6 +893,7 @@
 		FAAB96542EA6A72E0030A2DB /* SentryCrashScopeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAAB96532EA6A72D0030A2DB /* SentryCrashScopeHelper.m */; };
 		FAB359982E05D7E90083D5E3 /* SentryEventSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */; };
 		FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */; };
+		FAC2FE832F33D011002B39C1 /* SentryReplayApi.m in Sources */ = {isa = PBXBuildFile; fileRef = FAC2FE822F33D011002B39C1 /* SentryReplayApi.m */; };
 		FAC62B652E15A4100003909D /* SentrySDKThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */; };
 		FAC735232E25AA81006C5A64 /* SentryProfilingSwiftHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAC735222E25AA7A006C5A64 /* SentryProfilingSwiftHelpersTests.m */; };
 		FAC880B62EE5FA31007B4796 /* TestNSURLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC880B52EE5FA2A007B4796 /* TestNSURLRequestBuilder.swift */; };
@@ -1911,7 +1911,6 @@
 		D88D25E92B8E0BAC0073C3D5 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		D8918B212849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKIntegrationTestsBase.swift; sourceTree = "<group>"; };
 		D8A3649A2C91AA3300AC569B /* SentryReplayApi.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryReplayApi.h; path = Public/SentryReplayApi.h; sourceTree = "<group>"; };
-		D8A3649B2C91AA3300AC569B /* SentryReplayApi.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryReplayApi.m; sourceTree = "<group>"; };
 		D8A65B5C2C98656000974B74 /* SentryReplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayView.swift; sourceTree = "<group>"; };
 		D8ACE3C52762187200F5A213 /* SentryFileIOTrackerHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryFileIOTrackerHelper.m; sourceTree = "<group>"; };
 		D8ACE3CB2762187D00F5A213 /* SentryFileIOTrackerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryFileIOTrackerHelper.h; path = include/SentryFileIOTrackerHelper.h; sourceTree = "<group>"; };
@@ -2025,6 +2024,7 @@
 		FAAB96532EA6A72D0030A2DB /* SentryCrashScopeHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashScopeHelper.m; sourceTree = "<group>"; };
 		FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEventSwiftHelper.h; path = include/SentryEventSwiftHelper.h; sourceTree = "<group>"; };
 		FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEventSwiftHelper.m; sourceTree = "<group>"; };
+		FAC2FE822F33D011002B39C1 /* SentryReplayApi.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryReplayApi.m; sourceTree = "<group>"; };
 		FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKThreadTests.swift; sourceTree = "<group>"; };
 		FAC735222E25AA7A006C5A64 /* SentryProfilingSwiftHelpersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfilingSwiftHelpersTests.m; sourceTree = "<group>"; };
 		FAC880B52EE5FA2A007B4796 /* TestNSURLRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSURLRequestBuilder.swift; sourceTree = "<group>"; };
@@ -3815,7 +3815,7 @@
 				D82859412C3E753C009A28AA /* SentrySessionReplaySyncC.h */,
 				D82859422C3E753C009A28AA /* SentrySessionReplaySyncC.c */,
 				D8A3649A2C91AA3300AC569B /* SentryReplayApi.h */,
-				D8A3649B2C91AA3300AC569B /* SentryReplayApi.m */,
+				FAC2FE822F33D011002B39C1 /* SentryReplayApi.m */,
 			);
 			name = SessionReplay;
 			sourceTree = "<group>";
@@ -4721,6 +4721,7 @@
 				92D957732E05A44600E20E66 /* SentryAsyncLog.m in Sources */,
 				15E0A8ED240F2CB000F044E3 /* SentrySerialization.m in Sources */,
 				7BC85235245880AE005A70F0 /* SentryDataCategoryMapper.m in Sources */,
+				FAC2FE832F33D011002B39C1 /* SentryReplayApi.m in Sources */,
 				63FE713B20DA4C1100CDBAE8 /* SentryCrashFileUtils.c in Sources */,
 				63FE716920DA4C1100CDBAE8 /* SentryCrashStackCursor.c in Sources */,
 				7BA61CCA247D128B00C130A8 /* SentryDefaultThreadInspector.m in Sources */,
@@ -4837,7 +4838,6 @@
 				FAE2DAB82E1F317900262307 /* SentryProfilingSwiftHelpers.m in Sources */,
 				9286059729A5098900F96038 /* SentryGeo.m in Sources */,
 				D43B26D82D70A550007747FD /* SentryTraceOrigin.m in Sources */,
-				D8A3649C2C91AA3300AC569B /* SentryReplayApi.m in Sources */,
 				639FCFAD1EBC811400778193 /* SentryUser.m in Sources */,
 				63FE711920DA4C1000CDBAE8 /* SentryCrashMachineContext.c in Sources */,
 				63FE711B20DA4C1000CDBAE8 /* SentryCrashString.c in Sources */,

--- a/SentryTestUtils/Headers/SentryHub+Test.h
+++ b/SentryTestUtils/Headers/SentryHub+Test.h
@@ -4,7 +4,8 @@
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;
 @class SentryClientInternal;
-@protocol SentryIntegrationProtocol;
+@class IntegrationRegistry;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** Expose the internal test init for testing. */
@@ -15,7 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
                andCrashWrapper:(SentryCrashWrapper *)crashAdapter
               andDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue;
 
-- (NSArray<id<SentryIntegrationProtocol>> *)installedIntegrations;
+@property (nonatomic, readonly, strong) IntegrationRegistry *integrationRegistry;
+
 - (NSSet<NSString *> *)installedIntegrationNames;
 
 - (BOOL)eventContainsOnlyHandledErrors:(NSDictionary *)eventDictionary;

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -323,17 +323,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {
-
-    NSArray *integrations = [[SentrySDKInternal currentHub] installedIntegrations];
-    SentrySessionReplayIntegration *replayIntegration;
-    for (id obj in integrations) {
-        if ([obj isKindOfClass:[SentrySessionReplayIntegration class]]) {
-            replayIntegration = obj;
-            break;
-        }
-    }
-
-    return replayIntegration;
+    return [SentryReplayApiHelper getSessionReplayIntegration];
 }
 
 + (void)captureReplay

--- a/Sources/Sentry/SentryReplayApi.m
+++ b/Sources/Sentry/SentryReplayApi.m
@@ -26,35 +26,31 @@
 - (void)pause
 {
     SENTRY_LOG_INFO(@"[Session Replay] Pausing session");
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
     [replayIntegration pause];
 }
 
 - (void)resume
 {
     SENTRY_LOG_INFO(@"[Session Replay] Resuming session");
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
     [replayIntegration resume];
 }
 
 - (void)start SENTRY_DISABLE_THREAD_SANITIZER("double-checked lock produce false alarms")
 {
     SENTRY_LOG_INFO(@"[Session Replay] Starting session");
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
 
     // Start could be misused and called multiple times, causing it to
     // be initialized more than once before being installed.
     // Synchronizing it will prevent this problem.
     if (replayIntegration == nil) {
         @synchronized(self) {
-            replayIntegration = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-                getInstalledIntegration:SentrySessionReplayIntegration.class];
+            replayIntegration = [SentryReplayApiHelper getSessionReplayIntegration];
             if (replayIntegration == nil && SentrySDKInternal.currentHub.client.options) {
                 SentryOptions *currentOptions = SENTRY_UNWRAP_NULLABLE(
                     SentryOptions, SentrySDKInternal.currentHub.client.options);
@@ -87,9 +83,8 @@
 - (void)stop
 {
     SENTRY_LOG_INFO(@"[Session Replay] Stopping session");
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
     [replayIntegration stop];
 }
 
@@ -102,9 +97,8 @@
 - (void)showMaskPreview:(CGFloat)opacity
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Showing mask preview with opacity: %f", opacity);
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
 
     [replayIntegration showMaskPreview:opacity];
 }
@@ -112,9 +106,8 @@
 - (void)hideMaskPreview
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Hiding mask preview");
-    SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
+    SentrySessionReplayIntegration *replayIntegration =
+        [SentryReplayApiHelper getSessionReplayIntegration];
 
     [replayIntegration hideMaskPreview];
 }

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -510,20 +510,12 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)pauseAppHangTracking
 {
-    SentryHangTrackerIntegrationObjC *anrTrackingIntegration
-        = (SentryHangTrackerIntegrationObjC *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:[SentryHangTrackerIntegrationObjC class]];
-
-    [anrTrackingIntegration pauseAppHangTracking];
+    [[SentryHangTrackingHelper getHangTrackerIntegration] pauseAppHangTracking];
 }
 
 + (void)resumeAppHangTracking
 {
-    SentryHangTrackerIntegrationObjC *anrTrackingIntegration
-        = (SentryHangTrackerIntegrationObjC *)[SentrySDKInternal.currentHub
-            getInstalledIntegration:[SentryHangTrackerIntegrationObjC class]];
-
-    [anrTrackingIntegration resumeAppHangTracking];
+    [[SentryHangTrackingHelper getHangTrackerIntegration] resumeAppHangTracking];
 }
 
 + (void)flush:(NSTimeInterval)timeout

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -14,7 +14,6 @@
 @class SentryReplayEvent;
 @class SentryAttachment;
 @class SentryReplayRecording;
-@protocol SentryIntegrationProtocol;
 @protocol SentrySessionListener;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -22,8 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryHubInternal ()
 
 @property (nullable, nonatomic, strong) SentrySession *session;
-
-@property (nonatomic, strong) NSMutableArray<id<SentryIntegrationProtocol>> *installedIntegrations;
 
 @property (nonatomic, readonly, strong) NSObject *_swiftLogger;
 
@@ -33,9 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<NSString *> *)trimmedInstalledIntegrationNames;
 
-- (void)addInstalledIntegration:(SENTRY_SWIFT_MIGRATION_ID(
-                                    id<SentryIntegrationProtocol>))integration
-                           name:(NSString *)name;
+- (void)addInstalledIntegration:(id)integration name:(NSString *)name;
 - (void)removeAllIntegrations;
 
 - (SentryClientInternal *_Nullable)client;
@@ -76,8 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)storeEnvelope:(SentryEnvelope *)envelope;
 - (void)captureEnvelope:(SentryEnvelope *)envelope;
 
-- (nullable SENTRY_SWIFT_MIGRATION_ID(
-    id<SentryIntegrationProtocol>))getInstalledIntegration:(Class)integrationClass;
 - (NSSet<NSString *> *)installedIntegrationNames;
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED

--- a/Sources/Swift/Core/Integrations/FlushableIntegration.swift
+++ b/Sources/Swift/Core/Integrations/FlushableIntegration.swift
@@ -4,7 +4,7 @@
 ///
 /// Integrations conforming to this protocol can be flushed synchronously,
 /// typically during app lifecycle events or manual flush operations.
-protocol FlushableIntegration: SentryIntegrationProtocol {
+protocol FlushableIntegration: SwiftIntegration {
     /// Flushes any buffered data synchronously.
     /// - Returns: The time taken to flush in seconds
     @discardableResult func flush() -> TimeInterval

--- a/Sources/Swift/Core/Integrations/IntegrationRegistry.swift
+++ b/Sources/Swift/Core/Integrations/IntegrationRegistry.swift
@@ -1,0 +1,133 @@
+// swiftlint:disable missing_docs
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+/// Thread-safe registry for managing installed integrations.
+/// This class is the single source of truth for integration storage,
+/// allowing SentryIntegrationProtocol to be a pure Swift protocol.
+@_spi(Private) @objc public final class IntegrationRegistry: NSObject {
+    private let lock = NSLock()
+    private var integrations: [any SwiftIntegration] = []
+    private var integrationNames: Set<String> = []
+    
+    @objc public func add(_ integration: Any, name: String) {
+        guard let swiftIntegration = integration as? (any SwiftIntegration) else {
+            SentrySDKLog.error("Attempted to add non-SentryIntegrationProtocol integration: \(type(of: integration))")
+            return
+        }
+        lock.synchronized {
+            integrations.append(swiftIntegration)
+            integrationNames.insert(name)
+        }
+        SentrySDKLog.debug("Integration installed: \(name)")
+    }
+    
+    /// Gets an integration by its class. This method is kept for backwards compatibility
+    /// but Swift callers should use the generic `getIntegration<T>(_ type: T.Type)` instead.
+    func getIntegration(_ integrationClass: AnyClass) -> (any SwiftIntegration)? {
+        lock.synchronized {
+            for integration in integrations {
+                if type(of: integration) == integrationClass {
+                    return integration
+                }
+            }
+            return nil
+        }
+    }
+    
+    /// Gets an integration by its Swift type. Use this from Swift code.
+    func getIntegration<T: SwiftIntegration>(_ type: T.Type) -> T? {
+        lock.synchronized {
+            for integration in integrations {
+                if let match = integration as? T {
+                    return match
+                }
+            }
+            return nil
+        }
+    }
+    
+    @objc public func isInstalled(_ integrationClass: AnyClass) -> Bool {
+        lock.synchronized {
+            for integration in integrations {
+                if type(of: integration) == integrationClass {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+    
+    @objc public func hasIntegration(_ name: String) -> Bool {
+        lock.synchronized {
+            integrationNames.contains(name)
+        }
+    }
+    
+    @objc public func removeAll() {
+        let integrationsToUninstall = lock.synchronized {
+            let snapshot = integrations
+            integrations.removeAll()
+            integrationNames.removeAll()
+            return snapshot
+        }
+        
+        for integration in integrationsToUninstall {
+            integration.uninstall()
+        }
+    }
+    
+    /// Returns all installed integrations.
+    var allIntegrations: [any SwiftIntegration] {
+        lock.synchronized {
+            integrations
+        }
+    }
+    
+    @objc public var allIntegrationNames: Set<String> {
+        lock.synchronized {
+            integrationNames
+        }
+    }
+    
+    /// Flushes all flushable integrations with the given timeout.
+    /// - Parameter timeout: Maximum time to spend flushing.
+    /// - Returns: The actual time spent flushing.
+    @objc public func flushIntegrations(timeout: TimeInterval) -> TimeInterval {
+        let dateProvider = SentryDependencyContainer.sharedInstance().dateProvider
+        let startTimeNs = dateProvider.getAbsoluteTime()
+        
+        let integrationsSnapshot = lock.synchronized { integrations }
+        
+        for integration in integrationsSnapshot {
+            let currentTimeNs = dateProvider.getAbsoluteTime()
+            let elapsedTime = TimeInterval(currentTimeNs - startTimeNs) / 1_000_000_000
+            if elapsedTime >= timeout {
+                SentrySDKLog.debug("Flush integrations timeout exceeded (\(elapsedTime)s >= \(timeout)s). Stopping flush of remaining integrations.")
+                break
+            }
+            
+            if let flushable = integration as? any FlushableIntegration {
+                flushable.flush()
+            }
+        }
+        
+        let endTimeNs = dateProvider.getAbsoluteTime()
+        return TimeInterval(endTimeNs - startTimeNs) / 1_000_000_000
+    }
+}
+// MARK: - SentryHubInternal Extension
+
+/// Extension to expose the integration registry on SentryHubInternal.
+/// This is necessary because the ObjC header declares `integrationRegistry` as an
+/// `IntegrationRegistry*` property, but `IntegrationRegistry` is `@_spi(Private)`,
+/// so Swift code can't see the property through the ObjC bridging without this extension.
+extension SentryHubInternal {
+    /// Provides typed access to the integration registry.
+    /// This computed property accesses the underlying ObjC property and casts it to the proper type.
+    var integrationRegistry: IntegrationRegistry {
+        // swiftlint:disable:next force_cast
+        value(forKey: "integrationRegistry") as! IntegrationRegistry
+    }
+}
+// swiftlint:enable missing_docs

--- a/Sources/Swift/Core/Integrations/Integrations.swift
+++ b/Sources/Swift/Core/Integrations/Integrations.swift
@@ -1,16 +1,9 @@
 // swiftlint:disable missing_docs
 @_implementationOnly import _SentryPrivate
 
-// We cannot expose `SwiftIntegration` to objc due to the associated type, so we have this base integration protocol
-@_spi(Private) @objc public protocol SentryIntegrationProtocol: NSObjectProtocol {
-    
-    // Uninstalls the integration
-    func uninstall()
-}
-
 // This protocol allows injecting the dependencies in a way that does not
 // require the Integration to depend on SentryDependencyContainer.
-protocol SwiftIntegration: SentryIntegrationProtocol {
+protocol SwiftIntegration {
     // The dependencies required for the integration. The easiest way to satisfy this requirement when migrating from ObjC
     // is to define it as `SentryDependencyContainer` with a typealias. However, a generic Swift class that has a protocol
     // constraint on the `Dependencies` type can make it easier to test and to use without a direct dependency on all
@@ -22,6 +15,9 @@ protocol SwiftIntegration: SentryIntegrationProtocol {
     
     // Name of the integration that is used by `SentrySdkInfo`
     static var name: String { get }
+    
+    /// Uninstalls the integration
+    func uninstall()
 }
 
 // Type erases the `Integration` so that it can be stored in an array and used for `addInstalledIntegration`

--- a/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
@@ -2,7 +2,7 @@
 import MetricKit
 
 @available(macOS 12.0, *)
-final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration {
+final class SentryMetricKitIntegration<Dependencies>: SwiftIntegration {
     
     let mxManager: SentryMXManager
     
@@ -12,7 +12,6 @@ final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration
         }
 
         mxManager = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: options.inAppIncludes), attachDiagnosticAsAttachment: options.enableMetricKitRawPayload)
-        super.init()
 
         mxManager.receiveReports()
     }

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTrackingIntegration.swift
@@ -2,7 +2,7 @@
 
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
-final class SentryAppStartTrackingIntegration<Dependencies: SentryAppStartTrackerBuilder>: NSObject, SwiftIntegration {
+final class SentryAppStartTrackingIntegration<Dependencies: SentryAppStartTrackerBuilder>: SwiftIntegration {
     let tracker: SentryAppStartTracker
 
     init?(with options: Options, dependencies: Dependencies) {
@@ -16,8 +16,6 @@ final class SentryAppStartTrackingIntegration<Dependencies: SentryAppStartTracke
         }
 
         tracker = dependencies.getAppStartTracker(options)
-
-        super.init()
 
         // Start tracking
         tracker.start()

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
@@ -90,6 +90,6 @@ extension SentryDependencyContainer: SentryMetricsApiDependencies {
     }
 
     var metricsIntegration: SentryMetricsIntegration<SentryDependencyContainer>? {
-        SentrySDKInternal.currentHub().getInstalledIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self) as? SentryMetricsIntegration
+        SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self)
     }
 }

--- a/Sources/Swift/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegration.swift
@@ -3,7 +3,7 @@
 
 typealias CoreDataTrackingIntegrationProvider = SentryCoreDataSwizzlingProvider & SentryCoreDataTrackerBuilder
 
-final class SentryCoreDataTrackingIntegration<Dependencies: CoreDataTrackingIntegrationProvider>: NSObject, SwiftIntegration {
+final class SentryCoreDataTrackingIntegration<Dependencies: CoreDataTrackingIntegrationProvider>: SwiftIntegration {
     private let tracker: SentryCoreDataTracker
     private let coreDataSwizzling: SentryCoreDataSwizzling
 
@@ -30,8 +30,6 @@ final class SentryCoreDataTrackingIntegration<Dependencies: CoreDataTrackingInte
 
         self.tracker = dependencies.getCoreDataTracker(options)
         self.coreDataSwizzling = dependencies.coreDataSwizzling
-
-        super.init()
 
         self.coreDataSwizzling.start(with: tracker)
     }

--- a/Sources/Swift/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegration.swift
@@ -2,7 +2,7 @@
 
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
-final class SentryFramesTrackingIntegration<Dependencies: FramesTrackingProvider>: NSObject, SwiftIntegration {
+final class SentryFramesTrackingIntegration<Dependencies: FramesTrackingProvider>: SwiftIntegration {
     let tracker: SentryFramesTracker
 
     init?(with options: Options, dependencies: Dependencies) {

--- a/Sources/Swift/Integrations/Performance/IO/SentryFileIOTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/IO/SentryFileIOTrackingIntegration.swift
@@ -2,7 +2,7 @@
 
 typealias FileIOTrackingIntegrationProvider = FileIOTrackerProvider & NSDataSwizzlingProvider & NSFileManagerSwizzlingProvider
 
-final class SentryFileIOTrackingIntegration<Dependencies: FileIOTrackingIntegrationProvider>: NSObject, SwiftIntegration {
+final class SentryFileIOTrackingIntegration<Dependencies: FileIOTrackingIntegrationProvider>: SwiftIntegration {
     private let tracker: SentryFileIOTracker
     private let nsDataSwizzling: SentryNSDataSwizzling
     private let nsFileManagerSwizzling: SentryNSFileManagerSwizzling
@@ -29,8 +29,6 @@ final class SentryFileIOTrackingIntegration<Dependencies: FileIOTrackingIntegrat
         self.tracker = dependencies.fileIOTracker
         self.nsDataSwizzling = dependencies.nsDataSwizzling
         self.nsFileManagerSwizzling = dependencies.nsFileManagerSwizzling
-
-        super.init()
 
         tracker.enable()
 

--- a/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvider>: NSObject, SwiftIntegration {
+final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvider>: SwiftIntegration {
     
     /// References the shared `SentryNetworkTracker` instance (injected via dependencies).
     ///
@@ -37,8 +37,6 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
         guard shouldEnableNetworkTracking || options.enableNetworkBreadcrumbs || options.enableCaptureFailedRequests else {
             return nil
         }
-
-        super.init()
 
         SentrySwizzleWrapperHelper.swizzleURLSessionTask(networkTracker)
     }

--- a/Sources/Swift/Integrations/SentryHangTrackingHelper.swift
+++ b/Sources/Swift/Integrations/SentryHangTrackingHelper.swift
@@ -1,0 +1,12 @@
+// swiftlint:disable missing_docs
+@_implementationOnly import _SentryPrivate
+
+/// Helper class to provide typed access to hang tracking integration.
+/// This bridges ObjC code to the Swift IntegrationRegistry.
+@_spi(Private) @objc public final class SentryHangTrackingHelper: NSObject {
+    
+    @_spi(Private) @objc public static func getHangTrackerIntegration() -> SentryHangTrackerIntegrationObjC? {
+        SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryHangTrackerIntegrationObjC.self)
+    }
+}
+// swiftlint:enable missing_docs

--- a/Sources/Swift/Integrations/Session/SentryAutoSessionTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Session/SentryAutoSessionTrackingIntegration.swift
@@ -5,7 +5,7 @@ protocol AutoSessionTrackingProvider {
     var processInfoWrapper: SentryProcessInfoSource { get }
 }
 
-final class SentryAutoSessionTrackingIntegration<Dependencies: AutoSessionTrackingProvider>: NSObject, SwiftIntegration {
+final class SentryAutoSessionTrackingIntegration<Dependencies: AutoSessionTrackingProvider>: SwiftIntegration {
     let tracker: SessionTracker
     
     init?(with options: Options, dependencies: Dependencies) {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayApiHelper.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayApiHelper.swift
@@ -1,0 +1,16 @@
+// swiftlint:disable missing_docs
+@_implementationOnly import _SentryPrivate
+
+#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+
+/// Helper class to provide typed access to session replay integration.
+/// This bridges ObjC code to the Swift IntegrationRegistry.
+@_spi(Private) @objc public final class SentryReplayApiHelper: NSObject {
+    
+    @_spi(Private) @objc public static func getSessionReplayIntegration() -> SentrySessionReplayIntegration? {
+        SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentrySessionReplayIntegration.self)
+    }
+}
+
+#endif // (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+// swiftlint:enable missing_docs

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
@@ -392,8 +392,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     
     func getTouchTracker() -> SentryTouchTracker? { touchTracker }
     
-    // Helper function to cast SentrySessionReplayIntegration to SentryIntegrationProtocol
-    // Used only for testing with `addInstalledIntegration` or it fails to compile
+    // Helper function used for testing to add the integration to the hub
     func addItselfToSentryHub(hub: SentryHubInternal) {
         hub.addInstalledIntegration(self, name: Self.name)
     }

--- a/Sources/Swift/Integrations/SwiftAsyncIntegration.swift
+++ b/Sources/Swift/Integrations/SwiftAsyncIntegration.swift
@@ -1,6 +1,6 @@
 @_implementationOnly import _SentryPrivate
 
-final class SwiftAsyncIntegration<Dependencies>: NSObject, SwiftIntegration {
+final class SwiftAsyncIntegration<Dependencies>: SwiftIntegration {
     init?(with options: Options, dependencies: Dependencies) {
         guard options.swiftAsyncStacktraces else { return nil }
 

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.swift
@@ -22,7 +22,7 @@
     }
     
     private func getIntegration() -> UserFeedbackIntegration<SentryDependencyContainer>? {
-        SentrySDKInternal.currentHub().getInstalledIntegration(UserFeedbackIntegration<SentryDependencyContainer>.self) as? UserFeedbackIntegration<SentryDependencyContainer>
+        SentrySDKInternal.currentHub().integrationRegistry.getIntegration(UserFeedbackIntegration<SentryDependencyContainer>.self)
     }
 }
 #endif

--- a/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
@@ -6,7 +6,7 @@ protocol ScreenshotSourceProvider {
     var screenshotSource: SentryScreenshotSource? { get }
 }
 
-final class UserFeedbackIntegration<Dependencies: ScreenshotSourceProvider>: NSObject, SwiftIntegration {
+final class UserFeedbackIntegration<Dependencies: ScreenshotSourceProvider>: SwiftIntegration {
 
     let driver: SentryUserFeedbackIntegrationDriver
 

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -519,7 +519,7 @@ class SentryMetricsApiE2ETests: XCTestCase {
     }
     
     private func getIntegration() throws -> SentryMetricsIntegration<SentryDependencyContainer>? {
-        return SentrySDKInternal.currentHub().getInstalledIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self) as? SentryMetricsIntegration
+        return SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self)
     }
     
     private func flushMetrics() throws {

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -547,7 +547,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
     }
 
     private func getSut() throws -> SentryMetricsIntegration<SentryDependencyContainer> {
-        return try XCTUnwrap(SentrySDKInternal.currentHub().getInstalledIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self) as? SentryMetricsIntegration)
+        return try XCTUnwrap(SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryMetricsIntegration<SentryDependencyContainer>.self))
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -143,6 +143,6 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
     }
     
     private func getInstalledIntegration() throws -> SentryCoreDataTrackingIntegration<SentryDependencyContainer> {
-        return try XCTUnwrap(SentrySDKInternal.currentHub().getInstalledIntegration(SentryCoreDataTrackingIntegration<SentryDependencyContainer>.self) as? SentryCoreDataTrackingIntegration)
+        return try XCTUnwrap(SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryCoreDataTrackingIntegration<SentryDependencyContainer>.self))
     }
 }

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.h
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.h
@@ -1,13 +1,18 @@
-#import "SentrySwift.h"
 #import <Foundation/Foundation.h>
 
 @class SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryTestIntegration : NSObject <SentryIntegrationProtocol>
+/// Test integration that conforms to the integration protocol requirements.
+/// Since SentryIntegrationProtocol is now a pure Swift protocol, ObjC test
+/// integrations just need to implement the required methods.
+@interface SentryTestIntegration : NSObject
 
 @property (nonatomic, strong) SentryOptions *options;
+
+- (BOOL)installWithOptions:(SentryOptions *)options;
+- (void)uninstall;
 
 @end
 

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -36,7 +36,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         // Assert
         XCTAssertEqual(testHub.installedIntegrationNames().count, 1)
         XCTAssertEqual(try XCTUnwrap(testHub.installedIntegrationNames().first), "SentrySwiftAsyncIntegration")
-        XCTAssertEqual(testHub.installedIntegrations().count, 1)
+        XCTAssertEqual(testHub.integrationRegistry.allIntegrations.count, 1)
     }
 
     func testInstall_WithDisabledIntegration_DoesNotAddIntegration() {
@@ -63,6 +63,6 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(testHub.installedIntegrationNames().count, 0)
-        XCTAssertEqual(testHub.installedIntegrations().count, 0)
+        XCTAssertEqual(testHub.integrationRegistry.allIntegrations.count, 0)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayApiTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayApiTests.swift
@@ -33,7 +33,7 @@ class SentryReplayApiTests: XCTestCase {
 
         // Assert
         XCTAssertTrue(mockReplayIntegration.startCalled)
-        XCTAssertEqual(mockHub.installedIntegrations().count, 1) // No new integration added
+        XCTAssertEqual(mockHub.integrationRegistry.allIntegrations.count, 1) // No new integration added
     }
 
     func testStart_whenReplayIntegrationNilAndUnreliableToEnable_shouldNotCreateIntegration() {
@@ -54,7 +54,7 @@ class SentryReplayApiTests: XCTestCase {
         sut.start()
 
         // Assert
-        XCTAssertTrue(mockHub.installedIntegrations().isEmpty)
+        XCTAssertTrue(mockHub.integrationRegistry.allIntegrations.isEmpty)
     }
 
     func testStart_whenReplayIntegrationNilWithUnreliableEnvironmentAndOverrideOptionEnabled_shouldCreateAndInstallIntegration() throws {
@@ -84,8 +84,8 @@ class SentryReplayApiTests: XCTestCase {
         sut.start()
         
         // Assert
-        XCTAssertEqual(mockHub.installedIntegrations().count, 1)
-        let integration = try XCTUnwrap(mockHub.installedIntegrations().first as? SentrySessionReplayIntegration)
+        XCTAssertEqual(mockHub.integrationRegistry.allIntegrations.count, 1)
+        let integration = try XCTUnwrap(mockHub.integrationRegistry.getIntegration(SentrySessionReplayIntegration.self))
         XCTAssertNotNil(integration.sessionReplay)
         XCTAssertTrue(integration.sessionReplay?.isRunning ?? false)
         SentrySDKInternal.currentHub().endSession()

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -47,7 +47,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     private func getSut() throws -> SentrySessionReplayIntegration {
-        return try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
+        return try XCTUnwrap(SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentrySessionReplayIntegration.self))
     }
     
     private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true, noIntegrations: Bool = false, configure: ((Options) -> Void)? = nil) {
@@ -80,7 +80,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testInstallNoSwizzlingNoTouchTracker() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0, enableSwizzling: false)
-        guard let integration = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
+        guard let integration = SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentrySessionReplayIntegration.self)
         else {
             XCTFail("Could not find session replay integration")
             return
@@ -385,7 +385,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testStartWithNoSessionReplay() throws {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0, noIntegrations: true)
-        var sut = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
+        var sut = SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentrySessionReplayIntegration.self)
         XCTAssertNil(sut)
         SentrySDK.replay.start()
         sut = try getSut()

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -445,7 +445,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
 
     private func getFirstIntegrationAsReplay() throws -> SentrySessionReplayIntegration {
-        return try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
+        return try XCTUnwrap(SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentrySessionReplayIntegration.self))
     }
     
     private let VALID_REPLAY_ID = "0eac7ab503354dd5819b03e263627a29"

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1341,7 +1341,7 @@ class SentryHubTests: XCTestCase {
         let logs = logOutput.loggedMessages.joined()
         XCTAssertTrue(logs.contains("Integration installed: MyIntegrationName"), "Should log when MyIntegrationName is installed")
         XCTAssertTrue(sut.hasIntegration("MyIntegrationName"))
-        XCTAssertNotNil(sut.getInstalledIntegration(EmptyIntegration.self))
+        XCTAssertNotNil(sut.integrationRegistry.getIntegration(EmptyIntegration.self))
     }
     
     func testModifyIntegrationsConcurrently() {
@@ -1362,7 +1362,7 @@ class SentryHubTests: XCTestCase {
                     let integrationName = "Integration\(i)\(j)"
                     sut.addInstalledIntegration(EmptyIntegration(), name: integrationName)
                     XCTAssertTrue(sut.hasIntegration(integrationName))
-                    XCTAssertNotNil(sut.getInstalledIntegration(EmptyIntegration.self))
+                    XCTAssertNotNil(sut.integrationRegistry.getIntegration(EmptyIntegration.self))
                 }
                 expectation.fulfill()
             }
@@ -1370,7 +1370,7 @@ class SentryHubTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5.0)
 
-        XCTAssertEqual(innerLoopAmount * outerLoopAmount, sut.installedIntegrations().count)
+        XCTAssertEqual(innerLoopAmount * outerLoopAmount, sut.integrationRegistry.allIntegrations.count)
         XCTAssertEqual(innerLoopAmount * outerLoopAmount, sut.installedIntegrationNames().count)
         
     }
@@ -1395,10 +1395,10 @@ class SentryHubTests: XCTestCase {
                     sut.addInstalledIntegration(EmptyIntegration(), name: integrationName)
                     sut.hasIntegration(integrationName)
                     sut.isIntegrationInstalled(EmptyIntegration.self)
-                    sut.getInstalledIntegration(EmptyIntegration.self)
+                    sut.integrationRegistry.getIntegration(EmptyIntegration.self)
                 }
-                XCTAssertLessThanOrEqual(0, sut.installedIntegrations().count)
-                sut.installedIntegrations().forEach { XCTAssertNotNil($0) }
+                XCTAssertLessThanOrEqual(0, sut.integrationRegistry.allIntegrations.count)
+                sut.integrationRegistry.allIntegrations.forEach { XCTAssertNotNil($0) }
                 
                 XCTAssertLessThanOrEqual(0, sut.installedIntegrationNames().count)
                 sut.installedIntegrationNames().forEach { XCTAssertNotNil($0) }
@@ -1415,7 +1415,7 @@ class SentryHubTests: XCTestCase {
         let integration = EmptyIntegration()
         sut.addInstalledIntegration(integration, name: "EmptyIntegration")
         
-        let installedIntegration = sut.getInstalledIntegration(EmptyIntegration.self) as? NSObject
+        let installedIntegration = sut.integrationRegistry.getIntegration(EmptyIntegration.self)
         
         XCTAssert(integration === installedIntegration)
     }
@@ -1424,7 +1424,7 @@ class SentryHubTests: XCTestCase {
         let integration = EmptyIntegration()
         sut.addInstalledIntegration(integration, name: "EmptyIntegration")
         
-        XCTAssertNil(sut.getInstalledIntegration(SentryHangTrackerIntegrationObjC.self))
+        XCTAssertNil(sut.integrationRegistry.getIntegration(SentryHangTrackerIntegrationObjC.self))
     }
     
     func testEventContainsOnlyHandledErrors() {

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -442,9 +442,9 @@ class SentrySDKInternalTests: XCTestCase {
         }
 
         let hub = SentrySDKInternal.currentHub()
-        XCTAssertEqual(1, hub.installedIntegrations().count)
+        XCTAssertEqual(1, hub.integrationRegistry.allIntegrations.count)
         SentrySDK.close()
-        XCTAssertEqual(0, hub.installedIntegrations().count)
+        XCTAssertEqual(0, hub.integrationRegistry.allIntegrations.count)
         assertIntegrationsInstalled(integrations: [])
     }
 
@@ -546,7 +546,7 @@ class SentrySDKInternalTests: XCTestCase {
         let client = fixture.client
         SentrySDKInternal.currentHub().bindClient(client)
 
-        let anrTrackingIntegration = try XCTUnwrap(SentrySDKInternal.currentHub().getInstalledIntegration(SentryHangTrackerIntegrationObjC.self))
+        let anrTrackingIntegration = try XCTUnwrap(SentrySDKInternal.currentHub().integrationRegistry.getIntegration(SentryHangTrackerIntegrationObjC.self))
 
         SentrySDK.pauseAppHangTracking()
         Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
@@ -973,7 +973,7 @@ private extension SentrySDKInternalTests {
     }
 
     func assertIntegrationsInstalled(integrations: [String]) {
-        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
+        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().integrationRegistry.allIntegrations.count)
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
                 XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -483,7 +483,7 @@ extension SentrySDKTests {
     }
     
     private func assertIntegrationsInstalled(integrations: [String]) {
-        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
+        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().integrationRegistry.allIntegrations.count)
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
                 XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")

--- a/Tests/SentryTests/TestUtils/EmptyIntegration.swift
+++ b/Tests/SentryTests/TestUtils/EmptyIntegration.swift
@@ -1,4 +1,5 @@
 import Foundation
+@_spi(Private) import Sentry
 
 class EmptyIntegration: NSObject, SentryIntegrationProtocol {
     func install(with options: Options) -> Bool {


### PR DESCRIPTION
Now that all the integrations are out of objc, they don't need to be `NSObject` subclasses anymore

Closes #7376