### PR TITLE
ci: Update CI to Xcode 26.2 runtimes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,8 +278,8 @@ jobs:
           # iOS 26
           - name: iOS 26 Sentry
             runs-on: tahoe
-            xcode: "26.1.1"
-            test-destination-os: "26.1"
+            xcode: "26.2"
+            test-destination-os: "26.2"
             platform: "iOS"
             device: "iPhone 17 Pro"
 
@@ -304,8 +304,8 @@ jobs:
           # macOS 26
           - name: macOS 26 Sentry
             runs-on: tahoe
-            xcode: "26.1.1"
-            test-destination-os: "26.1"
+            xcode: "26.2"
+            test-destination-os: "26.2"
             platform: "macOS"
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
@@ -346,16 +346,16 @@ jobs:
           # tvOS 26
           - name: tvOS 26 Sentry
             runs-on: tahoe
-            xcode: "26.1.1"
-            test-destination-os: "26.1"
+            xcode: "26.2"
+            test-destination-os: "26.2"
             platform: "tvOS"
             device: "Apple TV"
 
           # visionOS 26
           - name: visionOS 26 Sentry
             runs-on: tahoe
-            xcode: "26.1.1"
-            test-destination-os: "26.1"
+            xcode: "26.2"
+            test-destination-os: "26.2"
             platform: "visionOS"
             device: "Apple Vision Pro"
             timeout: 30

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ VISIONOS_DEVICE_NAME ?= Apple Vision Pro
 # watchOS Simulator OS version (defaults to 'latest', can be overridden via WATCHOS_SIMULATOR_OS=11.0)
 WATCHOS_SIMULATOR_OS ?= latest
 
-# watchOS Simulator device name (defaults to 'Apple Watch Series 11 (46mm)', can be overridden via WATCHOS_DEVICE_NAME='Apple Watch SE 3 (44mm)')
-WATCHOS_DEVICE_NAME ?= Apple Watch Series 11 (46mm)
+# watchOS Simulator device name (defaults to 'Apple Watch SE 3 (44mm)', can be overridden via WATCHOS_DEVICE_NAME='Apple Watch Ultra 3 (49mm)')
+WATCHOS_DEVICE_NAME ?= Apple Watch SE 3 (44mm)
 
 # Current git reference name
 GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
## Summary
- Cirrus Labs tahoe runner dropped tvOS/visionOS 26.1 simulator runtimes. Updated Xcode from 26.1.1 to 26.2 and test-destination-os from 26.1 to 26.2 for iOS 26, macOS 26, tvOS 26, and visionOS 26 entries. Xcode 26.2 is needed because Xcode 26.1.1 doesn't have tvOS/visionOS platform support installed on the tahoe runner.
- On Xcode 26.2, watchOS simulators paired with iPhones cause "multiple devices matched" errors. Changed default watchOS device to Apple Watch SE 3 (44mm) which is not paired.

### Cirrus Labs runtime changes (proof)
The runtimes were removed in two commits to [cirruslabs/macos-image-templates](https://github.com/cirruslabs/macos-image-templates):
1. [Xcode 26.3 RC (fbaec2a, Feb 4)](https://github.com/cirruslabs/macos-image-templates/commit/fbaec2adaa) — "Removed unavailable runtimes from Tahoe list" — dropped tvOS/watchOS/visionOS 26.0
2. [Xcode 26.4 Beta (09fce08, Feb 17)](https://github.com/cirruslabs/macos-image-templates/commit/09fce08792) — dropped tvOS/watchOS/visionOS 26.1, added 26.4 beta runtimes

Current expected runtimes: [data/expected.tahoe.runtimes.txt](https://github.com/cirruslabs/macos-image-templates/blob/main/data/expected.tahoe.runtimes.txt)

Related issue: [cirruslabs/macos-image-templates#303](https://github.com/cirruslabs/macos-image-templates/issues/303)

#skip-changelog