### PR TITLE
ref: Remove isEnabled check from DefaultSentryMetricsTelemetryBuffer

### DIFF
--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -25,7 +25,6 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
         #endif
 
         let metricsBuffer = DefaultSentryMetricsTelemetryBuffer(
-            options: options,
             dateProvider: dependencies.dateProvider,
             dispatchQueue: dependencies.dispatchQueueWrapper,
             itemForwardingTriggers: itemForwardingTriggers,


### PR DESCRIPTION
## Summary

Based on #7483.

- Removes the `isEnabled` property and `SentryMetricsTelemetryBufferOptions` dependency from `DefaultSentryMetricsTelemetryBuffer`
- The check was redundant because `SentryMetricsIntegration`'s failable init already returns `nil` when metrics are disabled, so the buffer is never created in the first place
- The buffer no longer knows about options at all

Part of https://github.com/getsentry/sentry-cocoa/issues/7333.

#skip-changelog
