### PR TITLE
test: Use XCTAssertGreaterThan for comparisons

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryHangTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryHangTrackingIntegrationTests.swift
@@ -139,14 +139,14 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 ($0.stacktrace?.frames.count ?? 0) >= 1
             }.count
             
-            XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+            XCTAssertGreaterThan(threadsWithFrames, 1, "Not enough threads with frames")
 
             XCTAssertEqual(event?.debugMeta?.count, 1)
             let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
             XCTAssertEqual(eventDebugImage.debugID, TestData.debugImage.debugID)
         }
     }
-    
+
     func testV1_ANRDetected_FullyBlocking_EventCaptured() throws {
         setUpThreadInspector()
         givenInitializedTracker()
@@ -179,7 +179,7 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 ($0.stacktrace?.frames.count ?? 0) >= 1
             }.count
 
-            XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+            XCTAssertGreaterThan(threadsWithFrames, 1, "Not enough threads with frames")
 
             XCTAssertEqual(event?.debugMeta?.count, 1)
             let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
@@ -220,14 +220,14 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 ($0.stacktrace?.frames.count ?? 0) >= 1
             }.count
 
-            XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+            XCTAssertGreaterThan(threadsWithFrames, 1, "Not enough threads with frames")
 
             XCTAssertEqual(event?.debugMeta?.count, 1)
             let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
             XCTAssertEqual(eventDebugImage.debugID, TestData.debugImage.debugID)
         }
     }
-    
+
     func testV1_ANRDetected_Unknown_EventCaptured() throws {
         setUpThreadInspector()
         givenInitializedTracker()
@@ -261,7 +261,7 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 ($0.stacktrace?.frames.count ?? 0) >= 1
             }.count
 
-            XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+            XCTAssertGreaterThan(threadsWithFrames, 1, "Not enough threads with frames")
 
             XCTAssertEqual(event?.debugMeta?.count, 1)
             let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
@@ -150,7 +150,7 @@ class SentryFileIOTrackerTests: XCTestCase {
         let transactionEvent = Dynamic(transaction).toTransaction().asObject as? Transaction
 
         XCTAssertNotNil(transactionEvent?.debugMeta)
-        XCTAssertTrue(transactionEvent?.debugMeta?.count ?? 0 > 0)
+        XCTAssertGreaterThan(transactionEvent?.debugMeta?.count ?? 0, 0)
         XCTAssertEqual(transactionEvent?.debugMeta?.first, TestData.debugImage)
     }
 

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -345,8 +345,8 @@ class SentrySdkInfoTests: XCTestCase {
         let actual = SentrySdkInfo.global()
         XCTAssertEqual(actual.name, SentryMeta.sdkName)
         XCTAssertEqual(actual.version, SentryMeta.versionString)
-        XCTAssertTrue(actual.integrations.count > 0)
-        XCTAssertTrue(actual.features.count > 0)
+        XCTAssertGreaterThan(actual.integrations.count, 0)
+        XCTAssertGreaterThan(actual.features.count, 0)
     }
     
     func testFromGlobalsWithExtraPackage() throws {

--- a/Tests/SentryTests/SentryCrash/SentryDefaultThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryDefaultThreadInspectorTests.swift
@@ -42,8 +42,8 @@ class SentryDefaultThreadInspectorTests: XCTestCase {
         let actual = fixture.getSut(testWithRealMachineContextWrapper: true).getCurrentThreads()
         let stacktrace = try XCTUnwrap(actual.first).stacktrace
         
-        // The stacktrace has usually more than 40 frames. Feel free to change the number if the tests are failing
-        XCTAssertTrue(30 < stacktrace?.frames.count ?? 0, "Not enough stacktrace frames.")
+        // The stacktrace has usually more than 30 frames. Feel free to change the number if the tests are failing
+        XCTAssertGreaterThan(stacktrace?.frames.count ?? 0, 30, "Not enough stacktrace frames. It should be more than 30, but was \(stacktrace?.frames.count ?? 0)")
     }
     
     func testGetCurrentThreadsWithStacktrace() {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -35,7 +35,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         let actual = fixture.sut.buildStacktraceForCurrentThread()
         
         // The stacktrace has usually more than 40 frames. Feel free to change the number if the tests are failing
-        XCTAssertTrue(30 < actual.frames.count, "Not enough stacktrace frames. It should be more than 30, but was \(actual.frames.count)")
+        XCTAssertGreaterThan(actual.frames.count, 30, "Not enough stacktrace frames. It should be more than 30, but was \(actual.frames.count)")
     }
     
     func testFramesAreFilled() {


### PR DESCRIPTION
## Summary
- Replace `XCTAssertTrue(x > y)` with `XCTAssertGreaterThan(x, y)` across 5 test files
- On failure, `XCTAssertGreaterThan` shows the actual and expected values (e.g., `"0" is not greater than "30"`) instead of just `"XCTAssertTrue failed"`
- Fix inaccurate comment in `SentryDefaultThreadInspectorTests` that said "40 frames" when the threshold is 30

#skip-changelog

Closes #7574