### PR TITLE
ci: Skip macOS CLI check on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,8 @@ jobs:
 
   check-macOS-CLI-Xcode-no-UI-framework:
     name: macOS CLI (NoUIFramework) builds and has no AppKit/UIKit
-    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
+    # Don't run this on release branches, cause the SPM Package.swift points to the unreleased versions.
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
     runs-on: macos-26
     steps:


### PR DESCRIPTION
## Summary
- Skip `check-macOS-CLI-Xcode-no-UI-framework` on release branches
- Same approach already used for `build-sample-spm`, `build-spm`, `build-distribution`, and `ios-swift-release`
- Fixes https://github.com/getsentry/sentry-cocoa/actions/runs/22956545057

#skip-changelog

Closes #7674