### PR TITLE
test: Replace bare XCTAssert with specific assertions

### DIFF
--- a/Samples/.swiftlint.yml
+++ b/Samples/.swiftlint.yml
@@ -1,5 +1,12 @@
 parent_config: ../.swiftlint.yml
 
+custom_rules:
+  no_bare_xctassert:
+    name: "No bare XCTAssert"
+    regex: 'XCTAssert\('
+    message: "Use XCTAssertTrue, XCTAssertEqual, XCTAssertIdentical, etc. instead of bare XCTAssert(). Specific assertions provide better failure messages."
+    severity: error
+
 disabled_rules:
   - force_cast
   - force_try

--- a/Samples/AGENTS.md
+++ b/Samples/AGENTS.md
@@ -14,6 +14,10 @@ TargetName/
 - Info.plist and entitlements go in `Configuration/`, not `Resources/`
 - Add `.gitkeep` to empty directories
 
+## UI Tests
+
+Follow assertion conventions in [`Tests/AGENTS.md`](../Tests/AGENTS.md) — see "Prefer Specific Assertions Over `XCTAssert`".
+
 ## Commands
 
 | Command                    | Description                               |

--- a/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
@@ -138,7 +138,7 @@ extension ProfilingUITests {
         let configFileExists = try checkLaunchProfileMarkerFileExistence()
 
         if shouldProfileNextLaunch {
-            XCTAssert(configFileExists, "A launch profile config file should be present on disk if SentrySDK.startWithOptions configured launch profiling for the next launch.")
+            XCTAssertTrue(configFileExists, "A launch profile config file should be present on disk if SentrySDK.startWithOptions configured launch profiling for the next launch.")
         } else {
             XCTAssertFalse(configFileExists, "Launch profile config files should be removed upon starting launch profiles. If SentrySDK.startWithOptions doesn't reconfigure launch profiling, the config file should not be present.")
         }
@@ -195,7 +195,7 @@ extension ProfilingUITests {
         let sample = try XCTUnwrap(samples.first { nextSample in
             try XCTUnwrap(nextSample["stack_id"] as? NSNumber).intValue == stackID
         })
-        XCTAssert(try XCTUnwrap(sample["thread_id"] as? String) == "259") // the main thread is always ID 259
+        XCTAssertEqual(try XCTUnwrap(sample["thread_id"] as? String), "259") // the main thread is always ID 259
     }
 }
 

--- a/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
@@ -35,26 +35,26 @@ extension UserFeedbackUITests {
     func testUIElementsWithDefaults() {
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue])
         // widget button text
-        XCTAssert(app.otherElements["Report a Bug"].exists)
+        XCTAssertTrue(app.otherElements["Report a Bug"].exists)
         
         widgetButton.tap()
         
         // Form title
-        XCTAssert(app.staticTexts["Report a Bug"].exists)
+        XCTAssertTrue(app.staticTexts["Report a Bug"].exists)
         
         // form buttons
-        XCTAssert(app.staticTexts["Cancel"].exists)
-        XCTAssert(app.staticTexts["Send Bug Report"].exists)
+        XCTAssertTrue(app.staticTexts["Cancel"].exists)
+        XCTAssertTrue(app.staticTexts["Send Bug Report"].exists)
                 
         // Input field placeholders
         XCTAssertEqual(try XCTUnwrap(nameField.placeholderValue), "Your Name")
         XCTAssertEqual(try XCTUnwrap(emailField.placeholderValue), "your.email@example.org")
-        XCTAssert(app.staticTexts["What's the bug? What did you expect?"].exists)
+        XCTAssertTrue(app.staticTexts["What's the bug? What did you expect?"].exists)
         
         // Input field labels
-        XCTAssert(app.staticTexts["Email"].exists)
-        XCTAssert(app.staticTexts["Name"].exists)
-        XCTAssert(app.staticTexts["Description (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Email"].exists)
+        XCTAssertTrue(app.staticTexts["Name"].exists)
+        XCTAssertTrue(app.staticTexts["Description (Required)"].exists)
         XCTAssertFalse(app.staticTexts["Email (Required)"].exists)
         XCTAssertFalse(app.staticTexts["Name (Required)"].exists)
     }
@@ -63,26 +63,26 @@ extension UserFeedbackUITests {
         launchApp()
         
         // widget button text
-        XCTAssert(app.otherElements["Report Jank"].exists)
+        XCTAssertTrue(app.otherElements["Report Jank"].exists)
         
         widgetButton.tap()
         
         // Form title
-        XCTAssert(app.staticTexts["Jank Report"].exists)
+        XCTAssertTrue(app.staticTexts["Jank Report"].exists)
         
         // form buttons
-        XCTAssert(app.staticTexts["Report that jank"].exists)
-        XCTAssert(app.staticTexts["What, me worry?"].exists)
+        XCTAssertTrue(app.staticTexts["Report that jank"].exists)
+        XCTAssertTrue(app.staticTexts["What, me worry?"].exists)
                 
         // Input field placeholders
         XCTAssertEqual(try XCTUnwrap(nameField.placeholderValue), "Yo name")
         XCTAssertEqual(try XCTUnwrap(emailField.placeholderValue), "Yo email")
-        XCTAssert(app.staticTexts["Describe the nature of the jank. Its essence, if you will."].exists)
+        XCTAssertTrue(app.staticTexts["Describe the nature of the jank. Its essence, if you will."].exists)
         
         // Input field labels
-        XCTAssert(app.staticTexts["Thine email"].exists)
-        XCTAssert(app.staticTexts["Thy name"].exists)
-        XCTAssert(app.staticTexts["Thy complaint (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thine email"].exists)
+        XCTAssertTrue(app.staticTexts["Thy name"].exists)
+        XCTAssertTrue(app.staticTexts["Thy complaint (Required)"].exists)
         XCTAssertFalse(app.staticTexts["Thine email (Required)"].exists)
         XCTAssertFalse(app.staticTexts["Thy name (Required)"].exists)
     }
@@ -126,7 +126,7 @@ extension UserFeedbackUITests {
         try assertHookMarkersNotExist()
         
         widgetButton.tap()
-        XCTAssert(nameField.waitForExistence(timeout: 1))
+        XCTAssertTrue(nameField.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
         
         let testName = "Andrew"
@@ -167,7 +167,7 @@ extension UserFeedbackUITests {
         try assertHookMarkersNotExist()
         
         widgetButton.tap()
-        XCTAssert(nameField.waitForExistence(timeout: 1))
+        XCTAssertTrue(nameField.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
         
         let testMessage = "UITest user feedback"
@@ -214,7 +214,7 @@ extension UserFeedbackUITests {
         errorsAreaTabBarButton.tap()
 
         customButton.tap()
-        XCTAssert(nameField.waitForExistence(timeout: 1))
+        XCTAssertTrue(nameField.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
 
         let testName = "Andrew"
@@ -255,7 +255,7 @@ extension UserFeedbackUITests {
         try assertHookMarkersNotExist()
         
         widgetButton.tap()
-        XCTAssert(sendButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(sendButton.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
         
         messageTextView.tap()
@@ -266,7 +266,7 @@ extension UserFeedbackUITests {
         try assertOnlyHookMarkersExist(names: [.onFormClose, .onSubmitSuccess])
         XCTAssertEqual(try dictionaryFromSuccessHookFile(), ["name": testName, "message": "UITest user feedback", "email": testContactEmail])
         
-        XCTAssert(widgetButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(widgetButton.waitForExistence(timeout: 1))
     }
     
     // MARK: Tests validating cancellation functions correctly
@@ -284,7 +284,7 @@ extension UserFeedbackUITests {
         try assertHookMarkersNotExist()
         
         widgetButton.tap()
-        XCTAssert(sendButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(sendButton.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
         
         messageTextView.tap()
@@ -321,14 +321,14 @@ extension UserFeedbackUITests {
         try assertHookMarkersNotExist()
         
         widgetButton.tap()
-        XCTAssert(sendButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(sendButton.waitForExistence(timeout: 1))
         try assertOnlyHookMarkersExist(names: [.onFormOpen])
 
         // the modal cancel gesture
         app.swipeDown(velocity: .fast)
         
         // the swipe dismiss animation takes an extra moment, so we need to wait for the widget to be visible again
-        XCTAssert(widgetButton.waitForExistence(timeout: 1))
+        XCTAssertTrue(widgetButton.waitForExistence(timeout: 1))
         
         try assertOnlyHookMarkersExist(names: [.onFormClose])
         
@@ -347,7 +347,7 @@ extension UserFeedbackUITests {
         launchApp(args: [
             SentrySDKOverrides.Feedback.injectScreenshot.rawValue
         ])
-        XCTAssert(removeScreenshotButton.isHittable)
+        XCTAssertTrue(removeScreenshotButton.isHittable)
         
         let testMessage = "UITest user feedback"
         fillInFields(testMessage)
@@ -361,7 +361,7 @@ extension UserFeedbackUITests {
         launchApp(args: [
             SentrySDKOverrides.Feedback.injectScreenshot.rawValue
         ])
-        XCTAssert(removeScreenshotButton.isHittable)
+        XCTAssertTrue(removeScreenshotButton.isHittable)
         removeScreenshotButton.tap()
         XCTAssertFalse(removeScreenshotButton.isHittable)
         
@@ -385,8 +385,8 @@ extension UserFeedbackUITests {
         
         submit(expectingError: true)
         
-        XCTAssert(app.staticTexts["Error"].exists)
-        XCTAssert(app.staticTexts["You must provide all required information before submitting. Please check the following field: description."].exists)
+        XCTAssertTrue(app.staticTexts["Error"].exists)
+        XCTAssertTrue(app.staticTexts["You must provide all required information before submitting. Please check the following field: description."].exists)
         
         app.buttons["OK"].tap()
         
@@ -406,15 +406,15 @@ extension UserFeedbackUITests {
         
         widgetButton.tap()
         
-        XCTAssert(app.staticTexts["Thine email (Required)"].exists)
-        XCTAssert(app.staticTexts["Thy name"].exists)
+        XCTAssertTrue(app.staticTexts["Thine email (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thy name"].exists)
         XCTAssertFalse(app.staticTexts["Thy name (Required)"].exists)
-        XCTAssert(app.staticTexts["Thy complaint (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thy complaint (Required)"].exists)
         
         submit(expectingError: true)
         
-        XCTAssert(app.staticTexts["Error"].exists)
-        XCTAssert(app.staticTexts["You got many errors in this form: thine email and thy complaint."].exists)
+        XCTAssertTrue(app.staticTexts["Error"].exists)
+        XCTAssertTrue(app.staticTexts["You got many errors in this form: thine email and thy complaint."].exists)
         
         app.buttons["OK"].tap()
         
@@ -434,14 +434,14 @@ extension UserFeedbackUITests {
         
         widgetButton.tap()
         
-        XCTAssert(app.staticTexts["Thine email (Required)"].exists)
-        XCTAssert(app.staticTexts["Thy name (Required)"].exists)
-        XCTAssert(app.staticTexts["Thy complaint (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thine email (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thy name (Required)"].exists)
+        XCTAssertTrue(app.staticTexts["Thy complaint (Required)"].exists)
         
         submit(expectingError: true)
         
-        XCTAssert(app.staticTexts["Error"].exists)
-        XCTAssert(app.staticTexts.element(matching: NSPredicate(format: "label LIKE 'You got many errors in this form: thy name, thine email and thy complaint.'")).exists)
+        XCTAssertTrue(app.staticTexts["Error"].exists)
+        XCTAssertTrue(app.staticTexts.element(matching: NSPredicate(format: "label LIKE 'You got many errors in this form: thy name, thine email and thy complaint.'")).exists)
         
         app.buttons["OK"].tap()
         
@@ -459,8 +459,8 @@ extension UserFeedbackUITests {
         
         submit(expectingError: true)
         
-        XCTAssert(app.staticTexts["Error"].exists)
-        XCTAssert(app.staticTexts["You must provide all required information before submitting. Please check the following field: description."].exists)
+        XCTAssertTrue(app.staticTexts["Error"].exists)
+        XCTAssertTrue(app.staticTexts["You must provide all required information before submitting. Please check the following field: description."].exists)
         
         app.buttons["OK"].tap()
         
@@ -484,7 +484,7 @@ extension UserFeedbackUITests {
         
         submit(expectingError: true)
         
-        XCTAssert(app.staticTexts["Error"].exists)
+        XCTAssertTrue(app.staticTexts["Error"].exists)
         app.buttons["OK"].tap()
         
         try assertOnlyHookMarkersExist(names: [.onFormOpen, .onSubmitError])
@@ -510,7 +510,7 @@ extension UserFeedbackUITests {
         cancelButton.tap()
 
         customButton.waitForExistence("Form should have been dismissed and custom button should be visible again.")
-        XCTAssert(customButton.isHittable)
+        XCTAssertTrue(customButton.isHittable)
     }
 
     func testNoAutomaticallyInjectedWidgetWithCustomButton() {
@@ -519,13 +519,13 @@ extension UserFeedbackUITests {
         ])
 
         XCTAssertFalse(widgetButton.isHittable)
-        XCTAssert(customButton.isHittable)
+        XCTAssertTrue(customButton.isHittable)
 
         customButton.tap()
         cancelButton.tap()
 
         customButton.waitForExistence("Form should have been dismissed and custom button should be visible again.")
-        XCTAssert(customButton.isHittable)
+        XCTAssertTrue(customButton.isHittable)
         XCTAssertFalse(widgetButton.isHittable)
     }
 
@@ -536,7 +536,7 @@ extension UserFeedbackUITests {
         XCTAssertFalse(widgetButton.isHittable)
         extrasAreaTabBarButton.tap()
         app.buttons["io.sentry.ui-test.button.show-widget"].tap()
-        XCTAssert(widgetButton.isHittable)
+        XCTAssertTrue(widgetButton.isHittable)
         app.buttons["io.sentry.ui-test.button.hide-widget"].tap()
         XCTAssertFalse(widgetButton.isHittable)
     }
@@ -610,7 +610,7 @@ extension UserFeedbackUITests {
     func assertFormHookFile(type: HookMarkerFile, exists: Bool) throws {
         let path = try path(for: type)
         if exists {
-            XCTAssert(fm.fileExists(atPath: path), "Expected file to exist at \(path)")
+            XCTAssertTrue(fm.fileExists(atPath: path), "Expected file to exist at \(path)")
         } else {
             XCTAssertFalse(fm.fileExists(atPath: path), "Expected file to not exist at \(path)")
         }

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/FeedbackUITests.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/FeedbackUITests.swift
@@ -11,14 +11,14 @@ final class FeedbackUITests: XCTestCase {
         app.launch()
 
         // ensure the widget button is displayed
-        XCTAssert(app.otherElements["Report a Bug"].exists)
+        XCTAssertTrue(app.otherElements["Report a Bug"].exists)
 
         // ensure tapping the widget displays the form
         app.otherElements["io.sentry.feedback.widget"].tap()
-        XCTAssert(app.staticTexts["Report a Bug"].exists)
+        XCTAssertTrue(app.staticTexts["Report a Bug"].exists)
 
         // ensure cancelling the flow hides the form and redisplays the widget
         app.buttons["io.sentry.feedback.form.cancel"].tap()
-        XCTAssert(app.otherElements["Report a Bug"].exists)
+        XCTAssertTrue(app.otherElements["Report a Bug"].exists)
     }
 }

--- a/Samples/macOS-Swift/macOS-Swift-UITests/MacOSSwiftUITests.swift
+++ b/Samples/macOS-Swift/macOS-Swift-UITests/MacOSSwiftUITests.swift
@@ -163,7 +163,7 @@ private extension MacOSSwiftUITests {
         let sample = try XCTUnwrap(samples.first { nextSample in
             try XCTUnwrap(nextSample["stack_id"] as? NSNumber).intValue == stackID
         })
-        XCTAssert(try XCTUnwrap(sample["thread_id"] as? String) == "259") // the main thread is always ID 259
+        XCTAssertEqual(try XCTUnwrap(sample["thread_id"] as? String), "259") // the main thread is always ID 259
     }
 
     func retrieveFirstProfileChunkData(app: XCUIApplication) {

--- a/Samples/tvOS-Swift/tvOS-SBSwift-UITests/LaunchUITests.swift
+++ b/Samples/tvOS-Swift/tvOS-SBSwift-UITests/LaunchUITests.swift
@@ -16,22 +16,22 @@ class LaunchUITests: XCTestCase {
   
         let collectionViewsQuery = app.collectionViews
         
-        XCTAssert(collectionViewsQuery.children(matching: .cell).element(boundBy: 0).hasFocus)
+        XCTAssertTrue(collectionViewsQuery.children(matching: .cell).element(boundBy: 0).hasFocus)
         
         XCUIRemote.shared.press(.select)
-        XCTAssert(app.tables["TABLE_VIEW"].waitForExistence(timeout: timeout))
+        XCTAssertTrue(app.tables["TABLE_VIEW"].waitForExistence(timeout: timeout))
         XCUIRemote.shared.press(.menu)
         
-        XCTAssert(collectionViewsQuery.children(matching: .cell).element(boundBy: 1).waitForExistence(timeout: timeout))
+        XCTAssertTrue(collectionViewsQuery.children(matching: .cell).element(boundBy: 1).waitForExistence(timeout: timeout))
         XCUIRemote.shared.press(.right)
-        XCTAssert(collectionViewsQuery.children(matching: .cell).element(boundBy: 1).hasFocus)
+        XCTAssertTrue(collectionViewsQuery.children(matching: .cell).element(boundBy: 1).hasFocus)
         XCUIRemote.shared.press(.select)
-        XCTAssert(app/*@START_MENU_TOKEN@*/.buttons["LONELY_BUTTON"]/*[[".buttons[\"A lonely button\"]",".buttons[\"LONELY_BUTTON\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.waitForExistence(timeout: timeout))
+        XCTAssertTrue(app/*@START_MENU_TOKEN@*/.buttons["LONELY_BUTTON"]/*[[".buttons[\"A lonely button\"]",".buttons[\"LONELY_BUTTON\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.waitForExistence(timeout: timeout))
         XCUIRemote.shared.press(.select)
         XCUIRemote.shared.press(.menu)
-        XCTAssert(collectionViewsQuery.children(matching: .cell).element(boundBy: 2).waitForExistence(timeout: timeout))
+        XCTAssertTrue(collectionViewsQuery.children(matching: .cell).element(boundBy: 2).waitForExistence(timeout: timeout))
         XCUIRemote.shared.press(.right)
-        XCTAssert(collectionViewsQuery.children(matching: .cell).element(boundBy: 2).hasFocus)
+        XCTAssertTrue(collectionViewsQuery.children(matching: .cell).element(boundBy: 2).hasFocus)
         XCUIRemote.shared.press(.select)
         XCUIRemote.shared.press(.menu)
         

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -10,6 +10,12 @@ custom_rules:
     message: "Avoid background QoS for dispatch queues in tests, as in CI, work on dispatch queues with background QoS can take a long time to run and lead to flaky tests."
     severity: error
 
+  no_bare_xctassert:
+    name: "No bare XCTAssert"
+    regex: 'XCTAssert\('
+    message: "Use XCTAssertTrue, XCTAssertEqual, XCTAssertIdentical, etc. instead of bare XCTAssert(). Specific assertions provide better failure messages."
+    severity: error
+
   avoid_dispatch_groups_in_tests:
     name: "Avoid DispatchGroups in tests"
     regex: 'DispatchGroup\(\)'

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -55,6 +55,21 @@ func testExample() {
 }
 ```
 
+### Prefer Specific Assertions Over `XCTAssert`
+
+Never use bare `XCTAssert()` — it produces poor failure messages. Use the most specific assertion available:
+
+| Instead of                | Use                           |
+| ------------------------- | ----------------------------- |
+| `XCTAssert(a == b)`       | `XCTAssertEqual(a, b)`        |
+| `XCTAssert(a != b)`       | `XCTAssertNotEqual(a, b)`     |
+| `XCTAssert(a === b)`      | `XCTAssertIdentical(a, b)`    |
+| `XCTAssert(a !== b)`      | `XCTAssertNotIdentical(a, b)` |
+| `XCTAssert(x)` (any Bool) | `XCTAssertTrue(x)`            |
+| `XCTAssert(!x)`           | `XCTAssertFalse(x)`           |
+| `XCTAssert(x == nil)`     | `XCTAssertNil(x)`             |
+| `XCTAssert(x != nil)`     | `XCTAssertNotNil(x)`          |
+
 ### DAMP Over DRY
 
 Prefer self-contained, readable tests. Duplicate test code if it improves clarity. Use helpers only for complex setup, shared fixtures, or genuinely reusable assertion logic.

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -35,7 +35,7 @@ extension SentryAppLaunchProfilingTests {
         sentry_sdkInitProfilerTasks(options, TestHub(client: nil, andScope: nil))
 
         // Assert
-        XCTAssert(appLaunchProfileConfigFileExists())
+        XCTAssertTrue(appLaunchProfileConfigFileExists())
         let dict = try XCTUnwrap(sentry_persistedLaunchProfileConfigurationOptions())
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRate]), 1)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRand]), 0.5)
@@ -47,7 +47,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testContinuousLaunchProfileV2ManualLifecycleConfiguration() throws {
@@ -66,7 +66,7 @@ extension SentryAppLaunchProfilingTests {
         sentry_sdkInitProfilerTasks(options, TestHub(client: nil, andScope: nil))
 
         // Assert
-        XCTAssert(appLaunchProfileConfigFileExists())
+        XCTAssertTrue(appLaunchProfileConfigFileExists())
         let dict = try XCTUnwrap(sentry_persistedLaunchProfileConfigurationOptions())
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRate]), 1)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRand]), 0.5)
@@ -78,7 +78,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 }
 
@@ -100,7 +100,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertNotNil(sentry_launchTracer)
 
         // Act
@@ -114,7 +114,7 @@ extension SentryAppLaunchProfilingTests {
         fixture.displayLinkWrapper.call()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testLaunchContinuousProfileV2ManualLifecycleNotStoppedOnFullyDisplayed() throws {
@@ -131,7 +131,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertNil(sentry_launchTracer)
 
         // Act
@@ -145,7 +145,7 @@ extension SentryAppLaunchProfilingTests {
         fixture.displayLinkWrapper.call()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testLaunchContinuousProfileV2TraceLifecycleNotStoppedOnInitialDisplayWithoutWaitingForFullDisplay() throws {
@@ -163,7 +163,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertNotNil(sentry_launchTracer)
 
         // Act
@@ -176,7 +176,7 @@ extension SentryAppLaunchProfilingTests {
         fixture.displayLinkWrapper.call()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testLaunchContinuousProfileV2ManualLifecycleNotStoppedOnInitialDisplayWithoutWaitingForFullDisplay() throws {
@@ -193,7 +193,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertNil(sentry_launchTracer)
 
         // Act
@@ -206,7 +206,7 @@ extension SentryAppLaunchProfilingTests {
         fixture.displayLinkWrapper.call()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 }
 #endif // !os(macOS)

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -48,7 +48,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -88,7 +88,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -132,7 +132,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -173,7 +173,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -217,7 +217,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -257,7 +257,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -301,7 +301,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start
@@ -348,7 +348,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         _sentry_nondeduplicated_startLaunchProfile()
 
         // Assert correct type of profile started
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         XCTAssertFalse(SentryTraceProfiler.isCurrentlyProfiling())
 
         // Act: simulate SDK start

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
@@ -55,7 +55,7 @@ private extension SentryAppStartProfilingConfigurationTests {
 
         let actualIsValid = sentry_willProfileNextLaunch(actualOptions)
         if shouldProfileLaunch {
-            XCTAssert(actualIsValid, "Expected to enable app launch profiling with options:\n\(expectedOptions.description)")
+            XCTAssertTrue(actualIsValid, "Expected to enable app launch profiling with options:\n\(expectedOptions.description)")
         } else {
             XCTAssertFalse(actualIsValid, "Expected to disable app launch profiling with options:\n\(expectedOptions.description)")
         }

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -78,7 +78,7 @@ final class SentryContinuousProfilerTests: XCTestCase {
     // profiler after it has been started manually
     func testStoppingContinuousProfilerStopsOnBackground() throws {
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         fixture.notificationCenter.post(Notification(name: UIApplication.willResignActiveNotification, object: nil))
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
     }
@@ -89,15 +89,15 @@ final class SentryContinuousProfilerTests: XCTestCase {
     // profiler's timeout timer does not affect the continuous profiler
     func testContinuousProfilerNotStoppedAfter30Seconds() throws {
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         fixture.currentDateProvider.advanceBy(interval: 31)
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
     
     func testClosingSDKStopsProfile() throws {
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         SentrySDK.close()
         try assertContinuousProfileStoppage()
     }
@@ -115,7 +115,7 @@ final class SentryContinuousProfilerTests: XCTestCase {
     // chunk and transmits that before stopping
     func testStoppingProfilerTransmitsLastFullChunk() throws {
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         
         // assert that the first chunk was sent
         fixture.currentDateProvider.advanceBy(interval: 60)
@@ -139,7 +139,7 @@ final class SentryContinuousProfilerTests: XCTestCase {
     
     func testChunkSerializationExecutesOnBackgroundThread() throws {
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         
         // Prevent background serialization from executing automatically
         fixture.dispatchQueueWrapper.dispatchAsyncExecutesBlock = false
@@ -168,7 +168,7 @@ final class SentryContinuousProfilerTests: XCTestCase {
         XCTAssertEqual("profile_chunk", profileItem.header.type)
         
         // Profiler should still be running after chunk serialization
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         
         // Clean up
         SentryContinuousProfiler.stop()
@@ -178,21 +178,21 @@ final class SentryContinuousProfilerTests: XCTestCase {
     func testStoppingAndStartingAgainBeforeFinalChunkCompletesResultsInOneProfile() throws {
         // arrange
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // act
         fixture.currentDateProvider.advanceBy(interval: 1)
         SentryContinuousProfiler.stop()
 
         fixture.currentDateProvider.advanceBy(interval: 1)
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         fixture.currentDateProvider.advanceBy(interval: 1)
         SentryContinuousProfiler.start()
 
         fixture.currentDateProvider.advanceBy(interval: 60)
         try fixture.timeoutTimerFactory.check()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         fixture.currentDateProvider.advanceBy(interval: 1)
         SentryContinuousProfiler.stop()
@@ -255,7 +255,7 @@ private extension SentryContinuousProfilerTests {
     func performContinuousProfilingTest(expectedEnvironment: String = Options.defaultEnvironment) throws {
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
         SentryContinuousProfiler.start()
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         
         func runTestPart(expectedAddresses: [NSNumber], mockMetrics: SentryProfileTestFixture.MockMetric, countMetricsReadingAtProfileStart: Bool = true) throws {
             fixture.setMockMetrics(mockMetrics)
@@ -264,7 +264,7 @@ private extension SentryContinuousProfilerTests {
             try addMockSamples(mockAddresses: expectedAddresses)
             fixture.currentDateProvider.advanceBy(interval: 1)
             try fixture.timeoutTimerFactory.check()
-            XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+            XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
             try assertValidData(expectedEnvironment: expectedEnvironment, expectedAddresses: expectedAddresses, countMetricsReadingAtProfileStart: countMetricsReadingAtProfileStart)
     #if  os(iOS) || os(tvOS)
             fixture.resetProfileGPUExpectations()
@@ -276,13 +276,13 @@ private extension SentryContinuousProfilerTests {
         try runTestPart(expectedAddresses: [0x4, 0x5, 0x6], mockMetrics: SentryProfileTestFixture.MockMetric(cpuUsage: 1.23, memoryFootprint: 456, cpuEnergyUsage: 7), countMetricsReadingAtProfileStart: false)
         try runTestPart(expectedAddresses: [0x7, 0x8, 0x9], mockMetrics: SentryProfileTestFixture.MockMetric(cpuUsage: 9.87, memoryFootprint: 654, cpuEnergyUsage: 3), countMetricsReadingAtProfileStart: false)
         
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         SentryContinuousProfiler.stop()
         try assertContinuousProfileStoppage()
     }
     
     func assertContinuousProfileStoppage() throws {
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
         fixture.currentDateProvider.advance(by: 60)
         try fixture.timeoutTimerFactory.check()
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
@@ -351,7 +351,7 @@ private extension SentryContinuousProfilerTests {
                 XCTAssertNotNil(frames[frameIdx])
             }
         }
-        XCTAssert(foundAtLeastOneNonEmptySample)
+        XCTAssertTrue(foundAtLeastOneNonEmptySample)
 
         for sample in samples {
             XCTAssertNotNil(sample["timestamp"] as? NSNumber)

--- a/Tests/SentryProfilerTests/SentryNSProcessInfoWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentryNSProcessInfoWrapperTests.swift
@@ -8,6 +8,6 @@ class SentryNSProcessInfoWrapperTests: XCTestCase {
     lazy private var fixture = Fixture()
 
     func testProcessorCount() {
-        XCTAssert((0...Int.max).contains(fixture.processInfoWrapper.processorCount))
+        XCTAssertTrue((0...Int.max).contains(fixture.processInfoWrapper.processorCount))
     }
 }

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -139,7 +139,7 @@ extension SentryProfilingPublicAPITests {
         SentrySDK.startProfiler()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // Act
         try stopProfilerV2()
@@ -232,13 +232,13 @@ extension SentryProfilingPublicAPITests {
         givenSdkWithHub()
         fixture.currentDate.advance(by: 1)
         let span = SentrySDK.startTransaction(name: "test", operation: "test")
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // Act - using manual stop method is a no-op in trace profile lifecycle mode
         try stopProfilerV2()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // Arrange
         fixture.currentDate.advance(by: 1)
@@ -247,7 +247,7 @@ extension SentryProfilingPublicAPITests {
         span.finish()
 
         // Assert - profile chunk must complete
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // Arrange - simulate chunk completion
         fixture.currentDate.advance(by: 60)
@@ -311,7 +311,7 @@ extension SentryProfilingPublicAPITests {
         SentrySDK.startProfiler()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testContinuousProfilerV2ManualLifecycleStartWithSampleSessionDecisionNo() throws {
@@ -401,7 +401,7 @@ extension SentryProfilingPublicAPITests {
         span = SentrySDK.startTransaction(name: "test", operation: "test")
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 
     func testContinuousProfileV2TraceLifecycleTracesSampleDecisionNoSessionSampleDecisionYes() throws {
@@ -451,7 +451,7 @@ extension SentryProfilingPublicAPITests {
         SentrySDK.startProfiler()
 
         // Assert
-        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
 
         // Act
         nc.post(Notification(name: UIApplication.willResignActiveNotification))

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -10,7 +10,7 @@ class SentrySystemWrapperTests: XCTestCase {
     func testCPUUsageReportsData() throws {
         XCTAssertNoThrow({
             let cpuUsage = try XCTUnwrap(self.fixture.systemWrapper.cpuUsage())
-            XCTAssert((0.0 ... 100.0).contains(cpuUsage.doubleValue))
+            XCTAssertTrue((0.0 ... 100.0).contains(cpuUsage.doubleValue))
         })
     }
 
@@ -18,7 +18,7 @@ class SentrySystemWrapperTests: XCTestCase {
         let error: NSErrorPointer = nil
         let memoryFootprint = fixture.systemWrapper.memoryFootprintBytes(error)
         XCTAssertNil(error?.pointee)
-        XCTAssert((0...UINT64_MAX).contains(memoryFootprint))
+        XCTAssertTrue((0...UINT64_MAX).contains(memoryFootprint))
     }
 }
 #endif // os(iOS) || os(macOS)

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -28,9 +28,9 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("captureFailedRequests"))
-        XCTAssert(features.contains("timeToFullDisplayTracing"))
-        XCTAssert(features.contains("swiftAsyncStacktraces"))
+        XCTAssertTrue(features.contains("captureFailedRequests"))
+        XCTAssertTrue(features.contains("timeToFullDisplayTracing"))
+        XCTAssertTrue(features.contains("swiftAsyncStacktraces"))
     }
 
     func testEnablePersistingTracesWhenCrashing() {
@@ -43,7 +43,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("persistingTracesWhenCrashing"))
+        XCTAssertTrue(features.contains("persistingTracesWhenCrashing"))
     }
 
     func testGetEnabledFeatures_optionsAreNil_shouldReturnEmptyArray() {
@@ -99,7 +99,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("fastViewRendering"))
+        XCTAssertTrue(features.contains("fastViewRendering"))
 #else
         throw XCTSkip("Test not supported on this platform")
 #endif
@@ -115,7 +115,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("dataSwizzling"))
+        XCTAssertTrue(features.contains("dataSwizzling"))
     }
 
     func testEnableDataSwizzling_isDisabled_shouldNotAddFeature() throws {
@@ -141,7 +141,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("fileManagerSwizzling"))
+        XCTAssertTrue(features.contains("fileManagerSwizzling"))
     }
 
     func testEnableFileManagerSwizzling_isDisabled_shouldNotAddFeature() throws {
@@ -167,7 +167,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("unhandledCPPExceptionsV2"))
+        XCTAssertTrue(features.contains("unhandledCPPExceptionsV2"))
     }
 
     func testEnableMetrics_isEnabled_shouldAddFeature() throws {
@@ -180,7 +180,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssert(features.contains("metrics"))
+        XCTAssertTrue(features.contains("metrics"))
     }
 
     func testEnableMetrics_isDisabled_shouldNotAddFeature() throws {

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -201,7 +201,7 @@ class SentryFeedbackTests: XCTestCase {
 
             switch viewModel.validate() {
             case .success(let hint):
-                XCTAssert(input.shouldValidate)
+                XCTAssertTrue(input.shouldValidate)
                 XCTAssertEqual(hint, input.expectedSubmitButtonAccessibilityHint, testCaseDescription())
             case .failure(let error):
                 let errorDescription = try XCTUnwrap(error.errorDescription)

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -376,7 +376,7 @@ private extension SentryCoreDataTrackerTests {
         XCTAssertEqual(dbSpan.spanDescription, expectedDescription, file: file, line: line)
         XCTAssertEqual(dbSpan.data["blocked_main_thread"] as? Bool ?? false, mainThread, file: file, line: line)
         XCTAssertEqual(try XCTUnwrap(dbSpan.data["db.system"] as? String), "SQLite", file: file, line: line)
-        XCTAssert(try XCTUnwrap(dbSpan.data["db.name"] as? NSString).contains(databaseFilename), file: file, line: line)
+        XCTAssertTrue(try XCTUnwrap(dbSpan.data["db.name"] as? NSString).contains(databaseFilename), file: file, line: line)
 
         if mainThread {
             guard let frames = (dbSpan as? SentrySpanInternal)?.frames else {

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -48,7 +48,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         
         let scopeSpan = fixture.scope.span
         
-        XCTAssert(scopeSpan === transaction)
+        XCTAssertIdentical(scopeSpan, transaction)
         XCTAssertTrue(Dynamic(transaction).configuration.waitForChildren.asBool ?? false)
         XCTAssertEqual(transaction.transactionContext.name, fixture.someTransaction)
         XCTAssertEqual(transaction.transactionContext.nameSource, SentryTransactionNameSource.custom)
@@ -64,8 +64,8 @@ class SentryPerformanceTrackerTests: XCTestCase {
         let transaction = sut.getSpan(spanId)
         let scopeSpan = SentrySDKInternal.currentHub().scope.span
         
-        XCTAssert(scopeSpan !== transaction)
-        XCTAssert(scopeSpan === firstTransaction)
+        XCTAssertNotIdentical(scopeSpan, transaction)
+        XCTAssertIdentical(scopeSpan, firstTransaction)
     }
 
 #if os(iOS) || os(tvOS)
@@ -77,8 +77,8 @@ class SentryPerformanceTrackerTests: XCTestCase {
         let transaction = sut.getSpan(spanId)
         let scopeSpan = SentrySDKInternal.currentHub().scope.span
         
-        XCTAssert(scopeSpan === transaction)
-        XCTAssert(scopeSpan !== firstTransaction)
+        XCTAssertIdentical(scopeSpan, transaction)
+        XCTAssertNotIdentical(scopeSpan, firstTransaction)
         XCTAssertTrue(firstTransaction.isFinished)
         XCTAssertEqual(.cancelled, firstTransaction.status)
     }
@@ -100,7 +100,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
             let children = Dynamic(transaction).children as [Span]?
             
             XCTAssertEqual(1, children?.count)
-            XCTAssert(children!.first === childSpan)
+            XCTAssertIdentical(children!.first, childSpan)
             XCTAssertEqual(spanId, childSpan?.parentSpanId)
         }
         XCTAssertTrue(blockCalled)

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -227,12 +227,12 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         
         let initialDisplaySpan = try XCTUnwrap(sut.initialDisplaySpan)
         let fullDisplaySpan = try XCTUnwrap(sut.fullDisplaySpan)
-        XCTAssert(initialDisplaySpan.isFinished)
+        XCTAssertTrue(initialDisplaySpan.isFinished)
         XCTAssertEqual(initialDisplaySpan.timestamp, Date(timeIntervalSince1970: 12))
         XCTAssertEqual(initialDisplaySpan.status, .ok)
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 3_000)
         
-        XCTAssert(fullDisplaySpan.isFinished)
+        XCTAssertTrue(fullDisplaySpan.isFinished)
         XCTAssertEqual(fullDisplaySpan.timestamp, Date(timeIntervalSince1970: 12))
         XCTAssertEqual(fullDisplaySpan.status, .ok)
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -111,10 +111,10 @@ class SentryTransportFactoryTests: XCTestCase {
 
         // -- Assert --
         XCTAssertEqual(transports.count, 2)
-        XCTAssert(transports.contains {
+        XCTAssertTrue(transports.contains {
             $0.isKind(of: SentrySpotlightTransport.self)
         })
-        XCTAssert(transports.contains {
+        XCTAssertTrue(transports.contains {
             $0.isKind(of: SentryHttpTransport.self)
         })
     }
@@ -167,7 +167,7 @@ class SentryTransportFactoryTests: XCTestCase {
 
         // -- Assert --
         XCTAssertEqual(transports.count, 1)
-        XCTAssert(transports.contains {
+        XCTAssertTrue(transports.contains {
             $0.isKind(of: SentrySpotlightTransport.self)
         })
     }

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -149,8 +149,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(spans.count, 1)
         let firstSpan = try XCTUnwrap(spans.firstObject as? NSDictionary)
         XCTAssertEqual(try XCTUnwrap(firstSpan["description"] as? String), "UIKit init")
-        XCTAssert(firstSpan["start_timestamp_ms"] is NSNumber)
-        XCTAssert(firstSpan["end_timestamp_ms"] is NSNumber)
+        XCTAssertTrue(firstSpan["start_timestamp_ms"] is NSNumber)
+        XCTAssertTrue(firstSpan["end_timestamp_ms"] is NSNumber)
     }
 
     func testGetAppStartMeasurementWithSpansPreWarmed() throws {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1530,7 +1530,7 @@ class SentryClientTests: XCTestCase {
             options.beforeSendSpan = { span in
                 let childSpan = span.startChild(operation: "op")
                 
-                XCTAssert(childSpan.isKind(of: SentryNoOpSpan.self))
+                XCTAssertTrue(childSpan.isKind(of: SentryNoOpSpan.self))
                 
                 return span
             }
@@ -1960,7 +1960,7 @@ class SentryClientTests: XCTestCase {
         
         let actual = try lastSentEvent()
         let features = try XCTUnwrap(actual.sdk?["features"] as? [String])
-        XCTAssert(features.contains("captureFailedRequests"))
+        XCTAssertTrue(features.contains("captureFailedRequests"))
     }
     
     func testFileManagerCantBeInit() throws {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1417,7 +1417,7 @@ class SentryHubTests: XCTestCase {
         
         let installedIntegration = sut.getInstalledIntegration(EmptyIntegration.self) as? NSObject
         
-        XCTAssert(integration === installedIntegration)
+        XCTAssertIdentical(integration, installedIntegration)
     }
     
     func testGetInstalledIntegration_ReturnsNilIfNotFound() {

--- a/Tests/SentryTests/SentryNSURLRequestTests.swift
+++ b/Tests/SentryTests/SentryNSURLRequestTests.swift
@@ -12,7 +12,7 @@ class SentryNSURLRequestTests: XCTestCase {
     func testRequestWithEnvelopeEndpoint() throws {
         let request = try SentryURLRequestFactory.envelopeRequest(with: SentryNSURLRequestTests.dsn(), data: Data())
         let string = try XCTUnwrap(request.url?.absoluteString as? NSString)
-        XCTAssert(string.hasSuffix("/envelope/"))
+        XCTAssertTrue(string.hasSuffix("/envelope/"))
     }
     
     func testRequestWithEnvelopeEndpoint_hasUserAgentWithSdkNameAndVersion() throws {

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -340,7 +340,7 @@ class SentrySDKInternalTests: XCTestCase {
 
         let newSpan = SentrySDK.span
 
-        XCTAssert(transaction === newSpan)
+        XCTAssertIdentical(transaction, newSpan)
     }
 
 #if SENTRY_HAS_UIKIT


### PR DESCRIPTION
## Summary
- Replaced all bare `XCTAssert()` calls with specific assertions
  (`XCTAssertTrue`, `XCTAssertEqual`, `XCTAssertIdentical`, `XCTAssertNotIdentical`)
  across all test files
- Added a SwiftLint custom rule to `Tests/.swiftlint.yml` to prevent future usage
- Documented the convention in `Tests/AGENTS.md`

Bare `XCTAssert()` produces generic failure messages like "XCTAssert failed",
while specific assertions show actual vs expected values, making test failures
easier to diagnose.

#skip-changelog

Agent transcript: https://claudescope.sentry.dev/share/ttVdWwG6vaN_qH5CuIU3zknHYjs9JweD5GoLaSPrb4M

Closes #7577