### PR TITLE
docs: Update CocoaPods deprecation timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 SPM is the recommended way to include Sentry into your project. We also provide pre-built XCFrameworks on [our GitHub Releases page](https://github.com/getsentry/sentry-cocoa/releases).
 
 > [!WARNING]
-> CocoaPods support has been deprecated and will no longer receive updates after July 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
+> CocoaPods support has been deprecated and will no longer receive updates after June 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
 
 # Initialization
 


### PR DESCRIPTION
## :scroll: Description

Updates the CocoaPods deprecation notice in `README.md` from July to June 2026.

## :bulb: Motivation and Context

This change aligns the CocoaPods deprecation date with the messaging in the `sentry` and `sentry-docs` repositories.

Related commit: https://github.com/getsentry/sentry-cocoa/commit/55da7eb3a3637847b9bae7c84d4217d1a6f35155

## :green_heart: How did you test it?

Manually verified the updated text in `README.md`.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
[Slack Thread](https://sentry.slack.com/archives/C09MQRJGBU2/p1772058250321889?thread_ts=1772058250.321889&cid=C09MQRJGBU2)

<p><a href="https://cursor.com/agents/bc-0b3fa3a6-1b7a-502d-8120-9b261903b2a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b3fa3a6-1b7a-502d-8120-9b261903b2a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

