### PR TITLE
test: Fix flaky HangTracker deallocated test

### DIFF
--- a/Sources/Swift/HangTracker.swift
+++ b/Sources/Swift/HangTracker.swift
@@ -76,6 +76,9 @@ final class DefaultHangTracker<T: RunLoopObserver> {
         mainQueueState = .init()
     }
     
+    // It's safe to access mainQueueState here regardless of the thread
+    // because this is the only reference to `self` while
+    // it is being deallocated.
     deinit {
         guard let observer = mainQueueState.observer else {
             return

--- a/Tests/SentryTests/Integrations/ANR/HangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/HangTrackerTests.swift
@@ -208,6 +208,14 @@ final class HangTrackerTests: XCTestCase {
         
         sut = nil
         
+        // Allow the hang tracker's background thread to finish since it holds
+        // a strong reference while it is running
+        let expectation = XCTestExpectation()
+        queue.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation])
+        
         XCTAssertNil(weakSut, "Expected observer to be deallocated")
     }
     


### PR DESCRIPTION
This test would flake if the hang tracker's background thread hadn't finished running (a race condition). This fixes it and adds a comment to help explain why accessing `mainThreadState` is safe even when the deinit isn't documented to only be called on the main thread

Closes #7640