### PR TITLE
fix: add Package@swift-6.1.swift for Xcode 26 compatibility

### DIFF
--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,0 +1,81 @@
+// swift-tools-version:6.1
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
+import PackageDescription
+
+let products: [Product] = [
+    .library(name: "Sentry", targets: ["Sentry", "SentryCppHelper"]),
+    .library(name: "Sentry-Dynamic", targets: ["Sentry-Dynamic"]),
+    .library(name: "Sentry-Dynamic-WithARM64e", targets: ["Sentry-Dynamic-WithARM64e"]),
+    .library(name: "Sentry-WithoutUIKitOrAppKit", targets: ["Sentry-WithoutUIKitOrAppKit", "SentryCppHelper"]),
+    .library(name: "Sentry-WithoutUIKitOrAppKit-WithARM64e", targets: ["Sentry-WithoutUIKitOrAppKit-WithARM64e", "SentryCppHelper"]),
+    .library(name: "SentrySwiftUI", targets: ["Sentry", "SentrySwiftUI", "SentryCppHelper"])
+]
+
+let targets: [Target] = [
+    .binaryTarget(
+        name: "Sentry",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.58.0/Sentry.xcframework.zip",
+        checksum: "d883f19575ab064633237c2c58ee16a1e596c58f5efe1c110f65998bc71b0389"
+    ),
+    .binaryTarget(
+        name: "Sentry-Dynamic",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.58.0/Sentry-Dynamic.xcframework.zip",
+        checksum: "07d2a8a928bf49d44ed498a4a994d736d3e9e44667e5c5082dba0d6be526b339"
+    ),
+    .binaryTarget(
+        name: "Sentry-Dynamic-WithARM64e",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.58.0/Sentry-Dynamic-WithARM64e.xcframework.zip",
+        checksum: "2f13dc949fb3f795222f7420aca649b32f365137d27cc13311e2e59eeb902691"
+    ),
+    .binaryTarget(
+        name: "Sentry-WithoutUIKitOrAppKit",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.58.0/Sentry-WithoutUIKitOrAppKit.xcframework.zip",
+        checksum: "d6e65593d9538db22d318afda5828889d3eacd1aa89957a37fe81725ec91141e"
+    ),
+    .binaryTarget(
+        name: "Sentry-WithoutUIKitOrAppKit-WithARM64e",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.58.0/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip",
+        checksum: "93377c7cb7a020c5bab375ca32bd26f954e54dcb1b21860b9c6dff0f3476413e"
+    ),
+    .target(
+        name: "SentrySwiftUI",
+        dependencies: ["Sentry", "SentryInternal"],
+        path: "Sources/SentrySwiftUI",
+        exclude: ["SentryInternal/", "module.modulemap"],
+        linkerSettings: [
+            .linkedFramework("Sentry")
+        ]),
+    .target(
+        name: "SentryInternal",
+        path: "Sources/SentrySwiftUI",
+        sources: [
+            "SentryInternal/"
+        ],
+        publicHeadersPath: "SentryInternal/"),
+    .target(
+        name: "SentryCppHelper",
+        path: "Sources/SentryCppHelper",
+        linkerSettings: [
+            .linkedLibrary("c++")
+        ]
+    )
+]
+
+let package = Package(
+    name: "Sentry",
+    platforms: [.iOS(.v12), .macOS(.v10_13), .tvOS(.v12), .watchOS(.v4)],
+    products: products,
+    traits: [
+        .default(enabledTraits: [])
+    ],
+    targets: targets,
+    swiftLanguageModes: [.v5],
+    cxxLanguageStandard: .cxx14
+)


### PR DESCRIPTION
## Problem

Xcode 26 (Swift 6.1) enforces [SE-0450 Package Traits](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md). When resolving SPM packages, it uses the version-specific manifest `Package@swift-6.1.swift` if available, and rejects packages that declare no traits with the error:

```
Disabled default traits on package 'sentry-cocoa' (Sentry) that declares no traits.
This is prohibited to allow packages to adopt traits initially without causing an API break.
```

This affects all users of sentry-cocoa 8.x on Xcode 26.

## Solution

Add `Package@swift-6.1.swift` — a version-specific manifest that SPM uses when the Swift 6.1 compiler is active (Xcode 26). This is the same approach used on the `main` branch for 9.x.

The manifest:
- Uses `swift-tools-version:6.1` (required for `traits` parameter)
- Declares `traits: [.default(enabledTraits: [])]` (satisfies SE-0450)
- Adds `swiftLanguageModes: [.v5]` (maintains Swift 5 compatibility)
- Points to the same 8.58.0 xcframework binaries (no SDK change)

The original `Package.swift` (swift-tools-version:5.3) is untouched and continues to work with older Xcode versions.

## Verification

Tested on macOS 26 + Xcode 26 (Swift 6.1):
- `swift package dump-package` ✅
- SPM resolution in Xcode 26 ✅ (no traits error)

Fixes: getsentry/sentry-kotlin-multiplatform#535