### PR TITLE
fix(ios): Report ObjC exceptions that bypass NSSetUncaughtExceptionHandler

### DIFF
--- a/Samples/iOS-Swift/App/Sources/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/App/Sources/ErrorsViewController.swift
@@ -88,11 +88,11 @@ class ErrorsViewController: UIViewController {
 
     @IBAction func captureNSException(_ sender: UIButton) {
         highlightButton(sender)
-        let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
-        let scope = Scope()
-        scope.setLevel(.fatal)
-        // !!!: By explicity just passing the scope, only the data in this scope object will be added to the event; the global scope (calls to configureScope) will be ignored. If you do that, be careful–a lot of useful info is lost. If you just want to mutate what's in the scope use the callback, see: captureError.
-        SentrySDK.capture(exception: exception, scope: scope)
+        // Repro: NSException inside dispatch callout bypasses NSSetUncaughtExceptionHandler.
+        DispatchQueue.main.async {
+            let array = NSArray()
+            array.object(at: 42)
+        }
     }
 
     @IBAction func captureFatalError(_ sender: UIButton) {

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		63FE70DF20DA4C1000CDBAE8 /* SentryCrashMonitorType.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE6FF520DA4C1000CDBAE8 /* SentryCrashMonitorType.c */; };
 		63FE70E120DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 63FE6FF620DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.cpp */; };
 		63FE70E520DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE6FF820DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h */; };
+		D100000100000001000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = D100000200000002000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.h */; };
+		D100000300000003000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.mm in Sources */ = {isa = PBXBuildFile; fileRef = D100000400000004000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.mm */; };
 		63FE70E720DA4C1000CDBAE8 /* SentryCrashMonitor.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE6FF920DA4C1000CDBAE8 /* SentryCrashMonitor.c */; };
 		63FE70EB20DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE6FFB20DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.h */; };
 		63FE70ED20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE6FFC20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h */; };
@@ -741,6 +743,8 @@
 		63FE6FF520DA4C1000CDBAE8 /* SentryCrashMonitorType.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashMonitorType.c; sourceTree = "<group>"; };
 		63FE6FF620DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SentryCrashMonitor_CPPException.cpp; sourceTree = "<group>"; };
 		63FE6FF820DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryCrashMonitor_CPPException.h; path = ../../../Sentry/include/SentryCrashMonitor_CPPException.h; sourceTree = "<group>"; };
+		D100000200000002000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryCrashMonitor_CPPException_ObjCHelper.h; sourceTree = "<group>"; };
+		D100000400000004000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryCrashMonitor_CPPException_ObjCHelper.mm; sourceTree = "<group>"; };
 		63FE6FF920DA4C1000CDBAE8 /* SentryCrashMonitor.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashMonitor.c; sourceTree = "<group>"; };
 		63FE6FFB20DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashMonitor_MachException.h; sourceTree = "<group>"; };
 		63FE6FFC20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashMonitor_NSException.h; sourceTree = "<group>"; };
@@ -1673,6 +1677,8 @@
 				63FE6FFD20DA4C1000CDBAE8 /* SentryCrashMonitor_AppState.h */,
 				63FE6FF620DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.cpp */,
 				63FE6FF820DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h */,
+				D100000200000002000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.h */,
+				D100000400000004000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.mm */,
 				63FE6FF120DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.c */,
 				63FE6FFB20DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.h */,
 				63FE6FFC20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h */,
@@ -2475,6 +2481,7 @@
 				D8853C842833EABC00700D64 /* SentryANRTrackerV1.h in Headers */,
 				63FE715B20DA4C1100CDBAE8 /* SentryCrashSignalInfo.h in Headers */,
 				63FE70E520DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h in Headers */,
+				D100000100000001000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.h in Headers */,
 				7D9B07A023D1E89900C5FC8E /* SentryMeta.h in Headers */,
 				7B4E375525822C4500059C93 /* SentryAttachment.h in Headers */,
 				63FE716F20DA4C1100CDBAE8 /* SentryCrashCPU_Apple.h in Headers */,
@@ -2945,6 +2952,7 @@
 				7BE912AD272162D900E49E62 /* SentryNoOpSpan.m in Sources */,
 				63FE710D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c in Sources */,
 				63FE70E120DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.cpp in Sources */,
+				D100000300000003000000D1 /* SentryCrashMonitor_CPPException_ObjCHelper.mm in Sources */,
 				84A305582BC9EF8C00D84283 /* SentryTraceProfiler.mm in Sources */,
 				7D082B8323C628790029866B /* SentryMeta.m in Sources */,
 				63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m in Sources */,

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -29,6 +29,7 @@
 #include "SentryCrashID.h"
 #include "SentryCrashMachineContext.h"
 #include "SentryCrashMonitorContext.h"
+#include "SentryCrashMonitor_CPPException_ObjCHelper.h"
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
@@ -216,12 +217,42 @@ CPPExceptionTerminate(void)
         isObjCExc = isObjCException(tinfo);
     }
 
-    if (!isObjCExc) {
-        thread_act_array_t threads = NULL;
-        mach_msg_type_number_t numThreads = 0;
-        // The cxa_throw hook reenters only from other threads. Edge case:
-        // throwing from within cxa_throw itself, which is less defined
-        // than raising a signal from a signal handler.
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+
+    if (isObjCExc) {
+        SENTRY_ASYNC_SAFE_LOG_DEBUG("Handling ObjC exception in C++ terminate handler.");
+
+        sentrycrashcm_notifyFatalException(false, &threads, &numThreads);
+
+        SentryCrash_MonitorContext *crashContext = &g_monitorContext;
+        memset(crashContext, 0, sizeof(*crashContext));
+
+        const char *excName = NULL;
+        const char *excReason = NULL;
+        SentryCrashStackCursor exceptionCursor;
+        uintptr_t *callstack
+            = sentrycrashcm_extractCurrentObjCException(&excName, &excReason, &exceptionCursor);
+
+        SentryCrashMC_NEW_CONTEXT(machineContext);
+        sentrycrashmc_getContextForThread(sentrycrashthread_self(), machineContext, true);
+
+        crashContext->crashType = SentryCrashMonitorTypeNSException;
+        crashContext->eventID = g_eventID;
+        crashContext->registersAreValid = false;
+        crashContext->stackCursor = &exceptionCursor;
+        crashContext->NSException.name = excName;
+        crashContext->exceptionName = excName;
+        crashContext->crashReason = excReason;
+        crashContext->offendingMachineContext = machineContext;
+
+        sentrycrashcm_handleException(crashContext);
+
+        if (callstack != NULL) {
+            free(callstack);
+        }
+        sentrycrashmc_resumeEnvironment(threads, numThreads);
+    } else {
         sentrycrashcm_notifyFatalException(false, &threads, &numThreads);
 
         SentryCrash_MonitorContext *crashContext = &g_monitorContext;
@@ -299,9 +330,6 @@ CPPExceptionTerminate(void)
 
         sentrycrashcm_handleException(crashContext);
         sentrycrashmc_resumeEnvironment(threads, numThreads);
-    } else {
-        SENTRY_ASYNC_SAFE_LOG_DEBUG("Detected ObjC exception. Letting the current "
-                                    "NSException handler deal with it.");
     }
 
     sentrycrashcm_cppexception_callOriginalTerminationHandler();

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException_ObjCHelper.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException_ObjCHelper.h
@@ -1,0 +1,27 @@
+#ifndef HDR_SentryCrashMonitor_CPPException_ObjCHelper_h
+#define HDR_SentryCrashMonitor_CPPException_ObjCHelper_h
+
+#include "SentryCrashStackCursor.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Extract NSException info from the current in-flight C++ exception.
+ *
+ * Must be called while an ObjC exception is active in the C++ terminate handler.
+ *
+ * @param outName On success, points to the UTF8 name. Valid until the exception is destroyed.
+ * @param outReason On success, points to the UTF8 reason. Valid until the exception is destroyed.
+ * @param outCursor On success, initialized with the exception's callStackReturnAddresses.
+ * @return Allocated callstack array (caller must free), or NULL.
+ */
+uintptr_t *sentrycrashcm_extractCurrentObjCException(
+    const char **outName, const char **outReason, SentryCrashStackCursor *outCursor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HDR_SentryCrashMonitor_CPPException_ObjCHelper_h

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException_ObjCHelper.mm
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException_ObjCHelper.mm
@@ -1,0 +1,45 @@
+#import "SentryCrashMonitor_CPPException_ObjCHelper.h"
+#import "SentryCrashStackCursor_Backtrace.h"
+#import "SentryCrashStackCursor_SelfThread.h"
+
+#import "SentryLogC.h"
+
+#import <Foundation/Foundation.h>
+#include <exception>
+
+uintptr_t *
+sentrycrashcm_extractCurrentObjCException(
+    const char **outName, const char **outReason, SentryCrashStackCursor *outCursor)
+{
+    *outName = NULL;
+    *outReason = NULL;
+
+    @try {
+        throw;
+    } @catch (NSException *exception) {
+        *outName = exception.name.UTF8String;
+        *outReason = exception.reason.UTF8String;
+
+        NSArray<NSNumber *> *addresses = exception.callStackReturnAddresses;
+        NSUInteger numFrames = addresses.count;
+
+        if (numFrames == 0) {
+            sentrycrashsc_initSelfThread(outCursor, 0);
+            return NULL;
+        }
+
+        uintptr_t *callstack = (uintptr_t *)malloc(numFrames * sizeof(*callstack));
+        if (callstack == NULL) {
+            sentrycrashsc_initSelfThread(outCursor, 0);
+            return NULL;
+        }
+
+        for (NSUInteger i = 0; i < numFrames; i++) {
+            callstack[i] = (uintptr_t)addresses[i].unsignedLongLongValue;
+        }
+        sentrycrashsc_initWithBacktrace(outCursor, callstack, (int)numFrames, 0);
+        return callstack;
+    } @catch (id exception) {
+        return NULL;
+    }
+}

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_CppException_Tests.mm
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_CppException_Tests.mm
@@ -45,6 +45,7 @@ mockTerminationHandler(void)
     }
     sentrycrashcm_setEventCallback(NULL);
     capturedExceptionContextCrashReason = NULL;
+    capturedExceptionName = NULL;
     capturedCrashType = (SentryCrashMonitorType)0;
 }
 
@@ -124,6 +125,8 @@ mockTerminationHandler(void)
         stackCursor.stackEntry.address, (uintptr_t)0, "Stack trace should NOT be captured.");
 }
 
+NSString *capturedExceptionName;
+
 void
 mockHandleExceptionHandler(struct SentryCrash_MonitorContext *context)
 {
@@ -134,6 +137,9 @@ mockHandleExceptionHandler(struct SentryCrash_MonitorContext *context)
     capturedCrashType = context->crashType;
     if (context->crashReason) {
         capturedExceptionContextCrashReason = [NSString stringWithUTF8String:context->crashReason];
+    }
+    if (context->NSException.name) {
+        capturedExceptionName = [NSString stringWithUTF8String:context->NSException.name];
     }
 }
 
@@ -158,27 +164,43 @@ mockHandleExceptionHandler(struct SentryCrash_MonitorContext *context)
         stackCursor.stackEntry.address, (uintptr_t)0, "Stack trace should NOT be captured.");
 }
 
-- (void)testTerminateWithNSExceptionSubclass_NotHandledByCppHandler
+- (void)testTerminateWithNSExceptionSubclass_HandledAsNSException
 {
-    // Arrange
-    std::set_terminate(&mockTerminationHandler);
     sentrycrashcm_setEventCallback(mockHandleExceptionHandler);
     api->setEnabled(true);
 
-    // Act
     @try {
         [[SentryTestNSExceptionSubclass exceptionWithName:@"TestException"
-                                                   reason:@"Test"
+                                                   reason:@"Test reason"
                                                  userInfo:nil] raise];
     } @catch (...) {
         std::get_terminate()();
     }
 
+    XCTAssertEqual(capturedCrashType, SentryCrashMonitorTypeNSException);
+    XCTAssertEqualObjects(capturedExceptionName, @"TestException");
+    XCTAssertEqualObjects(capturedExceptionContextCrashReason, @"Test reason");
+}
+
+- (void)testTerminateWithNSException_HandledAsNSException
+{
+    // Arrange
+    sentrycrashcm_setEventCallback(mockHandleExceptionHandler);
+    api->setEnabled(true);
+
+    // Act
+    @try {
+        [NSException raise:NSRangeException format:@"index 0 beyond bounds for empty NSArray"];
+    } @catch (...) {
+        std::get_terminate()();
+    }
+
     // Assert
-    XCTAssertTrue(
-        terminateCalled, "Original terminate handler should be called for ObjC exceptions.");
-    XCTAssertNotEqual(capturedCrashType, SentryCrashMonitorTypeCPPException,
-        "NSException subclass should NOT be handled by C++ exception handler.");
+    XCTAssertEqual(capturedCrashType, SentryCrashMonitorTypeNSException,
+        "NSException in terminate handler should be reported as NSException.");
+    XCTAssertEqualObjects(capturedExceptionName, @"NSRangeException");
+    XCTAssertTrue([capturedExceptionContextCrashReason containsString:@"index 0 beyond bounds"],
+        @"Should capture the NSException reason. Got: %@", capturedExceptionContextCrashReason);
 }
 
 - (void)testCallHandler_shouldCaptureExceptionDescription


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

On iOS, ObjC exceptions inside dispatch callouts bypass NSSetUncaughtExceptionHandler and reach CPPExceptionTerminate via objc_terminate → std::terminate. Previously we skipped these, and the crash became SIGABRT with garbage notable addresses. Now we extract the NSException info and report it before forwarding to the original terminate handler.

The ObjC helper calls NSException properties which aren't async-signal-safe. This is more of a POC, needs review of what's safe in the terminate handler context and if this is even feasible at all.

Relates to #1562

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
