### PR TITLE
fix: Support test apps in dev environments

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/Info.plist
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/Info.plist
@@ -26,6 +26,11 @@
 	<string>&lt;status&gt;</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
When sending events from the test app to sentry running locally the DSN doesn't use https. So far I've been manually adding this every time I needed to test a backend change, so seemed like it would be useful to have in this test app for everyone to use. I only added it to the SwiftUI test app here since that's what I test my backend changes with, but it could be added to other test apps as well

#skip-changelog

Closes #7625