### PR TITLE
chore: Move changelog entry #7379 to `Unreleased` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Record client report when dropping in `beforeSendLog` (#7379)
+
 ### Fixes
 
 - Cleanup SessionReplay when maximum duration reached (#7421)
@@ -16,10 +20,6 @@
 ### Breaking Changes
 
 - `Sentry.metrics.count(..)` does not support units, therefore the API was incorrectly defined. This breaking change applies to a method marked as experimental. (#7358)
-
-### Improvements
-
-- Record client report when dropping in `beforeSendLog` (#7379)
 
 ### Fixes
 


### PR DESCRIPTION
## :scroll: Description

Moves a changelog entry from 9.4.0 to `Unreleased`

#skip-changelog

