### PR TITLE
test: Replace force unwraps with XCTUnwrap

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -395,7 +395,7 @@ class SentryFileManagerTests: XCTestCase {
         }
         sut.store(fixture.sessionUpdateEnvelope)
         
-        try assertSessionInitMoved(sut.getAllEnvelopes().last!)
+        try assertSessionInitMoved(try XCTUnwrap(sut.getAllEnvelopes().last))
         assertSessionEnvelopesStored(count: 2)
     }
     
@@ -406,7 +406,7 @@ class SentryFileManagerTests: XCTestCase {
             sut.store(TestConstants.envelope)
         }
         
-        try assertSessionInitMoved(sut.getAllEnvelopes().first!)
+        try assertSessionInitMoved(try XCTUnwrap(sut.getAllEnvelopes().first))
         assertSessionEnvelopesStored(count: 1)
     }
     
@@ -467,7 +467,7 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.store(fixture.sessionUpdateEnvelope)
         
-        try assertSessionInitMoved(sut.getAllEnvelopes().last!)
+        try assertSessionInitMoved(try XCTUnwrap(sut.getAllEnvelopes().last))
     }
     
     func testMigrateSessionInit_DoesNotCallEnvelopeItemDeleted() {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -81,7 +81,10 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     func testUILifeCycle_ViewDidAppear() throws {
         try assertUILifeCycle(finishStatus: SentrySpanStatus.ok) { sut, viewController, tracker, callbackExpectation, transactionSpan in
             sut.viewControllerViewDidAppear(viewController) {
-                let blockSpan = self.getStack(tracker).last!
+                guard let blockSpan = self.getStack(tracker).last else {
+                    XCTFail("Expected a span on the stack")
+                    return
+                }
                 XCTAssertEqual(blockSpan.parentSpanId, transactionSpan.spanId)
                 XCTAssertEqual(blockSpan.spanDescription, self.viewDidAppear)
                 XCTAssertEqual(blockSpan.origin, self.origin)
@@ -101,7 +104,10 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
 
         try assertUILifeCycle(finishStatus: SentrySpanStatus.cancelled) { sut, viewController, tracker, callbackExpectation, transactionSpan in
             sut.viewControllerViewWillDisappear(viewController) {
-                let blockSpan = self.getStack(tracker).last!
+                guard let blockSpan = self.getStack(tracker).last else {
+                    XCTFail("Expected a span on the stack")
+                    return
+                }
                 XCTAssertEqual(blockSpan.parentSpanId, transactionSpan.spanId)
                 XCTAssertEqual(blockSpan.spanDescription, self.viewWillDisappear)
                 XCTAssertEqual(blockSpan.origin, self.origin)
@@ -569,11 +575,17 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         XCTAssertFalse(unwrappedTransactionSpan.isFinished)
         
         sut.viewControllerViewDidLoad(viewController) {
-            let blockSpan = self.getStack(tracker).last!
-            
+            guard let blockSpan = self.getStack(tracker).last else {
+                XCTFail("Expected a span on the stack")
+                return
+            }
+
             //this is the same as calling super.viewDidLoad in a custom class sub class
             sut.viewControllerViewDidLoad(viewController) {
-                let innerblockSpan = self.getStack(tracker).last!
+                guard let innerblockSpan = self.getStack(tracker).last else {
+                    XCTFail("Expected a span on the stack")
+                    return
+                }
                 XCTAssertTrue(innerblockSpan === blockSpan)
                 
                 callbackExpectation.fulfill()

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
@@ -79,7 +79,7 @@ class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {
         sut.addSerializedBreadcrumb(breadcrumb)
 
         let fileOneContents = try String(contentsOfFile: fixture.fileManager.breadcrumbsFilePathOne)
-        let firstLine = String(fileOneContents.split(separator: "\n").first!)
+        let firstLine = String(try XCTUnwrap(fileOneContents.split(separator: "\n").first))
         let dict = try XCTUnwrap(try JSONSerialization.jsonObject(with: firstLine.data(using: .utf8)!) as? [String: String])
 
         XCTAssertEqual(dict, breadcrumb)

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -36,7 +36,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         PrivateSentrySDKOnly.store(envelope)
         
         let storedEnvelope = client?.storedEnvelopeInvocations.first
-        let attachedSessionData = try XCTUnwrap(storedEnvelope!.items.last!.data)
+        let attachedSessionData = try XCTUnwrap(XCTUnwrap(storedEnvelope).items.last?.data)
         let attachedSession = try XCTUnwrap(try JSONSerialization.jsonObject(with: attachedSessionData) as? [String: Any])
         
         XCTAssertEqual(0, hub.startSessionInvocations)
@@ -67,7 +67,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         PrivateSentrySDKOnly.capture(envelope)
 
         let capturedEnvelope = client?.captureEnvelopeInvocations.first
-        let attachedSessionData = try XCTUnwrap(capturedEnvelope!.items.last!.data)
+        let attachedSessionData = try XCTUnwrap(XCTUnwrap(capturedEnvelope).items.last?.data)
         let attachedSession = try XCTUnwrap(try JSONSerialization.jsonObject(with: attachedSessionData) as? [String: Any])
         
         // Assert new session was started

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1162,10 +1162,10 @@ class SentryClientTests: XCTestCase {
         
         eventId.assertIsNotEmpty()
         let actual = try lastSentEventWithAttachment()
-        assertValidExceptionEvent(actual)
+        try assertValidExceptionEvent(actual)
     }
-    
-    func testCaptureException_IncreasesSessionErrors() {
+
+    func testCaptureException_IncreasesSessionErrors() throws {
         let sut = fixture.getSut()
         let sessionDelegate = SentryTestSessionDelegate { self.fixture.session }
         sut.sessionDelegate = sessionDelegate
@@ -1174,7 +1174,7 @@ class SentryClientTests: XCTestCase {
         eventId.assertIsNotEmpty()
         XCTAssertNotNil(fixture.transportAdapter.sentEventsWithSessionTraceState.last)
         if let eventWithSessionArguments = fixture.transportAdapter.sentEventsWithSessionTraceState.last {
-            assertValidExceptionEvent(eventWithSessionArguments.event)
+            try assertValidExceptionEvent(eventWithSessionArguments.event)
             XCTAssertEqual(fixture.session, eventWithSessionArguments.session)
             XCTAssertEqual([TestData.dataAttachment], eventWithSessionArguments.attachments)
         }
@@ -2706,10 +2706,11 @@ private extension SentryClientTests {
         assertValidThreads(actual: event.threads)
     }
     
-    private func assertValidExceptionEvent(_ event: Event) {
+    private func assertValidExceptionEvent(_ event: Event) throws {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertEqual(exception.reason, event.exceptions!.first!.value)
-        XCTAssertEqual(exception.name.rawValue, event.exceptions!.first!.type)
+        let firstException = try XCTUnwrap(XCTUnwrap(event.exceptions).first)
+        XCTAssertEqual(exception.reason, firstException.value)
+        XCTAssertEqual(exception.name.rawValue, firstException.type)
         assertValidDebugMeta(actual: event.debugMeta, forThreads: event.threads)
         assertValidThreads(actual: event.threads)
     }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1178,18 +1178,18 @@ class SentryHubTests: XCTestCase {
         try assertSessionWithIncrementedErrorCountedAdded()
     }
 
-    func testCaptureEnvelope_WithEventWithFatal_SessionNotStarted() {
+    func testCaptureEnvelope_WithEventWithFatal_SessionNotStarted() throws {
         captureEventEnvelope(level: SentryLevel.fatal)
-        
-        assertNoSessionAddedToCapturedEnvelope()
+
+        try assertNoSessionAddedToCapturedEnvelope()
     }
 
-    func testCaptureEnvelope_WithEventWithWarning() {
+    func testCaptureEnvelope_WithEventWithWarning() throws {
         sut.startSession()
-        
+
         captureEventEnvelope(level: SentryLevel.warning)
-        
-        assertNoSessionAddedToCapturedEnvelope()
+
+        try assertNoSessionAddedToCapturedEnvelope()
     }
 
     func testCaptureEnvelope_WithClientNil() {
@@ -1589,15 +1589,15 @@ class SentryHubTests: XCTestCase {
     
     private func assertSessionWithIncrementedErrorCountedAdded() throws {
         XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
-        let envelope = fixture.client.captureEnvelopeInvocations.first!
+        let envelope = try XCTUnwrap(fixture.client.captureEnvelopeInvocations.first)
         XCTAssertEqual(2, envelope.items.count)
         let session = SentrySerializationSwift.session(with: try XCTUnwrap(XCTUnwrap(envelope.items.element(at: 1)).data))
         XCTAssertEqual(1, session?.errors)
     }
     
-    private func assertNoSessionAddedToCapturedEnvelope() {
+    private func assertNoSessionAddedToCapturedEnvelope() throws {
         XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
-        let envelope = fixture.client.captureEnvelopeInvocations.first!
+        let envelope = try XCTUnwrap(fixture.client.captureEnvelopeInvocations.first)
         XCTAssertEqual(1, envelope.items.count)
     }
     

--- a/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
+++ b/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
@@ -213,7 +213,7 @@ final class TelemetryBufferTests: XCTestCase {
         XCTAssertEqual(testTelemetryBuffer.flushCallCount, 1)
     }
     
-    func testCapture_whenMultipleItems_shouldPassCorrectItemCount() {
+    func testCapture_whenMultipleItems_shouldPassCorrectItemCount() throws {
         // -- Arrange --
         let sut = getSut()
         sut.add(TestItem(body: "Item 1"))
@@ -225,7 +225,7 @@ final class TelemetryBufferTests: XCTestCase {
         
         // -- Assert --
         XCTAssertEqual(capturedDataInvocations.count, 1)
-        let invocation = capturedDataInvocations.invocations.first!
+        let invocation = try XCTUnwrap(capturedDataInvocations.invocations.first)
         XCTAssertEqual(invocation.1, 3, "Callback should receive item count, not byte size")
     }
     


### PR DESCRIPTION
## Summary

Replace `.first!` / `.last!` with `XCTUnwrap` (or `guard let` in non-throwing closures) across 7 test files. Force unwraps crash the entire test suite on failure; `XCTUnwrap` fails only the single test with a clear message.

#skip-changelog

Agent transcript: https://claudescope.sentry.dev/share/aTL-CD6tkcl__nXD9nwz7JMKuwa3S8xZpOdx3Y7DpLA

Closes #7593