### PR TITLE
fix(ci): Scope GitHub App token to repository

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -69,6 +69,7 @@ jobs:
           app-id: ${{ vars.SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_ID }}
           private-key: ${{ secrets.SENTRY_DEPENDENCY_UPDATER_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Scope the GitHub App token in the auto-update-tools workflow to this
specific repository by adding the `repositories` parameter.

The workflow was failing with `Resource not accessible by integration`
when `peter-evans/create-pull-request` tried to create git blobs via
the REST API (needed for `sign-commits: true`). An org-scoped token
(no `repositories` parameter) doesn't always grant `contents: write`
to the blob endpoint, even when the app installation has that permission.

#skip-changelog

Closes #7742