### PR TITLE
feat(ci): Use GitHub App token instead of default token

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -61,8 +61,17 @@ jobs:
     needs: files-changed
     runs-on: macos-15
     steps:
+      - name: Generate GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_ID }}
+          private-key: ${{ secrets.SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app_token.outputs.token }}
       - name: Update Homebrew
         run: brew update
 
@@ -84,6 +93,7 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         with:
+          token: ${{ steps.app_token.outputs.token }}
           add-paths: scripts/.clang-format-version
           branch: github-actions/auto-update-tools-clang-format
           commit-message: "chore(deps): Update clang-format version"
@@ -96,6 +106,7 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         with:
+          token: ${{ steps.app_token.outputs.token }}
           add-paths: scripts/.swiftlint-version
           branch: github-actions/auto-update-tools-swiftlint
           commit-message: "chore(deps): Update swiftlint version"


### PR DESCRIPTION
Switch the Auto Update Tools workflow to authenticate with the configured GitHub App instead of the default GITHUB_TOKEN.

Dependency update PRs (like #7675) will now be created and updated using the SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_* credentials. This ensures PRs and commits are attributed to the app rather than the default workflow token.

The workflow generates and uses the app token for checkout and both create-pull-request steps (clang-format and swiftlint).

This applies the same fix from https://github.com/getsentry/sentry-fastlane-plugin/pull/429 to this repository.

#skip-changelog