### PR TITLE
feat(network-details): Introduce data classes for extracting network details to session replay

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// Warning codes for network body capture issues.
+enum NetworkBodyWarning: String {
+    case jsonTruncated = "JSON_TRUNCATED"
+    case textTruncated = "TEXT_TRUNCATED"
+    case invalidJson = "INVALID_JSON"
+    case bodyParseError = "BODY_PARSE_ERROR"
+}
+
+/// Main container for network request/response tracking.
+///
+/// ObjC callers (SentryNetworkTracker) create this object and populate it
+/// via `setRequest`/`setResponse`. Swift callers (SentrySRDefaultBreadcrumbConverter)
+/// consume it via `serialize()`.
+@objc
+@_spi(Private) public class SentryReplayNetworkDetails: NSObject {
+
+    // MARK: - Nested Types (Swift-only)
+
+    /// Typed representation of captured body content.
+    enum BodyContent {
+        /// Parsed JSON body (dictionary or array).
+        case json(Any)
+        /// Text body (plain text, HTML, XML, etc.).
+        case text(String)
+
+        init(_ value: Any) {
+            if let string = value as? String {
+                self = .text(string)
+            } else {
+                self = .json(value)
+            }
+        }
+
+        var serializedValue: Any {
+            switch self {
+            case .json(let value): return value
+            case .text(let string): return string
+            }
+        }
+    }
+
+    /// Captured request or response body with optional parsing warnings.
+    struct Body {
+        let content: BodyContent
+        let warnings: [NetworkBodyWarning]
+
+        init(content: Any, warnings: [NetworkBodyWarning] = []) {
+            self.content = BodyContent(content)
+            self.warnings = warnings
+        }
+
+        func serialize() -> [String: Any] {
+            var result = [String: Any]()
+            result["body"] = content.serializedValue
+            if !warnings.isEmpty {
+                result["warnings"] = warnings.map(\.rawValue)
+            }
+            return result
+        }
+    }
+
+    /// Captured HTTP request or response details (size, body, headers).
+    struct Detail {
+        let size: NSNumber?
+        let body: Body?
+        let headers: [String: String]
+
+        func serialize() -> [String: Any] {
+            var result = [String: Any]()
+            if let size { result["size"] = size }
+            if let body { result["body"] = body.serialize() }
+            result["headers"] = headers
+            return result
+        }
+    }
+
+    // MARK: - Properties
+
+    /// Key used to store network details in breadcrumb data dictionary.
+    @objc public static let replayNetworkDetailsKey = "_networkDetails"
+
+    private(set) var method: String?
+    private(set) var statusCode: NSNumber?
+    private(set) var request: Detail?
+    private(set) var response: Detail?
+
+    /// Request body size in bytes, derived from request details.
+    var requestBodySize: NSNumber? { request?.size }
+
+    /// Response body size in bytes, derived from response details.
+    var responseBodySize: NSNumber? { response?.size }
+
+    // MARK: - Initialization
+
+    /// Creates a new instance with the given HTTP method.
+    @objc
+    public init(method: String?) {
+        self.method = method
+        super.init()
+    }
+
+    // MARK: - ObjC Setters
+
+    /// Sets request details from raw components.
+    ///
+    /// - Parameters:
+    ///   - size: Request body size in bytes, or nil if unknown.
+    ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
+    ///   - headers: Filtered HTTP request headers.
+    @objc
+    public func setRequest(size: NSNumber?, body: Any?, headers: [String: String]) {
+        self.request = Detail(
+            size: size,
+            body: body.map { Body(content: $0) },
+            headers: headers
+        )
+    }
+
+    /// Sets response details from raw components.
+    ///
+    /// - Parameters:
+    ///   - statusCode: HTTP status code.
+    ///   - size: Response body size in bytes, or nil if unknown.
+    ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
+    ///   - headers: Filtered HTTP response headers.
+    @objc
+    public func setResponse(statusCode: Int, size: NSNumber?, body: Any?, headers: [String: String]) {
+        self.statusCode = NSNumber(value: statusCode)
+        self.response = Detail(
+            size: size,
+            body: body.map { Body(content: $0) },
+            headers: headers
+        )
+    }
+
+    // MARK: - Serialization
+
+    /// Serializes to dictionary for inclusion in breadcrumb data.
+    public func serialize() -> [String: Any] {
+        var result = [String: Any]()
+        if let method { result["method"] = method }
+        if let statusCode { result["statusCode"] = statusCode }
+        if let requestBodySize { result["requestBodySize"] = requestBodySize }
+        if let responseBodySize { result["responseBodySize"] = responseBodySize }
+        if let request { result["request"] = request.serialize() }
+        if let response { result["response"] = response.serialize() }
+        return result
+    }
+
+    public override var description: String {
+        "SentryReplayNetworkDetails: \(serialize())"
+    }
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 /// Warning codes for network body capture issues.
+///
+/// Raw values must match the frontend constants so the Sentry UI renders the correct warnings.
+/// - SeeAlso: https://github.com/getsentry/sentry/blob/8b79857b2eff86f4df2f3abaf1e46c74893e3781/static/app/utils/replays/replay.tsx#L5
 enum NetworkBodyWarning: String {
     case jsonTruncated = "JSON_TRUNCATED"
     case textTruncated = "TEXT_TRUNCATED"

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -71,7 +71,7 @@ enum NetworkBodyWarning: String {
             var result = [String: Any]()
             if let size { result["size"] = size }
             if let body { result["body"] = body.serialize() }
-            result["headers"] = headers
+            if !headers.isEmpty { result["headers"] = headers }
             return result
         }
     }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -715,17 +715,14 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Parameter userHeaders: Headers specified by the user (can be nil)
      * - Parameter defaults: Default headers that must always be included
-     * - Returns: Array containing both user headers and default headers (with duplicates removed)
+     * - Returns: Array containing both user headers and default headers with duplicates removed.
      */
     private static func mergeWithDefaultHeaders(_ userHeaders: [String]?, defaults: [String]) -> [String] {
         let providedHeaders = userHeaders ?? []
         
-        // Use Set to remove duplicates, then convert back to Array
-        // Case-insensitive comparison to avoid duplicate headers with different casing
         var seenHeaders = Set<String>()
         var result: [String] = []
-        
-        // Add default headers first
+
         for header in defaults {
             let lowercased = header.lowercased()
             if !seenHeaders.contains(lowercased) {
@@ -733,8 +730,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
                 result.append(header)
             }
         }
-        
-        // Add user-provided headers
+
         for header in providedHeaders {
             let lowercased = header.lowercased()
             if !seenHeaders.contains(lowercased) {


### PR DESCRIPTION
## :scroll: Description

**Class diagram**
```
SentryReplayNetworkDetails.swift     (@objc, @_spi(Private) public)
├── method: String?
├── statusCode: NSNumber?
├── requestBodySize: NSNumber?       (computed from request.size)
├── responseBodySize: NSNumber?      (computed from response.size)
├── request: Detail?
├── response: Detail?
│
├── Detail                           (Swift-only struct)
│   ├── size: NSNumber?
│   ├── body: Body?
│   └── headers: [String: String]
│
├── Body                             (Swift-only struct)
│   ├── content: BodyContent
│   └── warnings: [NetworkBodyWarning]
│
├── BodyContent                      (Swift-only enum)
│   ├── .json(Any)                   — parsed dict/array
│   └── .text(String)                — plain text or placeholder
│
└── NetworkBodyWarning               (Swift-only enum)
    ├── .jsonTruncated
    ├── .textTruncated
    ├── .invalidJson
    └── .bodyParseError
```

**Expected usage**  
```
SentryNetworkTracker.m (ObjC — producer)
  │
  │  let details = SentryReplayNetworkDetails(method: "POST")
  │  [details setRequestWithSize:… body:… headers:…]
  │  [details setResponseWithStatusCode:… size:… body:… headers:…]
  │  breadcrumbData["_networkDetails"] = details
  │
  ▼
SentrySRDefaultBreadcrumbConverter.swift (Swift — consumer)
  │
  │  let details = breadcrumb.data["_networkDetails"] as? SentryReplayNetworkDetails
  │  let serialized = details.serialize()
  │  // → { method, statusCode, requestBodySize, responseBodySize,
  │  //     request: { size, headers, body: { body, warnings } },
  │  //     response: { size, headers, body: { body, warnings } } }
  │
  ▼
  RRWebSpanEvent data payload
```



## :bulb: Motivation and Context

See corresponding [class definitions in sentry-java](https://github.com/getsentry/sentry-java/tree/b8bd88061259ff86c9472d203d3f17d1c106336e/sentry/src/main/java/io/sentry/util/network)

This PR only defines the data contract used by PRs higher in the stack.

See [first PR](https://github.com/getsentry/sentry-cocoa/pull/7580) for more motivation/context.

## :green_heart: How did you test it?
Unit tests are in the next PR in the stack, which introduces the body parsing and header extraction logic that operates on these types.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes. **See future PRs where impl is added**
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled. **requires opt-in via specifying networkDetailAllowUrls**
- [x] I updated the docs if needed. **future PR**
- [x] I updated the wizard if needed. **N/A**
- [x] Review from the native team if needed. **N/A**
- [x] No breaking change or entry added to the changelog. #skip-changelog **future PR**
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs. **internal classes**


Closes #7623