### PR TITLE
fix(replay): Keep replayType as `buffer` for Session Replay triggered by an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Detect development builds via provisioning profile and debugger attachment (#7702)
+- Keep replayType as `buffer` for Session Replay triggered by an error
 
 ## 9.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Detect development builds via provisioning profile and debugger attachment (#7702)
-- Keep replayType as `buffer` for Session Replay triggered by an error
+- Keep replayType as `buffer` for Session Replay triggered by an error (#7804)
 
 ## 9.10.0
 

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -27,6 +27,7 @@ import UIKit
     private var currentSegmentId = 0
     private var processingScreenshot = false
     private var reachedMaximumDuration = false
+    private var replayType = SentryReplayType.buffer
     private(set) var isSessionPaused = false
     
     private let replayOptions: SentryReplayOptions
@@ -99,6 +100,7 @@ import UIKit
         currentSegmentId = 0
         sessionReplayId = SentryId()
         imageCollection = []
+        replayType = fullSession ? .session : .buffer
 
         if fullSession {
             startFullReplay()
@@ -170,7 +172,7 @@ import UIKit
             return
         }
 
-        guard (event.error != nil || event.exceptions?.isEmpty == false) && captureReplay() else { 
+        guard (event.error != nil || event.exceptions?.isEmpty == false) && captureReplay(replayType: .buffer) else {
             SentrySDKLog.debug("[Session Replay] Not capturing replay, reason: event is not an error or exceptions are empty")
             return
         }
@@ -180,13 +182,18 @@ import UIKit
 
     @discardableResult
     public func captureReplay() -> Bool {
+        captureReplay(replayType: .buffer)
+    }
+
+    @discardableResult
+    func captureReplay(replayType: SentryReplayType) -> Bool {
         guard isRunning else {
             SentrySDKLog.debug("[Session Replay] Session replay is not running, not capturing replay")
-            return false 
+            return false
         }
-        guard !isFullSession else { 
+        guard !isFullSession else {
             SentrySDKLog.debug("[Session Replay] Session replay is full, not capturing replay")
-            return true 
+            return true
         }
 
         guard delegate?.sessionReplayShouldCaptureReplayForError() == true else {
@@ -194,10 +201,11 @@ import UIKit
             return false
         }
 
+        self.replayType = replayType
         startFullReplay()
         let replayStart = dateProvider.date().addingTimeInterval(-replayOptions.errorReplayDuration - (Double(replayOptions.frameRate) / 2.0))
 
-        createAndCaptureInBackground(startedAt: replayStart, replayType: .buffer)
+        createAndCaptureInBackground(startedAt: replayStart, replayType: replayType)
         return true
     }
 
@@ -270,7 +278,7 @@ import UIKit
         pathToSegment = pathToSegment.appendingPathComponent("\(currentSegmentId).mp4")
         let segmentStart = videoSegmentStart ?? dateProvider.date().addingTimeInterval(-replayOptions.sessionSegmentDuration)
 
-        createAndCaptureInBackground(startedAt: segmentStart, replayType: .session)
+        createAndCaptureInBackground(startedAt: segmentStart, replayType: replayType)
     }
 
     private func createAndCaptureInBackground(startedAt: Date, replayType: SentryReplayType) {

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
@@ -286,7 +286,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         }
         if let replay = sessionReplay {
             if !replay.isFullSession {
-                replay.captureReplay()
+                replay.captureReplay(replayType: .session)
             }
             return
         }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -236,6 +236,28 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(event.context?["replay"]?["replay_id"] as? String, sut.sessionReplayId?.sentryIdString)
         assertFullSession(sut, expected: true)
     }
+
+    func testChangeReplayMode_forErrorEvent_shouldKeepBufferReplayTypeForFollowingSegments() throws {
+        // -- Arrange --
+        let fixture = Fixture()
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1))
+        sut.start(rootView: fixture.rootView, fullSession: false)
+
+        // -- Act --
+        let event = Event(error: NSError(domain: "Some error", code: 1))
+        sut.captureReplayFor(event: event)
+        let firstSegment = try XCTUnwrap(fixture.lastReplayEvent)
+
+        fixture.dateProvider.advance(by: 5)
+        Dynamic(sut).newFrame(nil)
+        let secondSegment = try XCTUnwrap(fixture.lastReplayEvent)
+
+        // -- Assert --
+        XCTAssertEqual(firstSegment.replayType, .buffer)
+        XCTAssertEqual(firstSegment.segmentId, 0)
+        XCTAssertEqual(secondSegment.replayType, .buffer)
+        XCTAssertEqual(secondSegment.segmentId, 1)
+    }
     
     func testDontChangeReplayMode_forNonErrorEvent() {
         let fixture = Fixture()
@@ -258,6 +280,27 @@ class SentrySessionReplayTests: XCTestCase {
 
         XCTAssertEqual(fixture.lastReplayId, sut.sessionReplayId)
         assertFullSession(sut, expected: true)
+    }
+
+    func testCaptureReplay_whenRequestedAsSession_shouldKeepSessionReplayTypeForFollowingSegments() throws {
+        // -- Arrange --
+        let fixture = Fixture()
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1))
+        sut.start(rootView: fixture.rootView, fullSession: false)
+
+        // -- Act --
+        _ = sut.captureReplay(replayType: .session)
+        let firstSegment = try XCTUnwrap(fixture.lastReplayEvent)
+
+        fixture.dateProvider.advance(by: 5)
+        Dynamic(sut).newFrame(nil)
+        let secondSegment = try XCTUnwrap(fixture.lastReplayEvent)
+
+        // -- Assert --
+        XCTAssertEqual(firstSegment.replayType, .session)
+        XCTAssertEqual(firstSegment.segmentId, 0)
+        XCTAssertEqual(secondSegment.replayType, .session)
+        XCTAssertEqual(secondSegment.segmentId, 1)
     }
 
     func testSessionReplayMaximumDuration() {


### PR DESCRIPTION
Keep the replayType as `buffer` when Session Replay is triggered by an error.

When an on-error replay starts from a buffered session, the first replay segment is tagged as `buffer` but later segments were emitted as `session`. 

This preserves the initial replay type across later segments and keeps explicit manual promotion through the replay API as `session`. It also adds regression coverage for both the error-triggered buffer path and the explicit session path.

Example replay: https://sentry-sdks.sentry.io/explore/replays/4ea41582cd8747d98835d8c018c7182e

Closes getsentry/sentry-react-native#5879