### PR TITLE
fix(tests): Fix flaky SentryCrashInstallationReporterTests

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -10,8 +10,8 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         sentrycrash_deleteAllReports()
-        clearTestState()
         sut.uninstall()
+        clearTestState()
     }
     
     func testReportIsSentAndDeleted() throws {
@@ -90,6 +90,9 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         SentrySDKInternal.setCurrentHub(hub)
         
         sut = SentryCrashInstallationReporter(inAppLogic: SentryInAppLogic(inAppIncludes: []), crashWrapper: TestSentryCrashWrapper(processInfoWrapper: ProcessInfo.processInfo), dispatchQueue: TestSentryDispatchQueueWrapper())
+        // Reset global SentryCrash state so install() fully reinitializes the report store path,
+        // even if a previous test class left g_installed = 1.
+        sentrycrash_uninstall()
         sut.install(options.cacheDirectoryPath)
         // Works only if SentryCrash is installed
         sentrycrash_deleteAllReports()


### PR DESCRIPTION
## Description

`SentryCrashInstallationReporterTests.testShouldCaptureCrashReportWithLegacyStorageInfo` is flaky on CI — all assertions fail with 0 reports processed.

The C-level `sentrycrash_install()` has a global `g_installed` guard: if another test class left it at `1`, the call returns early **without** reinitializing the report store (i.e., `sentrycrashcrs_initialize` is skipped and `g_reportsPath` stays stale). If that stale path's directory was deleted by a previous test's cleanup, `sentrycrashcrs_addUserReport` silently fails to write the report file, and `allReports` returns an empty array.

### Changes

1. Call `sentrycrash_uninstall()` before `sut.install()` in test setup — resets the global `g_installed` flag so `sentrycrash_install()` fully reinitializes the report store path.
2. Reorder `tearDown` so `sut.uninstall()` runs before `clearTestState()` — ensures `uninstall` operates on the original dependency container rather than creating a throwaway one after the container is reset.

## Motivation

Fix flaky test: `SentryCrashInstallationReporterTests.testShouldCaptureCrashReportWithLegacyStorageInfo`

## How it was tested

Ran the full test class locally — all 4 tests pass.

#skip-changelog

Closes #7683