### PR TITLE
fix: SPM manifest compilation on Swift 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `Package@swift-6.1.swift` SPM manifest compilation on Swift 6.1 / Xcode 26 (#7800)
+
 ## 8.58.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix `Package@swift-6.1.swift` SPM manifest compilation on Swift 6.1 / Xcode 26 (#7800, #7819)
+- Fix `Package@swift-6.1.swift` SPM manifest compilation on Swift 6.1 / Xcode 26 (#7800)
 
 ## 8.58.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix `Package@swift-6.1.swift` SPM manifest compilation on Swift 6.1 / Xcode 26 (#7800)
+- Fix `Package@swift-6.1.swift` SPM manifest compilation on Swift 6.1 / Xcode 26 (#7800, #7819)
 
 ## 8.58.1
 

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -69,7 +69,7 @@ var targets: [Target] = [
 ]
 
 let env = getenv("EXPERIMENTAL_SPM_BUILDS")
-if let env = env, String(cString: env, encoding: .utf8) == "1" {
+if let env = env, String(cString: env) == "1" {
     products.append(.library(name: "SentrySPM", type: .dynamic, targets: ["SentryObjc"]))
     targets.append(contentsOf: [
         // At least one source file is required, therefore we use a dummy class to satisfy the SPM build system


### PR DESCRIPTION
## :scroll: Description

Remove the `encoding:` argument from `String(cString:)` in `Package@swift-6.1.swift` so the manifest compiles on Swift 6.1 / Xcode 16+.

## :bulb: Motivation and Context

`String(cString:encoding:)` is a Foundation extension on `String` and is not available in the manifest context. On Swift 6.1 / Xcode 16+, manifest compilation fails with:

    /Package@swift-6.1.swift:72:51: error: extra argument 'encoding' in call
    /Package@swift-6.1.swift:72:51: error: cannot infer contextual base in reference to member 'utf8'

This breaks `swift package resolve` for downstream projects consuming affected 8.x versions on Xcode 16+.

The stdlib `String(cString:)` already decodes the C string as UTF-8, so behavior is preserved.

Fixes #7797

## :green_heart: How did you test it?

- `swift package dump-package` now succeeds on Xcode 16 / Swift 6.1.
- End-to-end dependency resolution was verified on a consumer project pinning sentry-cocoa in the 8.x range.

No unit tests added — this is a manifest-only change, and the current
test/CI setup does not include a dedicated manifest-compilation check.

## :pencil: Checklist

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.