### PR TITLE
feat(network-details): New swizzling to capture response bodies for session replay

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -562,4 +562,15 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     return breadcrumbLevel;
 }
 
+- (void)captureResponseDetails:(NSData *)data
+                      response:(NSURLResponse *)response
+                    requestURL:(NSURL *)requestURL
+                          task:(NSURLSessionTask *)task
+{
+    // TODO: Implementation
+    // 2. Parse response body data
+    // 3. Store in appropriate location for session replay
+    // 4. Handle size limits and truncation if needed
+}
+
 @end

--- a/Sources/Sentry/SentrySwizzleWrapperHelper.m
+++ b/Sources/Sentry/SentrySwizzleWrapperHelper.m
@@ -131,9 +131,9 @@ NS_ASSUME_NONNULL_BEGIN
                 wrappedHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
                     if (!error && data && task) {
                         [networkTracker captureResponseDetails:data
-                                                     response:response
-                                                   requestURL:request.URL
-                                                         task:task];
+                                                      response:response
+                                                    requestURL:request.URL
+                                                          task:task];
                     }
                     completionHandler(data, response, error);
                 };
@@ -164,9 +164,9 @@ NS_ASSUME_NONNULL_BEGIN
                 wrappedHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
                     if (!error && data && task) {
                         [networkTracker captureResponseDetails:data
-                                                     response:response
-                                                   requestURL:url
-                                                         task:task];
+                                                      response:response
+                                                    requestURL:url
+                                                          task:task];
                     }
                     completionHandler(data, response, error);
                 };

--- a/Sources/Sentry/SentrySwizzleWrapperHelper.m
+++ b/Sources/Sentry/SentrySwizzleWrapperHelper.m
@@ -97,6 +97,87 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 }
 
+/**
+ * Swizzles NSURLSession data task creation methods that use completion handlers
+ * to enable response body capture for session replay.
+ *
+ * Both dataTaskWithRequest: and dataTaskWithURL: are independent implementations
+ * (neither calls through to the other), so both need swizzling.
+ *
+ * See SentryNSURLSessionTaskSearchTests that verifies these assumptions still hold.
+ */
++ (void)swizzleURLSessionDataTasksForResponseCapture:(SentryNetworkTracker *)networkTracker
+{
+    [self swizzleDataTaskWithRequestCompletionHandler:networkTracker];
+    [self swizzleDataTaskWithURLCompletionHandler:networkTracker];
+}
+
+/**
+ * Swizzles -[NSURLSession dataTaskWithRequest:completionHandler:] to intercept response data.
+ */
++ (void)swizzleDataTaskWithRequestCompletionHandler:(SentryNetworkTracker *)networkTracker
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+    SEL selector = @selector(dataTaskWithRequest:completionHandler:);
+    SentrySwizzleInstanceMethod([NSURLSession class], selector,
+        SentrySWReturnType(NSURLSessionDataTask *),
+        SentrySWArguments(NSURLRequest * request,
+            void (^completionHandler)(NSData *, NSURLResponse *, NSError *)),
+        SentrySWReplacement({
+            __block NSURLSessionDataTask *task = nil;
+            void (^wrappedHandler)(NSData *, NSURLResponse *, NSError *) = nil;
+            if (completionHandler) {
+                wrappedHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+                    if (!error && data && task) {
+                        [networkTracker captureResponseDetails:data
+                                                     response:response
+                                                   requestURL:request.URL
+                                                         task:task];
+                    }
+                    completionHandler(data, response, error);
+                };
+            }
+            task = SentrySWCallOriginal(request, wrappedHandler ?: completionHandler);
+            return task;
+        }),
+        SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
+#pragma clang diagnostic pop
+}
+
+/**
+ * Swizzles -[NSURLSession dataTaskWithURL:completionHandler:] to intercept response data.
+ */
++ (void)swizzleDataTaskWithURLCompletionHandler:(SentryNetworkTracker *)networkTracker
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+    SEL selector = @selector(dataTaskWithURL:completionHandler:);
+    SentrySwizzleInstanceMethod([NSURLSession class], selector,
+        SentrySWReturnType(NSURLSessionDataTask *),
+        SentrySWArguments(
+            NSURL * url, void (^completionHandler)(NSData *, NSURLResponse *, NSError *)),
+        SentrySWReplacement({
+            __block NSURLSessionDataTask *task = nil;
+            void (^wrappedHandler)(NSData *, NSURLResponse *, NSError *) = nil;
+            if (completionHandler) {
+                wrappedHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+                    if (!error && data && task) {
+                        [networkTracker captureResponseDetails:data
+                                                     response:response
+                                                   requestURL:url
+                                                         task:task];
+                    }
+                    completionHandler(data, response, error);
+                };
+            }
+            task = SentrySWCallOriginal(url, wrappedHandler ?: completionHandler);
+            return task;
+        }),
+        SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
+#pragma clang diagnostic pop
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryNetworkTracker.h
+++ b/Sources/Sentry/include/SentryNetworkTracker.h
@@ -26,6 +26,11 @@ static NSString *const SENTRY_NETWORK_REQUEST_TRACKER_BREADCRUMB
 @property (nonatomic, readonly) BOOL isCaptureFailedRequestsEnabled;
 @property (nonatomic, readonly) BOOL isGraphQLOperationTrackingEnabled;
 
+- (void)captureResponseDetails:(NSData *)data
+                      response:(NSURLResponse *)response
+                    requestURL:(nullable NSURL *)requestURL
+                          task:(NSURLSessionTask *)task;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySwizzleWrapperHelper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapperHelper.h
@@ -26,6 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)swizzleURLSessionTask:(SentryNetworkTracker *)networkTracker;
 
+// Swizzle [NSURLSession dataTaskWithURL:completionHandler:]
+//         [NSURLSession dataTaskWithRequest:completionHandler:]
++ (void)swizzleURLSessionDataTasksForResponseCapture:(SentryNetworkTracker *)networkTracker;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
@@ -42,7 +42,7 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
 
         SentrySwizzleWrapperHelper.swizzleURLSessionTask(networkTracker)
 
-        #if os(iOS) || os(tvOS)
+        #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
          if options.sessionReplay.networkDetailHasUrls {
              SentrySwizzleWrapperHelper.swizzleURLSessionDataTasks(forResponseCapture: networkTracker)
          }

--- a/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
@@ -41,6 +41,12 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
         super.init()
 
         SentrySwizzleWrapperHelper.swizzleURLSessionTask(networkTracker)
+
+        #if os(iOS) || os(tvOS)
+         if options.sessionReplay.networkDetailHasUrls {
+             SentrySwizzleWrapperHelper.swizzleURLSessionDataTasks(forResponseCapture: networkTracker)
+         }
+        #endif
     }
 
     func uninstall() {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNSURLSessionTaskSearchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNSURLSessionTaskSearchTests.swift
@@ -1,13 +1,156 @@
 import XCTest
 
+// We need to know whether Apple changes the NSURLSessionTask implementation.
 class SentryNSURLSessionTaskSearchTests: XCTestCase {
 
-    // We need to know whether Apple changes the NSURLSessionTask implementation.
-     func test_URLSessionTask_ByIosVersion() {
+    func test_URLSessionTask_ByIosVersion() {
         let classes = SentryNSURLSessionTaskSearch.urlSessionTaskClassesToTrack()
-        
+
         XCTAssertEqual(classes.count, 1)
         XCTAssertTrue(classes.first === URLSessionTask.self)
     }
 
+    // MARK: - NSURLSession class hierarchy validation tests
+    //
+    // Based on testing, NSURLSession implements dataTaskWithRequest:completionHandler:
+    // and dataTaskWithURL:completionHandler: directly on the base class.
+    //
+    // The swizzling code relies on this by swizzling [NSURLSession class] directly
+    // rather than doing runtime discovery. These tests verify that assumption
+    // still holds — if Apple ever moves these methods to a subclass, these tests
+    // will fail and we'll know to update the swizzling approach.
+
+    func test_URLSession_isNotClassCluster_dataTaskWithRequest() {
+        let selector = #selector(URLSession.dataTask(with:completionHandler:)
+            as (URLSession) -> (URLRequest, @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask)
+        assertNSURLSessionImplementsDirectly(selector: selector, selectorName: "dataTaskWithRequest:completionHandler:")
+    }
+
+    func test_URLSession_isNotClassCluster_dataTaskWithURL() {
+        let selector = #selector(URLSession.dataTask(with:completionHandler:)
+            as (URLSession) -> (URL, @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask)
+        assertNSURLSessionImplementsDirectly(selector: selector, selectorName: "dataTaskWithURL:completionHandler:")
+    }
+
+    // MARK: - dataTaskWithURL: / dataTaskWithRequest: independence
+    //
+    // We swizzle both dataTaskWithRequest:completionHandler: and
+    // dataTaskWithURL:completionHandler: because they are independent
+    // implementations — dataTaskWithURL: does NOT dispatch to
+    // dataTaskWithRequest: via objc_msgSend.
+    //
+    // If this test ever fails, Apple has changed the internal dispatch so
+    // one calls through to the other. In that case, remove the redundant
+    // swizzle and add a deduplication guard to avoid double-capture.
+
+    func test_dataTaskWithURL_doesNotCallThrough_dataTaskWithRequest() {
+        assertNoCallThrough(
+            from: NSSelectorFromString("dataTaskWithURL:completionHandler:"),
+            to: NSSelectorFromString("dataTaskWithRequest:completionHandler:"),
+            call: { session in
+                let url = URL(string: "https://example.com")!
+                let task = session.dataTask(with: url) { _, _, _ in }
+                task.cancel()
+            }
+        )
+    }
+
+    func test_dataTaskWithRequest_doesNotCallThrough_dataTaskWithURL() {
+        assertNoCallThrough(
+            from: NSSelectorFromString("dataTaskWithRequest:completionHandler:"),
+            to: NSSelectorFromString("dataTaskWithURL:completionHandler:"),
+            call: { session in
+                let request = URLRequest(url: URL(string: "https://example.com")!)
+                let task = session.dataTask(with: request) { _, _, _ in }
+                task.cancel()
+            }
+        )
+    }
+
+    /// Temporarily replaces the IMP of `targetSelector` with one that increments
+    /// a counter, then invokes `call` (which should trigger `sourceSelector`).
+    /// Asserts the counter stays at 0 — meaning `sourceSelector` does not
+    /// internally dispatch to `targetSelector` via objc_msgSend.
+    private func assertNoCallThrough(
+        from sourceSelector: Selector,
+        to targetSelector: Selector,
+        call: (URLSession) -> Void
+    ) {
+        guard let method = class_getInstanceMethod(URLSession.self, targetSelector) else {
+            XCTFail("URLSession should implement \(targetSelector)")
+            return
+        }
+
+        let originalIMP = method_getImplementation(method)
+        defer { method_setImplementation(method, originalIMP) }
+
+        var hitCount = 0
+
+        let replacementBlock: @convention(block) (NSObject, AnyObject, Any?) -> AnyObject = { obj, arg, handler in
+            hitCount += 1
+            typealias Fn = @convention(c) (NSObject, Selector, AnyObject, Any?) -> AnyObject
+            let original = unsafeBitCast(originalIMP, to: Fn.self)
+            return original(obj, targetSelector, arg, handler)
+        }
+
+        method_setImplementation(method, imp_implementationWithBlock(replacementBlock))
+
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+
+        call(session)
+
+        XCTAssertEqual(
+            hitCount, 0,
+            "\(sourceSelector) called through to \(targetSelector). "
+            + "These methods are no longer independent — remove the redundant swizzle "
+            + "in SentrySwizzleWrapperHelper and add a deduplication guard."
+        )
+    }
+
+    // MARK: - Helper
+
+    /// Walks the class hierarchy for sessions created with default and ephemeral
+    /// configurations and asserts that no subclass overrides `selector`.
+    private func assertNSURLSessionImplementsDirectly(selector: Selector, selectorName: String) {
+        let baseClass: AnyClass = URLSession.self
+
+        // The base class must implement the method.
+        XCTAssertNotNil(
+            class_getInstanceMethod(baseClass, selector),
+            "URLSession should implement \(selectorName)"
+        )
+
+        // Check sessions created with each relevant configuration.
+        let configs: [URLSessionConfiguration] = [
+            .default,
+            .ephemeral
+        ]
+
+        for config in configs {
+            let session = URLSession(configuration: config)
+            let sessionClass: AnyClass = type(of: session)
+
+            defer { session.invalidateAndCancel() }
+
+            if sessionClass === baseClass {
+                continue
+            }
+
+            // If Apple returns a subclass, it must NOT provide its own
+            // implementation — it should inherit from URLSession.
+            let subMethod = class_getInstanceMethod(sessionClass, selector)
+            let baseMethod = class_getInstanceMethod(baseClass, selector)
+
+            if let subMethod, let baseMethod {
+                let subIMP = method_getImplementation(subMethod)
+                let baseIMP = method_getImplementation(baseMethod)
+                XCTAssertEqual(
+                    subIMP, baseIMP,
+                    "\(NSStringFromClass(sessionClass)) overrides \(selectorName) with an unexpected IMP — "
+                    + "Verify swizzling in SentrySwizzleWrapperHelper is correct for dataTasks."
+                )
+            }
+        }
+    }
 }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNSURLSessionTaskSearchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNSURLSessionTaskSearchTests.swift
@@ -17,95 +17,19 @@ class SentryNSURLSessionTaskSearchTests: XCTestCase {
     //
     // The swizzling code relies on this by swizzling [NSURLSession class] directly
     // rather than doing runtime discovery. These tests verify that assumption
-    // still holds — if Apple ever moves these methods to a subclass, these tests
+    // still holds — if Apple ever moves these methods, these tests
     // will fail and we'll know to update the swizzling approach.
 
-    func test_URLSession_isNotClassCluster_dataTaskWithRequest() {
+    func test_URLSessionDataTaskWithRequest_ByIosVersion() {
         let selector = #selector(URLSession.dataTask(with:completionHandler:)
             as (URLSession) -> (URLRequest, @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask)
         assertNSURLSessionImplementsDirectly(selector: selector, selectorName: "dataTaskWithRequest:completionHandler:")
     }
 
-    func test_URLSession_isNotClassCluster_dataTaskWithURL() {
+    func test_URLSessionDataTaskWithURL_ByIosVersion() {
         let selector = #selector(URLSession.dataTask(with:completionHandler:)
             as (URLSession) -> (URL, @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask)
         assertNSURLSessionImplementsDirectly(selector: selector, selectorName: "dataTaskWithURL:completionHandler:")
-    }
-
-    // MARK: - dataTaskWithURL: / dataTaskWithRequest: independence
-    //
-    // We swizzle both dataTaskWithRequest:completionHandler: and
-    // dataTaskWithURL:completionHandler: because they are independent
-    // implementations — dataTaskWithURL: does NOT dispatch to
-    // dataTaskWithRequest: via objc_msgSend.
-    //
-    // If this test ever fails, Apple has changed the internal dispatch so
-    // one calls through to the other. In that case, remove the redundant
-    // swizzle and add a deduplication guard to avoid double-capture.
-
-    func test_dataTaskWithURL_doesNotCallThrough_dataTaskWithRequest() {
-        assertNoCallThrough(
-            from: NSSelectorFromString("dataTaskWithURL:completionHandler:"),
-            to: NSSelectorFromString("dataTaskWithRequest:completionHandler:"),
-            call: { session in
-                let url = URL(string: "https://example.com")!
-                let task = session.dataTask(with: url) { _, _, _ in }
-                task.cancel()
-            }
-        )
-    }
-
-    func test_dataTaskWithRequest_doesNotCallThrough_dataTaskWithURL() {
-        assertNoCallThrough(
-            from: NSSelectorFromString("dataTaskWithRequest:completionHandler:"),
-            to: NSSelectorFromString("dataTaskWithURL:completionHandler:"),
-            call: { session in
-                let request = URLRequest(url: URL(string: "https://example.com")!)
-                let task = session.dataTask(with: request) { _, _, _ in }
-                task.cancel()
-            }
-        )
-    }
-
-    /// Temporarily replaces the IMP of `targetSelector` with one that increments
-    /// a counter, then invokes `call` (which should trigger `sourceSelector`).
-    /// Asserts the counter stays at 0 — meaning `sourceSelector` does not
-    /// internally dispatch to `targetSelector` via objc_msgSend.
-    private func assertNoCallThrough(
-        from sourceSelector: Selector,
-        to targetSelector: Selector,
-        call: (URLSession) -> Void
-    ) {
-        guard let method = class_getInstanceMethod(URLSession.self, targetSelector) else {
-            XCTFail("URLSession should implement \(targetSelector)")
-            return
-        }
-
-        let originalIMP = method_getImplementation(method)
-        defer { method_setImplementation(method, originalIMP) }
-
-        var hitCount = 0
-
-        let replacementBlock: @convention(block) (NSObject, AnyObject, Any?) -> AnyObject = { obj, arg, handler in
-            hitCount += 1
-            typealias Fn = @convention(c) (NSObject, Selector, AnyObject, Any?) -> AnyObject
-            let original = unsafeBitCast(originalIMP, to: Fn.self)
-            return original(obj, targetSelector, arg, handler)
-        }
-
-        method_setImplementation(method, imp_implementationWithBlock(replacementBlock))
-
-        let session = URLSession(configuration: .ephemeral)
-        defer { session.invalidateAndCancel() }
-
-        call(session)
-
-        XCTAssertEqual(
-            hitCount, 0,
-            "\(sourceSelector) called through to \(targetSelector). "
-            + "These methods are no longer independent — remove the redundant swizzle "
-            + "in SentrySwizzleWrapperHelper and add a deduplication guard."
-        )
     }
 
     // MARK: - Helper

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -791,6 +791,13 @@
         "declKind": "Import",
         "kind": "Import",
         "moduleName": "Sentry",
+        "name": "UniformTypeIdentifiers",
+        "printedName": "UniformTypeIdentifiers"
+      },
+      {
+        "declKind": "Import",
+        "kind": "Import",
+        "moduleName": "Sentry",
         "name": "WebKit",
         "printedName": "WebKit"
       },


### PR DESCRIPTION
## :scroll: Description

- Newly swizzled methods: 
`[NSURLSession dataTaskWithURL:completionHandler:]`
`[NSURLSession dataTaskWithRequest:completionHandler:]`

- This swizzling is [skipped](https://github.com/getsentry/sentry-cocoa/pull/7584/changes/22e2b20fdaf426597538da8c1bafc9200d28791f) when network detail capture is not enabled (SentryReplayOptions#networkDetailAllowUrls is empty)

- Added testing to validate for future iOS SDKs that the `IMP`s we are swizzling are implemented directly on NSURLSession: _SentryNSURLSessionTaskSearchTests_
    - `test_URLSessionDataTaskWithRequest_ByIosVersion`
    - `test_URLSessionDataTaskWithURL_ByIosVersion`


## :bulb: Motivation and Context
With this change sentry-cocoa can inspect response bodies of NSURLSession `dataTask`'s that use completionHandlers.

Swizzling is added to inspect the NSURLResponse before delegating to the original completionHandler. 
The request body will be captured via existing swizzling into SentryNetworkTracker (`setState`, `resume`).

See [swizzling discussion on #7582](https://github.com/getsentry/sentry-cocoa/issues/4944#issuecomment-3856073897) for more context.

## :green_heart: How did you test it?

## Unit tests
> xcodebuild test -workspace Sentry.xcworkspace -scheme Sentry -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:Tests/SentryTests/Integrations/Performance/Network/SentryNSURLSessionTaskSearchTests.swift | xcbeautify
```
test_URLSessionTask_ByIosVersion ✅
test_URLSessionDataTaskWithRequest_ByIosVersion ✅
test_URLSessionDataTaskWithURL_ByIosVersion ✅
```

>  SKIP_SWIFTLINT=1 xcodebuild test -workspace Sentry.xcworkspace -scheme Sentry -destination 'platform=iOS Simulator,name=iPhone 16 Pro'  -only-testing:SentryTests/SentrySwizzleWrapperHelperTests

> make test-ios ONLY_TESTING=SentryNetworkDetailSwizzlingTests 2>&1 | xcbeautify
> ...
> Test Suite 'SentryNetworkDetailSwizzlingTests' started at 2026-04-13 13:55:14.423.
> Executed 2 tests, with 0 failures (0 unexpected) in 2.100 (2.100) seconds

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes. 
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled. **gated by networkDetailAllowUrls**
- [x] I updated the docs if needed. **future pr**
- [x] I updated the wizard if needed. **N/A**
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog. #skip-changelog **future PR**
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.  🤔
