### PR TITLE
chore: Update CHANGELOG to remove duplicate fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Write reports on concurrent crashes (#7340)
-
 ### Features
 
 - Enable MetricKit Integration for visionOS ([#7466](https://github.com/getsentry/sentry-cocoa/pull/7466))
@@ -13,6 +9,7 @@
 ### Fixes
 
 - SentryRedactViewHelper had been erroneously made public, it has been removed from the public interface ([#7474](https://github.com/getsentry/sentry-cocoa/pull/7474))
+- Write reports on concurrent crashes (#7340)
 
 ## 9.4.1
 


### PR DESCRIPTION
Removed duplicate entry for concurrent crash reports and adjusted formatting.

#skip-changelog

Closes #7482