### PR TITLE
chore(tests): Manually print failed test if xcbeautify fails to parse

### DIFF
--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -121,6 +121,7 @@ jobs:
       # Use a separate result bundle name to avoid conflicts with the regular test run.
       # xcodebuild fails if a result bundle already exists at the target path.
       - name: Run Flaky Tests
+        id: run_flaky_tests
         # Only the Sentry Scheme has the Flaky TestPlan.
         if: ${{ inputs.scheme == 'Sentry' }}
         env:
@@ -142,6 +143,7 @@ jobs:
             --result-bundle flaky-results.xcresult
 
       - name: Run tests
+        id: run_tests
         # We call a script with the platform so the destination
         # passed to xcodebuild doesn't end up in the job name,
         # because GitHub Actions don't provide an easy way of
@@ -164,6 +166,7 @@ jobs:
             --result-bundle results.xcresult
 
       - name: Publish Test Report
+        id: publish_test_report
         uses: mikepenz/action-junit-report@74626db7353a25a20a72816467ebf035f674c5f8 # v6.2.0
         if: always()
         with:
@@ -171,6 +174,23 @@ jobs:
           fail_on_failure: true
           fail_on_parse_error: true
           detailed_summary: true
+
+      # When a test crashes, xcbeautify may not report the failure in the junit.xml,
+      # so the test step fails but Publish Test Report finds no failures. In that case,
+      # extract failure info from the raw xcodebuild log.
+      - name: Analyze raw test output for crashes
+        if: ${{ always() && steps.publish_test_report.outcome == 'success' && (steps.run_tests.outcome == 'failure' || steps.run_flaky_tests.outcome == 'failure') }}
+        run: |
+          echo "::warning::Tests failed but no failures were found in the test report. This usually indicates a test crashed without proper reporting to xcbeautify."
+          echo ""
+          if [ -f raw-test-output.log ]; then
+            if grep -q "Failing tests:" raw-test-output.log; then
+              echo "=== Failing tests from raw output ==="
+              sed -n '/Failing tests:/,/^$/p' raw-test-output.log
+            fi
+          else
+            echo "raw-test-output.log not found."
+          fi
 
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## :scroll: Description

Adds a fallback step that detects when xcbeautify silently misses failed tests and prints them directly from the raw log, ensuring failures are always visible in CI output:
```
=== Failing tests from raw output ===
Failing tests:
	SentrySDKInternalTests.testLogger_TransactionWithBindToScope_LogsInsideDispatchQueueMainAsync_simulatesCOCOA1119()
```

## :bulb: Motivation and Context

When a test process crashes, xcodebuild may not emit the structured output that xcbeautify needs to detect and report failures. In those cases, xcbeautify continues with no failed tests reported (even though CI correctly fails with exit code 65) making it very hard to identify what went wrong without digging into raw logs manually.

This was observed in [this CI run](https://github.com/getsentry/sentry-cocoa/actions/runs/22222528408/job/64290024136?pr=7467).

The fallback works by checking whether xcbeautify reported any failures, and if not, parsing the raw log directly to surface them.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7494
#skip-changelog