### PR TITLE
chore: bump action-app-sdk-overhead-metrics SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect app metrics
         if: needs.files-changed.outputs.is_dependabot != 'true'
-        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
+        uses: getsentry/action-app-sdk-overhead-metrics@44fb5489ac4ac252c87d84811972dc93a1e490b8
         with:
           config: Tests/Perf/metrics-test.yml
           sauce-user: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
## Description

Bump `getsentry/action-app-sdk-overhead-metrics` to `44fb5489ac4ac252c87d84811972dc93a1e490b8`.

See: https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/30

#skip-changelog

Closes #7740