### PR TITLE
ref(ci): Use `low-priority` label for CI unless running on main or release branches

### DIFF
--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -53,7 +53,10 @@ jobs:
     name: Build XCFrameworks
     needs: files-changed
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on:
+      - "ghcr.io/cirruslabs/macos-runner:sequoia"
+      - "runner_group_id:10"
+      - ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -73,7 +76,10 @@ jobs:
     name: SPM Tests | ${{matrix.integration_dir}}
     needs: [files-changed, build-xcframeworks]
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on:
+      - "ghcr.io/cirruslabs/macos-runner:sequoia"
+      - "runner_group_id:10"
+      - ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -39,7 +39,10 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_test_cross_platform_for_prs == 'true'
     needs: files-changed
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on:
+      - "ghcr.io/cirruslabs/macos-runner:sequoia"
+      - "runner_group_id:10"
+      - ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     # This job can take a while to run, so we set a timeout.
     timeout-minutes: 30
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,10 @@ jobs:
   # of a bug solely on a specific OS version is minimal.
   unit-tests-with-test-server:
     name: Unit with Test Server ${{matrix.name}}
-    runs-on: ${{matrix.runs-on}}
+    runs-on:
+      - ${{ format('ghcr.io/cirruslabs/macos-runner:{0}', matrix.runs-on) }}
+      - "runner_group_id:10"
+      - ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: 20
     needs: build-test-server
 
@@ -155,8 +158,7 @@ jobs:
           # with communicating with the test server in CI.
           # We are going to add these back in https://github.com/getsentry/sentry-cocoa/issues/6361
           - name: macOS 15
-            runs-on:
-              ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+            runs-on: sequoia
             platform: "macOS"
             xcode: "16.4"
             test-destination-os: "15.0"

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -69,7 +69,10 @@ jobs:
   common-ui-tests:
     if: ${{ !inputs.should_skip }}
     name: UI Tests Common
-    runs-on: ${{ inputs.run_on_cirrus_labs && fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0}", "runner_group_id:10"]', inputs.macos_version)) || inputs.macos_version }}
+    runs-on:
+      - ${{ inputs.run_on_cirrus_labs && format('ghcr.io/cirruslabs/macos-runner:{0}', inputs.macos_version) || inputs.macos_version }}
+      - ${{ inputs.run_on_cirrus_labs && 'runner_group_id:10' || '' }}
+      - ${{ (inputs.run_on_cirrus_labs && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -88,7 +88,10 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_critical_for_prs == 'true'
     needs: files-changed
     name: Run SwiftUI Crash Test
-    runs-on: ["ghcr.io/cirruslabs/macos-runner:sequoia", "runner_group_id:10"]
+    runs-on:
+      - "ghcr.io/cirruslabs/macos-runner:sequoia"
+      - "runner_group_id:10"
+      - ${{ (github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -60,7 +60,10 @@ on:
 jobs:
   unit-tests:
     name: Unit ${{inputs.name}}
-    runs-on: ${{ inputs.run_on_cirrus_labs && fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0}", "runner_group_id:10"]', inputs.runs-on)) || inputs.runs-on }}
+    runs-on:
+      - ${{ inputs.run_on_cirrus_labs && format('ghcr.io/cirruslabs/macos-runner:{0}', inputs.runs-on) || inputs.runs-on }}
+      - ${{ inputs.run_on_cirrus_labs && 'runner_group_id:10' || '' }}
+      - ${{ (inputs.run_on_cirrus_labs && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/release/') && github.event_name != 'workflow_dispatch') && 'low-priority' || '' }}
     timeout-minutes: ${{inputs.timeout}}
     if: ${{!inputs.should_skip}}
     steps:


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

We don't want CI jobs to be blocked on release branches, so we can use the low priority label to jobs run on repositories.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
