### PR TITLE
chore: Bump xcodebuildmcp to 2.0.7

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "XcodeBuildMCP": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "xcodebuildmcp@0.3.2", "mcp"]
+      "args": ["-y", "xcodebuildmcp@2.0.7", "mcp"]
     },
     "sentry": {
       "type": "http",


### PR DESCRIPTION
Fix version pin from #7490 which accidentally used 0.3.2.