### PR TITLE
ref(samples): Restructure tvOS-SwiftUI-SPM sample

### DIFF
--- a/Samples/tvOS-SwiftUI-SPM/tvOS-SwiftUI-SPM.yml
+++ b/Samples/tvOS-SwiftUI-SPM/tvOS-SwiftUI-SPM.yml
@@ -11,17 +11,31 @@ configs:
 packages:
   Sentry:
     path: ../..
-fileGroups:
-  - tvOS-SwiftUI-SPM.yml
 options:
   bundleIdPrefix: io.sentry
+  defaultSourceDirectoryType: syncedFolder
 targets:
-  tvOS-SwiftUI-SPM:
+  App:
     type: application
     platform: tvOS
     deploymentTarget: "15.0"
     sources:
-      - Sources
+      # Sources
+      - path: Sources
+        type: group
+        group: App
+        excludes:
+          - "**/.gitkeep"
+      # Resources
+      - path: Resources
+        type: group
+        group: App
+        excludes:
+          - "**/.gitkeep"
+      # Configurations
+      - path: tvOS-SwiftUI-SPM.yml
+        group: App
+        buildPhase: none
     dependencies:
       - package: Sentry
         product: SentrySPM
@@ -38,7 +52,7 @@ schemes:
   tvOS-SwiftUI-SPM:
     build:
       targets:
-        tvOS-SwiftUI-SPM: all
+        App: all
     run:
       config: Debug
     archive:


### PR DESCRIPTION
Updates the tvOS-SwiftUI-SPM sample to use the standardized directory structure and configuration patterns.

## Changes

- Renamed target from `tvOS-SwiftUI-SPM` to `App` for consistency with other samples
- Added `syncedFolder` support to `tvOS-SwiftUI-SPM.yml` for automatic file discovery
- Added explicit source grouping with `.gitkeep` exclusions for cleaner project structure
- Added `buildPhase: none` to YAML file reference to prevent build phase inclusion
- Removed legacy `fileGroups` configuration in favor of explicit source paths

The source files were already in the correct `Sources/` and `Resources/` directories, so only the YAML configuration needed updates.

Part of the ongoing sample app restructuring effort to establish consistent directory patterns across all samples.

#skip-changelog

Closes #7622