### PR TITLE
chore: Bump validate-pr action to include sentry-mobile-updater allowlist

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@4ff40ada546d4a31b852a4279828b989a6193497
+      - uses: getsentry/github-workflows/validate-pr@f5db9d2c95b51d068edc78871970c10e0ff09b56
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps the validate-pr action SHA to pick up getsentry/github-workflows#156,
which adds `sentry-mobile-updater[bot]` to the trusted bot allowlist.

#skip-changelog

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>