### PR TITLE
fix(ci): Use default token for auto-update-tools on pull requests

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -63,6 +63,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app_token
+        if: github.event_name != 'pull_request'
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
           app-id: ${{ vars.SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_ID }}
@@ -71,7 +72,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ steps.app_token.outputs.token }}
+          token: ${{ github.event_name != 'pull_request' && steps.app_token.outputs.token || github.token }}
       - name: Update Homebrew
         run: brew update
 


### PR DESCRIPTION
Fixes the auto-update-tools workflow failing on pull requests when it tries to access the GitHub App private key secret.

## Problem

The workflow was failing with `[@octokit/auth-app] privateKey option is required` error when running on pull requests, particularly Dependabot PRs. This happened because:

1. The "Generate GitHub App Token" step ran for all events including pull requests
2. The secret `SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_PRIVATE_KEY` is not available in the pull request context
3. Without the secret, the token generation step failed

## Solution

- Only generate the GitHub App token for `schedule` and `workflow_dispatch` events (when we need to create PRs)
- For `pull_request` events, use the default `GITHUB_TOKEN` instead (sufficient for validation-only runs)
- The checkout step now conditionally selects the appropriate token based on the event type

This allows the workflow to:
- Continue using the GitHub App token for scheduled runs (needed for creating PRs)
- Use the standard token for PR validation runs (which don't create new PRs)

Fixes #7696

#skip-changelog