### PR TITLE
test: Remove attachAllThreads from undocumented options list

### DIFF
--- a/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
+++ b/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
@@ -38,9 +38,7 @@ final class SentryOptionsDocumentationSyncTests: XCTestCase {
         options.insert("profiling") // @_spi(Private) - internal backing for configureProfiling
         options.insert("configureProfiling")
         #endif
-        
-        options.insert("attachAllThreads") // SDK not released yet
-        
+
         return options
     }
 


### PR DESCRIPTION
## Description

Remove `attachAllThreads` from the `undocumentedOptions` set in `SentryOptionsDocumentationSyncTests` since the option is now documented in sentry-docs.

## Motivation and Context

The `attachAllThreads` option (added in 9.9.0) was marked as undocumented with the comment "SDK not released yet". Now that 9.9.0 is released and the docs PR is up, this option should be validated by the sync test.

## How did you test it?

The `SentryOptionsDocumentationSyncTests` will now validate that `attachAllThreads` is documented.

## Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog