### PR TITLE
feat(samples): Add UI test targets to Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ make test-ios ONLY_TESTING=<AffectedTestClass>
 
 # 5. If samples changed
 make build-sample-iOS-Swift
+make test-sample-iOS-Swift-ui  # if UI behavior changed
 ```
 
 ### Platform Decision Tree

--- a/Makefile
+++ b/Makefile
@@ -688,6 +688,95 @@ stop-test-server:
 test-ui-critical:
 	./scripts/test-ui-critical.sh
 
+## Run all sample UI tests
+#
+# Runs UI tests for all sample apps with UI test suites.
+.PHONY: test-samples-ui
+test-samples-ui: \
+	test-sample-iOS-Swift-ui \
+	test-sample-iOS-SwiftUI-ui \
+	test-sample-iOS-Swift6-ui \
+	test-sample-iOS-ObjectiveC-ui \
+	test-sample-macOS-Swift-ui \
+	test-sample-tvOS-Swift-ui
+
+## Run iOS-Swift sample UI tests
+#
+# Generates the iOS-Swift project and runs its UI tests.
+.PHONY: test-sample-iOS-Swift-ui
+test-sample-iOS-Swift-ui: xcode-ci-iOS-Swift
+	@echo "--> Running iOS-Swift UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme iOS-Swift \
+		-testPlan iOS-Swift_Base \
+		-destination 'platform=iOS Simulator,OS=$(IOS_SIMULATOR_OS),name=$(IOS_DEVICE_NAME)' \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
+## Run iOS-SwiftUI sample UI tests
+#
+# Generates the iOS-SwiftUI project and runs its UI tests.
+.PHONY: test-sample-iOS-SwiftUI-ui
+test-sample-iOS-SwiftUI-ui: xcode-ci-iOS-SwiftUI
+	@echo "--> Running iOS-SwiftUI UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme iOS-SwiftUI \
+		-testPlan iOS-SwiftUI_Base \
+		-destination 'platform=iOS Simulator,OS=$(IOS_SIMULATOR_OS),name=$(IOS_DEVICE_NAME)' \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
+## Run iOS-Swift6 sample UI tests
+#
+# Generates the iOS-Swift6 project and runs its UI tests.
+.PHONY: test-sample-iOS-Swift6-ui
+test-sample-iOS-Swift6-ui: xcode-ci-iOS-Swift6
+	@echo "--> Running iOS-Swift6 UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme iOS-Swift6 \
+		-testPlan iOS-Swift6_Base \
+		-destination 'platform=iOS Simulator,OS=$(IOS_SIMULATOR_OS),name=$(IOS_DEVICE_NAME)' \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
+## Run iOS-ObjectiveC sample UI tests
+#
+# Generates the iOS-ObjectiveC project and runs its UI tests.
+.PHONY: test-sample-iOS-ObjectiveC-ui
+test-sample-iOS-ObjectiveC-ui: xcode-ci-iOS-ObjectiveC
+	@echo "--> Running iOS-ObjectiveC UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme iOS-ObjectiveC \
+		-testPlan iOS-ObjectiveC_Base \
+		-destination 'platform=iOS Simulator,OS=$(IOS_SIMULATOR_OS),name=$(IOS_DEVICE_NAME)' \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
+## Run macOS-Swift sample UI tests
+#
+# Generates the macOS-Swift project and runs its UI tests.
+.PHONY: test-sample-macOS-Swift-ui
+test-sample-macOS-Swift-ui: xcode-ci-macOS-Swift
+	@echo "--> Running macOS-Swift UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme macOS-Swift \
+		-testPlan macOS-Swift_Base \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
+## Run tvOS-Swift sample UI tests
+#
+# Generates the tvOS-Swift project and runs its UI tests.
+.PHONY: test-sample-tvOS-Swift-ui
+test-sample-tvOS-Swift-ui: xcode-ci-tvOS-Swift
+	@echo "--> Running tvOS-Swift UI tests"
+	set -o pipefail && xcodebuild test \
+		-workspace Sentry.xcworkspace \
+		-scheme tvOS-Swift \
+		-testPlan tvOS-Swift_Base \
+		-destination 'platform=tvOS Simulator,OS=$(TVOS_SIMULATOR_OS),name=$(TVOS_DEVICE_NAME)' \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+
 # ============================================================================
 # LINTING & FORMATTING
 # ============================================================================

--- a/Samples/AGENTS.md
+++ b/Samples/AGENTS.md
@@ -23,20 +23,50 @@ Follow assertion conventions in [`Tests/AGENTS.md`](../Tests/AGENTS.md) — see 
 **CRITICAL**: ALWAYS use the Makefile to regenerate sample projects. Never run `xcodegen` directly.
 
 ```bash
-# Regenerate and build a specific sample
-make build-sample-iOS-Swift
+# Regenerate a specific project (without building)
+make xcode-ci-iOS-Swift
 
 # Regenerate all Xcode projects
 make xcode-ci
+
+# Regenerate AND build a specific sample
+make build-sample-iOS-Swift
 ```
 
 Rationale: The Makefile ensures correct build order and dependencies (e.g., SentrySampleShared must be generated before iOS-Swift).
 
+## Sample Workflow
+
+For each sample app, you can:
+
+1. **Generate** — Create/update Xcode project from `.yml` spec
+2. **Build** — Compile the sample app
+3. **Test** — Run UI tests (for samples with UI test suites)
+
 ## Commands
 
-| Command                    | Description                               |
-| -------------------------- | ----------------------------------------- |
-| `make build-samples`       | Build all sample apps                     |
-| `make build-sample-<name>` | Build specific sample (e.g., `iOS-Swift`) |
-| `make xcode-ci`            | Regenerate all Xcode projects             |
-| `make xcode-ci-<name>`     | Regenerate specific project (e.g., `SPM`) |
+| Command                         | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| **Generate (Project Creation)** |                                                        |
+| `make xcode-ci`                 | Regenerate all Xcode projects                          |
+| `make xcode-ci-<name>`          | Regenerate specific project (e.g., `xcode-ci-SPM`)     |
+| **Build**                       |                                                        |
+| `make build-samples`            | Build all sample apps                                  |
+| `make build-sample-<name>`      | Build specific sample (e.g., `build-sample-iOS-Swift`) |
+| **Test (UI Tests)**             |                                                        |
+| `make test-samples-ui`          | Run all sample UI tests                                |
+| `make test-sample-<name>-ui`    | Run specific sample UI tests (e.g., `iOS-Swift-ui`)    |
+| `make test-ui-critical`         | Run critical UI test suites for validation             |
+
+## Samples with UI Tests
+
+The following samples have UI test suites:
+
+- `iOS-Swift` — Comprehensive UI tests for iOS Swift sample
+- `iOS-SwiftUI` — SwiftUI-specific UI tests including feedback
+- `iOS-Swift6` — Swift 6 compatibility tests
+- `iOS-ObjectiveC` — Objective-C UI tests
+- `macOS-Swift` — macOS app UI tests
+- `tvOS-Swift` — tvOS app UI tests
+
+Each UI test target follows the naming pattern `<SampleName>-UITests` and references a test plan at `Plans/<SampleName>_Base.xctestplan`.


### PR DESCRIPTION
Add comprehensive UI test support for sample apps through new Makefile targets.

This PR introduces seven new test targets that enable running UI tests for sample apps:

- `test-samples-ui` — Runs all sample UI tests
- `test-sample-iOS-Swift-ui` — iOS Swift sample UI tests
- `test-sample-iOS-SwiftUI-ui` — iOS SwiftUI sample UI tests
- `test-sample-iOS-Swift6-ui` — iOS Swift 6 sample UI tests
- `test-sample-iOS-ObjectiveC-ui` — iOS Objective-C sample UI tests
- `test-sample-macOS-Swift-ui` — macOS Swift sample UI tests
- `test-sample-tvOS-Swift-ui` — tvOS Swift sample UI tests

Each target automatically generates the project (via xcodegen) before running tests, ensuring the test environment is always up to date.

Documentation updates:
- `Samples/AGENTS.md` now explains the three-phase workflow: Generate → Build → Test
- Added a table listing all samples with UI test suites
- Updated `AGENTS.md` verification loop to include sample UI testing

This makes it easier to validate sample apps during development and CI.

Closes #7690

#skip-changelog