### PR TITLE
docs: Improve command execution guidance in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,9 @@ search_issues  → check for new/regressed issues
 
 ## Command Execution
 
-- **Set the working directory once** with `cd`, then run commands directly — do not prefix every command with `cd <path> &&`
-- **Wildcard permissions** — many commands are pre-approved with wildcards (e.g., `git add:*`). Flags like `-C` change the command prefix (`git -C path add` ≠ `git add`), triggering a confirmation prompt. Avoid `-C` when you can `cd` instead
+- **Verify working directory** — use `pwd` to confirm you're in the correct path before running commands. The shell persists working directory across tool calls
+- **Avoid redundant `cd`** — do not prefix every command with `cd <path> &&`. Change directory once if needed, then verify with `pwd`
+- **Wildcard permissions** — many commands are pre-approved with wildcards (e.g., `git add:*`). Flags like `-C` change the command prefix (`git -C path add` ≠ `git add`), triggering a confirmation prompt. Avoid `-C` when you can change directory instead
 - **Prefer small, focused commands** over one massive pipeline. Break complex operations into multiple steps
 - **JSON processing** — always use `jq`; do not shell out to `node` or `python` for JSON parsing
 - **GitHub** — prefer `gh` CLI over web scraping when interacting with GitHub.com


### PR DESCRIPTION
Updates the "Command Execution" section in AGENTS.md to provide clearer guidance about working directory management for agents.

The previous guidance told agents to "set the working directory once with cd" but this was ambiguous and led to confusion. The new guidance explicitly instructs agents to:

1. Verify their working directory using `pwd` before running commands
2. Understand that the shell persists working directory across tool calls
3. Avoid the anti-pattern of prefixing every command with `cd <path> &&`

This change helps agents work more efficiently by reducing redundant directory changes and making it clear they should verify their location rather than repeatedly changing it.

#skip-changelog

Closes #7611