### PR TITLE
chore: Add CocoaPods token keep-alive workflow to maintain session validity

### DIFF
--- a/.github/workflows/cocoapods-keepalive.yml
+++ b/.github/workflows/cocoapods-keepalive.yml
@@ -19,5 +19,7 @@ jobs:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
     steps:
+      - name: Install CocoaPods
+        run: gem install cocoapods
       - name: Refresh CocoaPods Session
         run: pod trunk me > /dev/null 2>&1


### PR DESCRIPTION
## :scroll: Description

Creates a daily job that uses cocoapods token so its expiration time increases.

## :bulb: Motivation and Context

Cocoapods tokens now expire 3 days after being last used, but we don't want to update them manually every time we make a release.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7441