### PR TITLE
chore: Add error monitoring solution question to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -44,6 +44,25 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: other_error_monitoring
+    attributes:
+      description: Are you using any other error monitoring solution alongside Sentry?
+      label: Other Error Monitoring Solution
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+  - type: input
+    id: other_error_monitoring_name
+    attributes:
+      label: Other Error Monitoring Solution Name
+      description: If you're using another error monitoring solution side-by-side, please enter the name of the other solution.
+    validations:
+      required: false
+
   - type: input
     id: version
     attributes:


### PR DESCRIPTION
## Description

Adds a new dropdown and optional input field to the Cocoa bug report issue template asking users if they are using any other error monitoring solution alongside Sentry, and if so, which one.

## Motivation and Context

Other error monitoring SDKs (e.g. Crashlytics, Bugsnag) can interfere with Sentry's crash reporting on Apple platforms. Knowing upfront whether a user has another solution installed helps triage bugs faster.

## How did you test it?

Reviewed the YAML template manually.

#skip-changelog

Closes #7671