### PR TITLE
chore: Remove unused rest-client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "bundler", ">= 2"
 gem "cocoapods", ">= 1.9.1"
 gem "fastlane"
-gem "rest-client"
 gem "slather"
 
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1213.0)
+    aws-partitions (1.1220.0)
     aws-sdk-core (3.242.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -32,7 +32,7 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.121.0)
+    aws-sdk-kms (1.122.0)
       aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
     aws-sdk-s3 (1.213.0)
@@ -182,7 +182,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-sentry (2.1.0)
+    fastlane-plugin-sentry (2.1.1)
       os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
@@ -204,7 +204,7 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-playcustomapp_v1 (0.17.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.60.0)
+    google-apis-storage_v1 (0.61.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-core (1.8.0)
       google-cloud-env (>= 1.0, < 3.a)
@@ -229,7 +229,6 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
-    http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     httpclient (2.9.0)
@@ -241,14 +240,11 @@ GEM
     jwt (2.10.2)
       base64
     logger (1.7.0)
-    mime-types (3.7.0)
-      logger
-      mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0203)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.1)
+    minitest (6.0.2)
+      drb (~> 2.0)
       prism (~> 1.5)
     molinillo (0.8.0)
     multi_json (1.19.1)
@@ -274,12 +270,7 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    retriable (3.1.2)
+    retriable (3.2.1)
     rexml (3.4.4)
     rouge (3.28.0)
     ruby-macho (2.5.1)
@@ -342,7 +333,6 @@ DEPENDENCIES
   fastlane-plugin-sentry
   mutex_m
   ostruct
-  rest-client
   slather
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary

- Removes `rest-client` gem from Gemfile (added in 2021, never used)
- No Ruby code in the repo imports or references `RestClient`
- Not a dependency of fastlane, cocoapods, slather, or any fastlane plugin
- Also removes its unique transitive dependency `http-accept` from the lockfile

Closes #7548

#skip-changelog