### PR TITLE
test: verify replay restarts after background session expiry

### DIFF
--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -186,6 +186,34 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         SentrySDKInternal.currentHub().startSession()
         XCTAssertFalse(oldSessionReplay?.isRunning ?? true)
     }
+
+    func testNewReplayStartsAfterBackgroundSessionExpiry() throws {
+        // -- Arrange --
+        startSDK(sessionSampleRate: 1, errorSampleRate: 0)
+        let sut = try getSut()
+
+        let oldReplay = try XCTUnwrap(sut.sessionReplay)
+        let oldReplayId = try XCTUnwrap(oldReplay.sessionReplayId)
+        XCTAssertTrue(oldReplay.isRunning)
+
+        // -- Act --
+        // Simulate background → session expiry → foreground, matching
+        // the sequence SessionTracker triggers when background time
+        // exceeds sessionTrackingIntervalMillis.
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        XCTAssertFalse(oldReplay.isRunning)
+
+        let hub = SentrySDKInternal.currentHub()
+        hub.endSession()
+        hub.startSession()
+
+        // -- Assert --
+        let newReplay = try XCTUnwrap(sut.sessionReplay)
+        let newReplayId = try XCTUnwrap(newReplay.sessionReplayId)
+        XCTAssertTrue(newReplay.isRunning)
+        XCTAssertNotEqual(oldReplayId, newReplayId)
+        XCTAssertFalse(oldReplay.isRunning)
+    }
     
     func testScreenNameFromSentryUIApplication() throws {
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## :scroll: Description

Adds a test that verifies session replay correctly restarts when the app returns to foreground after the session has expired due to background time exceeding `sessionTrackingIntervalMillis`.

**Investigation results:** The existing code already handles this scenario correctly through the `SentrySessionListener` protocol:

1. When the app backgrounds, `SentrySessionReplayIntegration` pauses the replay via `didEnterBackgroundNotification`
2. When the app returns to foreground, `SessionTracker.didBecomeActive()` detects background time > `sessionTrackingIntervalMillis` and calls `hub.endSession()` then `hub.startSession()`
3. `sentrySessionEnded()` tears down the old replay (pause, remove observers, nil out)
4. `sentrySessionStarted()` starts a new replay (re-samples, creates new `SentrySessionReplay`, starts display link, re-adds observers)

The new replay gets a fresh `SentryId` and begins recording independently.

## :bulb: Motivation and Context

Addresses the question from #7979: "with replay enabled when in background for more than session interval millis then the session replay is terminated, when I return back to foreground, will a new session replay start?"

The answer is **yes** — the code correctly handles this. This PR adds a test to codify and verify this behavior, since no existing test covered the full background → session expiry → foreground → new replay lifecycle.

## :green_heart: How did you test it?

Added `testNewReplayStartsAfterBackgroundSessionExpiry` which:
- Starts SDK with session replay at 100% sample rate
- Captures the initial replay instance and its ID
- Posts `didEnterBackgroundNotification` and verifies the replay pauses
- Calls `hub.endSession()` and `hub.startSession()` (matching `SessionTracker` behavior on session expiry)
- Verifies a new replay is running with a different replay ID
- Verifies the old replay is stopped

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e9eed0f-f0e1-48c3-bb9d-72260cdd3495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e9eed0f-f0e1-48c3-bb9d-72260cdd3495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

