### PR TITLE
chore(ci): Bumps the getsentry/action-app-sdk-overhead-metrics action to version ecce2e27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect app metrics
         if: needs.files-changed.outputs.is_dependabot != 'true'
-        uses: getsentry/action-app-sdk-overhead-metrics@5f2d99b8e5a7b833386524924d24320501099a44
+        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
         with:
           config: Tests/Perf/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
## :scroll: Description

Bumps getsentry/action-app-sdk-overhead-metrics to use the latest version with `latest` instead of `stable` version of Appium

## :bulb: Motivation and Context

SauceLabs no longer offers a `stable` version, so we are updating to use `latest`: https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-versions/#end-of-life

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.


Closes #7707