### PR TITLE
docs: clarify trace_id and span_id source in TelemetryScopeApplier

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -15,18 +15,38 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        print("[iOS-Swift] [debug] launch arguments: \(args)")
-        print("[iOS-Swift] [debug] launch environment: \(env)")
+//        print("[iOS-Swift] [debug] launch arguments: \(args)")
+//        print("[iOS-Swift] [debug] launch environment: \(env)")
+//
+//        if args.contains(SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue) {
+//            removeAppData()
+//        }
+//
+//        SentrySDKWrapper.shared.startSentry()
+//        SampleAppDebugMenu.shared.display()
+//        
+//        metricKit.receiveReports()
 
-        if args.contains(SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue) {
-            removeAppData()
+        SentrySDK.start { options in
+            options.dsn = SentrySDKWrapper.defaultDSN
+            options.debug = true
+            options.enableLogs = true
+            options.tracesSampleRate = 1
         }
 
-        SentrySDKWrapper.shared.startSentry()
-        SampleAppDebugMenu.shared.display()
-        
-        metricKit.receiveReports()
-        
+        let transaction = SentrySDK.startTransaction(name: "camera-test", operation: "configure-test")
+        DispatchQueue.main.async {
+            SentrySDK.logger.warn("Going to error")
+            SentrySDK.capture(error: NSError(domain: "camera", code: 404))
+            DispatchQueue.main.async {
+                SentrySDK.logger.warn("After error")
+                transaction.finish()
+                // Can't run this because it will block the main thread
+                // SentrySDK.flush(timeout: 5) 
+                print("done")
+            }
+        }
+
         return true
     }
     

--- a/Sources/Swift/Protocol/SentryLog.swift
+++ b/Sources/Swift/Protocol/SentryLog.swift
@@ -10,6 +10,9 @@ public final class SentryLog: NSObject {
     public var timestamp: Date
     /// The trace ID to associate this log with distributed tracing. This will be set to a valid non-empty value during processing.
     public var traceId: SentryId
+    /// The span ID of the span that was active when the log was collected.
+    /// Only set when there is an active span; a propagated span_id must not be used.
+    public var spanId: SpanId?
     /// The severity level of the log entry
     public var level: Level
     /// The main log message content
@@ -58,6 +61,7 @@ public final class SentryLog: NSObject {
     internal init(
         timestamp: Date,
         traceId: SentryId,
+        spanId: SpanId? = nil,
         level: Level,
         body: String,
         attributes: [String: Attribute],
@@ -65,6 +69,7 @@ public final class SentryLog: NSObject {
     ) {
         self.timestamp = timestamp
         self.traceId = traceId
+        self.spanId = spanId
         self.level = level
         self.body = body
         self.attributes = attributes
@@ -106,6 +111,7 @@ extension SentryLog: TelemetryItem {
     private enum CodingKeys: String, CodingKey {
         case timestamp
         case traceId = "trace_id"
+        case spanId = "span_id"
         case level
         case body
         case attributes
@@ -118,6 +124,7 @@ extension SentryLog: TelemetryItem {
         
         try container.encode(timestamp, forKey: .timestamp)
         try container.encode(traceId.sentryIdString, forKey: .traceId)
+        try container.encodeIfPresent(spanId?.sentrySpanIdString, forKey: .spanId)
         try container.encode(level, forKey: .level)
         try container.encode(body, forKey: .body)
         try container.encode(attributes, forKey: .attributes)

--- a/Sources/Swift/Protocol/SentryMetric.swift
+++ b/Sources/Swift/Protocol/SentryMetric.swift
@@ -26,6 +26,9 @@ public struct SentryMetric {
     /// which applies scope-based attribute enrichment including trace context.
     public var traceId: SentryId
 
+    /// The span ID is not used for metrics; exists to satisfy ``TelemetryItem`` conformance.
+    public var spanId: SpanId?
+
     /// The numeric value of the metric.
     ///
     /// The setter performs automatic type conversion when needed:

--- a/Sources/Swift/Tools/TelemetryBuffer/TelemetryItem.swift
+++ b/Sources/Swift/Tools/TelemetryBuffer/TelemetryItem.swift
@@ -1,4 +1,5 @@
 protocol TelemetryItem: Encodable {
     var attributesDict: [String: SentryAttributeContent] { get set }
     var traceId: SentryId { get set }
+    var spanId: SpanId? { get set }
 }

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
@@ -48,6 +48,11 @@ extension TelemetryScopeApplier {
         // trace_id: From propagation context (https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload).
         // When an active span exists, span.traceId and propagationContextTraceId match; use span's for consistency with span_id.
         item.traceId = span?.traceId ?? propagationContextTraceId
+        // span_id: Top-level field per spec, only set when there is an active span (scope.span).
+        // A propagated span_id must not be used
+        // (https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload,
+        // https://develop.sentry.dev/sdk/telemetry/logs/#tracing).
+        item.spanId = span?.spanId
     }
 
     private func addDefaultAttributes(to attributes: inout [String: SentryAttributeContent], metadata: any TelemetryScopeMetadata) {
@@ -56,12 +61,6 @@ extension TelemetryScopeApplier {
         attributes["sentry.environment"] = .string(metadata.environment)
         if let releaseName = metadata.releaseName {
             attributes["sentry.release"] = .string(releaseName)
-        }
-        // span_id: Only set when there is an active span (scope.span). A propagated span_id must not be used
-        // (https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload,
-        // https://develop.sentry.dev/sdk/telemetry/logs/#tracing).
-        if let span = self.span {
-            attributes["span_id"] = .string(span.spanId.sentrySpanIdString)
         }
     }
 

--- a/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
+++ b/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
@@ -5,6 +5,7 @@ import XCTest
 private struct TestItem: TelemetryItem {
     var attributesDict: [String: SentryAttributeContent]
     var traceId: SentryId
+    var spanId: SpanId?
     var body: String
 
     init(body: String = "test", attributes: [String: SentryAttributeContent] = [:]) {

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -7,11 +7,13 @@ final class TelemetryScopeApplierTests: XCTestCase {
         var attributes: [String: SentryAttribute]
         var attributesDict: [String: SentryAttributeContent]
         var traceId: SentryId
+        var spanId: SpanId?
         var body: String
 
         enum CodingKeys: String, CodingKey {
             case body
             case traceId = "trace_id"
+            case spanId = "span_id"
             case attributes
         }
 
@@ -19,6 +21,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(body, forKey: .body)
             try container.encode(traceId.sentryIdString, forKey: .traceId)
+            try container.encodeIfPresent(spanId?.sentrySpanIdString, forKey: .spanId)
             try container.encode(attributesDict, forKey: .attributes)
         }
     }
@@ -114,7 +117,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertNil(item.attributesDict["sentry.release"])
     }
 
-    func testApplyToItem_withSpan_shouldAddParentSpanId() {
+    func testApplyToItem_withSpan_shouldSetSpanId() {
         // -- Arrange --
         let spanId = SentryId()
         let span = TestSpan(spanId: spanId)
@@ -129,10 +132,10 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata)
 
         // -- Assert --
-        XCTAssertEqual(item.attributesDict["span_id"], .string(span.spanId.sentrySpanIdString))
+        XCTAssertEqual(item.spanId, span.spanId)
     }
 
-    func testApplyToItem_withoutSpan_shouldNotAddParentSpanId() {
+    func testApplyToItem_withoutSpan_shouldNotSetSpanId() {
         // -- Arrange --
         let scope = TestScope(propagationContextTraceId: SentryId())
         let metadata = createTestMetadata()
@@ -142,7 +145,27 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata)
 
         // -- Assert --
-        XCTAssertNil(item.attributesDict["sentry.trace.parent_span_id"])
+        XCTAssertNil(item.spanId)
+    }
+
+    func testApplyToItem_whenNoSpan_simulatingCOCOA1119_shouldUsePropagationContextForTraceIdAndOmitSpanId() {
+        // Reproduces COCOA-1119 scenario: when a log is captured in a context where the scope has no
+        // active span (e.g. DispatchQueue.main.async where scope might not have the transaction), the
+        // log gets trace_id from propagation context and no span_id. If propagation context differs
+        // from the transaction's trace, logs appear in a different trace and are not connected to spans.
+        //
+        // -- Arrange --
+        let propagationTraceId = SentryId()
+        let scope = TestScope(propagationContextTraceId: propagationTraceId)
+        let metadata = createTestMetadata()
+        var item = createTestItem()
+
+        // -- Act --
+        scope.addAttributesToItem(&item, metadata: metadata)
+
+        // -- Assert --
+        XCTAssertEqual(item.traceId, propagationTraceId)
+        XCTAssertNil(item.spanId)
     }
 
     // MARK: - OS Attributes Tests
@@ -645,7 +668,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         // This ensures consistency with span_id which also comes from the span
         XCTAssertEqual(item.traceId, spanTraceId)
         XCTAssertNotEqual(item.traceId, propagationTraceId)
-        XCTAssertEqual(item.attributesDict["span_id"], .string(span.spanId.sentrySpanIdString))
+        XCTAssertEqual(item.spanId, span.spanId)
     }
 
     func testApplyToItem_whenSpanIsActive_shouldUseSpanTraceIdEvenIfDifferentFromPropagationContext() {
@@ -710,7 +733,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertEqual(item.attributesDict["sentry.sdk.version"], .string(SentryMeta.versionString))
         XCTAssertEqual(item.attributesDict["sentry.environment"], .string("production"))
         XCTAssertEqual(item.attributesDict["sentry.release"], .string("1.0.0"))
-        XCTAssertEqual(item.attributesDict["span_id"], .string(span.spanId.sentrySpanIdString))
+        XCTAssertEqual(item.spanId, span.spanId)
 
         // OS attributes
         XCTAssertEqual(item.attributesDict["os.name"], .string("iOS"))


### PR DESCRIPTION
## Description

Add documentation comments to `TelemetryScopeApplier` clarifying how `trace_id` and `span_id` are set for logs (and other telemetry items), with links to the official SDK telemetry docs. No behavior change; this PR is for discussion and to capture what we discovered while investigating #7415

**This PR serves as common grounds as we need to discuss if either our develop docs are wrong.**

## Motivation and Context

Closes #7415

The issue asks to ensure `span_id` is only set when there is an active span, and that a propagated `span_id` is not considered an active span.

We cross-checked the implementation against develop.sentry.dev and the codebase and concluded the following.

**Docs (develop.sentry.dev):**

- Log envelope item payload: https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload
  - `trace_id`:
> The trace id should be grabbed from the current propagation context in the SDK.

  - `span_id`: "The span id of the span that was active when the log was collected."
> The span id should be grabbed from the current active span in the SDK.

- Tracing section: https://develop.sentry.dev/sdk/telemetry/logs/#tracing

> If a log is recorded during an active span, the SDK should set the `span_id` property of the log to the span id of the span that was active when the log was collected.

- Tracing without Performance: https://develop.sentry.dev/sdk/telemetry/traces/tracing-without-performance/
  - Propagation context holds `trace_id` and `span_id` (from incoming headers or random). 

> A non-existing spanId will be propagated along with the trace" and that propagated `span_id` must not be used for logs.

**Current implementation (`TelemetryScopeApplier.swift`):**

- `trace_id`: `item.traceId = span?.traceId ?? propagationContextTraceId`. When a span is active we use its `traceId`; otherwise propagation context. When span is active, scope has been set with that span so the two sources match.
- `span_id`: Only set inside `addDefaultAttributes` when `self.span` is non-nil: `if let span = self.span { attributes["span_id"] = .string(span.spanId.sentrySpanIdString) }`. So `span_id` is only set when `scope.span` exists.

**Why no code change is required:**

- `scope.span` in Sentry Cocoa is only set when a transaction/tracer is started (`SentryHub.m` `setSpan` when starting a tracer). It is never set from propagation context. So `scope.span` always represents an active span we created.
- `TelemetryScopeApplier` only receives `propagationContextTraceId` from the scope, not the propagation context's `span_id`. So we never have access to a "propagated span_id" in this path and cannot accidentally use it. The only span we see is `scope.span`, which is the active span.
- Therefore we already only set `span_id` when an active span exists. The comments we added document this and link to the docs so future readers and other SDKs can align.

**Possible follow-ups (not in this PR):**

- The docs describe `span_id` as a top-level field in the log envelope payload. We currently put `span_id` in the `attributes` dict. Moving it to a top-level field on the log payload might require `SentryLog`/encoding changes and could be a separate change.

## How did you test it?

No behavior change. `make build-macos` and `make test-ios ONLY_TESTING=TelemetryScopeApplierTests` were run; existing tests pass.

## Checklist

- [ ] I added tests to verify the changes. (N/A: documentation only; tests could be added in follow-up)
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled.
- [ ] I updated the docs if needed. (Only inline comments with doc links.)
- [ ] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog