### PR TITLE
docs: Add SentryCrash analysis and improvement plan document

### DIFF
--- a/develop-docs/SENTRYCRASH.md
+++ b/develop-docs/SENTRYCRASH.md
@@ -451,10 +451,10 @@ The tracking issue [sentry-cocoa #5619](https://github.com/getsentry/sentry-coco
 
 | Issue                                       | File                                     | Details                                                                                                                   |
 | ------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **NSDictionary introspection broken**       | `SentryCrashObjC.c:1810`                 | Marked "TODO: This is broken". `sentrycrashobjc_dictionaryCount()` returns 0. Falls back to generic object introspection. |
-| **CPU architecture detection unavailable**  | `SentryCrashCPU.c:40`                    | `sentrycrashcpu_currentArch()` returns NULL. `NXGetLocalArchInfo()` blocked by App Store.                                 |
-| **Thread-local storage for C++ exceptions** | `SentryCrashMonitor_CPPException.cpp:68` | Global stack cursor instead of thread-local. Could cause issues with concurrent C++ exceptions.                           |
-| **Mach exception freeze workaround**        | `SentryCrashMonitor_MachException.c:340` | "TODO: This was put here to avoid a freeze. Does secondary thread ever fire?"                                             |
+| **NSDictionary introspection broken**       | `SentryCrashObjC.c:1816`                 | Marked "TODO: This is broken". `sentrycrashobjc_dictionaryCount()` returns 0. Falls back to generic object introspection. |
+| **CPU architecture detection unavailable**  | `SentryCrashCPU.c:42`                    | `sentrycrashcpu_currentArch()` returns NULL. `NXGetLocalArchInfo()` blocked by App Store.                                 |
+| **Thread-local storage for C++ exceptions** | `SentryCrashMonitor_CPPException.cpp:71` | Global stack cursor instead of thread-local. Could cause issues with concurrent C++ exceptions.                           |
+| **Mach exception freeze workaround**        | `SentryCrashMonitor_MachException.c:338` | "TODO: This was put here to avoid a freeze. Does secondary thread ever fire?"                                             |
 | **Unimplemented report sections**           | `SentryCrashReport.c:653`                | "TODO: Implement these" for NSDictionary and NSException introspection cases.                                             |
 
 ### LOW Priority (TODOs & Technical Debt)
@@ -462,7 +462,7 @@ The tracking issue [sentry-cocoa #5619](https://github.com/getsentry/sentry-coco
 | File                          | Line     | TODO                                                                 |
 | ----------------------------- | -------- | -------------------------------------------------------------------- |
 | `SentryCrashMonitor_System.m` | 406, 531 | "use SentryDevice API here now?" / "combine this into SentryDevice?" |
-| `SentryCrashObjC.c`           | 1047     | Possible bad access in `sentrycrashobjc_ivarList`                    |
+| `SentryCrashObjC.c`           | 1045     | Possible bad access in `sentrycrashobjc_ivarList`                    |
 | `SentryCrashObjC.c`           | 1111     | Uncertainty about tagged pointer NSNumber handling                   |
 | `SentryCrashObjC.c`           | 1691     | Bit-field unpacking not implemented for mutable arrays               |
 

--- a/develop-docs/SENTRYCRASH_IMPROVEMENT_PLAN.md
+++ b/develop-docs/SENTRYCRASH_IMPROVEMENT_PLAN.md
@@ -136,7 +136,7 @@ This document was generated with Claude using the prompt below. To refresh it, r
 
 #### 1. Monolithic Tools Directory
 
-The `Recording/Tools/` directory contains **56% of all SentryCrash code** (11,872 lines across 20+ files) with no further organization. Files range from CPU-specific register handling to JSON encoding to ObjC runtime introspection.
+The `Recording/Tools/` directory contains **~56% of all SentryCrash code** (11,872 lines across 20+ files) with no further organization. Files range from CPU-specific register handling to JSON encoding to ObjC runtime introspection.
 
 #### 2. Implicit Dependencies via Global State
 
@@ -224,11 +224,11 @@ The same directory mixes:
 
 | Priority | Issue                                   | Location                                          | Description                                          |
 | -------- | --------------------------------------- | ------------------------------------------------- | ---------------------------------------------------- |
-| MEDIUM   | NSDictionary introspection broken       | `SentryCrashObjC.c:1810`                          | `sentrycrashobjc_dictionaryCount()` always returns 0 |
-| MEDIUM   | CPU arch detection returns NULL         | `SentryCrashCPU.c:40`                             | `NXGetLocalArchInfo()` blocked by App Store          |
-| MEDIUM   | Mach exception freeze workaround        | `SentryCrashMonitor_MachException.c:340`          | Unclear if secondary thread fires                    |
+| MEDIUM   | NSDictionary introspection broken       | `SentryCrashObjC.c:1816`                          | `sentrycrashobjc_dictionaryCount()` always returns 0 |
+| MEDIUM   | CPU arch detection returns NULL         | `SentryCrashCPU.c:42`                             | `NXGetLocalArchInfo()` blocked by App Store          |
+| MEDIUM   | Mach exception freeze workaround        | `SentryCrashMonitor_MachException.c:338`          | Unclear if secondary thread fires                    |
 | MEDIUM   | Unimplemented report introspection      | `SentryCrashReport.c:653`                         | NSDictionary/NSException cases not implemented       |
-| LOW      | Thread-local storage for C++ exceptions | `SentryCrashMonitor_CPPException.cpp:68`          | Global cursor, potential concurrent issue            |
+| LOW      | Thread-local storage for C++ exceptions | `SentryCrashMonitor_CPPException.cpp:71`          | Global cursor, potential concurrent issue            |
 | LOW      | SentryDevice API consolidation          | `SentryCrashMonitor_System.m:406,531`             | Duplicate device info collection                     |
 | LOW      | Deprecated 32-bit platform code         | `SentryCrashCPU_arm.c`, `SentryCrashCPU_x86_32.c` | Dead code, maintenance burden                        |
 


### PR DESCRIPTION
Created this doc after running analysis with claude to find how to improve SentryCrash.

Feel free to suggest edits and add more insights

Closes #7669