### PR TITLE
ref: Use DefaultTelemetryBufferDataForwardingTriggers for metrics buffer

### DIFF
--- a/Sources/Swift/Integrations/Metrics/SentryMetricsBuffer.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsBuffer.swift
@@ -37,6 +37,7 @@ struct DefaultSentryMetricsTelemetryBuffer: SentryMetricsTelemetryBuffer {
         maxBufferSizeBytes: Int = 1_024 * 1_024, // 1MB buffer size for trace metrics
         dateProvider: SentryCurrentDateProvider,
         dispatchQueue: SentryDispatchQueueWrapper,
+        itemForwardingTriggers: TelemetryBufferItemForwardingTriggers,
         capturedDataCallback: @escaping (_ data: Data, _ count: Int) -> Void
     ) {
         self.isEnabled = options.enableMetrics
@@ -50,8 +51,7 @@ struct DefaultSentryMetricsTelemetryBuffer: SentryMetricsTelemetryBuffer {
             buffer: InMemoryInternalTelemetryBuffer(),
             dateProvider: dateProvider,
             dispatchQueue: dispatchQueue,
-            // The MetricsIntegration still contains the data forwarding triggers. Therefore, we still use the NoOpTelemetryBufferDataForwardingTriggers here.
-            itemForwardingTriggers: NoOpTelemetryBufferDataForwardingTriggers()
+            itemForwardingTriggers: itemForwardingTriggers
         )
     }
     

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsBufferTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsBufferTests.swift
@@ -37,6 +37,7 @@ final class DefaultSentryMetricsTelemetryBufferTests: XCTestCase {
             maxBufferSizeBytes: 8_000, // byte limit for testing
             dateProvider: testDateProvider,
             dispatchQueue: testDispatchQueue,
+            itemForwardingTriggers: NoOpTelemetryBufferDataForwardingTriggers(),
             capturedDataCallback: testCallbackHelper.captureCallback
         )
     }
@@ -177,6 +178,7 @@ final class DefaultSentryMetricsTelemetryBufferTests: XCTestCase {
             options: options,
             dateProvider: testDateProvider,
             dispatchQueue: testDispatchQueue,
+            itemForwardingTriggers: NoOpTelemetryBufferDataForwardingTriggers(),
             capturedDataCallback: testCallbackHelper.captureCallback
         )
         
@@ -197,6 +199,7 @@ final class DefaultSentryMetricsTelemetryBufferTests: XCTestCase {
             options: options,
             dateProvider: testDateProvider,
             dispatchQueue: testDispatchQueue,
+            itemForwardingTriggers: NoOpTelemetryBufferDataForwardingTriggers(),
             capturedDataCallback: testCallbackHelper.captureCallback
         )
         
@@ -230,6 +233,7 @@ final class DefaultSentryMetricsTelemetryBufferTests: XCTestCase {
             maxMetricCount: 100_000, // High count to avoid count-based flush, focus on size limit
             dateProvider: testDateProvider,
             dispatchQueue: testDispatchQueue,
+            itemForwardingTriggers: NoOpTelemetryBufferDataForwardingTriggers(),
             capturedDataCallback: testCallbackHelper.captureCallback
         )
 


### PR DESCRIPTION
## Summary
- Refactoring: Align metrics buffer lifecycle handling with the pattern already used by the log buffer
- Instead of `SentryMetricsIntegration` managing its own notification observers, the `DefaultSentryMetricsTelemetryBuffer` now receives a `DefaultTelemetryBufferDataForwardingTriggers` which handles lifecycle flushing internally via `DefaultTelemetryBuffer`
- Removes ~180 lines of duplicate lifecycle management code from the integration and its tests

This is the first step towards https://github.com/getsentry/sentry-cocoa/issues/7333.

I also tested manually with a simulator if, when moving the sample to the background, metrics are still captured and sent to Sentry, and yes, it works. 

#skip-changelog