### PR TITLE
test: Fix test naming convention in SentryLevelMapperTests

### DIFF
--- a/Tests/SentryTests/Helper/SentryLevelMapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryLevelMapperTests.swift
@@ -2,19 +2,19 @@
 import XCTest
 
 class SentryLevelMapperTests: XCTestCase {
-    func testSentryLevelForString_nilParameter_shouldReturnDefault() {
+    func testSentryLevelForString_whenNilParameter_shouldReturnDefault() {
         XCTAssertEqual(sentryLevelForString(nil), .error)
     }
 
-    func testSentryLevelForString_emptyString_shouldReturnDefault() {
+    func testSentryLevelForString_whenEmptyString_shouldReturnDefault() {
         XCTAssertEqual(sentryLevelForString(""), .error)
     }
 
-    func testSentryLevelForString_invalidString_shouldReturnDefault() {
+    func testSentryLevelForString_whenInvalidString_shouldReturnDefault() {
         XCTAssertEqual(sentryLevelForString("invalid"), .error)
     }
 
-    func testSentryLevelForString_validString_shouldReturnCorrectLevel() {
+    func testSentryLevelForString_whenValidString_shouldReturnCorrectLevel() {
         XCTAssertEqual(sentryLevelForString("none"), .none)
         XCTAssertEqual(sentryLevelForString("debug"), .debug)
         XCTAssertEqual(sentryLevelForString("info"), .info)


### PR DESCRIPTION
Add missing `when` keyword to test method names to follow the `test<Function>_when<Condition>_should<Expected>()` convention from `Tests/AGENTS.md`.

#skip-changelog

Closes #7686