### PR TITLE
ref(dx): Add descriptions to xcodegen project schema

### DIFF
--- a/schema/xcodegen.schema.json
+++ b/schema/xcodegen.schema.json
@@ -138,7 +138,7 @@
         },
         "tabWidth": {
           "type": "integer",
-          "description": "Override user's setting for indent width in number of spaces"
+          "description": "Override user's setting for tab width in number of spaces"
         },
         "disabledValidations": {
           "type": "array",


### PR DESCRIPTION
Enables better IDE integration and auto-completion by agents.
Based on the [documentation](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md).

#skip-changelog

Closes #7609