### PR TITLE
feat(network-details): Implement header and body extraction

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -66,18 +66,26 @@ enum NetworkBodyWarning: String {
             let slice = data.prefix(limit)
 
             var warnings = [NetworkBodyWarning]()
-            let lower = contentType?.lowercased() ?? ""
-            let utType = contentType.flatMap { UTType(mimeType: $0.lowercased()) }
+            // Strip MIME parameters (e.g. "; charset=utf-8") — UTType doesn't handle them.
+            let mimeType = contentType.flatMap {
+                $0.split(separator: ";").first.map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+            }
+            let utType = mimeType.flatMap { UTType(mimeType: $0) }
 
-            if lower.contains("application/x-www-form-urlencoded") {
+            if mimeType == "application/x-www-form-urlencoded" {
                 if isTruncated { warnings.append(.textTruncated) }
                 self = Body.parseFormEncoded(slice, warnings: &warnings)
             } else if let utType, utType.conforms(to: .json) {
                 if isTruncated { warnings.append(.jsonTruncated) }
                 self = Body.parseJSON(slice, warnings: &warnings)
-            } else {
+            } else if utType?.conforms(to: .text) == true {
                 if isTruncated { warnings.append(.textTruncated) }
                 self = Body.parseText(slice, warnings: &warnings)
+            } else {
+                // UTType is nil (unknown MIME type) or not text —
+                // don't attempt to decode; use a placeholder description instead.
+                let description = "[Body not captured: contentType=\(contentType ?? "unknown") (\(data.count) bytes)]"
+                self = Body(content: description)
             }
         }
 
@@ -144,7 +152,7 @@ enum NetworkBodyWarning: String {
     // MARK: - Constants
 
     /// Maximum body size in bytes before truncation (150KB).
-    static let maxBodySize = 150 * 1024
+    static let maxBodySize = 150 * 1_024
 
     /// Key used to store network details in breadcrumb data dictionary.
     @objc public static let replayNetworkDetailsKey = "_networkDetails"

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -147,17 +147,38 @@ enum NetworkBodyWarning: String {
             }
         }
 
+        /// Parses `application/x-www-form-urlencoded` data into a dictionary.
         private static func parseFormEncoded(_ data: Data, encoding: String.Encoding, warnings: inout [NetworkBodyWarning]) -> Body {
-            guard let string = String(data: data, encoding: encoding) ?? String(data: data, encoding: .utf8),
-                  let components = URLComponents(string: "http://x?" + string),
-                  let items = components.queryItems else {
+            guard let urlEncodedFormData = String(data: data, encoding: encoding) ?? String(data: data, encoding: .utf8) else {
                 warnings.append(.bodyParseError)
                 return parseText(data, encoding: encoding, warnings: &warnings)
             }
 
-            var formData = [String: String]()
-            for item in items where item.name.isEmpty == false {
-                formData[item.name] = item.value ?? ""
+            var formData = [String: Any]()
+            for rawElement in urlEncodedFormData.components(separatedBy: "&") where !rawElement.isEmpty {
+                let comps = rawElement.components(separatedBy: "=")
+                if comps.count < 2 {
+                    warnings.append(.bodyParseError)
+                    return parseText(data, encoding: encoding, warnings: &warnings)
+                }
+                // In form-urlencoded, + means space (rdar://40751862).
+                let key = comps[0]
+                    .replacingOccurrences(of: "+", with: " ")
+                    .removingPercentEncoding ?? comps[0]
+                let value = comps.dropFirst().joined(separator: "=")
+                    .replacingOccurrences(of: "+", with: " ")
+                    .removingPercentEncoding ?? comps[1]
+                guard !key.isEmpty else { continue }
+                if let existing = formData[key] {
+                    if var list = existing as? [String] {
+                        list.append(value)
+                        formData[key] = list
+                    } else if let text = existing as? String {
+                        formData[key] = [text, value]
+                    }
+                } else {
+                    formData[key] = value
+                }
             }
             return Body(content: formData, warnings: warnings)
         }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -70,26 +70,35 @@ enum NetworkBodyWarning: String {
             let mimeType = contentType.flatMap {
                 $0.split(separator: ";").first.map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
             }
-            let utType = mimeType.flatMap { UTType(mimeType: $0) }
 
             if mimeType == "application/x-www-form-urlencoded" {
                 if isTruncated { warnings.append(.textTruncated) }
                 self = Body.parseFormEncoded(slice, warnings: &warnings)
-            } else if let utType, utType.conforms(to: .json) {
-                if isTruncated { warnings.append(.jsonTruncated) }
-                self = Body.parseJSON(slice, warnings: &warnings)
-            } else if utType?.conforms(to: .text) == true {
-                if isTruncated { warnings.append(.textTruncated) }
-                self = Body.parseText(slice, warnings: &warnings)
+            } else if #available(macOS 11, *), let parsed = Body.parseByMimeType(mimeType, data: slice, isTruncated: isTruncated, warnings: &warnings) {
+                self = parsed
             } else {
-                // UTType is nil (unknown MIME type) or not text —
-                // don't attempt to decode; use a placeholder description instead.
                 let description = "[Body not captured: contentType=\(contentType ?? "unknown") (\(data.count) bytes)]"
                 self = Body(content: description)
             }
         }
 
         // MARK: - Private Parsing
+
+        /// Uses UTType to detect JSON/text content types. Returns nil for
+        /// unrecognized types so the caller can fall through to a placeholder.
+        /// UTType requires macOS 11+;  so this will not compile there.
+        @available(macOS 11, *)
+        private static func parseByMimeType(_ mimeType: String?, data: Data, isTruncated: Bool, warnings: inout [NetworkBodyWarning]) -> Body? {
+            let utType = mimeType.flatMap { UTType(mimeType: $0) }
+            if let utType, utType.conforms(to: .json) {
+                if isTruncated { warnings.append(.jsonTruncated) }
+                return parseJSON(data, warnings: &warnings)
+            } else if utType?.conforms(to: .text) == true {
+                if isTruncated { warnings.append(.textTruncated) }
+                return parseText(data, warnings: &warnings)
+            }
+            return nil
+        }
 
         private static func parseJSON(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
             do {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -161,13 +161,8 @@ enum NetworkBodyWarning: String {
                     warnings.append(.bodyParseError)
                     return parseText(data, encoding: encoding, warnings: &warnings)
                 }
-                // In form-urlencoded, + means space (rdar://40751862).
-                let key = comps[0]
-                    .replacingOccurrences(of: "+", with: " ")
-                    .removingPercentEncoding ?? comps[0]
-                let value = comps.dropFirst().joined(separator: "=")
-                    .replacingOccurrences(of: "+", with: " ")
-                    .removingPercentEncoding ?? comps[1]
+                let key = decodeFormComponent(comps[0])
+                let value = decodeFormComponent(comps.dropFirst().joined(separator: "="))
                 guard !key.isEmpty else { continue }
                 if let existing = formData[key] {
                     if var list = existing as? [String] {
@@ -181,6 +176,13 @@ enum NetworkBodyWarning: String {
                 }
             }
             return Body(content: formData, warnings: warnings)
+        }
+
+        /// Decodes a form-urlencoded component: converts `+` to space and removes percent-encoding.
+        /// Falls back to the `+`-to-space result if percent-decoding fails (e.g. `%ZZ`).
+        private static func decodeFormComponent(_ component: String) -> String {
+            let plusDecoded = component.replacingOccurrences(of: "+", with: " ")
+            return plusDecoded.removingPercentEncoding ?? plusDecoded
         }
 
         private static func parseText(_ data: Data, encoding: String.Encoding = .utf8, warnings: inout [NetworkBodyWarning]) -> Body {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -1,13 +1,13 @@
 import Foundation
+import UniformTypeIdentifiers
 
 /// Warning codes for network body capture issues.
 ///
 /// Raw values must match the frontend constants so the Sentry UI renders the correct warnings.
 /// - SeeAlso: https://github.com/getsentry/sentry/blob/8b79857b2eff86f4df2f3abaf1e46c74893e3781/static/app/utils/replays/replay.tsx#L5
 enum NetworkBodyWarning: String {
-    case jsonTruncated = "JSON_TRUNCATED"
+    case jsonTruncated = "MAYBE_JSON_TRUNCATED"
     case textTruncated = "TEXT_TRUNCATED"
-    case invalidJson = "INVALID_JSON"
     case bodyParseError = "BODY_PARSE_ERROR"
 }
 
@@ -54,6 +54,68 @@ enum NetworkBodyWarning: String {
             self.warnings = warnings
         }
 
+        /// Parses raw body data based on content type.
+        ///
+        /// Returns nil if data is empty. Truncates to `maxBodySize` and adds
+        /// appropriate warnings. Supports JSON, form-urlencoded, and text.
+        init?(data: Data, contentType: String?) {
+            guard !data.isEmpty else { return nil }
+
+            let limit = SentryReplayNetworkDetails.maxBodySize
+            let isTruncated = data.count > limit
+            let slice = data.prefix(limit)
+
+            var warnings = [NetworkBodyWarning]()
+            let lower = contentType?.lowercased() ?? ""
+            let utType = contentType.flatMap { UTType(mimeType: $0.lowercased()) }
+
+            if lower.contains("application/x-www-form-urlencoded") {
+                if isTruncated { warnings.append(.textTruncated) }
+                self = Body.parseFormEncoded(slice, warnings: &warnings)
+            } else if let utType, utType.conforms(to: .json) {
+                if isTruncated { warnings.append(.jsonTruncated) }
+                self = Body.parseJSON(slice, warnings: &warnings)
+            } else {
+                if isTruncated { warnings.append(.textTruncated) }
+                self = Body.parseText(slice, warnings: &warnings)
+            }
+        }
+
+        // MARK: - Private Parsing
+
+        private static func parseJSON(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
+                return Body(content: json, warnings: warnings)
+            } catch {
+                warnings.append(.bodyParseError)
+                return parseText(data, warnings: &warnings)
+            }
+        }
+
+        private static func parseFormEncoded(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
+            guard let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1),
+                  let components = URLComponents(string: "http://x?" + string),
+                  let items = components.queryItems else {
+                warnings.append(.bodyParseError)
+                return parseText(data, warnings: &warnings)
+            }
+
+            var formData = [String: String]()
+            for item in items where item.name.isEmpty == false {
+                formData[item.name] = item.value ?? ""
+            }
+            return Body(content: formData, warnings: warnings)
+        }
+
+        private static func parseText(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
+            if let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) {
+                return Body(content: string, warnings: warnings)
+            }
+            warnings.append(.bodyParseError)
+            return Body(content: "", warnings: warnings)
+        }
+
         func serialize() -> [String: Any] {
             var result = [String: Any]()
             result["body"] = content.serializedValue
@@ -79,10 +141,15 @@ enum NetworkBodyWarning: String {
         }
     }
 
-    // MARK: - Properties
+    // MARK: - Constants
+
+    /// Maximum body size in bytes before truncation (150KB).
+    static let maxBodySize = 150 * 1024
 
     /// Key used to store network details in breadcrumb data dictionary.
     @objc public static let replayNetworkDetailsKey = "_networkDetails"
+
+    // MARK: - Properties
 
     private(set) var method: String?
     private(set) var statusCode: NSNumber?

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -66,15 +66,12 @@ enum NetworkBodyWarning: String {
             let slice = data.prefix(limit)
 
             var warnings = [NetworkBodyWarning]()
-            // Strip MIME parameters (e.g. "; charset=utf-8") — UTType doesn't handle them.
-            let mimeType = contentType.flatMap {
-                $0.split(separator: ";").first.map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
-            }
+            let (mimeType, encoding) = Body.parseMimeAndEncoding(from: contentType)
 
             if mimeType == "application/x-www-form-urlencoded" {
                 if isTruncated { warnings.append(.textTruncated) }
-                self = Body.parseFormEncoded(slice, warnings: &warnings)
-            } else if #available(macOS 11, *), let parsed = Body.parseByMimeType(mimeType, data: slice, isTruncated: isTruncated, warnings: &warnings) {
+                self = Body.parseFormEncoded(slice, encoding: encoding, warnings: &warnings)
+            } else if #available(macOS 11, *), let parsed = Body.parseByMimeType(mimeType, data: slice, encoding: encoding, isTruncated: isTruncated, warnings: &warnings) {
                 self = parsed
             } else {
                 let description = "[Body not captured: contentType=\(contentType ?? "unknown") (\(data.count) bytes)]"
@@ -84,11 +81,48 @@ enum NetworkBodyWarning: String {
 
         // MARK: - Private Parsing
 
+        /// Extracts MIME type and string encoding from a Content-Type header value.
+        ///
+        /// Returns `.utf8` when the charset parameter is missing or unrecognized.
+        ///
+        /// Examples:
+        /// - `"application/json"` → `("application/json", .utf8)`
+        /// - `"text/html; charset=iso-8859-1"` → `("text/html", .isoLatin1)`
+        /// - `nil` → `(nil, .utf8)`
+        static func parseMimeAndEncoding(from contentType: String?) -> (mimeType: String?, encoding: String.Encoding) {
+            guard let contentType else { return (nil, .utf8) }
+
+            let parts = contentType.split(separator: ";")
+            let mimeType = parts.first.map { String($0).trimmingCharacters(in: .whitespaces).lowercased() }
+
+            var encoding: String.Encoding = .utf8
+            for part in parts.dropFirst() {
+                let trimmed = part.trimmingCharacters(in: .whitespaces)
+                guard trimmed.lowercased().hasPrefix("charset=") else { continue }
+                let charsetValue = String(trimmed.dropFirst("charset=".count))
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                encoding = stringEncoding(fromCharset: charsetValue)
+                break
+            }
+            return (mimeType, encoding)
+        }
+
+        /// Converts an IANA charset name to a `String.Encoding`.
+        ///
+        /// Returns `.utf8` for unrecognized or empty charset names.
+        private static func stringEncoding(fromCharset charset: String) -> String.Encoding {
+            guard !charset.isEmpty else { return .utf8 }
+            let cfEncoding = CFStringConvertIANACharSetNameToEncoding(charset as CFString)
+            guard cfEncoding != kCFStringEncodingInvalidId else { return .utf8 }
+            return String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(cfEncoding))
+        }
+
         /// Uses UTType to detect JSON/text content types. Returns nil for
         /// unrecognized types so the caller can fall through to a placeholder.
         /// UTType requires macOS 11+;  so this will not compile there.
         @available(macOS 11, *)
-        private static func parseByMimeType(_ mimeType: String?, data: Data, isTruncated: Bool, warnings: inout [NetworkBodyWarning]) -> Body? {
+        private static func parseByMimeType(_ mimeType: String?, data: Data, encoding: String.Encoding, isTruncated: Bool, warnings: inout [NetworkBodyWarning]) -> Body? {
             guard let utType = mimeType.flatMap({ UTType(mimeType: $0) }) else {
                 return nil
             }
@@ -98,7 +132,7 @@ enum NetworkBodyWarning: String {
             }
             if utType.conforms(to: .text) {
                 if isTruncated { warnings.append(.textTruncated) }
-                return parseText(data, warnings: &warnings)
+                return parseText(data, encoding: encoding, warnings: &warnings)
             }
             return nil
         }
@@ -113,12 +147,12 @@ enum NetworkBodyWarning: String {
             }
         }
 
-        private static func parseFormEncoded(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
-            guard let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1),
+        private static func parseFormEncoded(_ data: Data, encoding: String.Encoding, warnings: inout [NetworkBodyWarning]) -> Body {
+            guard let string = String(data: data, encoding: encoding) ?? String(data: data, encoding: .utf8),
                   let components = URLComponents(string: "http://x?" + string),
                   let items = components.queryItems else {
                 warnings.append(.bodyParseError)
-                return parseText(data, warnings: &warnings)
+                return parseText(data, encoding: encoding, warnings: &warnings)
             }
 
             var formData = [String: String]()
@@ -128,8 +162,8 @@ enum NetworkBodyWarning: String {
             return Body(content: formData, warnings: warnings)
         }
 
-        private static func parseText(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
-            if let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) {
+        private static func parseText(_ data: Data, encoding: String.Encoding = .utf8, warnings: inout [NetworkBodyWarning]) -> Body {
+            if let string = String(data: data, encoding: encoding) ?? String(data: data, encoding: .utf8) {
                 return Body(content: string, warnings: warnings)
             }
             warnings.append(.bodyParseError)

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -128,7 +128,7 @@ enum NetworkBodyWarning: String {
             }
             if utType.conforms(to: .json) {
                 if isTruncated { warnings.append(.jsonTruncated) }
-                return parseJSON(data, warnings: &warnings)
+                return parseJSON(data, encoding: encoding, warnings: &warnings)
             }
             if utType.conforms(to: .text) {
                 if isTruncated { warnings.append(.textTruncated) }
@@ -137,13 +137,13 @@ enum NetworkBodyWarning: String {
             return nil
         }
 
-        private static func parseJSON(_ data: Data, warnings: inout [NetworkBodyWarning]) -> Body {
+        private static func parseJSON(_ data: Data, encoding: String.Encoding = .utf8, warnings: inout [NetworkBodyWarning]) -> Body {
             do {
                 let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers)
                 return Body(content: json, warnings: warnings)
             } catch {
                 warnings.append(.bodyParseError)
-                return parseText(data, warnings: &warnings)
+                return parseText(data, encoding: encoding, warnings: &warnings)
             }
         }
 

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -197,8 +197,10 @@ enum NetworkBodyWarning: String {
 
     // MARK: - Constants
 
-    /// Maximum body size in bytes before truncation (150KB).
-    static let maxBodySize = 150 * 1_024
+    /// Maximum body size in bytes before truncation.
+    /// Mirrors `NETWORK_BODY_MAX_SIZE` from sentry-javascript's replay-internal:
+    /// https://github.com/getsentry/sentry-javascript/blob/399cc859ce250ba5db3656685bd05794f571bee5/packages/replay-internal/src/constants.ts#L33
+    static let maxBodySize = 150_000
 
     /// Key used to store network details in breadcrumb data dictionary.
     @objc public static let replayNetworkDetailsKey = "_networkDetails"

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -184,8 +184,14 @@ enum NetworkBodyWarning: String {
         }
 
         private static func parseText(_ data: Data, encoding: String.Encoding = .utf8, warnings: inout [NetworkBodyWarning]) -> Body {
-            if let string = String(data: data, encoding: encoding) ?? String(data: data, encoding: .utf8) {
-                return Body(content: string, warnings: warnings)
+            // Truncation at a multi-byte boundary (e.g. UTF-8 CJK, emoji) makes
+            // String(data:encoding:) return nil. Try dropping up to 3 trailing bytes
+            // to find a valid boundary before giving up.
+            for drop in 0...min(3, data.count) {
+                let slice = drop == 0 ? data : data.dropLast(drop)
+                if let string = String(data: slice, encoding: encoding) ?? String(data: slice, encoding: .utf8) {
+                    return Body(content: string, warnings: warnings)
+                }
             }
             warnings.append(.bodyParseError)
             return Body(content: "", warnings: warnings)

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -195,13 +195,14 @@ enum NetworkBodyWarning: String {
     /// - Parameters:
     ///   - size: Request body size in bytes, or nil if unknown.
     ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
-    ///   - headers: Filtered HTTP request headers.
+    ///   - allHeaders: All headers from the request (e.g. from `NSURLRequest.allHTTPHeaderFields`).
+    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
     @objc
-    public func setRequest(size: NSNumber?, body: Any?, headers: [String: String]) {
+    public func setRequest(size: NSNumber?, body: Any?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
         self.request = Detail(
             size: size,
             body: body.map { Body(content: $0) },
-            headers: headers
+            headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
         )
     }
 
@@ -211,15 +212,41 @@ enum NetworkBodyWarning: String {
     ///   - statusCode: HTTP status code.
     ///   - size: Response body size in bytes, or nil if unknown.
     ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
-    ///   - headers: Filtered HTTP response headers.
+    ///   - allHeaders: All headers from the response (e.g. from `NSHTTPURLResponse.allHeaderFields`).
+    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
     @objc
-    public func setResponse(statusCode: Int, size: NSNumber?, body: Any?, headers: [String: String]) {
+    public func setResponse(statusCode: Int, size: NSNumber?, body: Any?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
         self.statusCode = NSNumber(value: statusCode)
         self.response = Detail(
             size: size,
             body: body.map { Body(content: $0) },
-            headers: headers
+            headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
         )
+    }
+
+    // MARK: - Header Extraction
+
+    /// Extracts headers from a source dictionary using case-insensitive matching.
+    /// Preserves the original casing of the header key as seen in the source.
+    ///
+    /// - Parameters:
+    ///   - sourceHeaders: All available headers (e.g. from `NSURLRequest` or `NSHTTPURLResponse`).
+    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
+    /// - Returns: Dictionary containing matched headers with original key casing preserved.
+    static func extractHeaders(from sourceHeaders: [String: Any]?, matching configuredHeaders: [String]?) -> [String: String] {
+        guard let sourceHeaders, let configuredHeaders else { return [:] }
+
+        var extracted = [String: String]()
+        for configured in configuredHeaders {
+            let lowered = configured.lowercased()
+            for (key, value) in sourceHeaders {
+                if key.lowercased() == lowered {
+                    extracted[key] = (value as? String) ?? "\(value)"
+                    break
+                }
+            }
+        }
+        return extracted
     }
 
     // MARK: - Serialization

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -89,11 +89,14 @@ enum NetworkBodyWarning: String {
         /// UTType requires macOS 11+;  so this will not compile there.
         @available(macOS 11, *)
         private static func parseByMimeType(_ mimeType: String?, data: Data, isTruncated: Bool, warnings: inout [NetworkBodyWarning]) -> Body? {
-            let utType = mimeType.flatMap { UTType(mimeType: $0) }
-            if let utType, utType.conforms(to: .json) {
+            guard let utType = mimeType.flatMap({ UTType(mimeType: $0) }) else {
+                return nil
+            }
+            if utType.conforms(to: .json) {
                 if isTruncated { warnings.append(.jsonTruncated) }
                 return parseJSON(data, warnings: &warnings)
-            } else if utType?.conforms(to: .text) == true {
+            }
+            if utType.conforms(to: .text) {
                 if isTruncated { warnings.append(.textTruncated) }
                 return parseText(data, warnings: &warnings)
             }

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -295,6 +295,51 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertEqual(dict["name"] as? String, "Jane Doe")
     }
 
+    // MARK: - Multi-byte Truncation
+
+    func testInit_withTruncatedMultiByteUTF8_shouldRecoverValidPrefix() throws {
+        // UTF-8 byte widths:
+        //   3-byte chars: CJK (e.g. "你" = E4 BD A0)
+        //   4-byte chars: emoji (e.g. "😀" = F0 9F 98 80)
+        //   2-byte chars: accented Latin (e.g. "é" = C3 A9)
+
+        // -- dropLast(1): 3-byte char split after 2 bytes --
+        // "你好" = 6 bytes; prefix(5) cuts second char after 2 of 3 bytes
+        let cjk = "你好".data(using: .utf8)!
+        XCTAssertEqual(cjk.count, 6)
+        let body1 = try XCTUnwrap(Body(data: cjk.prefix(5), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body1.serialize()["body"] as? String, "你")
+
+        // -- dropLast(2): 3-byte char split after 1 byte --
+        // prefix(4) cuts second char after 1 of 3 bytes
+        let body2 = try XCTUnwrap(Body(data: cjk.prefix(4), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body2.serialize()["body"] as? String, "你")
+
+        // -- dropLast(3): 4-byte emoji split after 1 byte --
+        // "A😀" = 1 + 4 = 5 bytes; prefix(2) cuts emoji after 1 of 4 bytes
+        let emoji = "A😀".data(using: .utf8)!
+        XCTAssertEqual(emoji.count, 5)
+        let body3 = try XCTUnwrap(Body(data: emoji.prefix(2), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body3.serialize()["body"] as? String, "A")
+
+        // -- no truncation needed: clean boundary --
+        // prefix(3) is exactly "你", no bytes to drop
+        let body4 = try XCTUnwrap(Body(data: cjk.prefix(3), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body4.serialize()["body"] as? String, "你")
+
+        // -- pure ASCII: never affected --
+        let ascii = "hello".data(using: .utf8)!
+        let body5 = try XCTUnwrap(Body(data: ascii.prefix(3), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body5.serialize()["body"] as? String, "hel")
+
+        // -- 2-byte char split after 1 byte --
+        // "Aé" = 1 + 2 = 3 bytes; prefix(2) cuts "é" after 1 of 2 bytes
+        let accented = "Aé".data(using: .utf8)!
+        XCTAssertEqual(accented.count, 3)
+        let body6 = try XCTUnwrap(Body(data: accented.prefix(2), contentType: "text/plain; charset=utf-8"))
+        XCTAssertEqual(body6.serialize()["body"] as? String, "A")
+    }
+
     // MARK: - Serialization Tests
 
     func testSerialize_withStringBody_shouldReturnDictionary() {

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -295,6 +295,20 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertEqual(dict["name"] as? String, "Jane Doe")
     }
 
+    func testFormEncoded_malformedPercentEncoding_shouldPreservePlusDecodingAndEquals() throws {
+        // %ZZ is invalid percent-encoding → removingPercentEncoding returns nil.
+        // The fallback should still preserve +-to-space and = in values.
+        let body = try XCTUnwrap(Body(
+            data: "key=a%ZZ=b&greeting=hello+world".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        // Value preserves the joined "=" and the +-to-space conversion on the valid pair
+        XCTAssertEqual(dict["key"] as? String, "a%ZZ=b")
+        XCTAssertEqual(dict["greeting"] as? String, "hello world")
+    }
+
     // MARK: - Multi-byte Truncation
 
     func testInit_withTruncatedMultiByteUTF8_shouldRecoverValidPrefix() throws {

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -1,0 +1,237 @@
+@testable import Sentry
+import XCTest
+
+class SentryReplayNetworkDetailsBodyTests: XCTestCase {
+
+    private typealias Body = SentryReplayNetworkDetails.Body
+
+    // MARK: - Initialization Tests
+
+    func testInit_withJSONDictionary_shouldParseCorrectly() {
+        // -- Arrange --
+        let bodyContent: [String: Any] = ["key": "value", "number": 42]
+        let bodyData: Data
+        do {
+            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
+        } catch {
+            return XCTFail("Failed to create JSON data: \(error)")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "application/json")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .json(let value) = body?.content {
+            let dict = value as? [String: Any]
+            XCTAssertEqual(dict?["key"] as? String, "value")
+            XCTAssertEqual(dict?["number"] as? Int, 42)
+        } else {
+            XCTFail("Expected .json content")
+        }
+    }
+
+    func testInit_withJSONArray_shouldParseCorrectly() {
+        // -- Arrange --
+        let bodyContent = ["item1", "item2", "item3"]
+        let bodyData: Data
+        do {
+            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
+        } catch {
+            return XCTFail("Failed to create JSON data: \(error)")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "application/json")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .json(let value) = body?.content {
+            let array = value as? [String]
+            XCTAssertEqual(array?.count, 3)
+            XCTAssertEqual(array?[0], "item1")
+            XCTAssertEqual(array?[1], "item2")
+            XCTAssertEqual(array?[2], "item3")
+        } else {
+            XCTFail("Expected .json content")
+        }
+    }
+
+    func testInit_withTextData_shouldStoreAsString() {
+        // -- Arrange --
+        let bodyContent = "This is plain text content"
+        guard let bodyData = bodyContent.data(using: .utf8) else {
+            return XCTFail("Failed to create text data")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "text/plain")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertEqual(string, bodyContent)
+        } else {
+            XCTFail("Expected .text content")
+        }
+    }
+
+    func testInit_withEmptyData_shouldReturnNil() {
+        // -- Act --
+        let body = Body(data: Data(), contentType: "application/json")
+
+        // -- Assert --
+        XCTAssertNil(body)
+    }
+
+    func testInit_withFormURLEncoded_shouldParseAsForm() {
+        // -- Arrange --
+        let formString = "key1=value1&key2=value2&key3=value%20with%20spaces"
+        guard let bodyData = formString.data(using: .utf8) else {
+            return XCTFail("Failed to create form data")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "application/x-www-form-urlencoded")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .json(let value) = body?.content {
+            let dict = value as? [String: String]
+            XCTAssertEqual(dict?["key1"], "value1")
+            XCTAssertEqual(dict?["key2"], "value2")
+            XCTAssertEqual(dict?["key3"], "value with spaces")
+        } else {
+            XCTFail("Expected .json content for form data")
+        }
+    }
+
+    func testInit_withInvalidJSON_shouldFallbackToString() {
+        // -- Arrange --
+        let invalidJSON = "{ invalid json }"
+        guard let bodyData = invalidJSON.data(using: .utf8) else {
+            return XCTFail("Failed to create data")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "application/json")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertEqual(string, invalidJSON)
+        } else {
+            XCTFail("Expected .text fallback for invalid JSON")
+        }
+        XCTAssertTrue(body?.warnings.contains(.bodyParseError) == true)
+    }
+
+    func testInit_withLargeData_shouldTruncate() {
+        // -- Arrange --
+        let largeString = String(repeating: "a", count: 200_000)
+        guard let bodyData = largeString.data(using: .utf8) else {
+            return XCTFail("Failed to create large data")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "text/plain")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertLessThanOrEqual(string.count, SentryReplayNetworkDetails.maxBodySize)
+        } else {
+            XCTFail("Expected .text content")
+        }
+
+        XCTAssertTrue(body?.warnings.contains(.textTruncated) == true)
+
+        // Check serialized warnings
+        let serialized = body?.serialize()
+        if let warningStrings = serialized?["warnings"] as? [String] {
+            XCTAssertEqual(warningStrings, ["TEXT_TRUNCATED"])
+        } else {
+            XCTFail("Expected warnings to be serialized as string array")
+        }
+    }
+
+    // MARK: - Serialization Tests
+
+    func testSerialize_withStringBody_shouldReturnDictionary() {
+        // -- Arrange --
+        let bodyContent = "test body"
+        guard let bodyData = bodyContent.data(using: .utf8) else {
+            return XCTFail("Failed to create data")
+        }
+        let body = Body(data: bodyData, contentType: "text/plain")
+
+        // -- Act --
+        let result = body?.serialize()
+
+        // -- Assert --
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?["body"] as? String, bodyContent)
+    }
+
+    func testSerialize_withJSONDictionary_shouldReturnDictionary() {
+        // -- Arrange --
+        let bodyContent: [String: Any] = ["user": "test", "id": 123]
+        let bodyData: Data
+        do {
+            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
+        } catch {
+            return XCTFail("Failed to create JSON data: \(error)")
+        }
+        let body = Body(data: bodyData, contentType: "application/json")
+
+        // -- Act --
+        let result = body?.serialize()
+
+        // -- Assert --
+        XCTAssertNotNil(result)
+        guard let bodyDict = result?["body"] as? NSDictionary else {
+            return XCTFail("Expected body to be NSDictionary")
+        }
+        XCTAssertEqual(bodyDict["user"] as? String, "test")
+        XCTAssertEqual(bodyDict["id"] as? Int, 123)
+    }
+
+    func testSerialize_withJSONArray_shouldReturnArray() {
+        // -- Arrange --
+        let bodyContent = ["item1", "item2", "item3"]
+        let bodyData: Data
+        do {
+            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
+        } catch {
+            return XCTFail("Failed to create JSON data: \(error)")
+        }
+        let body = Body(data: bodyData, contentType: "application/json")
+
+        // -- Act --
+        let result = body?.serialize()
+
+        // -- Assert --
+        XCTAssertNotNil(result)
+        guard let bodyArray = result?["body"] as? NSArray else {
+            return XCTFail("Expected body to be NSArray")
+        }
+        XCTAssertEqual(bodyArray.count, 3)
+        XCTAssertEqual(bodyArray[0] as? String, "item1")
+    }
+
+    func testSerialize_withNoContentType_shouldDefaultToText() {
+        // -- Arrange --
+        let bodyContent = "some content"
+        guard let bodyData = bodyContent.data(using: .utf8) else {
+            return XCTFail("Failed to create data")
+        }
+        let body = Body(data: bodyData, contentType: nil)
+
+        // -- Act --
+        let result = body?.serialize()
+
+        // -- Assert --
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?["body"] as? String, bodyContent)
+    }
+}

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -155,6 +155,68 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         }
     }
 
+    func testInit_withBinaryContentType_shouldCreateArtificialString() {
+        // -- Arrange --
+        let binaryData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) // PNG header
+        let contentType = "image/png"
+
+        // -- Act --
+        let body = Body(data: binaryData, contentType: contentType)
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertTrue(string.hasPrefix("[Body not captured"))
+            XCTAssertTrue(string.contains("8 bytes"))
+            XCTAssertTrue(string.contains("image/png"))
+        } else {
+            XCTFail("Expected .text content with binary description")
+        }
+
+        let result = body?.serialize()
+        if let bodyString = result?["body"] as? String {
+            XCTAssertTrue(bodyString.hasPrefix("[Body not captured"))
+        } else {
+            XCTFail("Expected body to be a string with binary data prefix")
+        }
+    }
+
+    func testInit_withNilContentType_shouldCreatePlaceholder() {
+        // -- Arrange --
+        let data = Data([0x00, 0x01, 0x02, 0x03])
+
+        // -- Act --
+        let body = Body(data: data, contentType: nil)
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertTrue(string.hasPrefix("[Body not captured"))
+            XCTAssertTrue(string.contains("4 bytes"))
+            XCTAssertTrue(string.contains("unknown"))
+        } else {
+            XCTFail("Expected .text content with placeholder description")
+        }
+    }
+
+    func testInit_withUnrecognizedContentType_shouldCreatePlaceholder() {
+        // -- Arrange --
+        let data = Data("some data".utf8)
+
+        // -- Act --
+        let body = Body(data: data, contentType: "application/x-custom-format")
+
+        // -- Assert --
+        XCTAssertNotNil(body)
+        if case .text(let string) = body?.content {
+            XCTAssertTrue(string.hasPrefix("[Body not captured"))
+            XCTAssertTrue(string.contains("application/x-custom-format"))
+            XCTAssertTrue(string.contains("9 bytes"))
+        } else {
+            XCTFail("Expected .text content with placeholder description")
+        }
+    }
+
     // MARK: - Serialization Tests
 
     func testSerialize_withStringBody_shouldReturnDictionary() {
@@ -219,7 +281,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertEqual(bodyArray[0] as? String, "item1")
     }
 
-    func testSerialize_withNoContentType_shouldDefaultToText() {
+    func testSerialize_withNoContentType_shouldCreatePlaceholder() {
         // -- Arrange --
         let bodyContent = "some content"
         guard let bodyData = bodyContent.data(using: .utf8) else {
@@ -232,6 +294,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
         // -- Assert --
         XCTAssertNotNil(result)
-        XCTAssertEqual(result?["body"] as? String, bodyContent)
+        let bodyString = result?["body"] as? String
+        XCTAssertTrue(bodyString?.hasPrefix("[Body not captured") == true)
     }
 }

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -1,4 +1,4 @@
-@testable import Sentry
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryReplayNetworkDetailsBodyTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -7,15 +7,10 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     // MARK: - Initialization Tests
 
-    func testInit_withJSONDictionary_shouldParseCorrectly() {
+    func testInit_withJSONDictionary_shouldParseCorrectly() throws {
         // -- Arrange --
         let bodyContent: [String: Any] = ["key": "value", "number": 42]
-        let bodyData: Data
-        do {
-            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
-        } catch {
-            return XCTFail("Failed to create JSON data: \(error)")
-        }
+        let bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "application/json")
@@ -30,15 +25,10 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         }
     }
 
-    func testInit_withJSONArray_shouldParseCorrectly() {
+    func testInit_withJSONArray_shouldParseCorrectly() throws {
         // -- Arrange --
         let bodyContent = ["item1", "item2", "item3"]
-        let bodyData: Data
-        do {
-            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
-        } catch {
-            return XCTFail("Failed to create JSON data: \(error)")
-        }
+        let bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "application/json")
@@ -58,9 +48,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withTextData_shouldStoreAsString() {
         // -- Arrange --
         let bodyContent = "This is plain text content"
-        guard let bodyData = bodyContent.data(using: .utf8) else {
-            return XCTFail("Failed to create text data")
-        }
+        let bodyData = Data(bodyContent.utf8)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "text/plain")
@@ -85,9 +73,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withInvalidJSON_shouldFallbackToString() {
         // -- Arrange --
         let invalidJSON = "{ invalid json }"
-        guard let bodyData = invalidJSON.data(using: .utf8) else {
-            return XCTFail("Failed to create data")
-        }
+        let bodyData = Data(invalidJSON.utf8)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "application/json")
@@ -102,12 +88,10 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertTrue(body?.warnings.contains(.bodyParseError) == true)
     }
 
-    func testInit_withLargeData_shouldTruncate() {
+    func testInit_withLargeData_shouldTruncate() throws {
         // -- Arrange --
         let largeString = String(repeating: "a", count: 200_000)
-        guard let bodyData = largeString.data(using: .utf8) else {
-            return XCTFail("Failed to create large data")
-        }
+        let bodyData = Data(largeString.utf8)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "text/plain")
@@ -123,15 +107,12 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertTrue(body?.warnings.contains(.textTruncated) == true)
 
         // Check serialized warnings
-        let serialized = body?.serialize()
-        if let warningStrings = serialized?["warnings"] as? [String] {
-            XCTAssertEqual(warningStrings, ["TEXT_TRUNCATED"])
-        } else {
-            XCTFail("Expected warnings to be serialized as string array")
-        }
+        let serialized = try XCTUnwrap(body?.serialize())
+        let warningStrings = try XCTUnwrap(serialized["warnings"] as? [String], "Expected warnings to be serialized as string array")
+        XCTAssertEqual(warningStrings, ["TEXT_TRUNCATED"])
     }
 
-    func testInit_withBinaryContentType_shouldCreateArtificialString() {
+    func testInit_withBinaryContentType_shouldCreateArtificialString() throws {
         // -- Arrange --
         let binaryData = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) // PNG header
         let contentType = "image/png"
@@ -149,12 +130,9 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
             XCTFail("Expected .text content with binary description")
         }
 
-        let result = body?.serialize()
-        if let bodyString = result?["body"] as? String {
-            XCTAssertTrue(bodyString.hasPrefix("[Body not captured"))
-        } else {
-            XCTFail("Expected body to be a string with binary data prefix")
-        }
+        let result = try XCTUnwrap(body?.serialize())
+        let bodyString = try XCTUnwrap(result["body"] as? String, "Expected body to be a string with binary data prefix")
+        XCTAssertTrue(bodyString.hasPrefix("[Body not captured"))
     }
 
     func testInit_withNilContentType_shouldCreatePlaceholder() {
@@ -198,9 +176,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_shouldParseAsForm() {
         // -- Arrange --
         let formString = "key1=value1&key2=value2&key3=value%20with%20spaces"
-        guard let bodyData = formString.data(using: .utf8) else {
-            return XCTFail("Failed to create form data")
-        }
+        let bodyData = Data(formString.utf8)
 
         // -- Act --
         let body = Body(data: bodyData, contentType: "application/x-www-form-urlencoded")
@@ -219,7 +195,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_duplicateKeys_shouldPromoteToArray() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "color=red&color=blue&color=green".data(using: .utf8)!,
+            data: Data("color=red&color=blue&color=green".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -231,7 +207,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_emptyValue_shouldParseAsEmptyString() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "key1=&key2=value2".data(using: .utf8)!,
+            data: Data("key1=&key2=value2".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -244,7 +220,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_missingEquals_shouldFallbackToText() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "key1=value1&malformed&key2=value2".data(using: .utf8)!,
+            data: Data("key1=value1&malformed&key2=value2".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -259,7 +235,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_emptyKeys_shouldBeSkipped() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "=value1&key2=value2".data(using: .utf8)!,
+            data: Data("=value1&key2=value2".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -272,7 +248,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_equalsInValue_shouldPreserve() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "query=a=1&token=abc".data(using: .utf8)!,
+            data: Data("query=a=1&token=abc".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -285,7 +261,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testInit_withFormURLEncoded_plusAsSpace_shouldDecode() throws {
         // -- Act --
         let body = try XCTUnwrap(Body(
-            data: "greeting=hello+world&name=Jane+Doe".data(using: .utf8)!,
+            data: Data("greeting=hello+world&name=Jane+Doe".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -299,7 +275,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         // %ZZ is invalid percent-encoding → removingPercentEncoding returns nil.
         // The fallback should still preserve +-to-space and = in values.
         let body = try XCTUnwrap(Body(
-            data: "key=a%ZZ=b&greeting=hello+world".data(using: .utf8)!,
+            data: Data("key=a%ZZ=b&greeting=hello+world".utf8),
             contentType: "application/x-www-form-urlencoded; charset=utf-8"
         ))
 
@@ -319,7 +295,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
         // -- dropLast(1): 3-byte char split after 2 bytes --
         // "你好" = 6 bytes; prefix(5) cuts second char after 2 of 3 bytes
-        let cjk = "你好".data(using: .utf8)!
+        let cjk = Data("你好".utf8)
         XCTAssertEqual(cjk.count, 6)
         let body1 = try XCTUnwrap(Body(data: cjk.prefix(5), contentType: "text/plain; charset=utf-8"))
         XCTAssertEqual(body1.serialize()["body"] as? String, "你")
@@ -331,7 +307,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
         // -- dropLast(3): 4-byte emoji split after 1 byte --
         // "A😀" = 1 + 4 = 5 bytes; prefix(2) cuts emoji after 1 of 4 bytes
-        let emoji = "A😀".data(using: .utf8)!
+        let emoji = Data("A😀".utf8)
         XCTAssertEqual(emoji.count, 5)
         let body3 = try XCTUnwrap(Body(data: emoji.prefix(2), contentType: "text/plain; charset=utf-8"))
         XCTAssertEqual(body3.serialize()["body"] as? String, "A")
@@ -342,13 +318,13 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertEqual(body4.serialize()["body"] as? String, "你")
 
         // -- pure ASCII: never affected --
-        let ascii = "hello".data(using: .utf8)!
+        let ascii = Data("hello".utf8)
         let body5 = try XCTUnwrap(Body(data: ascii.prefix(3), contentType: "text/plain; charset=utf-8"))
         XCTAssertEqual(body5.serialize()["body"] as? String, "hel")
 
         // -- 2-byte char split after 1 byte --
         // "Aé" = 1 + 2 = 3 bytes; prefix(2) cuts "é" after 1 of 2 bytes
-        let accented = "Aé".data(using: .utf8)!
+        let accented = Data("Aé".utf8)
         XCTAssertEqual(accented.count, 3)
         let body6 = try XCTUnwrap(Body(data: accented.prefix(2), contentType: "text/plain; charset=utf-8"))
         XCTAssertEqual(body6.serialize()["body"] as? String, "A")
@@ -359,9 +335,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testSerialize_withStringBody_shouldReturnDictionary() {
         // -- Arrange --
         let bodyContent = "test body"
-        guard let bodyData = bodyContent.data(using: .utf8) else {
-            return XCTFail("Failed to create data")
-        }
+        let bodyData = Data(bodyContent.utf8)
         let body = Body(data: bodyData, contentType: "text/plain")
 
         // -- Act --
@@ -372,48 +346,32 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         XCTAssertEqual(result?["body"] as? String, bodyContent)
     }
 
-    func testSerialize_withJSONDictionary_shouldReturnDictionary() {
+    func testSerialize_withJSONDictionary_shouldReturnDictionary() throws {
         // -- Arrange --
         let bodyContent: [String: Any] = ["user": "test", "id": 123]
-        let bodyData: Data
-        do {
-            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
-        } catch {
-            return XCTFail("Failed to create JSON data: \(error)")
-        }
+        let bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
         let body = Body(data: bodyData, contentType: "application/json")
 
         // -- Act --
-        let result = body?.serialize()
+        let result = try XCTUnwrap(body?.serialize())
 
         // -- Assert --
-        XCTAssertNotNil(result)
-        guard let bodyDict = result?["body"] as? NSDictionary else {
-            return XCTFail("Expected body to be NSDictionary")
-        }
+        let bodyDict = try XCTUnwrap(result["body"] as? NSDictionary, "Expected body to be NSDictionary")
         XCTAssertEqual(bodyDict["user"] as? String, "test")
         XCTAssertEqual(bodyDict["id"] as? Int, 123)
     }
 
-    func testSerialize_withJSONArray_shouldReturnArray() {
+    func testSerialize_withJSONArray_shouldReturnArray() throws {
         // -- Arrange --
         let bodyContent = ["item1", "item2", "item3"]
-        let bodyData: Data
-        do {
-            bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
-        } catch {
-            return XCTFail("Failed to create JSON data: \(error)")
-        }
+        let bodyData = try JSONSerialization.data(withJSONObject: bodyContent)
         let body = Body(data: bodyData, contentType: "application/json")
 
         // -- Act --
-        let result = body?.serialize()
+        let result = try XCTUnwrap(body?.serialize())
 
         // -- Assert --
-        XCTAssertNotNil(result)
-        guard let bodyArray = result?["body"] as? NSArray else {
-            return XCTFail("Expected body to be NSArray")
-        }
+        let bodyArray = try XCTUnwrap(result["body"] as? NSArray, "Expected body to be NSArray")
         XCTAssertEqual(bodyArray.count, 3)
         XCTAssertEqual(bodyArray[0] as? String, "item1")
     }
@@ -421,9 +379,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
     func testSerialize_withNoContentType_shouldCreatePlaceholder() {
         // -- Arrange --
         let bodyContent = "some content"
-        guard let bodyData = bodyContent.data(using: .utf8) else {
-            return XCTFail("Failed to create data")
-        }
+        let bodyData = Data(bodyContent.utf8)
         let body = Body(data: bodyData, contentType: nil)
 
         // -- Act --

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -21,7 +21,6 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         let body = Body(data: bodyData, contentType: "application/json")
 
         // -- Assert --
-        XCTAssertNotNil(body)
         if case .json(let value) = body?.content {
             let dict = value as? [String: Any]
             XCTAssertEqual(dict?["key"] as? String, "value")
@@ -45,7 +44,6 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         let body = Body(data: bodyData, contentType: "application/json")
 
         // -- Assert --
-        XCTAssertNotNil(body)
         if case .json(let value) = body?.content {
             let array = value as? [String]
             XCTAssertEqual(array?.count, 3)
@@ -82,28 +80,6 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
         // -- Assert --
         XCTAssertNil(body)
-    }
-
-    func testInit_withFormURLEncoded_shouldParseAsForm() {
-        // -- Arrange --
-        let formString = "key1=value1&key2=value2&key3=value%20with%20spaces"
-        guard let bodyData = formString.data(using: .utf8) else {
-            return XCTFail("Failed to create form data")
-        }
-
-        // -- Act --
-        let body = Body(data: bodyData, contentType: "application/x-www-form-urlencoded")
-
-        // -- Assert --
-        XCTAssertNotNil(body)
-        if case .json(let value) = body?.content {
-            let dict = value as? [String: String]
-            XCTAssertEqual(dict?["key1"], "value1")
-            XCTAssertEqual(dict?["key2"], "value2")
-            XCTAssertEqual(dict?["key3"], "value with spaces")
-        } else {
-            XCTFail("Expected .json content for form data")
-        }
     }
 
     func testInit_withInvalidJSON_shouldFallbackToString() {
@@ -215,6 +191,108 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         } else {
             XCTFail("Expected .text content with placeholder description")
         }
+    }
+    
+    // MARK: - Form URL-Encoded Parsing
+
+    func testInit_withFormURLEncoded_shouldParseAsForm() {
+        // -- Arrange --
+        let formString = "key1=value1&key2=value2&key3=value%20with%20spaces"
+        guard let bodyData = formString.data(using: .utf8) else {
+            return XCTFail("Failed to create form data")
+        }
+
+        // -- Act --
+        let body = Body(data: bodyData, contentType: "application/x-www-form-urlencoded")
+
+        // -- Assert --
+        if case .json(let value) = body?.content {
+            let dict = value as? [String: String]
+            XCTAssertEqual(dict?["key1"], "value1")
+            XCTAssertEqual(dict?["key2"], "value2")
+            XCTAssertEqual(dict?["key3"], "value with spaces")
+        } else {
+            XCTFail("Expected .json content for form data")
+        }
+    }
+
+    func testInit_withFormURLEncoded_duplicateKeys_shouldPromoteToArray() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "color=red&color=blue&color=green".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        XCTAssertEqual(dict["color"] as? [String], ["red", "blue", "green"])
+    }
+
+    func testInit_withFormURLEncoded_emptyValue_shouldParseAsEmptyString() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "key1=&key2=value2".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        XCTAssertEqual(dict["key1"] as? String, "")
+        XCTAssertEqual(dict["key2"] as? String, "value2")
+    }
+
+    func testInit_withFormURLEncoded_missingEquals_shouldFallbackToText() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "key1=value1&malformed&key2=value2".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let serialized = body.serialize()
+        let text = try XCTUnwrap(serialized["body"] as? String)
+        XCTAssertEqual(text, "key1=value1&malformed&key2=value2")
+        let warnings = try XCTUnwrap(serialized["warnings"] as? [String])
+        XCTAssertTrue(warnings.contains("BODY_PARSE_ERROR"))
+    }
+
+    func testInit_withFormURLEncoded_emptyKeys_shouldBeSkipped() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "=value1&key2=value2".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        XCTAssertNil(dict[""])
+        XCTAssertEqual(dict["key2"] as? String, "value2")
+    }
+
+    func testInit_withFormURLEncoded_equalsInValue_shouldPreserve() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "query=a=1&token=abc".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        XCTAssertEqual(dict["query"] as? String, "a=1")
+        XCTAssertEqual(dict["token"] as? String, "abc")
+    }
+
+    func testInit_withFormURLEncoded_plusAsSpace_shouldDecode() throws {
+        // -- Act --
+        let body = try XCTUnwrap(Body(
+            data: "greeting=hello+world&name=Jane+Doe".data(using: .utf8)!,
+            contentType: "application/x-www-form-urlencoded; charset=utf-8"
+        ))
+
+        // -- Assert --
+        let dict = try XCTUnwrap(body.serialize()["body"] as? [String: Any])
+        XCTAssertEqual(dict["greeting"] as? String, "hello world")
+        XCTAssertEqual(dict["name"] as? String, "Jane Doe")
     }
 
     // MARK: - Serialization Tests

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -297,4 +297,63 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
         let bodyString = result?["body"] as? String
         XCTAssertTrue(bodyString?.hasPrefix("[Body not captured") == true)
     }
+
+    // MARK: - parseMimeAndEncoding
+
+    func testParseMimeAndEncoding_shouldHandleEdgeCases() {
+        // nil → nil mime, UTF-8 default
+        let (nilMime, nilEnc) = Body.parseMimeAndEncoding(from: nil)
+        XCTAssertNil(nilMime)
+        XCTAssertEqual(nilEnc, .utf8)
+
+        // No charset → mime only, UTF-8 default
+        let (jsonMime, jsonEnc) = Body.parseMimeAndEncoding(from: "application/json")
+        XCTAssertEqual(jsonMime, "application/json")
+        XCTAssertEqual(jsonEnc, .utf8)
+
+        // Standard format with spaces
+        let (stdMime, stdEnc) = Body.parseMimeAndEncoding(from: "text/html; charset=utf-8")
+        XCTAssertEqual(stdMime, "text/html")
+        XCTAssertEqual(stdEnc, .utf8)
+
+        // No spaces around semicolon
+        let (noSpMime, noSpEnc) = Body.parseMimeAndEncoding(from: "text/html;charset=UTF-8")
+        XCTAssertEqual(noSpMime, "text/html")
+        XCTAssertEqual(noSpEnc, .utf8)
+
+        // Quoted charset value
+        let (qMime, qEnc) = Body.parseMimeAndEncoding(from: "text/html; charset=\"utf-8\"")
+        XCTAssertEqual(qMime, "text/html")
+        XCTAssertEqual(qEnc, .utf8)
+
+        // ISO-8859-1 charset
+        let (isoMime, isoEnc) = Body.parseMimeAndEncoding(from: "text/html; charset=iso-8859-1")
+        XCTAssertEqual(isoMime, "text/html")
+        XCTAssertEqual(isoEnc, .isoLatin1)
+
+        // Non-charset parameter only → UTF-8 default
+        let (mpMime, mpEnc) = Body.parseMimeAndEncoding(from: "multipart/form-data; boundary=----WebKitFormBoundary")
+        XCTAssertEqual(mpMime, "multipart/form-data")
+        XCTAssertEqual(mpEnc, .utf8)
+
+        // Multiple params — charset extracted correctly
+        let (multiMime, multiEnc) = Body.parseMimeAndEncoding(from: "application/json; charset=utf-8; boundary=something")
+        XCTAssertEqual(multiMime, "application/json")
+        XCTAssertEqual(multiEnc, .utf8)
+
+        // Completely malformed → returned as-is, UTF-8 default
+        let (badMime, badEnc) = Body.parseMimeAndEncoding(from: "totally-not-a-content-type")
+        XCTAssertEqual(badMime, "totally-not-a-content-type")
+        XCTAssertEqual(badEnc, .utf8)
+
+        // Unrecognized charset name → UTF-8 fallback
+        let (unkMime, unkEnc) = Body.parseMimeAndEncoding(from: "text/html; charset=made-up-encoding")
+        XCTAssertEqual(unkMime, "text/html")
+        XCTAssertEqual(unkEnc, .utf8)
+
+        // Empty string → nil mime, UTF-8 default
+        let (emptyMime, emptyEnc) = Body.parseMimeAndEncoding(from: "")
+        XCTAssertNil(emptyMime)
+        XCTAssertEqual(emptyEnc, .utf8)
+    }
 }

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsHeaderTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsHeaderTests.swift
@@ -1,0 +1,96 @@
+@_spi(Private) @testable import Sentry
+import XCTest
+
+class SentryReplayNetworkDetailsHeaderTests: XCTestCase {
+
+    // MARK: - Header Extraction Tests
+
+    func testExtractHeaders_caseInsensitiveMatching() {
+        // -- Arrange --
+        let sourceHeaders: [String: Any] = [
+            "Content-Type": "application/json",
+            "AUTHORIZATION": "Bearer token",
+            "x-request-id": "123"
+        ]
+        let configuredHeaders = ["content-type", "Authorization", "X-Request-ID"]
+
+        // -- Act --
+        let extracted = SentryReplayNetworkDetails.extractHeaders(
+            from: sourceHeaders,
+            matching: configuredHeaders
+        )
+
+        // -- Assert --
+        XCTAssertEqual(extracted.count, 3)
+        // Should preserve original casing from source
+        XCTAssertEqual(extracted["Content-Type"], "application/json")
+        XCTAssertEqual(extracted["AUTHORIZATION"], "Bearer token")
+        XCTAssertEqual(extracted["x-request-id"], "123")
+    }
+
+    func testExtractHeaders_withNilInputs_returnsEmptyDict() {
+        // Test nil source headers
+        XCTAssertEqual(
+            SentryReplayNetworkDetails.extractHeaders(from: nil, matching: ["test"]),
+            [:]
+        )
+
+        // Test nil configured headers
+        XCTAssertEqual(
+            SentryReplayNetworkDetails.extractHeaders(from: ["test": "value"], matching: nil),
+            [:]
+        )
+
+        // Test both nil
+        XCTAssertEqual(
+            SentryReplayNetworkDetails.extractHeaders(from: nil, matching: nil),
+            [:]
+        )
+    }
+
+    func testExtractHeaders_nonStringValues_convertedToStrings() {
+        // -- Arrange --
+        let sourceHeaders: [String: Any] = [
+            "Content-Length": NSNumber(value: 9_876),
+            "Retry-After": 60,
+            "X-Bool": true,
+            "X-Double": 3.14159
+        ]
+        let configuredHeaders = ["Content-Length", "Retry-After", "X-Bool", "X-Double"]
+
+        // -- Act --
+        let extracted = SentryReplayNetworkDetails.extractHeaders(
+            from: sourceHeaders,
+            matching: configuredHeaders
+        )
+
+        // -- Assert --
+        XCTAssertEqual(extracted.count, 4)
+        XCTAssertEqual(extracted["Content-Length"], "9876")
+        XCTAssertEqual(extracted["Retry-After"], "60")
+        XCTAssertEqual(extracted["X-Bool"], "true")
+        XCTAssertEqual(extracted["X-Double"], "3.14159")
+    }
+
+    func testExtractHeaders_unconfiguredHeadersAreExcluded() {
+        // -- Arrange --
+        let sourceHeaders: [String: Any] = [
+            "Content-Type": "application/json",
+            "Authorization": "Bearer token",
+            "X-Custom": "should not appear"
+        ]
+        let configuredHeaders = ["Content-Type", "Authorization"]
+
+        // -- Act --
+        let extracted = SentryReplayNetworkDetails.extractHeaders(
+            from: sourceHeaders,
+            matching: configuredHeaders
+        )
+
+        // -- Assert --
+        XCTAssertEqual(extracted.count, 2)
+        XCTAssertEqual(extracted["Content-Type"], "application/json")
+        XCTAssertEqual(extracted["Authorization"], "Bearer token")
+        XCTAssertNil(extracted["X-Custom"])
+    }
+}

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
@@ -1,0 +1,156 @@
+@_spi(Private) @testable import Sentry
+import XCTest
+
+class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
+
+    private typealias Body = SentryReplayNetworkDetails.Body
+
+    // MARK: - Initialization Tests
+
+    func testInit_withMethod_shouldSetMethod() {
+        // -- Arrange & Act --
+        let details = SentryReplayNetworkDetails(method: "POST")
+
+        // -- Assert --
+        XCTAssertEqual(details.method, "POST")
+        XCTAssertNil(details.statusCode)
+        XCTAssertNil(details.requestBodySize)
+        XCTAssertNil(details.responseBodySize)
+    }
+
+    // MARK: - Serialization Tests
+
+    func testSerialize_withFullData_shouldReturnCompleteDictionary() {
+        // -- Arrange --
+        let details = SentryReplayNetworkDetails(method: "PUT")
+
+        details.setRequest(
+            size: 100,
+            body: ["name": "test"],
+            allHeaders: ["Content-Type": "application/json", "Authorization": "Bearer token", "Accept": "*/*"],
+            configuredHeaders: ["Content-Type", "Authorization"]
+        )
+        details.setResponse(
+            statusCode: 201,
+            size: 150,
+            body: ["id": 123, "name": "test"],
+            allHeaders: ["Content-Type": "application/json", "Cache-Control": "no-cache", "Set-Cookie": "session=123"],
+            configuredHeaders: ["Content-Type", "Cache-Control"]
+        )
+
+        // -- Act --
+        let result = details.serialize()
+
+        // -- Assert --
+        let expectedJSON = """
+        {
+            "method": "PUT",
+            "statusCode": 201,
+            "requestBodySize": 100,
+            "responseBodySize": 150,
+            "request": {
+                "size": 100,
+                "headers": {
+                    "Authorization": "Bearer token",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "body": {
+                        "name": "test"
+                    }
+                }
+            },
+            "response": {
+                "size": 150,
+                "headers": {
+                    "Cache-Control": "no-cache",
+                    "Content-Type": "application/json"
+                },
+                "body": {
+                    "body": {
+                        "id": 123,
+                        "name": "test"
+                    }
+                }
+            }
+        }
+        """
+
+        assertJSONEqual(result, expectedJSON: expectedJSON)
+    }
+
+    func testSerialize_withPartialData_shouldOnlyIncludeSetFields() {
+        // -- Arrange --
+        let details = SentryReplayNetworkDetails(method: "GET")
+        details.setResponse(
+            statusCode: 404,
+            size: nil,
+            body: nil,
+            allHeaders: ["Cache-Control": "no-cache", "Content-Type": "text/plain", "X-Custom": "value"],
+            configuredHeaders: ["Cache-Control", "Content-Type"]
+        )
+
+        // -- Act --
+        let result = details.serialize()
+
+        // -- Assert --
+        let expectedJSON = """
+        {
+            "method": "GET",
+            "statusCode": 404,
+            "response": {
+                "headers": {
+                    "Cache-Control": "no-cache",
+                    "Content-Type": "text/plain"
+                }
+            }
+        }
+        """
+
+        assertJSONEqual(result, expectedJSON: expectedJSON)
+    }
+
+    func testSerialize_withHeaderFiltering_shouldOnlyIncludeConfiguredHeaders() {
+        // -- Arrange --
+        let details = SentryReplayNetworkDetails(method: "GET")
+        details.setRequest(
+            size: nil,
+            body: nil,
+            allHeaders: [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer secret",
+                "X-Internal": "hidden",
+                "Cookie": "session=abc"
+            ],
+            configuredHeaders: ["Content-Type"]
+        )
+
+        // -- Act --
+        let result = details.serialize()
+
+        // -- Assert --
+        guard let request = result["request"] as? [String: Any],
+              let headers = request["headers"] as? [String: String] else {
+            return XCTFail("Expected request with headers")
+        }
+        XCTAssertEqual(headers.count, 1)
+        XCTAssertEqual(headers["Content-Type"], "application/json")
+        XCTAssertNil(headers["Authorization"])
+    }
+
+    // MARK: - Test Helpers
+
+    private func assertJSONEqual(_ result: [String: Any], expectedJSON: String) {
+        guard let expectedData = expectedJSON.data(using: .utf8) else {
+            return XCTFail("Failed to convert expected JSON string to data")
+        }
+
+        do {
+            let expectedDict = try JSONSerialization.jsonObject(with: expectedData, options: []) as? NSDictionary
+            let actualDict = result as NSDictionary
+            XCTAssertEqual(actualDict, expectedDict)
+        } catch {
+            XCTFail("Failed to parse expected JSON: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Description

### `SentryNetworkBody`

Extract request/response bodies that are either JSON, formurlencoded, binary or text.

- Relies on having a `contentType` to decide how to interpret the body (`NSData`).
- Relies on iOS's `UTType` to decide whether something is JSON or text.


**text**:
  tries `.utf8` , then `.isoLatin1` then gives up with `BODY_PARSE_ERROR` warning.

**json**:
  tries `JSONSerialization.jsonObject`, gives up with `BODY_PARSE_ERROR` warning

**UTType doesn't know**:
  extracts a placeholder body E.g. `"[Body not captured: contentType=application/octet-stream (10240 bytes)]"`

### `SentryReplayNetworkRequestOrResponse`
- case-insensitive header extraction

## :bulb: Motivation and Context

See [first PR](https://github.com/getsentry/sentry-cocoa/pull/7580) in stack.

## :green_heart: How did you test it?

### Unit tests
`make test-ios ONLY_TESTING="SentryReplayNetworkDetailsBodyTests,SentryReplayNetworkDetailsHeaderTests,SentryReplayNetworkDetailsIntegrationTests"`

Test Suite **'SentryReplayNetworkDetailsBodyTests'** started at 2026-03-19 15:25:09.315.
    ✔ testInit_withBinaryContentType_shouldCreateArtificialString (0.005 seconds)
    ✔ testInit_withEmptyData_shouldReturnNil (0.000 seconds)
    ✔ testInit_withFormURLEncoded_duplicateKeys_shouldPromoteToArray (0.001 seconds)
    ✔ testInit_withFormURLEncoded_emptyKeys_shouldBeSkipped (0.000 seconds)
    ✔ testInit_withFormURLEncoded_emptyValue_shouldParseAsEmptyString (0.000 seconds)
Resolving Package Graph
    ✔ testInit_withFormURLEncoded_equalsInValue_shouldPreserve (0.000 seconds)
    ✔ testInit_withFormURLEncoded_missingEquals_shouldFallbackToText (0.001 seconds)
    ✔ testInit_withFormURLEncoded_shouldParseAsForm (0.001 seconds)
    ✔ testInit_withInvalidJSON_shouldFallbackToString (0.001 seconds)
    ✔ testInit_withJSONArray_shouldParseCorrectly (0.000 seconds)
    ✔ testInit_withJSONDictionary_shouldParseCorrectly (0.001 seconds)
    ✔ testInit_withLargeData_shouldTruncate (0.005 seconds)
    ✔ testInit_withNilContentType_shouldCreatePlaceholder (0.000 seconds)
    ✔ testInit_withTextData_shouldStoreAsString (0.000 seconds)
    ✔ testInit_withUnrecognizedContentType_shouldCreatePlaceholder (0.000 seconds)
    ✔ testParseMimeAndEncoding_shouldHandleEdgeCases (0.001 seconds)
    ✔ testSerialize_withJSONArray_shouldReturnArray (0.001 seconds)
    ✔ testSerialize_withJSONDictionary_shouldReturnDictionary (0.001 seconds)
    ✔ testSerialize_withNoContentType_shouldCreatePlaceholder (0.001 seconds)
    ✔ testSerialize_withStringBody_shouldReturnDictionary (0.001 seconds)
Executed 20 tests, with 0 failures (0 unexpected) in 0.021 (0.041) seconds
Test Suite 'SentryTests.xctest' passed at 2026-03-19 15:25:09.356.
Executed 20 tests, with 0 failures (0 unexpected) in 0.021 (0.041) seconds

**SentryReplayNetworkDetailsHeaderTests (4 tests):**
- `testExtractHeaders_withNilInputs_returnsEmptyDict` — nil headers/config returns empty
- `testExtractHeaders_unconfiguredHeadersAreExcluded` — only configured headers are extracted
- `testExtractHeaders_caseInsensitiveMatching` — header matching is case-insensitive
- `testExtractHeaders_nonStringValues_convertedToStrings` — non-string header values are converted

**SentryReplayNetworkDetailsIntegrationTests (4 tests):**
- `testInit_withMethod_shouldSetMethod` — HTTP method is stored
- `testSerialize_withFullData_shouldReturnCompleteDictionary` — full detail serializes all fields
- `testSerialize_withPartialData_shouldOnlyIncludeSetFields` — partial data omits unset fields
- `testSerialize_withHeaderFiltering_shouldOnlyIncludeConfiguredHeaders` — header filtering works end-to-end

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled. **N/A**
- [x] I updated the docs if needed. **future PR**
- [x] I updated the wizard if needed. **N/A**
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog. #skip-changelog **future PR**
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7710