### PR TITLE
fix: Set installationId as fallback userId when user has no userId

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -925,12 +925,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (void)setUserIdIfNoUserSet:(SentryEvent *)event
 {
-    // We only want to set the id if the customer didn't set a user so we at least set something to
-    // identify the user.
+    // We want to set the installationId as the userId if no userId is set so we at least set
+    // something to identify the user. This aligns with the Android SDK behavior.
     if (event.user == nil) {
         SentryUser *user = [[SentryUser alloc] init];
         user.userId = [SentryInstallation idWithCacheDirectoryPath:self.options.cacheDirectoryPath];
         event.user = user;
+    } else if (event.user.userId == nil || event.user.userId.length == 0) {
+        event.user.userId =
+            [SentryInstallation idWithCacheDirectoryPath:self.options.cacheDirectoryPath];
     }
 }
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1988,13 +1988,13 @@ class SentryClientTests: XCTestCase {
         XCTAssertEqual(SentryInstallation.id(withCacheDirectoryPath: PrivateSentrySDKOnly.options.cacheDirectoryPath), actual.user?.userId)
     }
     
-    func testInstallationIdNotSetWhenUserIsSetWithoutId() throws {
+    func testInstallationIdSetWhenUserIsSetWithoutId() throws {
         let scope = fixture.scope
         scope.setUser(fixture.user)
         fixture.getSut().capture(message: "any message", scope: scope)
-        
+
         let actual = try lastSentEventWithAttachment()
-        XCTAssertEqual(fixture.user.userId, actual.user?.userId)
+        XCTAssertEqual(SentryInstallation.id(withCacheDirectoryPath: PrivateSentrySDKOnly.options.cacheDirectoryPath), actual.user?.userId)
         XCTAssertEqual(fixture.user.email, actual.user?.email)
     }
     


### PR DESCRIPTION
## Summary
- Fixes #4036
- When a `SentryUser` object exists with fields like `email`/`username` but no `userId`, the SDK now falls back to `installationId` as the userId — aligning with Android SDK behavior
- Previously, the fallback only applied when no user object was set at all

## Test plan
- [x] Updated existing test `testInstallationIdSetWhenUserIsSetWithoutId` to verify installationId is now set as fallback
- [x] Verified `testInstallationIdNotSetWhenUserIsSetWithId` still passes — explicit userId is not overwritten
- [x] Verified `testInstallationIdSetWhenNoUserId` still passes — no-user case unchanged