### PR TITLE
fix: Capture transactions during launch profiling window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Capture transactions that finish during the launch profiling window instead of silently discarding them (#7602)
+
 ## 9.6.0
 
 ### Features

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -251,6 +251,12 @@ sentry_stopProfilerDueToFinishedTransaction(SentryHubInternal *hub,
             SentryProfileOptions, sentry_profileConfiguration.profileOptions))) {
         SENTRY_LOG_DEBUG(@"Stopping launch UI trace profile.");
         sentry_stopTrackingRootSpanForContinuousProfilerV2();
+        // The launch tracer is intentionally discarded by sentry_stopAndDiscardLaunchProfileTracer.
+        // Other transactions finishing during the launch profiling window (e.g., manual
+        // transactions or app start transactions) must still be captured.
+        if (transaction.trace != sentry_launchTracer) {
+            [hub captureTransaction:transaction withScope:hub.scope];
+        }
         return;
     }
 

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -208,6 +208,53 @@ extension SentryAppLaunchProfilingTests {
         // Assert
         XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
+
+    func testNonLaunchTracerTransactionCapturedDuringLaunchProfiling() throws {
+        // Arrange: set up launch profiling with trace lifecycle
+        fixture.options.tracesSampleRate = 1
+        fixture.options.configureProfiling = {
+            $0.profileAppStarts = true
+            $0.sessionSampleRate = 1
+            $0.lifecycle = .trace
+        }
+        sentry_configureContinuousProfiling(fixture.options)
+        sentry_configureLaunchProfilingForNextLaunch(fixture.options)
+
+        _sentry_nondeduplicated_startLaunchProfile()
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertNotNil(sentry_launchTracer)
+
+        // Act: start and finish a separate transaction during the launch profiling window
+        let tracer = try fixture.newTransaction()
+        tracer.finish()
+
+        // Assert: the transaction must be captured, not swallowed
+        let client = try XCTUnwrap(fixture.client)
+        XCTAssertEqual(client.captureEventWithScopeInvocations.count, 1)
+    }
+
+    func testLaunchTracerTransactionNotCapturedWhenDiscarded() throws {
+        // Arrange: set up launch profiling with trace lifecycle
+        fixture.options.tracesSampleRate = 1
+        fixture.options.configureProfiling = {
+            $0.profileAppStarts = true
+            $0.sessionSampleRate = 1
+            $0.lifecycle = .trace
+        }
+        sentry_configureContinuousProfiling(fixture.options)
+        sentry_configureLaunchProfilingForNextLaunch(fixture.options)
+
+        _sentry_nondeduplicated_startLaunchProfile()
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertNotNil(sentry_launchTracer)
+
+        // Act: discard the launch tracer (this is the normal flow)
+        sentry_stopAndDiscardLaunchProfileTracer(fixture.hub)
+
+        // Assert: the launch tracer's transaction must NOT be captured
+        let client = try XCTUnwrap(fixture.client)
+        XCTAssertEqual(client.captureEventWithScopeInvocations.count, 0)
+    }
 }
 #endif // !os(macOS)
 #endif // os(iOS) || os(macOS)


### PR DESCRIPTION
## :scroll: Description

When launch profiling with trace lifecycle is active, `sentry_stopProfilerDueToFinishedTransaction` discarded **all** transactions finishing during the launch window — not just the launch tracer itself. This prevented any concurrent transaction (e.g., manual transactions or app start transactions) from being captured and sent to Sentry.

The fix checks whether the finishing transaction is the launch tracer. Only the launch tracer is discarded (intentional, via `sentry_stopAndDiscardLaunchProfileTracer`); all other transactions are forwarded to the hub for capture.

Discovered while working on standalone app start transactions (#6883).

## :bulb: Motivation and Context

The launch tracer exists solely to drive profiling and is intentionally discarded — its transaction should never be sent. However, the early return in `sentry_stopProfilerDueToFinishedTransaction` was too broad: it caught every transaction that finished while `sentry_profileConfiguration` was still set during launch, silently dropping them.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

Agent transcript: https://claudescope.sentry.dev/share/Vwu89XdjtVlDOljOcvjOlrZJHIJOBNOtlqQhpy6oli4