### PR TITLE
fix: Add foreground state to app context in app hang events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Keep replayType as `buffer` for Session Replay triggered by an error (#7804)
 - Fix race condition in scope observer notifications causing EXC_BAD_ACCESS during cold launch (#7807)
 - Unsubscribe to system event during background to avoid reporting breadcrumbs with wrong timestamps on return to foreground (#7702)
-- Ensure app hangs have foreground app context (#7801)
+- Add foreground state to app context in app hang events (#7801)
 
 ## 9.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Detect development builds via provisioning profile and debugger attachment (#7702)
+- Ensure app hangs have foreground app context (#7801)
 
 ## 9.10.0
 

--- a/Sources/Swift/Integrations/SentryHangTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/SentryHangTrackingIntegration.swift
@@ -161,6 +161,7 @@ final class SentryHangTrackingIntegration<Dependencies: HangTrackingIntegrationS
         mechanism.data = [sentryANRMechanismDataAppHangDuration: appHangDurationInfo]
         let scope = SentrySDKInternal.currentHub().scope
         scope.applyTo(event: event, maxBreadcrumbs: options.maxBreadcrumbs)
+        addAppState(to: event)
         apply(options: SentrySDK.startOption, toEvent: event)
         fileManager.storeAppHang(event)
         #else
@@ -204,6 +205,15 @@ final class SentryHangTrackingIntegration<Dependencies: HangTrackingIntegrationS
     }
 
     #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+    private func addAppState(to event: Event) {
+        var context = event.context ?? [:]
+        var appContext = context["app"] ?? [:]
+        appContext["in_foreground"] = true
+        appContext["is_active"] = true
+        context["app"] = appContext
+        event.context = context
+    }
+
     private func captureStoredAppHangEvent() {
         dispatchQueueWrapper.dispatchAsync { [weak self] in
             guard let self else { return }

--- a/Tests/SentryTests/Integrations/ANR/SentryHangTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryHangTrackingIntegrationTests.swift
@@ -379,6 +379,9 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertEqual(event.releaseName, "my-release-name-test")
         XCTAssertEqual(event.environment, "testing-environment")
         XCTAssertEqual(event.dist, "adhoc")
+        let appContext = try XCTUnwrap(event.context?["app"] as? [String: Any])
+        XCTAssertEqual(true, appContext["in_foreground"] as? Bool)
+        XCTAssertEqual(true, appContext["is_active"] as? Bool)
     }
     
     func testV2_ANRDetected_DoesNotCaptureEvent() throws {


### PR DESCRIPTION
## :scroll: Description

Set app.in_foreground and app.is_active when creating new app hang events in SentryHangTrackingIntegration, so persisted and fatal app hangs always carry the expected foreground context.

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #5725

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
