### PR TITLE
fix: revert TelemetryScopeApplier gating of user attributes on sendDefaultPII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix user attributes from scope being omitted from logs when sendDefaultPII is false (#7437)
 - Cleanup SessionReplay when maximum duration reached (#7421)
 - Fix App hangs report with high durations (#7354)
 

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
@@ -89,10 +89,7 @@ extension TelemetryScopeApplier {
         }
     }
 
-    private func addUserAttributes(to attributes: inout [String: SentryAttributeContent], metadata: any TelemetryScopeMetadata) {
-        guard metadata.sendDefaultPii else {
-            return
-        }
+    private func addUserAttributes(to attributes: inout [String: SentryAttributeContent], metadata _: any TelemetryScopeMetadata) {
         if let userId = userObject?.userId {
             attributes["user.id"] = .string(userId)
         }

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -397,7 +397,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertNil(item.attributesDict["user.email"])
     }
 
-    func testApplyToItem_whenSendDefaultPiiFalse_shouldNotAddUserNameAndEmail() {
+    func testApplyToItem_whenSendDefaultPiiFalse_shouldStillAddUserAttributes() {
         // -- Arrange --
         let user = User(userId: "user-123")
         user.name = "John Doe"
@@ -416,9 +416,10 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata)
 
         // -- Assert --
-        XCTAssertEqual(item.attributesDict["user.id"], .string("installation-123"))
-        XCTAssertNil(item.attributesDict["user.name"])
-        XCTAssertNil(item.attributesDict["user.email"])
+        // User attributes are applied regardless of sendDefaultPII
+        XCTAssertEqual(item.attributesDict["user.id"], .string("user-123"))
+        XCTAssertEqual(item.attributesDict["user.name"], .string("John Doe"))
+        XCTAssertEqual(item.attributesDict["user.email"], .string("john@example.com"))
     }
 
     // MARK: - Replay Attributes Tests


### PR DESCRIPTION
## :scroll: Description

Reverts the TelemetryScopeApplier changes so user attributes are applied to logs regardless of `sendDefaultPII`. When a user manually sets data on the scope (e.g. via `scope.setUser()`), that data should always be attached to outgoing telemetry and not gated by the Send Default PII flag.

## :bulb: Motivation and Context

User attributes set on the scope were incorrectly being omitted from logs when `sendDefaultPII` was false (introduced in v9.2.0 via #7055). Per the SDK expected behavior, manually set data on the scope should not be gated by `sendDefaultPII`—that flag should only affect data the SDK automatically collects/infers. This was clarified in getsentry/sentry-docs#16299 reverted the behavior changed in v9.2.0.

Fixes #7416

## :green_heart: How did you test it?

- `make build-macos` - build succeeded
- `make test-ios ONLY_TESTING=TelemetryScopeApplierTests` - all tests passed
- Updated `testApplyToItem_whenSendDefaultPiiFalse_shouldStillAddUserAttributes` to assert user attributes are applied regardless of sendDefaultPII

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
