### PR TITLE
test: Add crash when SentryInitializeForGettingSubclassesNotCalled is…

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/SentryInitializeForGettingSubclassesNotCalled.m
+++ b/Tests/SentryTests/Integrations/Performance/SentryInitializeForGettingSubclassesNotCalled.m
@@ -5,6 +5,7 @@
 
 + (void)initialize
 {
+    NSAssert(false, @"This class should never be initialized");
     if (self == [SentryInitializeForGettingSubclassesNotCalled self]) {
         _SentryInitializeForGettingSubclassesCalled = YES;
     }


### PR DESCRIPTION
I ran into a flaky test that failed the assertion with `SentryInitializeForGettingSubclassesCalled`. So something was calling this "initialize" even though we expected it not to be called. I'm guessing some other test codepath is calling it and causing a race condition. With this assert we should be able to get a crash and a stacktrace if it happens again to debug what caused it

Closes #7638