### PR TITLE
feat(network-details): Extend SentryReplayOptions API

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length missing_docs
+// swiftlint:disable file_length missing_docs type_body_length
 import Foundation
 
 @objcMembers
@@ -24,6 +24,13 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
 
         public static let excludedViewClasses: Set<String> = []
         public static let includedViewClasses: Set<String> = []
+
+        // Network capture configuration defaults
+        public static let networkDetailAllowUrls: [Any] = []
+        public static let networkDetailDenyUrls: [Any] = []
+        public static let networkCaptureBodies: Bool = true
+        public static let networkRequestHeaders: [String] = ["Content-Type", "Content-Length", "Accept"]
+        public static let networkResponseHeaders: [String] = ["Content-Type", "Content-Length", "Accept"]
 
         // The following properties are defaults which are not configurable by the user.
 
@@ -293,6 +300,131 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     public var enableFastViewRendering: Bool
 
     /**
+     * A list of URL patterns to capture request and response details for during session replay.
+     * 
+     * When non-empty, network requests with URLs matching any of these patterns will have their
+     * headers and bodies captured for session replay.
+     * 
+     * Supports both String and NSRegularExpression patterns (See [JavaScript SDK](https://github.com/getsentry/sentry-javascript/blob/6fb1ee139a92a6055b52b0bbf5136fa0e5a9353f/packages/core/src/utils/string.ts#L114-L119)):
+     * - String: Uses substring contains
+     * - NSRegularExpression: Uses full regex matching
+     * 
+     * Default: empty array (network detail capture disabled)
+     *
+     * Example:
+     * ```swift
+     * // String patterns (substring matching)
+     * options.sessionReplay.networkDetailAllowUrls = [
+     *     "api.example.com",              // Matches any URL containing this string
+     *     "/api/v1/",                      // Matches any URL containing this path
+     *     "https://analytics.myapp.com"   // Matches any URL containing this prefix
+     * ]
+     * 
+     * // NSRegularExpression patterns (full regex matching)
+     * let apiRegex = try? NSRegularExpression(pattern: "^https://api\\.example\\.com/v[0-9]+/.*")
+     * let imageRegex = try? NSRegularExpression(pattern: ".*\\.(jpg|jpeg|png|gif)$")
+     * 
+     * // Mixed array of both types
+     * options.sessionReplay.networkDetailAllowUrls = [
+     *     "api.example.com",               // String: substring match
+     *     apiRegex!,                       // Regex: versioned API endpoints
+     *     imageRegex!                      // Regex: image files
+     * ]
+     * ```
+     *
+     * - Note: Request and response bodies are truncated to 150KB maximum.
+     * - Note: See ``SentryReplayOptions.DefaultValues.networkDetailAllowUrls`` for the default value.
+     */
+    public var networkDetailAllowUrls: [Any]
+
+    /**
+     * A list of URL patterns to exclude from network detail capture during session replay.
+     * 
+     * URLs matching any pattern in this array will NOT have their headers and bodies captured,
+     * even if they match patterns in `networkDetailAllowUrls`. This provides fine-grained 
+     * control for excluding sensitive endpoints from capture.
+     * 
+     * Supports both String and NSRegularExpression patterns (mirroring JavaScript SDK):
+     * - String: Uses substring containment check (like JavaScript's `includes()`)
+     * - NSRegularExpression: Uses full regex matching
+     * 
+     * Default: empty array (no URLs explicitly denied)
+     *
+     * Examples:
+     * - String patterns: "/auth/", "/payment/", "password", ".internal."
+     * - NSRegularExpression patterns: Use try NSRegularExpression(pattern:) to create regex objects
+     * - Mixed arrays are supported with both types
+     */
+    public var networkDetailDenyUrls: [Any]
+
+    /**
+     * Whether to capture request and response bodies for allowed URLs.
+     *
+     * When `true` (default), bodies will be captured and parsed (JSON bodies are
+     * parsed for structured display in the Sentry UI).
+     *
+     * When `false`, only headers and metadata will be captured for allowed URLs.
+     *
+     * Default: `true`
+     *
+     * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
+     * - Note: Bodies are automatically truncated to 150KB to prevent excessive memory usage.
+     */
+    public var networkCaptureBodies: Bool
+
+    /**
+     * Request headers to capture for allowed URLs during session replay.
+     * 
+     * Specifies which HTTP request headers should be captured and included in session replay
+     * network details. Header matching is case-insensitive (e.g., "content-type", "Content-Type", 
+     * and "CoNtEnT-tYpE" are all equivalent).
+     * 
+     * Default (always included): `["Content-Type", "Content-Length", "Accept"]`
+     *
+     * Example:
+     * ```
+     * options.sessionReplay.networkRequestHeaders = [
+     *     "Authorization",
+     *     "User-Agent"
+     * ]
+     * ```
+     *
+     * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
+     * - Note: Header names preserve the case seen on the request, not the case specified here.
+     */
+    public var networkRequestHeaders: [String] {
+        get { _networkRequestHeaders }
+        set { _networkRequestHeaders = Self.mergeWithDefaultHeaders(newValue, defaults: DefaultValues.networkRequestHeaders) }
+    }
+    private var _networkRequestHeaders: [String]
+
+    /**
+     * Response headers to capture for allowed URLs during session replay.
+     * 
+     * Specifies which HTTP response headers should be captured and included in session replay
+     * network details. Header matching is case-insensitive (e.g., "content-type", "Content-Type", 
+     * and "CoNtEnT-tYpE" are all equivalent).
+     * 
+     * Default (always included): `["Content-Type", "Content-Length", "Accept"]`
+     *
+     * Example:
+     * ```
+     * options.sessionReplay.networkResponseHeaders = [
+     *     "Cache-Control",    // Custom header
+     *     "Set-Cookie"        // Custom header
+     * ]
+     * ```
+     *
+     * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
+     * - Note: Header names preserve the case seen on the response, not the case specified here.
+     */
+    public var networkResponseHeaders: [String] {
+        get { _networkResponseHeaders }
+        set { _networkResponseHeaders = Self.mergeWithDefaultHeaders(newValue, defaults: DefaultValues.networkResponseHeaders) }
+    }
+    private var _networkResponseHeaders: [String]
+
+    /**
      * Defines the quality of the session replay.
      *
      * Higher bit rates better quality, but also bigger files to transfer.
@@ -352,6 +484,60 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     var sdkInfo: [String: Any]?
 
     /**
+     * Determines if network detail capture is enabled for a given URL.
+     *
+     * - Parameter urlString: The URL string to check
+     * - Returns: `true` if network details should be captured for this URL, `false` otherwise
+     */
+    @objc
+    public func isNetworkDetailCaptureEnabled(for urlString: String) -> Bool {
+        // If allow list is empty, network detail capture is disabled
+        guard !networkDetailAllowUrls.isEmpty else {
+            return false
+        }
+        
+        if matchesAnyPattern(urlString, patterns: networkDetailDenyUrls) {
+            return false
+        }
+        
+        return matchesAnyPattern(urlString, patterns: networkDetailAllowUrls)
+    }
+    
+    /**
+     * Helper method to check if a URL string matches any pattern in a list.
+     *
+     * Supports both String and NSRegularExpression patterns:
+     * - String: Uses substring containment check (like JavaScript's includes())
+     * - NSRegularExpression: Uses full regex matching
+     *
+     * - Parameters:
+     *   - urlString: The URL string to test
+     *   - patterns: Array of String or NSRegularExpression patterns
+     * - Returns: `true` if the URL matches any pattern, `false` otherwise
+     */
+    private func matchesAnyPattern(_ urlString: String, patterns: [Any]) -> Bool {
+        for pattern in patterns {
+            if let stringPattern = pattern as? String {
+                // String provided: substring match
+                // Filter out empty strings and whitespace-only strings
+                let trimmed = stringPattern.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { continue }
+                
+                if urlString.contains(stringPattern) {
+                    return true
+                }
+            } else if let regexPattern = pattern as? NSRegularExpression {
+                // NSRegularExpression: use regex matching
+                let range = NSRange(location: 0, length: urlString.utf16.count)
+                if regexPattern.firstMatch(in: urlString, options: [], range: range) != nil {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+    
+    /**
      * Initialize session replay options disabled
      *
      * - Note: This initializer is added for Objective-C compatibility, as constructors with default values
@@ -374,7 +560,12 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
             frameRate: nil,
             errorReplayDuration: nil,
             sessionSegmentDuration: nil,
-            maximumDuration: nil
+            maximumDuration: nil,
+            networkDetailAllowUrls: nil,
+            networkDetailDenyUrls: nil,
+            networkCaptureBodies: nil,
+            networkRequestHeaders: nil,
+            networkResponseHeaders: nil
         )
     }
 
@@ -409,7 +600,12 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
             sessionSegmentDuration: (dictionary["sessionSegmentDuration"] as? NSNumber)?.doubleValue,
             maximumDuration: (dictionary["maximumDuration"] as? NSNumber)?.doubleValue,
             excludedViewClasses: (dictionary["excludedViewClasses"] as? [String]).map { Set($0) },
-            includedViewClasses: (dictionary["includedViewClasses"] as? [String]).map { Set($0) }
+            includedViewClasses: (dictionary["includedViewClasses"] as? [String]).map { Set($0) },
+            networkDetailAllowUrls: Self.validateNetworkDetailUrlPatterns(from: dictionary["networkDetailAllowUrls"]),
+            networkDetailDenyUrls: Self.validateNetworkDetailUrlPatterns(from: dictionary["networkDetailDenyUrls"]),
+            networkCaptureBodies: (dictionary["networkCaptureBodies"] as? NSNumber)?.boolValue,
+            networkRequestHeaders: Self.parseStringArray(from: dictionary["networkRequestHeaders"]),
+            networkResponseHeaders: Self.parseStringArray(from: dictionary["networkResponseHeaders"])
         )
     }
 
@@ -456,8 +652,79 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
             sessionSegmentDuration: nil,
             maximumDuration: nil,
             excludedViewClasses: nil,
-            includedViewClasses: nil
+            includedViewClasses: nil,
+            networkDetailAllowUrls: nil,
+            networkDetailDenyUrls: nil,
+            networkCaptureBodies: nil,
+            networkRequestHeaders: nil,
+            networkResponseHeaders: nil
         )
+    }
+
+    /**
+     * Helper method to parse and filter string arrays from dictionary configuration.
+     * 
+     * Filters out non-string entries from mixed arrays while preserving valid strings.
+     * Returns nil when the input is not an array type, allowing callers to fall back to defaults.
+     * 
+     * - Parameter value: The value from the dictionary to parse
+     * - Returns: Filtered array of strings, or nil if input is not an array
+     */
+    private static func parseStringArray(from value: Any?) -> [String]? {
+        guard let array = value as? [Any] else {
+            return nil
+        }
+        return array.compactMap { $0 as? String }
+    }
+    
+    /**
+     * Validates developer-provided NetworkDetail URL patterns and returns a subset of only valid entries.
+     * 
+     * Accepts both String and NSRegularExpression objects.
+     * Filters out invalid entries and preserves valid patterns.
+     * Filters out empty strings and whitespace-only strings.
+     * 
+     * - Parameter value: The value from the dictionary to parse
+     * - Returns: Filtered array of String and NSRegularExpression patterns, or nil if input is not an array
+     */
+    private static func validateNetworkDetailUrlPatterns(from value: Any?) -> [Any]? {
+        guard let array = value as? [Any] else {
+            if let nonNilValue = value {
+                SentrySDKLog.log(message: "Invalid networkDetail URL pattern configuration: expected array, got \(type(of: nonNilValue))", 
+                               andLevel: .warning)
+            }
+            return nil
+        }
+        
+        var validPatterns: [Any] = []
+        var invalidCount = 0
+        
+        for (index, element) in array.enumerated() {
+            if let stringElement = element as? String {
+                // Filter out empty strings and whitespace-only strings
+                let trimmed = stringElement.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    SentrySDKLog.log(message: "Invalid networkDetail URL pattern at index \(index): empty or whitespace-only string discarded", 
+                                   andLevel: .warning)
+                    invalidCount += 1
+                } else {
+                    validPatterns.append(stringElement)
+                }
+            } else if let regexElement = element as? NSRegularExpression {
+                validPatterns.append(regexElement)
+            } else {
+                SentrySDKLog.log(message: "Invalid networkDetail URL pattern at index \(index): expected String or NSRegularExpression, got \(type(of: element))", 
+                               andLevel: .warning)
+                invalidCount += 1
+            }
+        }
+        
+        if invalidCount > 0 {
+            SentrySDKLog.log(message: "NetworkDetail URL patterns: \(invalidCount) invalid entries discarded, \(validPatterns.count) valid patterns retained", 
+                           andLevel: .info)
+        }
+        
+        return validPatterns
     }
 
     // swiftlint:disable:next function_parameter_count cyclomatic_complexity
@@ -477,7 +744,12 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
         sessionSegmentDuration: TimeInterval?,
         maximumDuration: TimeInterval?,
         excludedViewClasses: Set<String>? = nil,
-        includedViewClasses: Set<String>? = nil
+        includedViewClasses: Set<String>? = nil,
+        networkDetailAllowUrls: [Any]? = nil,
+        networkDetailDenyUrls: [Any]? = nil,
+        networkCaptureBodies: Bool? = nil,
+        networkRequestHeaders: [String]? = nil,
+        networkResponseHeaders: [String]? = nil
     ) {
         self.sessionSampleRate = sessionSampleRate ?? DefaultValues.sessionSampleRate
         self.onErrorSampleRate = onErrorSampleRate ?? DefaultValues.onErrorSampleRate
@@ -495,8 +767,49 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
         self.maximumDuration = maximumDuration ?? DefaultValues.maximumDuration
         self.excludedViewClasses = excludedViewClasses ?? DefaultValues.excludedViewClasses
         self.includedViewClasses = includedViewClasses ?? DefaultValues.includedViewClasses
+        self.networkDetailAllowUrls = Self.validateNetworkDetailUrlPatterns(from: networkDetailAllowUrls) ?? DefaultValues.networkDetailAllowUrls
+        self.networkDetailDenyUrls = Self.validateNetworkDetailUrlPatterns(from: networkDetailDenyUrls) ?? DefaultValues.networkDetailDenyUrls
+        self.networkCaptureBodies = networkCaptureBodies ?? DefaultValues.networkCaptureBodies
+        self._networkRequestHeaders = Self.mergeWithDefaultHeaders(networkRequestHeaders, defaults: DefaultValues.networkRequestHeaders)
+        self._networkResponseHeaders = Self.mergeWithDefaultHeaders(networkResponseHeaders, defaults: DefaultValues.networkResponseHeaders)
 
         super.init()
     }
+    
+    /**
+     * Merges user-provided headers with default headers, ensuring defaults are always included.
+     *
+     * - Parameter userHeaders: Headers specified by the user (can be nil)
+     * - Parameter defaults: Default headers that must always be included
+     * - Returns: Array containing both user headers and default headers (with duplicates removed)
+     */
+    private static func mergeWithDefaultHeaders(_ userHeaders: [String]?, defaults: [String]) -> [String] {
+        let providedHeaders = userHeaders ?? []
+        
+        // Use Set to remove duplicates, then convert back to Array
+        // Case-insensitive comparison to avoid duplicate headers with different casing
+        var seenHeaders = Set<String>()
+        var result: [String] = []
+        
+        // Add default headers first
+        for header in defaults {
+            let lowercased = header.lowercased()
+            if !seenHeaders.contains(lowercased) {
+                seenHeaders.insert(lowercased)
+                result.append(header)
+            }
+        }
+        
+        // Add user-provided headers
+        for header in providedHeaders {
+            let lowercased = header.lowercased()
+            if !seenHeaders.contains(lowercased) {
+                seenHeaders.insert(lowercased)
+                result.append(header)
+            }
+        }
+        
+        return result
+    }
 }
-// swiftlint:enable file_length missing_docs
+// swiftlint:enable file_length missing_docs type_body_length

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsNetworkTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsNetworkTests.swift
@@ -1,0 +1,407 @@
+import Foundation
+@_spi(Private) @testable import Sentry
+import XCTest
+
+class SentryReplayOptionsNetworkTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testInit_withInvalidTypes_shouldUseDefaults() {
+        // -- Arrange --
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": "invalid_string_type", // Should be array
+            "networkCaptureBodies": "invalid_string" // Should be boolean
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 0, "networkDetailAllowUrls should fallback to empty array on invalid data provided")
+        XCTAssertTrue(options.networkCaptureBodies, "networkCaptureBodies should fallback to true on invalid data provided")
+    }
+    
+    func testNetworkDetailUrls_withEmptyStrings_shouldFilterOutEmptyEntries() {
+        // -- Arrange --
+        let allowUrls = [
+            "https://api.example.com",
+            "", // Empty string
+            "https://valid.com",
+            "   ", // Whitespace only
+            "https://another.com"
+        ]
+        let denyUrls = [
+            "https://api.example.com/auth",
+            "", // Empty string
+            "https://secure.com",
+            "   ", // Whitespace only
+            "https://private.com"
+        ]
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": allowUrls,
+            "networkDetailDenyUrls": denyUrls
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Both should filter out empty/whitespace entries, leaving 3 valid URLs each
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 3)
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 3)
+        
+        // Verify deny URLs contain expected values
+        XCTAssertTrue(options.networkDetailDenyUrls.contains(where: { ($0 as? String) == "https://api.example.com/auth" }))
+        XCTAssertTrue(options.networkDetailDenyUrls.contains(where: { ($0 as? String) == "https://secure.com" }))
+        XCTAssertTrue(options.networkDetailDenyUrls.contains(where: { ($0 as? String) == "https://private.com" }))
+    }
+    
+    // MARK: - Network Details Headers Tests
+    
+    func testNetworkHeaders_withVariousConfigurations_shouldHandleCorrectly() {
+        let expectedDefaultHeaders = ["Content-Type", "Content-Length", "Accept"]
+        
+        // Test 1: Default configuration (empty dict)
+        let defaultOptions = SentryReplayOptions(dictionary: [:])
+        XCTAssertEqual(defaultOptions.networkRequestHeaders, expectedDefaultHeaders)
+        XCTAssertEqual(defaultOptions.networkResponseHeaders, expectedDefaultHeaders)
+        
+        // Test 2: Empty arrays should return defaults
+        let emptyOptions = SentryReplayOptions(dictionary: [
+            "networkRequestHeaders": [],
+            "networkResponseHeaders": []
+        ])
+        XCTAssertEqual(emptyOptions.networkRequestHeaders, expectedDefaultHeaders)
+        XCTAssertEqual(emptyOptions.networkResponseHeaders, expectedDefaultHeaders)
+        
+        // Test 3: Custom headers should be merged with defaults
+        let customRequestHeaders = ["Authorization", "User-Agent", "X-Custom-Header", "Accept-Language"]
+        let customResponseHeaders = ["Cache-Control", "Set-Cookie", "X-Rate-Limit-Remaining", "Server"]
+        let expectedMergedRequestHeaders = ["Content-Type", "Content-Length", "Accept", "Authorization", "User-Agent", "X-Custom-Header", "Accept-Language"]
+        let expectedMergedResponseHeaders = ["Content-Type", "Content-Length", "Accept", "Cache-Control", "Set-Cookie", "X-Rate-Limit-Remaining", "Server"]
+        let customOptions = SentryReplayOptions(dictionary: [
+            "networkRequestHeaders": customRequestHeaders,
+            "networkResponseHeaders": customResponseHeaders
+        ])
+        XCTAssertEqual(customOptions.networkRequestHeaders, expectedMergedRequestHeaders)
+        XCTAssertEqual(customOptions.networkResponseHeaders, expectedMergedResponseHeaders)
+    }
+    
+    func testNetworkHeaders_withVariousCases_shouldDeduplicateCaseInsensitively() {
+        // -- Arrange --
+        let requestHeaders = [
+            "content-type", // lowercase - will be skipped due to default "Content-Type"
+            "Content-Type", // regular case - will be skipped due to default "Content-Type"  
+            "CONTENT-LENGTH", // uppercase - will be skipped due to default "Content-Length"
+            "Accept-Encoding", // mixed case - new header
+            "x-api-key", // lowercase custom - first occurrence, will be kept
+            "X-API-Key" // uppercase custom - duplicate, will be skipped
+        ]
+        let responseHeaders = [
+            "server", // lowercase - new header, will be kept
+            "Server", // proper case - duplicate, will be skipped
+            "CACHE-CONTROL", // uppercase - new header, will be kept
+            "Set-Cookie", // mixed case - new header, will be kept
+            "x-rate-limit", // lowercase custom - new header, will be kept
+            "X-RATE-LIMIT" // uppercase custom - duplicate, will be skipped
+        ]
+        let dict: [String: Any] = [
+            "networkRequestHeaders": requestHeaders,
+            "networkResponseHeaders": responseHeaders
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Request headers: defaults + deduplicated user headers (case preserved from first occurrence)
+        // Expected: "Content-Type", "Content-Length", "Accept" (defaults), "Accept-Encoding", "x-api-key"
+        let expectedRequestCount = 5
+        XCTAssertEqual(options.networkRequestHeaders.count, expectedRequestCount, 
+                      "Request headers should be deduplicated, got: \(options.networkRequestHeaders)")
+        
+        // Check that each header appears exactly once (case-insensitive check)
+        let expectedRequestHeadersLowercase = ["content-type", "content-length", "accept", "accept-encoding", "x-api-key"]
+        for expectedHeader in expectedRequestHeadersLowercase {
+            let matchingHeaders = options.networkRequestHeaders.filter { 
+                $0.lowercased() == expectedHeader
+            }
+            XCTAssertEqual(matchingHeaders.count, 1, 
+                          "Header '\(expectedHeader)' should appear exactly once, but found: \(matchingHeaders)")
+        }
+        
+        // Response headers: defaults + deduplicated user headers (case preserved from first occurrence)
+        // Expected: "Content-Type", "Content-Length", "Accept" (defaults), "server", "CACHE-CONTROL", "Set-Cookie", "x-rate-limit"
+        let expectedResponseCount = 7
+        XCTAssertEqual(options.networkResponseHeaders.count, expectedResponseCount,
+                      "Response headers should be deduplicated, got: \(options.networkResponseHeaders)")
+        
+        // Check that each header appears exactly once (case-insensitive check)
+        let expectedResponseHeadersLowercase = ["content-type", "content-length", "accept", "server", "cache-control", "set-cookie", "x-rate-limit"]
+        for expectedHeader in expectedResponseHeadersLowercase {
+            let matchingHeaders = options.networkResponseHeaders.filter { 
+                $0.lowercased() == expectedHeader
+            }
+            XCTAssertEqual(matchingHeaders.count, 1, 
+                          "Header '\(expectedHeader)' should appear exactly once, but found: \(matchingHeaders)")
+        }
+    }
+    
+    // MARK: - Invalid networkDetailUrls Removal Tests
+    
+    func testNetworkDetailUrls_withInvalidTypes_shouldFilterOutInvalidEntries() throws {
+        // -- Arrange --
+        let allowRegex = try NSRegularExpression(pattern: "^https://api\\.example\\.com/.*")
+        let denyRegex = try NSRegularExpression(pattern: ".*/private/.*")
+        
+        let allowUrls: [Any] = [
+            "https://api.example.com", // Valid String
+            allowRegex, // Valid NSRegularExpression
+            123, // Invalid: number
+            NSObject(), // Invalid: object
+            "https://valid.com", // Valid String
+            Date(), // Invalid: Date object
+            nil as Any? as Any, // Invalid: nil
+            ["nested", "array"] // Invalid: nested array
+        ]
+        let denyUrls: [Any] = [
+            "https://api.example.com/auth", // Valid String
+            denyRegex, // Valid NSRegularExpression
+            42.5, // Invalid: float number
+            nil as Any? as Any, // Invalid: nil
+            ["nested", "array"], // Invalid: nested array
+            "https://secure.com", // Valid String
+            Set<String>(["invalid", "set"]) // Invalid: set object
+        ]
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": allowUrls,
+            "networkDetailDenyUrls": denyUrls
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Both should filter out invalid types, leaving only valid String and NSRegularExpression entries
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 3, "Should have 2 Strings and 1 NSRegularExpression")
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 3, "Should have 2 Strings and 1 NSRegularExpression")
+        
+        // Verify allow URLs contain both String and NSRegularExpression types
+        var stringCount = 0
+        var regexCount = 0
+        for entry in options.networkDetailAllowUrls {
+            if entry is String {
+                stringCount += 1
+            } else if entry is NSRegularExpression {
+                regexCount += 1
+            } else {
+                XCTFail("Unexpected type found in allowUrls: \(type(of: entry))")
+            }
+        }
+        XCTAssertEqual(stringCount, 2, "Should have exactly 2 String entries in allowUrls")
+        XCTAssertEqual(regexCount, 1, "Should have exactly 1 NSRegularExpression entry in allowUrls")
+        
+        // Verify deny URLs contain both String and NSRegularExpression types
+        stringCount = 0
+        regexCount = 0
+        for entry in options.networkDetailDenyUrls {
+            if entry is String {
+                stringCount += 1
+            } else if entry is NSRegularExpression {
+                regexCount += 1
+            } else {
+                XCTFail("Unexpected type found in denyUrls: \(type(of: entry))")
+            }
+        }
+        XCTAssertEqual(stringCount, 2, "Should have exactly 2 String entries in denyUrls")
+        XCTAssertEqual(regexCount, 1, "Should have exactly 1 NSRegularExpression entry in denyUrls")
+        
+        // Verify specific String entries are preserved
+        let stringAllowUrls = options.networkDetailAllowUrls.compactMap { $0 as? String }
+        XCTAssertTrue(stringAllowUrls.contains("https://api.example.com"), "Should preserve first String entry")
+        XCTAssertTrue(stringAllowUrls.contains("https://valid.com"), "Should preserve second String entry")
+        
+        let stringDenyUrls = options.networkDetailDenyUrls.compactMap { $0 as? String }
+        XCTAssertTrue(stringDenyUrls.contains("https://api.example.com/auth"), "Should preserve first String entry")
+        XCTAssertTrue(stringDenyUrls.contains("https://secure.com"), "Should preserve second String entry")
+        
+        // Verify NSRegularExpression entries are preserved
+        let regexAllowUrls = options.networkDetailAllowUrls.compactMap { $0 as? NSRegularExpression }
+        XCTAssertEqual(regexAllowUrls.count, 1, "Should have one NSRegularExpression in allowUrls")
+        XCTAssertEqual(regexAllowUrls[0].pattern, allowRegex.pattern, "Should preserve original regex pattern")
+        
+        let regexDenyUrls = options.networkDetailDenyUrls.compactMap { $0 as? NSRegularExpression }
+        XCTAssertEqual(regexDenyUrls.count, 1, "Should have one NSRegularExpression in denyUrls")
+        XCTAssertEqual(regexDenyUrls[0].pattern, denyRegex.pattern, "Should preserve original regex pattern")
+    }
+    
+    // MARK: - Testing isNetworkDetailCaptureEnabled (networkDetailAllowUrls | networkDetailDenyUrls)
+    
+    func testNetworkDetailUrls_withMixedStringAndRegexTypes_shouldMatchCorrectly() throws {
+        // -- Arrange --
+        let allowRegex = try NSRegularExpression(pattern: "^https://secure\\.api\\.com/v[0-9]+/.*")
+        let denyRegex = try NSRegularExpression(pattern: ".*\\?secret_key=.*")
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": [
+                "https://data.example.com", // String pattern (substring match)
+                allowRegex, // NSRegularExpression pattern - only matches secure.api.com with version
+                "/graphql" // Another string pattern
+            ],
+            "networkDetailDenyUrls": [
+                "/internal/", // String pattern (substring match)
+                denyRegex // NSRegularExpression pattern - blocks URLs with secret_key param
+            ]
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 3)
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 2)
+        
+        // substring pattern matching
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://data.example.com/api/users"),
+                     "Should match string pattern 'https://data.example.com'")
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://api.myapp.com/graphql"), 
+                     "Should match string pattern '/graphql'")
+        
+        // regex pattern matching
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://secure.api.com/v2/users"), 
+                     "Should match regex pattern for versioned API")
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://secure.api.com/users"), 
+                      "Should NOT match regex - missing version number")
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://api.com/v2/users"), 
+                      "Should NOT match regex - wrong domain")
+        
+        // Test deny patterns
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://data.example.com/internal/config"), 
+                      "Should be denied by string pattern '/internal/'")
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://secure.api.com/v2/users?secret_key=abc123"), 
+                      "Should be denied by regex pattern for secret_key")
+        
+        // URLs that don't match any allow pattern
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://other.site.com/api"), 
+                      "Should not match any allow pattern")
+    }
+    
+    func testIsNetworkDetailCaptureEnabled_withBasicAllowDenyLogic_shouldReturnCorrectResults() {
+        // -- Arrange --
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": ["api.example.com", "/public/"],
+            "networkDetailDenyUrls": ["api.example.com/auth", "/private/"]
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Should allow URLs matching allow patterns but not deny patterns
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/users"))
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://example.com/public/data"))
+        
+        // Should deny URLs matching deny patterns (deny takes precedence)
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/auth/login"))
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://example.com/private/data"))
+        
+        // Should deny URLs not matching any allow patterns
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://other.example.com/data"))
+    }
+    
+    func testIsNetworkDetailCaptureEnabled_withRegexPatterns_shouldMatchCorrectly() throws {
+        // -- Arrange --
+        let allowRegex = try NSRegularExpression(pattern: "^https://api\\.example\\.com/v[0-9]+/.*")
+        let denyRegex = try NSRegularExpression(pattern: ".*/(admin|secret)/.*")
+        let dict: [String: Any] = [
+            "networkDetailAllowUrls": [allowRegex],
+            "networkDetailDenyUrls": [denyRegex]
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Should allow URLs matching allow regex
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/v1/users"))
+        XCTAssertTrue(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/v2/data"))
+        
+        // Should deny URLs matching deny regex (even if they match allow)
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/v1/admin/users"))
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/v2/secret/data"))
+        
+        // Should deny URLs not matching allow regex
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://api.example.com/users")) // Missing version
+        XCTAssertFalse(options.isNetworkDetailCaptureEnabled(for: "https://other.example.com/v1/users"))
+    }
+    
+    // MARK: - Header Configuration Tests
+    
+    func testNetworkHeaders_withCustomHeaders_shouldAlwaysIncludeDefaultHeaders() {
+        // -- Arrange --
+        let customRequestHeaders = ["Authorization", "X-API-Key"]
+        let customResponseHeaders = ["Cache-Control", "X-Rate-Limit"]
+        let dict: [String: Any] = [
+            "networkRequestHeaders": customRequestHeaders,
+            "networkResponseHeaders": customResponseHeaders
+        ]
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        let expectedDefaults = ["Content-Type", "Content-Length", "Accept"]
+        
+        // Request headers should include both defaults and custom headers
+        for defaultHeader in expectedDefaults {
+            XCTAssertTrue(options.networkRequestHeaders.contains(defaultHeader), 
+                         "Default header '\(defaultHeader)' should always be included in request headers")
+        }
+        for customHeader in customRequestHeaders {
+            XCTAssertTrue(options.networkRequestHeaders.contains(customHeader), 
+                         "Custom header '\(customHeader)' should be included in request headers")
+        }
+        
+        // Response headers should include both defaults and custom headers
+        for defaultHeader in expectedDefaults {
+            XCTAssertTrue(options.networkResponseHeaders.contains(defaultHeader), 
+                         "Default header '\(defaultHeader)' should always be included in response headers")
+        }
+        for customHeader in customResponseHeaders {
+            XCTAssertTrue(options.networkResponseHeaders.contains(customHeader), 
+                         "Custom header '\(customHeader)' should be included in response headers")
+        }
+    }
+    
+    func testNetworkHeaders_withCaseInsensitiveDuplicates_shouldPreventDuplicateHeaders() {
+        // -- Arrange --
+        let headersWithDuplicates = [
+            "Content-Type", // Duplicate of default (exact case)
+            "content-length", // Duplicate of default (different case)
+            "ACCEPT", // Duplicate of default (different case)
+            "Authorization", // New header
+            "authorization" // Duplicate of above (different case)
+        ]
+        let dict: [String: Any] = [
+            "networkRequestHeaders": headersWithDuplicates
+        ]   
+        
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: dict)
+        
+        // -- Assert --
+        // Should have only unique headers (case-insensitive)
+        let expectedHeaders = ["Content-Type", "Content-Length", "Accept", "Authorization"]
+        XCTAssertEqual(options.networkRequestHeaders.count, expectedHeaders.count)
+        
+        // Verify each expected header appears exactly once (case-insensitive check)
+        for expectedHeader in expectedHeaders {
+            let matchingHeaders = options.networkRequestHeaders.filter { 
+                $0.lowercased() == expectedHeader.lowercased() 
+            }
+            XCTAssertEqual(matchingHeaders.count, 1, 
+                          "Header '\(expectedHeader)' should appear exactly once, but found: \(matchingHeaders)")
+        }
+    }
+}

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsObjcTests.m
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsObjcTests.m
@@ -34,6 +34,12 @@
     XCTAssertEqual(options.errorReplayDuration, 30);
     XCTAssertEqual(options.sessionSegmentDuration, 5);
     XCTAssertEqual(options.maximumDuration, 60 * 60);
+
+    XCTAssertNotNil(options.networkDetailAllowUrls);
+    XCTAssertEqual(options.networkDetailAllowUrls.count, 0);
+    XCTAssertNotNil(options.networkDetailDenyUrls);
+    XCTAssertEqual(options.networkDetailDenyUrls.count, 0);
+    XCTAssertTrue(options.networkCaptureBodies);
 }
 
 - (void)testInit_withAllArguments_shouldSetAllValues
@@ -65,6 +71,138 @@
     XCTAssertEqual(options.errorReplayDuration, 30);
     XCTAssertEqual(options.sessionSegmentDuration, 5);
     XCTAssertEqual(options.maximumDuration, 60 * 60);
+    XCTAssertNotNil(options.networkDetailAllowUrls);
+    XCTAssertEqual(options.networkDetailAllowUrls.count, 0);
+    XCTAssertNotNil(options.networkDetailDenyUrls);
+    XCTAssertEqual(options.networkDetailDenyUrls.count, 0);
+    XCTAssertTrue(options.networkCaptureBodies);
+    XCTAssertEqualObjects(options.networkRequestHeaders, (@[@"Content-Type", @"Content-Length", @"Accept"]));
+    XCTAssertEqualObjects(options.networkResponseHeaders, (@[@"Content-Type", @"Content-Length", @"Accept"]));
+}
+
+// MARK: - Network Details Tests (Objective-C Regex Interoperability)
+
+- (void)testIsNetworkDetailCaptureEnabled_withStringPatterns_shouldUseSubstringMatching
+{
+    // -- Arrange --
+    SentryReplayOptions *options = [[SentryReplayOptions alloc] init];
+    options.networkDetailAllowUrls =
+        @[ @"api.example.com", @"/analytics/", @"track" ];
+    options.networkDetailDenyUrls = @[];
+
+    // -- Act & Assert --
+    // Should match - substring found anywhere in URL
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/users"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://sub.api.example.com/data"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://myapp.com/v1/analytics/events"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://site.com/track/user"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://tracking.service.com/api"]);
+
+    // Should NOT match - substring not found
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://other.example.com"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://api.other.com"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://analyze.com/data"]);
+}
+
+- (void)testIsNetworkDetailCaptureEnabled_withNSRegularExpression_shouldUseProvidedRegexMatching
+{
+    // -- Arrange --
+    SentryReplayOptions *options = [[SentryReplayOptions alloc] init];
+    NSError *error = nil;
+    NSRegularExpression *regularRegex =
+        [NSRegularExpression regularExpressionWithPattern:@"^https://api\\.example\\.com/.*"
+                                                  options:0
+                                                    error:&error];
+    XCTAssertNil(error);
+
+    NSRegularExpression *caseInsensitiveRegex =
+        [NSRegularExpression regularExpressionWithPattern:@"^https://analytics\\."
+                                                  options:NSRegularExpressionCaseInsensitive
+                                                    error:&error];
+    XCTAssertNil(error);
+
+    options.networkDetailAllowUrls = @[ regularRegex, caseInsensitiveRegex ];
+    options.networkDetailDenyUrls = @[];
+
+    // -- Act & Assert --
+    // Should match case-sensitive 'api' subdomain
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/users"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/api/data"]);
+    
+    // Should match case-insensitive 'analytics' subdomain
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://analytics.myapp.com"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://ANALYTICS.example.com"]); // respects options:NSRegularExpressionCaseInsensitive
+
+    // Should NOT match - wrong subdomain or case
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://v2.example.com/api/users"]); // Wrong subdomain
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://other.com/api/users"]); // Wrong domain
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://API.example.com/users"]); // Case mismatch in subdomain
+}
+
+- (void)testIsNetworkDetailCaptureEnabled_withMixedPatterns_shouldSupportBoth
+{
+    // -- Arrange --
+    SentryReplayOptions *options = [[SentryReplayOptions alloc] init];
+    NSError *error = nil;
+    // Regex that requires version in path - won't match without /v[0-9]+/
+    NSRegularExpression *regex =
+        [NSRegularExpression regularExpressionWithPattern:@"^https://secure\\.api\\.com/v[0-9]+/.*"
+                                                  options:0
+                                                    error:&error];
+    XCTAssertNil(error);
+
+    // Mix substring pattern and regex pattern with distinct matching behavior
+    options.networkDetailAllowUrls = @[ @"/graphql", regex ];
+    options.networkDetailDenyUrls = @[];
+
+    // -- Act & Assert --
+    // Substring matches
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/graphql"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://myapp.com/api/graphql/query"]);
+
+    // Regex matches
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://secure.api.com/v1/users"]);
+    XCTAssertTrue([options isNetworkDetailCaptureEnabledFor:@"https://secure.api.com/v2/data"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://secure.api.com/users"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://api.com/v1/users"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://other.example.com"]);
+    XCTAssertFalse([options isNetworkDetailCaptureEnabledFor:@"https://api.other.com/rest"]);
+}
+
+- (void)testIsNetworkDetailCaptureEnabled_withDenyPatterns_shouldRespectDenyOverAllow
+{
+    // -- Arrange --
+    SentryReplayOptions *options = [[SentryReplayOptions alloc] init];
+    NSError *error = nil;
+    
+    // Allow everything regex
+    NSRegularExpression *allowAllRegex =
+        [NSRegularExpression regularExpressionWithPattern:@".*"
+                                                  options:0
+                                                    error:&error];
+    XCTAssertNil(error);
+    
+    NSRegularExpression *denyRegex =
+        [NSRegularExpression regularExpressionWithPattern:@".*/(auth|login|password).*"
+                                                  options:NSRegularExpressionCaseInsensitive
+                                                    error:&error];
+    XCTAssertNil(error);
+
+    options.networkDetailAllowUrls = @[ allowAllRegex ];
+    options.networkDetailDenyUrls = @[ @"https://api.example.com/sensitive", denyRegex ];
+
+    // -- Act & Assert --
+    // Should deny these (substring match)
+    XCTAssertFalse(
+        [options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/sensitive/data"]);
+
+    // Should deny these (regex match)
+    XCTAssertFalse(
+        [options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/auth/token"]);
+    XCTAssertFalse(
+        [options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/user/login"]);
+    XCTAssertFalse(
+        [options isNetworkDetailCaptureEnabledFor:@"https://api.example.com/PASSWORD/reset"]);
 }
 
 @end

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
@@ -25,6 +25,12 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.errorReplayDuration, 30)
         XCTAssertEqual(options.sessionSegmentDuration, 5)
         XCTAssertEqual(options.maximumDuration, 60 * 60)
+        
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 0)
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 0)
+        XCTAssertTrue(options.networkCaptureBodies)
+        XCTAssertEqual(options.networkRequestHeaders, ["Content-Type", "Content-Length", "Accept"])
+        XCTAssertEqual(options.networkResponseHeaders, ["Content-Type", "Content-Length", "Accept"])
     }
 
     func testInit_withAllArguments_shouldSetValues() {
@@ -38,6 +44,13 @@ class SentryReplayOptionsTests: XCTestCase {
             enableViewRendererV2: false,
             enableFastViewRendering: true
         )
+        
+        // Set network details options after initialization since they're not in the public initializer
+        options.networkDetailAllowUrls = ["https://api.example.com", "https://test.example.org"]
+        options.networkDetailDenyUrls = ["https://sensitive.example.com", "https://private.example.org"]
+        options.networkCaptureBodies = false
+        options.networkRequestHeaders = ["Authorization", "User-Agent", "X-Custom-Header"]
+        options.networkResponseHeaders = ["Cache-Control", "Set-Cookie", "X-Rate-Limit"]
 
         // -- Assert --
         XCTAssertEqual(options.sessionSampleRate, 0.5)
@@ -54,6 +67,13 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.errorReplayDuration, 30)
         XCTAssertEqual(options.sessionSegmentDuration, 5)
         XCTAssertEqual(options.maximumDuration, 60 * 60)
+        
+        // Network details assertions
+        XCTAssertEqual(options.networkDetailAllowUrls as? [String], ["https://api.example.com", "https://test.example.org"])
+        XCTAssertEqual(options.networkDetailDenyUrls as? [String], ["https://sensitive.example.com", "https://private.example.org"])
+        XCTAssertFalse(options.networkCaptureBodies)
+        XCTAssertEqual(options.networkRequestHeaders, ["Authorization", "User-Agent", "X-Custom-Header"])
+        XCTAssertEqual(options.networkResponseHeaders, ["Cache-Control", "Set-Cookie", "X-Rate-Limit"])
     }
 
     func testInit_sessionSampleRateOmitted_shouldUseDefaultValues() {
@@ -215,6 +235,13 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.errorReplayDuration, 30)
         XCTAssertEqual(options.sessionSegmentDuration, 5)
         XCTAssertEqual(options.maximumDuration, 60 * 60)
+        
+        // Network options should use defaults when not specified in dictionary
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 0)
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 0)
+        XCTAssertTrue(options.networkCaptureBodies)
+        XCTAssertEqual(options.networkRequestHeaders, ["Content-Type", "Content-Length", "Accept"])
+        XCTAssertEqual(options.networkResponseHeaders, ["Content-Type", "Content-Length", "Accept"])
     }
 
     func testInitFromDict_allValues_shouldSetValues() throws {
@@ -234,7 +261,12 @@ class SentryReplayOptionsTests: XCTestCase {
             "frameRate": 2,
             "errorReplayDuration": 300,
             "sessionSegmentDuration": 10,
-            "maximumDuration": 120
+            "maximumDuration": 120,
+            "networkDetailAllowUrls": ["https://api.example.com", "https://test.com"],
+            "networkDetailDenyUrls": ["https://sensitive.com", "https://auth.com"],
+            "networkCaptureBodies": false,
+            "networkRequestHeaders": ["Authorization", "User-Agent"],
+            "networkResponseHeaders": ["Cache-Control", "Set-Cookie"]
         ])
 
         // -- Assert --
@@ -265,6 +297,13 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.errorReplayDuration, 300)
         XCTAssertEqual(options.sessionSegmentDuration, 10)
         XCTAssertEqual(options.maximumDuration, 120)
+        
+        // Network options
+        XCTAssertEqual(options.networkDetailAllowUrls as? [String], ["https://api.example.com", "https://test.com"])
+        XCTAssertEqual(options.networkDetailDenyUrls as? [String], ["https://sensitive.com", "https://auth.com"])
+        XCTAssertFalse(options.networkCaptureBodies)
+        XCTAssertEqual(options.networkRequestHeaders, ["Authorization", "User-Agent"])
+        XCTAssertEqual(options.networkResponseHeaders, ["Cache-Control", "Set-Cookie"])
     }
 
     // MARK: onErrorSampleRate
@@ -743,6 +782,139 @@ class SentryReplayOptionsTests: XCTestCase {
 
         // -- Assert --
         XCTAssertEqual(options.maximumDuration, 60 * 60)
+    }
+    
+    // MARK: Network Options (Basic Dictionary Tests)
+    
+    func testInitFromDict_networkDetailAllowUrls_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkDetailAllowUrls": ["https://api.example.com", "https://test.com"]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkDetailAllowUrls as? [String], ["https://api.example.com", "https://test.com"])
+        XCTAssertTrue(options.networkCaptureBodies) // Should remain default
+    }
+    
+    func testInitFromDict_networkCaptureBodies_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkCaptureBodies": false
+        ])
+        
+        // -- Assert --
+        XCTAssertFalse(options.networkCaptureBodies)
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 0) // Should remain default
+    }
+    
+    func testInitFromDict_networkCaptureBodies_withNSNumber_shouldConvertCorrectly() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkCaptureBodies": NSNumber(value: true)
+        ])
+        
+        // -- Assert --
+        XCTAssertTrue(options.networkCaptureBodies)
+    }
+    
+    func testInitFromDict_networkDetailDenyUrls_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkDetailDenyUrls": ["https://sensitive.com", "https://auth.com"]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkDetailDenyUrls as? [String], ["https://sensitive.com", "https://auth.com"])
+        XCTAssertEqual(options.networkDetailAllowUrls.count, 0) // Should remain default
+    }
+    
+    func testInitFromDict_networkDetailDenyUrls_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkDetailDenyUrls": "invalid_value"
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkDetailDenyUrls.count, 0)
+    }
+    
+    func testInitFromDict_networkRequestHeaders_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkRequestHeaders": ["Authorization", "User-Agent"]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkRequestHeaders, ["Authorization", "User-Agent"])
+        XCTAssertEqual(options.networkResponseHeaders, ["Content-Type", "Content-Length", "Accept"]) // Should remain default
+    }
+    
+    func testInitFromDict_networkRequestHeaders_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkRequestHeaders": "invalid_value"
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkRequestHeaders, ["Content-Type", "Content-Length", "Accept"])
+    }
+    
+    func testInitFromDict_networkRequestHeaders_whenInvalidArrayValue_shouldFilterInvalidValues() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkRequestHeaders": [
+                "Authorization",        // Valid string
+                "User-Agent",           // Valid string
+                123,                    // Invalid type (number)
+                true,                   // Invalid type (boolean)
+                ["nested": "array"],    // Invalid type (dictionary)
+                NSNull(),               // Invalid type (NSNull)
+                ""                      // Empty string (still valid)
+            ] as [Any]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkRequestHeaders, ["Authorization", "User-Agent", ""])
+    }
+    
+    func testInitFromDict_networkResponseHeaders_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkResponseHeaders": ["Cache-Control", "Set-Cookie"]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkResponseHeaders, ["Cache-Control", "Set-Cookie"])
+        XCTAssertEqual(options.networkRequestHeaders, ["Content-Type", "Content-Length", "Accept"]) // Should remain default
+    }
+    
+    func testInitFromDict_networkResponseHeaders_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkResponseHeaders": "invalid_value"
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkResponseHeaders, ["Content-Type", "Content-Length", "Accept"])
+    }
+    
+    func testInitFromDict_networkResponseHeaders_whenInvalidArrayValue_shouldFilterInvalidValues() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "networkResponseHeaders": [
+                "Cache-Control",        // Valid string
+                "Set-Cookie",           // Valid string
+                123,                    // Invalid type (number)
+                true,                   // Invalid type (boolean)
+                ["nested": "array"],    // Invalid type (dictionary)
+                NSNull(),               // Invalid type (NSNull)
+                ""                      // Empty string (still valid)
+            ] as [Any]
+        ])
+        
+        // -- Assert --
+        XCTAssertEqual(options.networkResponseHeaders, ["Cache-Control", "Set-Cookie", ""])
     }
     
     // MARK: sdkInfo


### PR DESCRIPTION
Implement SDK fields, setters and validation for network details capture:
 https://docs.sentry.io/platforms/javascript/session-replay/configuration/#network-details

- String patterns for prefix matching (e.g., "https://api.example.com" matches subpaths)
- NSRegularExpression patterns for complex regex matching
- Deny list precedence over allow list
- Empty string filtering to handle invalid input gracefully

## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
