### PR TITLE
fix: Normalize profiling cpu usage to percent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- fix: Normalize profiling cpu usage to percent (#7798)
+- Normalize profiling cpu usage to percent (#7798)
 - Detect development builds via provisioning profile and debugger attachment (#7702)
 
 ## 9.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix: Normalize profiling cpu usage to percent (#7798)
+
 ## 9.10.0
 
 ### Features

--- a/Sources/Sentry/SentrySystemWrapper.mm
+++ b/Sources/Sentry/SentrySystemWrapper.mm
@@ -6,6 +6,10 @@
 #    import <mach/mach.h>
 #    include <thread>
 
+@interface SentrySystemWrapper ()
++ (float)normalizeCPUUsage:(integer_t)threadCPUUsage processorCount:(long)processorCount;
+@end
+
 @implementation SentrySystemWrapper {
     float processorCount;
 }
@@ -42,6 +46,11 @@
     return footprintBytes;
 }
 
++ (float)normalizeCPUUsage:(integer_t)threadCPUUsage processorCount:(long)processorCount
+{
+    return (static_cast<float>(threadCPUUsage) / TH_USAGE_SCALE) * 100.f / processorCount;
+}
+
 - (NSNumber *)cpuUsageWithError:(NSError **)error
 {
     mach_msg_type_number_t count;
@@ -76,7 +85,8 @@
             return nil;
         }
 
-        usage += data.cpu_usage / processorCount;
+        usage += [SentrySystemWrapper normalizeCPUUsage:data.cpu_usage
+                                         processorCount:static_cast<long>(processorCount)];
     }
 
     vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count);

--- a/Sources/Sentry/include/SentrySystemWrapper.h
+++ b/Sources/Sentry/include/SentrySystemWrapper.h
@@ -23,11 +23,18 @@ typedef mach_vm_size_t SentryRAMBytes;
 - (SentryRAMBytes)memoryFootprintBytes:(NSError **)error;
 
 /**
- * @return The CPU usage per core, where the order of results corresponds to the core number as
- * returned by the underlying system call, e.g. @c @[ @c <core-0-CPU-usage>, @c <core-1-CPU-usage>,
- * @c ...] .
+ * @return The CPU usage of this process as a percentage of the device's total CPU capacity,
+ * normalized to a range from @c 0.0 to @c 100.0.
  */
 - (nullable NSNumber *)cpuUsageWithError:(NSError **)error;
+
+#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+/**
+ * Test-only helper that normalizes a thread CPU usage value returned by Mach to the
+ * process's percentage of the device's total CPU capacity.
+ */
++ (float)normalizeCPUUsage:(integer_t)threadCPUUsage processorCount:(long)processorCount;
+#    endif
 
 // Only some architectures support reading energy.
 #    if defined(__arm__) || defined(__arm64__)

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 
 #if os(iOS) || os(macOS)
@@ -7,11 +8,16 @@ class SentrySystemWrapperTests: XCTestCase {
     }
     lazy private var fixture = Fixture()
 
-    func testCPUUsageReportsData() throws {
-        XCTAssertNoThrow({
-            let cpuUsage = try XCTUnwrap(self.fixture.systemWrapper.cpuUsage())
-            XCTAssertTrue((0.0 ... 100.0).contains(cpuUsage.doubleValue))
-        })
+    func testCPUUsage_whenIdle_shouldReportNormalizedPercent() throws {
+        let cpuUsage = try XCTUnwrap(fixture.systemWrapper.cpuUsage())
+
+        XCTAssertTrue((0.0 ... 100.0).contains(cpuUsage.doubleValue))
+    }
+
+    func testNormalizeCPUUsage_shouldConvertMachScaleToPercentOfTotalCapacity() {
+        XCTAssertEqual(SentrySystemWrapper.normalizeCPUUsage(1_000, processorCount: 4), 25.0, accuracy: 0.001)
+        XCTAssertEqual(SentrySystemWrapper.normalizeCPUUsage(500, processorCount: 8), 6.25, accuracy: 0.001)
+        XCTAssertEqual(SentrySystemWrapper.normalizeCPUUsage(1_000, processorCount: 10), 10.0, accuracy: 0.001)
     }
 
     func testMemoryFootprint() {


### PR DESCRIPTION
## :scroll: Description

Fix SentrySystemWrapper CPU usage calculation by dividing Mach thread cpu_usage by TH_USAGE_SCALE, then normalizing by processor count and converting to 0..100 percent. Updates docs and adds test for the normalization logic.

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #7456

## :green_heart: How did you test it?

Unit Tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
