### PR TITLE
chore: Add `dependencies` label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "ready-to-merge"
+      - "dependencies"
     ignore:
       - dependency-name: fastlane
         versions:
@@ -18,3 +19,4 @@ updates:
       interval: weekly
     labels:
       - "ready-to-merge"
+      - "dependencies"


### PR DESCRIPTION
## :scroll: Description
It seems like we've lost the default `dependencies` label with the changes made in https://github.com/getsentry/sentry-cocoa/pull/7352. We're using this for the managed PR reminders, so this PR adds it again.
In this PR it was still automatically added: https://github.com/getsentry/sentry-cocoa/pull/7347
<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7407