### PR TITLE
feat(network-details): Hook up request/response capture in SentryNetworkTracker

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -595,10 +595,38 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
                     requestURL:(NSURL *)requestURL
                           task:(NSURLSessionTask *)task
 {
-    // TODO: Implementation
-    // 2. Parse response body data
-    // 3. Store in appropriate location for session replay
-    // 4. Handle size limits and truncation if needed
+    NSString *urlString = requestURL.absoluteString;
+    SentryOptions *options = SentrySDK.startOption;
+    if (![self isNetworkDetailCaptureEnabledFor:urlString options:options]) {
+        return;
+    }
+
+    SentryReplayNetworkDetails *details = objc_getAssociatedObject(task, &SentryNetworkDetailsKey);
+    if (!details) {
+        SENTRY_LOG_WARN(@"[NetworkCapture] No SentryReplayNetworkDetails found for %@ - "
+                         @"skipping response capture",
+                         urlString);
+        return;
+    }
+
+    NSInteger statusCode = 0;
+    NSDictionary *allHeaders = nil;
+    NSString *contentType = nil;
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        statusCode = httpResponse.statusCode;
+        allHeaders = httpResponse.allHeaderFields;
+        contentType = httpResponse.allHeaderFields[@"Content-Type"];
+    }
+
+    NSData *bodyData = (options.sessionReplay.networkCaptureBodies && data.length > 0) ? data : nil;
+
+    [details setResponseWithStatusCode:statusCode
+                                  size:@(data ? data.length : 0)
+                              bodyData:bodyData
+                           contentType:contentType
+                            allHeaders:allHeaders
+                     configuredHeaders:options.sessionReplay.networkResponseHeaders];
 }
 
 - (void)captureRequestDetails:(NSURLSessionTask *)sessionTask

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -238,7 +238,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
     SentryOptions *options = SentrySDK.startOption;
-    NSString *urlString = sessionTask.currentRequest.URL.absoluteString;
+    NSString *urlString = sessionTask.originalRequest.URL.absoluteString;
     if ([self isNetworkDetailCaptureEnabledFor:urlString options:options]) {
         [self captureRequestDetails:sessionTask
                networkCaptureBodies:options.sessionReplay.networkCaptureBodies

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -606,32 +606,36 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
         return;
     }
 
-    SentryReplayNetworkDetails *details = objc_getAssociatedObject(task, &SentryNetworkDetailsKey);
-    if (!details) {
-        SENTRY_LOG_WARN(@"[NetworkCapture] No SentryReplayNetworkDetails found for %@ - "
-                         @"skipping response capture",
-                         urlString);
-        return;
+    @synchronized(task) {
+        SentryReplayNetworkDetails *details
+            = objc_getAssociatedObject(task, &SentryNetworkDetailsKey);
+        if (!details) {
+            SENTRY_LOG_WARN(@"[NetworkCapture] No SentryReplayNetworkDetails found for %@ - "
+                             @"skipping response capture",
+                             urlString);
+            return;
+        }
+
+        NSInteger statusCode = 0;
+        NSDictionary *allHeaders = nil;
+        NSString *contentType = nil;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+            statusCode = httpResponse.statusCode;
+            allHeaders = httpResponse.allHeaderFields;
+            contentType = httpResponse.allHeaderFields[@"Content-Type"];
+        }
+
+        NSData *bodyData
+            = (options.sessionReplay.networkCaptureBodies && data.length > 0) ? data : nil;
+
+        [details setResponseWithStatusCode:statusCode
+                                      size:@(data ? data.length : 0)
+                                  bodyData:bodyData
+                               contentType:contentType
+                                allHeaders:allHeaders
+                         configuredHeaders:options.sessionReplay.networkResponseHeaders];
     }
-
-    NSInteger statusCode = 0;
-    NSDictionary *allHeaders = nil;
-    NSString *contentType = nil;
-    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-        statusCode = httpResponse.statusCode;
-        allHeaders = httpResponse.allHeaderFields;
-        contentType = httpResponse.allHeaderFields[@"Content-Type"];
-    }
-
-    NSData *bodyData = (options.sessionReplay.networkCaptureBodies && data.length > 0) ? data : nil;
-
-    [details setResponseWithStatusCode:statusCode
-                                  size:@(data ? data.length : 0)
-                              bodyData:bodyData
-                           contentType:contentType
-                            allHeaders:allHeaders
-                     configuredHeaders:options.sessionReplay.networkResponseHeaders];
 }
 
 - (void)captureRequestDetails:(NSURLSessionTask *)sessionTask
@@ -642,16 +646,18 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
         return;
     }
 
-    SentryReplayNetworkDetails *existingDetails
-        = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
-    if (existingDetails) {
-        return;
-    }
-
     NSURLRequest *request = sessionTask.currentRequest;
+    SentryReplayNetworkDetails *details;
 
-    SentryReplayNetworkDetails *details =
-        [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
+    @synchronized(sessionTask) {
+        if (objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey)) {
+            return;
+        }
+        details =
+            [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
+        objc_setAssociatedObject(
+            sessionTask, &SentryNetworkDetailsKey, details, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
 
     // Prefer originalRequest.HTTPBody: currentRequest may reflect redirects, and its HTTPBody may be nil on in-flight tasks.
     NSData *bodyData
@@ -664,9 +670,6 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
                     contentType:request.allHTTPHeaderFields[@"Content-Type"]
                      allHeaders:request.allHTTPHeaderFields
               configuredHeaders:networkRequestHeaders];
-
-    objc_setAssociatedObject(
-        sessionTask, &SentryNetworkDetailsKey, details, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -573,7 +573,9 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 }
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-// Store extracted network details data for session replay.
+// Associated object key for attaching SentryReplayNetworkDetails to each NSURLSessionTask.
+// Safe: setAssociatedObject follows existing patterns in urlSessionTask:setState:
+// and getAssociatedObject is called from blocks that hold a strong reference to the task.
 static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
 
 - (BOOL)isNetworkDetailCaptureEnabledFor:(NSString *)urlString options:(SentryOptions *)options

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -236,6 +236,14 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         return;
     }
 
+    SentryOptions *options = SentrySDK.startOption;
+    NSString *urlString = sessionTask.currentRequest.URL.absoluteString;
+    if ([self isNetworkDetailCaptureEnabledFor:urlString options:options]) {
+        [self captureRequestDetails:sessionTask
+               networkCaptureBodies:options.sessionReplay.networkCaptureBodies
+              networkRequestHeaders:options.sessionReplay.networkRequestHeaders];
+    }
+
     if (![self isTaskSupported:sessionTask]) {
         return;
     }
@@ -562,6 +570,26 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     return breadcrumbLevel;
 }
 
+// Store extracted network details data for session replay.
+static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
+
+- (BOOL)isNetworkDetailCaptureEnabledFor:(NSString *)urlString options:(SentryOptions *)options
+{
+    if (!options) {
+        return NO;
+    }
+
+    if (!urlString) {
+        return NO;
+    }
+
+    if (!options.sessionReplay) {
+        return NO;
+    }
+
+    return [options.sessionReplay isNetworkDetailCaptureEnabledFor:urlString];
+}
+
 - (void)captureResponseDetails:(NSData *)data
                       response:(NSURLResponse *)response
                     requestURL:(NSURL *)requestURL
@@ -571,6 +599,47 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     // 2. Parse response body data
     // 3. Store in appropriate location for session replay
     // 4. Handle size limits and truncation if needed
+}
+
+- (void)captureRequestDetails:(NSURLSessionTask *)sessionTask
+         networkCaptureBodies:(BOOL)networkCaptureBodies
+        networkRequestHeaders:(NSArray<NSString *> *)networkRequestHeaders
+{
+    if (!sessionTask || !sessionTask.currentRequest) {
+        return;
+    }
+
+    SentryReplayNetworkDetails *existingDetails
+        = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
+    if (existingDetails) {
+        return;
+    }
+
+    NSURLRequest *request = sessionTask.currentRequest;
+
+    SentryReplayNetworkDetails *details =
+        [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
+
+    // Prefer originalRequest.HTTPBody to capture what the caller sent; currentRequest may differ
+    NSData *bodyData
+        = networkCaptureBodies ? (sessionTask.originalRequest.HTTPBody ?: request.HTTPBody) : nil;
+
+    NSNumber *requestSize = nil;
+    // Set request size - prefer actual bytes sent, fallback to local body data length
+    if (sessionTask.countOfBytesSent > 0) {
+        requestSize = [NSNumber numberWithLongLong:sessionTask.countOfBytesSent];
+    } else if (bodyData) {
+        requestSize = [NSNumber numberWithUnsignedInteger:bodyData.length];
+    }
+
+    [details setRequestWithSize:requestSize
+                       bodyData:bodyData
+                    contentType:request.allHTTPHeaderFields[@"Content-Type"]
+                     allHeaders:request.allHTTPHeaderFields
+              configuredHeaders:networkRequestHeaders];
+
+    objc_setAssociatedObject(
+        sessionTask, &SentryNetworkDetailsKey, details, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -660,10 +660,9 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
     }
 
     // Prefer originalRequest.HTTPBody: currentRequest may reflect redirects, and its HTTPBody may be nil on in-flight tasks.
-    NSData *bodyData
-        = networkCaptureBodies ? (sessionTask.originalRequest.HTTPBody ?: request.HTTPBody) : nil;
-
-    NSNumber *requestSize = bodyData ? [NSNumber numberWithUnsignedInteger:bodyData.length] : nil;
+    NSData *rawBody = sessionTask.originalRequest.HTTPBody ?: request.HTTPBody;
+    NSNumber *requestSize = rawBody ? [NSNumber numberWithUnsignedInteger:rawBody.length] : nil;
+    NSData *bodyData = networkCaptureBodies ? rawBody : nil;
 
     [details setRequestWithSize:requestSize
                        bodyData:bodyData

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -611,8 +611,8 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
             = objc_getAssociatedObject(task, &SentryNetworkDetailsKey);
         if (!details) {
             SENTRY_LOG_WARN(@"[NetworkCapture] No SentryReplayNetworkDetails found for %@ - "
-                             @"skipping response capture",
-                             urlString);
+                            @"skipping response capture",
+                urlString);
             return;
         }
 
@@ -653,13 +653,13 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
         if (objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey)) {
             return;
         }
-        details =
-            [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
+        details = [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
         objc_setAssociatedObject(
             sessionTask, &SentryNetworkDetailsKey, details, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 
-    // Prefer originalRequest.HTTPBody: currentRequest may reflect redirects, and its HTTPBody may be nil on in-flight tasks.
+    // Prefer originalRequest.HTTPBody: currentRequest may reflect redirects, and its HTTPBody may
+    // be nil on in-flight tasks.
     NSData *rawBody = sessionTask.originalRequest.HTTPBody ?: request.HTTPBody;
     NSNumber *requestSize = rawBody ? [NSNumber numberWithUnsignedInteger:rawBody.length] : nil;
     NSData *bodyData = networkCaptureBodies ? rawBody : nil;

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -236,6 +236,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         return;
     }
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
     SentryOptions *options = SentrySDK.startOption;
     NSString *urlString = sessionTask.currentRequest.URL.absoluteString;
     if ([self isNetworkDetailCaptureEnabledFor:urlString options:options]) {
@@ -243,6 +244,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
                networkCaptureBodies:options.sessionReplay.networkCaptureBodies
               networkRequestHeaders:options.sessionReplay.networkRequestHeaders];
     }
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
     if (![self isTaskSupported:sessionTask]) {
         return;
@@ -570,6 +572,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     return breadcrumbLevel;
 }
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 // Store extracted network details data for session replay.
 static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
 
@@ -648,7 +651,7 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
     SentryReplayNetworkDetails *details =
         [[SentryReplayNetworkDetails alloc] initWithMethod:request.HTTPMethod ?: @"GET"];
 
-    // Prefer originalRequest.HTTPBody to capture what the caller sent; currentRequest may differ
+    // Prefer originalRequest.HTTPBody: currentRequest may reflect redirects, and its HTTPBody may be nil on in-flight tasks.
     NSData *bodyData
         = networkCaptureBodies ? (sessionTask.originalRequest.HTTPBody ?: request.HTTPBody) : nil;
 
@@ -663,5 +666,6 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
     objc_setAssociatedObject(
         sessionTask, &SentryNetworkDetailsKey, details, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
 @end

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -624,13 +624,7 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
     NSData *bodyData
         = networkCaptureBodies ? (sessionTask.originalRequest.HTTPBody ?: request.HTTPBody) : nil;
 
-    NSNumber *requestSize = nil;
-    // Set request size - prefer actual bytes sent, fallback to local body data length
-    if (sessionTask.countOfBytesSent > 0) {
-        requestSize = [NSNumber numberWithLongLong:sessionTask.countOfBytesSent];
-    } else if (bodyData) {
-        requestSize = [NSNumber numberWithUnsignedInteger:bodyData.length];
-    }
+    NSNumber *requestSize = bodyData ? [NSNumber numberWithUnsignedInteger:bodyData.length] : nil;
 
     [details setRequestWithSize:requestSize
                        bodyData:bodyData

--- a/Sources/Sentry/SentrySwizzleWrapperHelper.m
+++ b/Sources/Sentry/SentrySwizzleWrapperHelper.m
@@ -118,8 +118,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)swizzleDataTaskWithRequestCompletionHandler:(SentryNetworkTracker *)networkTracker
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshadow"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow"
     SEL selector = @selector(dataTaskWithRequest:completionHandler:);
     SentrySwizzleInstanceMethod([NSURLSession class], selector,
         SentrySWReturnType(NSURLSessionDataTask *),
@@ -143,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
             return task;
         }),
         SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 }
 
 /**
@@ -151,8 +151,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)swizzleDataTaskWithURLCompletionHandler:(SentryNetworkTracker *)networkTracker
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshadow"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow"
     SEL selector = @selector(dataTaskWithURL:completionHandler:);
     SentrySwizzleInstanceMethod([NSURLSession class], selector,
         SentrySWReturnType(NSURLSessionDataTask *),
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
             return task;
         }),
         SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 }
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED
 

--- a/Sources/Sentry/SentrySwizzleWrapperHelper.m
+++ b/Sources/Sentry/SentrySwizzleWrapperHelper.m
@@ -97,6 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 }
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 /**
  * Swizzles NSURLSession data task creation methods that use completion handlers
  * to enable response body capture for session replay.
@@ -177,6 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
         SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
 #pragma clang diagnostic pop
 }
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
 @end
 

--- a/Sources/Sentry/include/SentryNetworkTracker.h
+++ b/Sources/Sentry/include/SentryNetworkTracker.h
@@ -1,3 +1,4 @@
+#import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -26,10 +27,12 @@ static NSString *const SENTRY_NETWORK_REQUEST_TRACKER_BREADCRUMB
 @property (nonatomic, readonly) BOOL isCaptureFailedRequestsEnabled;
 @property (nonatomic, readonly) BOOL isGraphQLOperationTrackingEnabled;
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 - (void)captureResponseDetails:(NSData *)data
                       response:(NSURLResponse *)response
                     requestURL:(nullable NSURL *)requestURL
                           task:(NSURLSessionTask *)task;
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
 @end
 

--- a/Sources/Sentry/include/SentrySwizzleWrapperHelper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapperHelper.h
@@ -26,9 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)swizzleURLSessionTask:(SentryNetworkTracker *)networkTracker;
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 // Swizzle [NSURLSession dataTaskWithURL:completionHandler:]
 //         [NSURLSession dataTaskWithRequest:completionHandler:]
 + (void)swizzleURLSessionDataTasksForResponseCapture:(SentryNetworkTracker *)networkTracker;
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
 @end
 

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -16,6 +16,11 @@ enum NetworkBodyWarning: String {
 /// ObjC callers (SentryNetworkTracker) create this object and populate it
 /// via `setRequest`/`setResponse`. Swift callers (SentrySRDefaultBreadcrumbConverter)
 /// consume it via `serialize()`.
+///
+/// - Important: `setRequest` and `setResponse` can be called concurrently from
+///   `SentryNetworkTracker` because they write to independent properties.
+///   Adding shared mutable state between will require adding synchronization.
+
 @objc
 @_spi(Private) public class SentryReplayNetworkDetails: NSObject {
 

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -258,36 +258,44 @@ enum NetworkBodyWarning: String {
 
     // MARK: - ObjC Setters
 
-    /// Sets request details from raw components.
+    /// Sets request details from raw body data.
+    ///
+    /// Parses the body data based on content type (JSON, form-urlencoded, text)
+    /// and applies size limits and truncation warnings automatically.
     ///
     /// - Parameters:
     ///   - size: Request body size in bytes, or nil if unknown.
-    ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
+    ///   - bodyData: Raw body bytes, or nil if body capture is disabled or unavailable.
+    ///   - contentType: MIME content type for body parsing (e.g. "application/json").
     ///   - allHeaders: All headers from the request (e.g. from `NSURLRequest.allHTTPHeaderFields`).
     ///   - configuredHeaders: Header names to extract, matched case-insensitively.
     @objc
-    public func setRequest(size: NSNumber?, body: Any?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
+    public func setRequest(size: NSNumber?, bodyData: Data?, contentType: String?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
         self.request = Detail(
             size: size,
-            body: body.map { Body(content: $0) },
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
             headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
         )
     }
 
-    /// Sets response details from raw components.
+    /// Sets response details from raw body data.
+    ///
+    /// Parses the body data based on content type (JSON, form-urlencoded, text)
+    /// and applies size limits and truncation warnings automatically.
     ///
     /// - Parameters:
     ///   - statusCode: HTTP status code.
     ///   - size: Response body size in bytes, or nil if unknown.
-    ///   - body: Pre-parsed body content (dictionary, array, or string), or nil if not captured.
+    ///   - bodyData: Raw body bytes, or nil if body capture is disabled or unavailable.
+    ///   - contentType: MIME content type for body parsing (e.g. "application/json").
     ///   - allHeaders: All headers from the response (e.g. from `NSHTTPURLResponse.allHeaderFields`).
     ///   - configuredHeaders: Header names to extract, matched case-insensitively.
     @objc
-    public func setResponse(statusCode: Int, size: NSNumber?, body: Any?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
+    public func setResponse(statusCode: Int, size: NSNumber?, bodyData: Data?, contentType: String?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
         self.statusCode = NSNumber(value: statusCode)
         self.response = Detail(
             size: size,
-            body: body.map { Body(content: $0) },
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
             headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
         )
     }

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
@@ -20,20 +20,25 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
 
     // MARK: - Serialization Tests
 
-    func testSerialize_withFullData_shouldReturnCompleteDictionary() {
+    func testSerialize_withFullData_shouldReturnCompleteDictionary() throws {
         // -- Arrange --
         let details = SentryReplayNetworkDetails(method: "PUT")
 
+        let requestBodyData = try JSONSerialization.data(withJSONObject: ["name": "test"])
         details.setRequest(
             size: 100,
-            body: ["name": "test"],
+            bodyData: requestBodyData,
+            contentType: "application/json",
             allHeaders: ["Content-Type": "application/json", "Authorization": "Bearer token", "Accept": "*/*"],
             configuredHeaders: ["Content-Type", "Authorization"]
         )
+
+        let responseBodyData = try JSONSerialization.data(withJSONObject: ["id": 123, "name": "test"])
         details.setResponse(
             statusCode: 201,
             size: 150,
-            body: ["id": 123, "name": "test"],
+            bodyData: responseBodyData,
+            contentType: "application/json",
             allHeaders: ["Content-Type": "application/json", "Cache-Control": "no-cache", "Set-Cookie": "session=123"],
             configuredHeaders: ["Content-Type", "Cache-Control"]
         )
@@ -85,7 +90,8 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
         details.setResponse(
             statusCode: 404,
             size: nil,
-            body: nil,
+            bodyData: nil,
+            contentType: nil,
             allHeaders: ["Cache-Control": "no-cache", "Content-Type": "text/plain", "X-Custom": "value"],
             configuredHeaders: ["Cache-Control", "Content-Type"]
         )
@@ -115,7 +121,8 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
         let details = SentryReplayNetworkDetails(method: "GET")
         details.setRequest(
             size: nil,
-            body: nil,
+            bodyData: nil,
+            contentType: nil,
             allHeaders: [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer secret",


### PR DESCRIPTION
## :scroll: Description
Hook the network details implementation into SentryNetworkTracker by implementing the 2 entrypoints
```objc
[SentryNetworkTracker captureRequestDetails:networkCaptureBodies:networkRequestHeaders:]
[SentryNetworkTracker captureResponseDetails:response:request:task:]
```


## :bulb: Motivation and Context

This PR updates SentryNetworkTracker to call into extraction logic introduced in previous PRs.

## :green_heart: How did you test it?
See other PRs for tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled. **requires SDKOptions config (networkDetailAllowUrls)**
- [x] I updated the docs if needed. **future PR**
- [x] I updated the wizard if needed. **n/a**
- [x] Review from the native team if needed. **n/a**
- [x] No breaking change or entry added to the changelog. **future PR** #skip-changelog
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7589