### PR TITLE
ci: Run Benchmarks only on main

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -119,7 +119,7 @@ run_benchmarking_for_prs: &run_benchmarking_for_prs # GH Actions
   - "Samples/iOS-Swift/iOS-Swift/Profiling/BenchmarkingViewController.swift"
   - "Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.h"
   - "Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.mm"
-  - "Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Benchmarking.xcscheme"
+  - "Samples/iOS-Swift/iOS-Swift.yml"
   - "Samples/SentrySampleShared/SentrySampleUITestShared/**"
   - ".sauce/benchmarking-config.yml"
   - "Plans/iOS-Benchmarking_Base.xctestplan"


### PR DESCRIPTION
The benchmark jobs take a long time to run and are often the bottleneck for PRs. As they rarely fail on PRs, we now only run them on main to speed up PR CI. On PRs, benchmarks only run when benchmarking-related files change (test target, sauce config, test plan, etc.), but not when SDK sources or tests change. SDK source changes are covered by the benchmarks running on every push to main.

#skip-changelog

Closes #7562