### PR TITLE
feat(network-details): Extract network details data to Session Replay

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -481,12 +481,14 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     }
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-    // Add network details if available
-    SentryReplayNetworkDetails *networkDetails
-        = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
-    if (networkDetails) {
-        // Store raw object; serialized at read time by SentrySRDefaultBreadcrumbConverter
-        breadcrumbData[SentryReplayNetworkDetails.replayNetworkDetailsKey] = networkDetails;
+    // Check if network details was enabled for this url.
+    @synchronized(sessionTask) {
+        SentryReplayNetworkDetails *networkDetails
+            = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
+        if (networkDetails) {
+            // Store raw object; serialized at read time by SentrySRDefaultBreadcrumbConverter
+            breadcrumbData[SentryReplayNetworkDetails.replayNetworkDetailsKey] = networkDetails;
+        }
     }
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -480,13 +480,15 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         breadcrumbData[@"http.fragment"] = urlComponents.fragment;
     }
 
-    // Add network details if available for session replay
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+    // Add network details if available
     SentryReplayNetworkDetails *networkDetails
         = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
     if (networkDetails) {
         // Store raw object; serialized at read time by SentrySRDefaultBreadcrumbConverter
         breadcrumbData[SentryReplayNetworkDetails.replayNetworkDetailsKey] = networkDetails;
     }
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
     breadcrumb.data = breadcrumbData;
     [SentrySDK addBreadcrumb:breadcrumb];

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -480,6 +480,14 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         breadcrumbData[@"http.fragment"] = urlComponents.fragment;
     }
 
+    // Add network details if available for session replay
+    SentryReplayNetworkDetails *networkDetails
+        = objc_getAssociatedObject(sessionTask, &SentryNetworkDetailsKey);
+    if (networkDetails) {
+        // Store raw object; serialized at read time by SentrySRDefaultBreadcrumbConverter
+        breadcrumbData[SentryReplayNetworkDetails.replayNetworkDetailsKey] = networkDetails;
+    }
+
     breadcrumb.data = breadcrumbData;
     [SentrySDK addBreadcrumb:breadcrumb];
 

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -26,6 +26,28 @@ final class SentryRRWebOptionsEvent: SentryRRWebCustomEvent {
             payload["unmaskedViewClasses"] = options.unmaskedViewClasses.map(String.init(describing:)).joined(separator: ", ")
         }
         
+        payload["networkDetailHasUrls"] = options.networkDetailHasUrls
+
+        if options.networkDetailHasUrls {
+            payload["networkDetailAllowUrls"] = options.networkDetailAllowUrls.map { pattern in
+                if let regex = pattern as? NSRegularExpression {
+                    return regex.pattern
+                } else {
+                    return String(describing: pattern)
+                }
+            }
+            payload["networkDetailDenyUrls"] = options.networkDetailDenyUrls.map { pattern in
+                if let regex = pattern as? NSRegularExpression {
+                    return regex.pattern
+                } else {
+                    return String(describing: pattern)
+                }
+            }
+            payload["networkCaptureBodies"] = options.networkCaptureBodies
+            payload["networkRequestHeaders"] = options.networkRequestHeaders
+            payload["networkResponseHeaders"] = options.networkResponseHeaders
+        }
+
         super.init(timestamp: timestamp, tag: "options", payload: payload)
     }
 }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -237,7 +237,8 @@ enum NetworkBodyWarning: String {
     static let maxBodySize = 150_000
 
     /// Key used to store network details in breadcrumb data dictionary.
-    @objc public static let replayNetworkDetailsKey = "_networkDetails"
+    /// The __sentry key prefix strips this from event serialization.
+    @objc public static let replayNetworkDetailsKey = "__sentry_networkDetails"
 
     // MARK: - Properties
 
@@ -333,7 +334,7 @@ enum NetworkBodyWarning: String {
     // MARK: - Serialization
 
     /// Serializes to dictionary for inclusion in breadcrumb data.
-    public func serialize() -> [String: Any] {
+    @objc public func serialize() -> [String: Any] {
         var result = [String: Any]()
         if let method { result["method"] = method }
         if let statusCode { result["statusCode"] = statusCode }

--- a/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
@@ -80,8 +80,66 @@ import Foundation
             data[newKey.snakeToCamelCase()] = value
         })
         
+        // Serialize here (not when creating the breadcrumb) to give completionHandler time to
+        // populate response data before setState(.completed) triggers breadcrumb creation.
+        if let networkDetails = breadcrumb.data?[SentryReplayNetworkDetails.replayNetworkDetailsKey] as? SentryReplayNetworkDetails {
+            addNetworkDetails(from: networkDetails.serialize(), to: &data)
+        }
+        
         //We dont have end of the request in the breadcrumb.
         return SentryRRWebSpanEvent(timestamp: startTimestamp, endTimestamp: timestamp, operation: "resource.http", description: description, data: data)
+    }
+    
+    private func addNetworkDetails(from networkData: [String: Any], to data: inout [String: Any]) {
+        // Add top-level network metadata
+        if let method = networkData["method"] as? String {
+            data["method"] = method
+        }
+        if let statusCode = networkData["statusCode"] as? NSNumber {
+            data["statusCode"] = statusCode
+        }
+        if let requestBodySize = networkData["requestBodySize"] as? NSNumber {
+            data["requestBodySize"] = requestBodySize
+        }
+        if let responseBodySize = networkData["responseBodySize"] as? NSNumber {
+            data["responseBodySize"] = responseBodySize
+        }
+        
+        // Process request and response details using shared logic
+        if let request = networkData["request"] as? [String: Any] {
+            if let requestData = processRequestOrResponseData(request), !requestData.isEmpty {
+                data["request"] = requestData
+            }
+        }
+        
+        if let response = networkData["response"] as? [String: Any] {
+            if let responseData = processRequestOrResponseData(response), !responseData.isEmpty {
+                data["response"] = responseData
+            }
+        }
+    }
+    
+    private func processRequestOrResponseData(_ sourceData: [String: Any]) -> [String: Any]? {
+        var result = [String: Any]()
+        
+        if let size = sourceData["size"] as? NSNumber {
+            result["size"] = size
+        }
+        
+        if let body = sourceData["body"] as? [String: Any] {
+            if let bodyContent = body["body"] {
+                result["body"] = bodyContent
+            }
+            if let warnings = body["warnings"] as? [String], !warnings.isEmpty {
+                result["_meta"] = ["warnings": warnings]
+            }
+        }
+        
+        if let headers = sourceData["headers"] as? [String: String], !headers.isEmpty {
+            result["headers"] = headers
+        }
+        
+        return result.isEmpty ? nil : result
     }
 }
 // swiftlint:enable missing_docs

--- a/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
@@ -90,6 +90,8 @@ import Foundation
         return SentryRRWebSpanEvent(timestamp: startTimestamp, endTimestamp: timestamp, operation: "resource.http", description: description, data: data)
     }
     
+    // Network details show up after selecting a request from the 'Network' tab of a session replay
+    // If any fields here are not populated, the UI will silently omit them but not report any error.
     private func addNetworkDetails(from networkData: [String: Any], to data: inout [String: Any]) {
         // Add top-level network metadata
         if let method = networkData["method"] as? String {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
@@ -1,0 +1,148 @@
+#if os(iOS) || os(tvOS)
+
+@_spi(Private) @testable import Sentry
+@_spi(Private) import SentryTestUtils
+import XCTest
+
+/// Integration tests that verify the completion-handler swizzling for replay's
+/// network detail capture actually works end-to-end.
+///
+/// Unlike the unit tests in SentryNetworkTrackerTests (which call tracker
+/// methods directly), these tests start the SDK, make real HTTP requests,
+/// and assert that the swizzled completion handler fires and populates
+/// network details on the resulting breadcrumb.
+///
+/// Uses postman-echo.com so no local test server is required.
+class SentryNetworkDetailSwizzlingTests: XCTestCase {
+
+    private let echoURL = URL(string: "https://postman-echo.com/get")!
+
+    override func setUp() {
+        super.setUp()
+
+        let options = Options()
+        options.dsn = TestConstants.dsnAsString(username: "SentryNetworkDetailSwizzlingTests")
+        options.tracesSampleRate = 1.0
+        options.enableNetworkBreadcrumbs = true
+        options.sessionReplay.networkDetailAllowUrls = ["postman-echo.com"]
+        options.sessionReplay.networkCaptureBodies = true
+        SentrySDK.start(options: options)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        clearTestState()
+    }
+
+    // MARK: - Tests
+
+    /// Verifies the swizzle of `-[NSURLSession dataTaskWithRequest:completionHandler:]`
+    /// captures response details into the breadcrumb.
+    func testDataTaskWithRequest_completionHandler_capturesNetworkDetails() throws {
+        let transaction = SentrySDK.startTransaction(
+            name: "Test", operation: "test", bindToScope: true
+        )
+
+        let expect = expectation(description: "Request completed")
+        expect.assertForOverFulfill = false
+
+        let session = URLSession(configuration: .default)
+        let request = URLRequest(url: echoURL)
+
+        var receivedData: Data?
+        var receivedResponse: URLResponse?
+        var receivedError: Error?
+
+        let task = session.dataTask(with: request) { data, response, error in
+            receivedData = data
+            receivedResponse = response
+            receivedError = error
+            expect.fulfill()
+        }
+        defer { task.cancel() }
+
+        task.resume()
+        wait(for: [expect], timeout: 5)
+
+        transaction.finish()
+
+        // Original completion handler received valid data
+        XCTAssertNil(receivedError, "Request should succeed")
+        XCTAssertNotNil(receivedData, "Should receive response data")
+        let httpResponse = try XCTUnwrap(receivedResponse as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 200)
+
+        // Network details were captured via the swizzled completion handler
+        let breadcrumb = try lastHTTPBreadcrumb(for: echoURL)
+        let details = try XCTUnwrap(
+            breadcrumb.data?[SentryReplayNetworkDetails.replayNetworkDetailsKey] as? SentryReplayNetworkDetails,
+            "Swizzled completion handler should have populated network details on the breadcrumb"
+        )
+        let serialized = details.serialize()
+        XCTAssertEqual(serialized["statusCode"] as? Int, 200)
+        XCTAssertNotNil(serialized["response"], "Response details should be captured")
+    }
+
+    /// Verifies the swizzle of `-[NSURLSession dataTaskWithURL:completionHandler:]`
+    /// captures response details into the breadcrumb.
+    func testDataTaskWithURL_completionHandler_capturesNetworkDetails() throws {
+        let transaction = SentrySDK.startTransaction(
+            name: "Test", operation: "test", bindToScope: true
+        )
+
+        let expect = expectation(description: "Request completed")
+        expect.assertForOverFulfill = false
+
+        let session = URLSession(configuration: .default)
+
+        var receivedData: Data?
+        var receivedResponse: URLResponse?
+        var receivedError: Error?
+
+        let task = session.dataTask(with: echoURL) { data, response, error in
+            receivedData = data
+            receivedResponse = response
+            receivedError = error
+            expect.fulfill()
+        }
+        defer { task.cancel() }
+
+        task.resume()
+        wait(for: [expect], timeout: 5)
+
+        transaction.finish()
+
+        // Original completion handler received valid data
+        XCTAssertNil(receivedError, "Request should succeed")
+        XCTAssertNotNil(receivedData, "Should receive response data")
+        let httpResponse = try XCTUnwrap(receivedResponse as? HTTPURLResponse)
+        XCTAssertEqual(httpResponse.statusCode, 200)
+
+        // Network details were captured via the swizzled completion handler
+        let breadcrumb = try lastHTTPBreadcrumb(for: echoURL)
+        let details = try XCTUnwrap(
+            breadcrumb.data?[SentryReplayNetworkDetails.replayNetworkDetailsKey] as? SentryReplayNetworkDetails,
+            "Swizzled completion handler should have populated network details on the breadcrumb"
+        )
+        let serialized = details.serialize()
+        XCTAssertEqual(serialized["statusCode"] as? Int, 200)
+        XCTAssertNotNil(serialized["response"], "Response details should be captured")
+    }
+
+    // MARK: - Helpers
+
+    /// Finds the most recent HTTP breadcrumb whose URL matches the given URL.
+    private func lastHTTPBreadcrumb(for url: URL) throws -> Breadcrumb {
+        let scope = SentrySDKInternal.currentHub().scope
+        let breadcrumbs = try XCTUnwrap(
+            Dynamic(scope).breadcrumbArray as [Breadcrumb]?,
+            "Scope should contain breadcrumbs"
+        )
+        let matching = breadcrumbs.filter {
+            $0.category == "http" && ($0.data?["url"] as? String)?.contains(url.host ?? "") == true
+        }
+        return try XCTUnwrap(matching.last, "Should find an HTTP breadcrumb for \(url)")
+    }
+}
+
+#endif // os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -559,6 +559,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let requestHeaders = try XCTUnwrap(requestDict["headers"] as? [String: String])
         // "Content-Type" is always extracted when present.
         XCTAssertEqual(requestHeaders["Content-Type"], "application/json")
+        XCTAssertEqual(requestHeaders.count, 1, "Only Content-Type should be captured (no networkRequestHeaders configured)")
 
         // Verify response details show up
         let responseDict = try XCTUnwrap(networkDetails["response"] as? [String: Any])
@@ -566,6 +567,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         // "Content-Type" is always extracted when present.
         XCTAssertEqual(responseHeaders["Content-Type"], "application/json")
         XCTAssertEqual(responseHeaders["Cache-Control"], "no-cache")
+        XCTAssertEqual(responseHeaders.count, 2, "Only Content-Type and the configured Cache-Control should be captured")
 
         clearTestState()
     }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -498,6 +498,78 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(payloadData["fragment"] as? String, "fragment")
     }
 
+    /// Simple case - when network details are enabled, `addBreadcrumbForSessionTask` will include
+    /// serialized network details in the breadcrumb data.
+    func testAddBreadcrumb_withNetworkDetails_shouldIncludeSerializedDetailsInBreadcrumbData() throws {
+        // -- Arrange --
+        let testUrl = URL(string: "https://api.example.com/users")!
+        let options = Options()
+        options.dsn = "https://key@sentry.io/1234"
+        options.sessionReplay.networkDetailAllowUrls = ["api.example.com"]
+        options.sessionReplay.networkResponseHeaders = ["Cache-Control"]
+        options.sessionReplay.networkCaptureBodies = false
+
+        let scope = Scope()
+        let client = TestClient(options: options)
+        let hub = TestHub(client: client, andScope: scope)
+        SentrySDKInternal.setCurrentHub(hub)
+        SentrySDK.setStart(with: options)
+
+        let tracker = SentryNetworkTracker.sharedInstance
+        tracker.enableNetworkTracking()
+        tracker.enableNetworkBreadcrumbs()
+
+        var request = URLRequest(url: testUrl)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let task = URLSessionDataTaskMock(request: request)
+
+        let httpResponse = try XCTUnwrap(HTTPURLResponse(
+            url: testUrl, statusCode: 200, httpVersion: "1.1",
+            headerFields: ["Content-Type": "application/json", "Cache-Control": "no-cache"]
+        ))
+        task.setResponse(httpResponse)
+
+        // -- Act --
+        // 1. setState(.running) triggers captureRequestDetails (associates details with task).
+        tracker.urlSessionTask(task, setState: .running)
+
+        // 2. completionHandler fires, capturing response details on the associated object.
+        tracker.captureResponseDetails(
+            Data(), response: httpResponse, request: testUrl, task: task
+        )
+
+        // 3. setState(.completed) triggers addBreadcrumbForSessionTask, which serializes
+        //    the now-complete details (request + response) into the breadcrumb.
+        tracker.urlSessionTask(task, setState: .completed)
+
+        // -- Assert --
+        let breadcrumbs = try XCTUnwrap(Dynamic(scope).breadcrumbArray as [Breadcrumb]?)
+        let breadcrumb = try XCTUnwrap(breadcrumbs.first)
+        let detailsObject = try XCTUnwrap(
+            breadcrumb.data?[SentryReplayNetworkDetails.replayNetworkDetailsKey] as? SentryReplayNetworkDetails
+        )
+        let networkDetails = detailsObject.serialize()
+
+        XCTAssertEqual(networkDetails["method"] as? String, "POST")
+        XCTAssertEqual(networkDetails["statusCode"] as? Int, 200)
+
+        // Verify request details show up
+        let requestDict = try XCTUnwrap(networkDetails["request"] as? [String: Any])
+        let requestHeaders = try XCTUnwrap(requestDict["headers"] as? [String: String])
+        // "Content-Type" is always extracted when present.
+        XCTAssertEqual(requestHeaders["Content-Type"], "application/json")
+
+        // Verify response details show up
+        let responseDict = try XCTUnwrap(networkDetails["response"] as? [String: Any])
+        let responseHeaders = try XCTUnwrap(responseDict["headers"] as? [String: String])
+        // "Content-Type" is always extracted when present.
+        XCTAssertEqual(responseHeaders["Content-Type"], "application/json")
+        XCTAssertEqual(responseHeaders["Cache-Control"], "no-cache")
+
+        clearTestState()
+    }
+
     func testBreadcrumb_GraphQLEnabled() throws {
         let body = """
         {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -498,9 +498,12 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(payloadData["fragment"] as? String, "fragment")
     }
 
+#if canImport(UIKit) && SENTRY_TARGET_REPLAY_SUPPORTED
     /// Simple case - when network details are enabled, `addBreadcrumbForSessionTask` will include
     /// serialized network details in the breadcrumb data.
     func testAddBreadcrumb_withNetworkDetails_shouldIncludeSerializedDetailsInBreadcrumbData() throws {
+        guard #available(iOS 16.0, tvOS 16.0, *) else { return }
+        
         // -- Arrange --
         let testUrl = URL(string: "https://api.example.com/users")!
         let options = Options()
@@ -571,6 +574,7 @@ class SentryNetworkTrackerTests: XCTestCase {
 
         clearTestState()
     }
+#endif
 
     func testBreadcrumb_GraphQLEnabled() throws {
         let body = """

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -198,13 +198,13 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
 
     // MARK: - Network Details (partial data)
 
-    /// All network detail fields are optional. The backend accepts partial data
-    /// and the replay UI simply omits missing fields. These tests lock down that
-    /// behavior so partial details are never accidentally rejected.
+    /// All network detail fields are optional. These tests document the SDK's
+    /// current serialization behavior — when fields on `SentryReplayNetworkDetails`
+    /// are unset, they are simply omitted from the RRWebEvent payload rather than
+    /// replaced with defaults or causing the details to be dropped entirely.
 
     func testHttpBreadcrumb_withNetworkDetails_onlyStatusCode() throws {
-        let details = SentryReplayNetworkDetails(method: nil)
-        let payloadData = try convertHttpBreadcrumbWithNetworkDetails(details: details) { details in
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
             details.setResponse(statusCode: 200, size: nil, bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
         }
 
@@ -212,10 +212,12 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertNil(payloadData["method"], "method should be absent when not set")
         XCTAssertNil(payloadData["requestBodySize"])
         XCTAssertNil(payloadData["responseBodySize"])
+        // Only statusCode should be present — nothing else leaks through.
+        XCTAssertEqual(payloadData.count, 1)
     }
 
     func testHttpBreadcrumb_withNetworkDetails_onlyMethod() throws {
-        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { _ in
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails(method: "POST") { _ in
             // method is set via the initializer; no response/request set
         }
 
@@ -223,6 +225,8 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertNil(payloadData["statusCode"], "statusCode should be absent when no response is set")
         XCTAssertNil(payloadData["requestBodySize"])
         XCTAssertNil(payloadData["responseBodySize"])
+        // Only method should be present.
+        XCTAssertEqual(payloadData.count, 1)
     }
 
     func testHttpBreadcrumb_withNetworkDetails_onlyResponseBodySize() throws {
@@ -232,6 +236,9 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
 
         XCTAssertEqual(payloadData["responseBodySize"] as? Int, 512)
         XCTAssertNil(payloadData["requestBodySize"])
+        // Expected keys: statusCode (set to 0 by setResponse),
+        // responseBodySize, and response (containing size).
+        XCTAssertEqual(payloadData.count, 3)
     }
 
     func testHttpBreadcrumb_withNetworkDetails_onlyRequestBodySize() throws {
@@ -241,11 +248,12 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
 
         XCTAssertEqual(payloadData["requestBodySize"] as? Int, 256)
         XCTAssertNil(payloadData["responseBodySize"])
+        // Expected keys: requestBodySize and request (containing size).
+        XCTAssertEqual(payloadData.count, 2)
     }
 
     func testHttpBreadcrumb_withNetworkDetails_emptyDetails_producesNoExtraKeys() throws {
-        let details = SentryReplayNetworkDetails(method: nil)
-        let payloadData = try convertHttpBreadcrumbWithNetworkDetails(details: details) { _ in }
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { _ in }
 
         XCTAssertNil(payloadData["method"])
         XCTAssertNil(payloadData["statusCode"])
@@ -253,21 +261,24 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertNil(payloadData["responseBodySize"])
         XCTAssertNil(payloadData["request"])
         XCTAssertNil(payloadData["response"])
+        XCTAssertEqual(payloadData.count, 0, "No keys should be present when details is empty")
     }
 
     // MARK: - Helpers
 
     /// Creates an HTTP breadcrumb with a `SentryReplayNetworkDetails` attached,
     /// runs it through the converter, and returns the payload data dictionary.
+    ///
+    /// - Parameter method: Optional HTTP method to set on the network details.
     private func convertHttpBreadcrumbWithNetworkDetails(
-        details: SentryReplayNetworkDetails? = nil,
+        method: String? = nil,
         configure: (SentryReplayNetworkDetails) -> Void
     ) throws -> [String: Any] {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "http")
         let start = Date(timeIntervalSince1970: 5)
 
-        let networkDetails = details ?? SentryReplayNetworkDetails(method: "POST")
+        let networkDetails = SentryReplayNetworkDetails(method: method)
         configure(networkDetails)
 
         breadcrumb.data = [

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -196,6 +196,92 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData["SomeInfo"] as? String, "Info")
     }
 
+    // MARK: - Network Details (partial data)
+
+    /// All network detail fields are optional. The backend accepts partial data
+    /// and the replay UI simply omits missing fields. These tests lock down that
+    /// behavior so partial details are never accidentally rejected.
+
+    func testHttpBreadcrumb_withNetworkDetails_onlyStatusCode() throws {
+        let details = SentryReplayNetworkDetails(method: nil)
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails(details: details) { details in
+            details.setResponse(statusCode: 200, size: nil, bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
+        }
+
+        XCTAssertEqual(payloadData["statusCode"] as? Int, 200)
+        XCTAssertNil(payloadData["method"], "method should be absent when not set")
+        XCTAssertNil(payloadData["requestBodySize"])
+        XCTAssertNil(payloadData["responseBodySize"])
+    }
+
+    func testHttpBreadcrumb_withNetworkDetails_onlyMethod() throws {
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { _ in
+            // method is set via the initializer; no response/request set
+        }
+
+        XCTAssertEqual(payloadData["method"] as? String, "POST")
+        XCTAssertNil(payloadData["statusCode"], "statusCode should be absent when no response is set")
+        XCTAssertNil(payloadData["requestBodySize"])
+        XCTAssertNil(payloadData["responseBodySize"])
+    }
+
+    func testHttpBreadcrumb_withNetworkDetails_onlyResponseBodySize() throws {
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
+            details.setResponse(statusCode: 0, size: NSNumber(value: 512), bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
+        }
+
+        XCTAssertEqual(payloadData["responseBodySize"] as? Int, 512)
+        XCTAssertNil(payloadData["requestBodySize"])
+    }
+
+    func testHttpBreadcrumb_withNetworkDetails_onlyRequestBodySize() throws {
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
+            details.setRequest(size: NSNumber(value: 256), bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
+        }
+
+        XCTAssertEqual(payloadData["requestBodySize"] as? Int, 256)
+        XCTAssertNil(payloadData["responseBodySize"])
+    }
+
+    func testHttpBreadcrumb_withNetworkDetails_emptyDetails_producesNoExtraKeys() throws {
+        let details = SentryReplayNetworkDetails(method: nil)
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails(details: details) { _ in }
+
+        XCTAssertNil(payloadData["method"])
+        XCTAssertNil(payloadData["statusCode"])
+        XCTAssertNil(payloadData["requestBodySize"])
+        XCTAssertNil(payloadData["responseBodySize"])
+        XCTAssertNil(payloadData["request"])
+        XCTAssertNil(payloadData["response"])
+    }
+
+    // MARK: - Helpers
+
+    /// Creates an HTTP breadcrumb with a `SentryReplayNetworkDetails` attached,
+    /// runs it through the converter, and returns the payload data dictionary.
+    private func convertHttpBreadcrumbWithNetworkDetails(
+        details: SentryReplayNetworkDetails? = nil,
+        configure: (SentryReplayNetworkDetails) -> Void
+    ) throws -> [String: Any] {
+        let sut = SentrySRDefaultBreadcrumbConverter()
+        let breadcrumb = Breadcrumb(level: .info, category: "http")
+        let start = Date(timeIntervalSince1970: 5)
+
+        let networkDetails = details ?? SentryReplayNetworkDetails(method: "POST")
+        configure(networkDetails)
+
+        breadcrumb.data = [
+            "url": "https://test.com",
+            "request_start": start,
+            SentryReplayNetworkDetails.replayNetworkDetailsKey: networkDetails
+        ]
+
+        let result = try XCTUnwrap(sut.convert(from: breadcrumb) as? SentryRRWebSpanEvent)
+        let crumbData = try XCTUnwrap(result.data)
+        let payload = try XCTUnwrap(crumbData["payload"] as? [String: Any])
+        return try XCTUnwrap(payload["data"] as? [String: Any])
+    }
+
     func testSerializedSRBreadcrumbLevelIsString() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb()


### PR DESCRIPTION
## :scroll: Description

Upload network details data (`SentryNetworkRequestData`) extracted by SentryNetworkTracker to the session replay backend.

`SentryNetworkRequestData`
Stored on the NSURLSessionTask while waiting for data (**see previous prs**)
```objc
SentryNetworkRequestData *networkRequestData
        = objc_setAssociatedObject(sessionTask, &SentryNetworkRequestDataKey);
```
Stored in the Breadcrumb data after task has completed (`addBreadcrumbForSessionTask`) (**THIS PR**)

```objc
breadcrumbData[SentryReplayNetworkDetailsKey]
```
Extracted from Breadcrumb into RRWebEvent (`SentrySRDefaultBreadcrumbConverter`) (**THIS PR**)
```swift
 SentryNetworkRequestData.serialize
```

## :bulb: Motivation and Context

Last leg of data upload; now data is visible in replay dash.

## :green_heart: How did you test it?
### Manual Testing with iOS-Swift test app

1) Build and install
```
xcodebuild -workspace Sentry.xcworkspace -scheme iOS-Swift -sdk iphonesimulator -destination  'platform=iOS Simulator,name=iPhone 16 Pro' clean build

xcrun simctl install "iPhone 16 Pro"  ~/Library/Developer/Xcode/DerivedData/Sentry-*/Build/Products/Debug-iphonesimulator/iOS-Swift.app
```

2) Navigate to Extras > Network Details

3) Initiate different types of request

4) Navigate to [sentry.io](https://sentry-sdks.sentry.io/explore/replays/?project=5428557&statsPeriod=1h) test project and confirm session replay 'Network' tab shows requests with correct body and headers.

[https://sentry-sdks.sentry.io/explore/replays/f5cff413ffd94561819...](https://sentry-sdks.sentry.io/explore/replays/f5cff413ffd94561819bfca90415e57b/?f_n_search=httpbin&n_detail_row=5&n_detail_tab=response&playlistEnd=2026-03-23T19%3A14%3A57&playlistStart=2026-03-09T19%3A14%3A57&project=5428557&query=&referrer=replayList&t_main=network)

- **Request + Response Headers correctly extracted**
```
options.sessionReplay.networkRequestHeaders = [
                "User-Agent",
                "X-Custom-Header",
                "X-Request-ID"
            ]
            options.sessionReplay.networkResponseHeaders = [
                "Server",
                "Access-Control-Allow-Origin",
                "access-control-allow-credentials"
            ]
```
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8c30640c-9f23-408d-bb70-234a79cd7510" />

- **Formurlencoded request/response bodies correctly extracted as structured data**
<img width="300" src="https://github.com/user-attachments/assets/fef97880-f1c1-45cb-86a3-4c27af4368a0" />
<img width="300" src="https://github.com/user-attachments/assets/bb0a306c-900e-4759-988e-cfcdbaeb3783" />

- **Binary content correct not extracted / extracted as placeholder**
<img width="300" src="https://github.com/user-attachments/assets/0d23533f-94f1-4ea7-b90f-17184e16d989" />

- **JSON Body over 150KB limit correctly truncated and 'fixed up' (server-side) with expected warning in UI**
 
<img width="350" src="https://github.com/user-attachments/assets/7d775959-b2be-4a17-9963-1d3eebce6192" />
<img width="300" src="https://github.com/user-attachments/assets/c12f95e8-4b30-4d6d-8b62-58d4839e0570" />

### Unit tests

<html><head></head><body><p>Summary:</p>

Test Suite | Tests | Failures | Status
-- | -- | -- | --
SentryNSURLSessionTaskSearchTests | 3 | 0 | ✅
SentrySRDefaultBreadcrumbConverterTests | 17 | 0 | ✅
SentryReplayNetworkDetailsIntegrationTests | 4 | 0 | ✅
SentryReplayOptionsNetworkTests | 11 | 0 | ✅
SentryReplayOptionsObjcTests | 2 | 0 | ✅
SentryReplayOptionsTests | 77 | 0 | ✅
Total | 97 | 0 | ✅


</body></html>

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled. **gated by SentryReplayOptions#networkDetailAllowUrls**
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed. **n/a**
- [x] Review from the native team if needed. **n/a**
- [x] No breaking change or entry added to the changelog. **future PR** #skip-changelog
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7591