### PR TITLE
fix: Copy mutable collections before passing to scope observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Detect development builds via provisioning profile and debugger attachment (#7702)
 - Keep replayType as `buffer` for Session Replay triggered by an error (#7804)
+- Fix race condition in scope observer notifications causing EXC_BAD_ACCESS during cold launch (#7807)
 
 ## 9.10.0
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -243,9 +243,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary setValue:value forKey:key];
 
-        NSDictionary *contextCopy = _contextDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setContext:contextCopy];
+            [observer setContext:_contextDictionary.copy];
         }
     }
 }
@@ -262,9 +261,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary removeObjectForKey:key];
 
-        NSDictionary *contextCopy = _contextDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setContext:contextCopy];
+            [observer setContext:_contextDictionary.copy];
         }
     }
 }
@@ -281,9 +279,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary setValue:value forKey:key];
 
-        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:extrasCopy];
+            [observer setExtras:_extraDictionary.copy];
         }
     }
 }
@@ -293,9 +290,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary removeObjectForKey:key];
 
-        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:extrasCopy];
+            [observer setExtras:_extraDictionary.copy];
         }
     }
 }
@@ -309,9 +305,8 @@ NS_ASSUME_NONNULL_BEGIN
         [_extraDictionary
             addEntriesFromDictionary:SENTRY_UNWRAP_NULLABLE_DICT(NSString *, id, extras)];
 
-        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:extrasCopy];
+            [observer setExtras:_extraDictionary.copy];
         }
     }
 }
@@ -328,9 +323,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         _tagDictionary[key] = value;
 
-        NSDictionary *tagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:tagsCopy];
+            [observer setTags:_tagDictionary.copy];
         }
     }
 }
@@ -340,9 +334,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary removeObjectForKey:key];
 
-        NSDictionary *tagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:tagsCopy];
+            [observer setTags:_tagDictionary.copy];
         }
     }
 }
@@ -356,9 +349,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary addEntriesFromDictionary:tagsCopy];
 
-        NSDictionary *internalTagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:internalTagsCopy];
+            [observer setTags:_tagDictionary.copy];
         }
     }
 }
@@ -408,9 +400,8 @@ NS_ASSUME_NONNULL_BEGIN
                 addObjectsFromArray:SENTRY_UNWRAP_NULLABLE(NSArray<NSString *>, fingerprint)];
         }
 
-        NSArray *fingerprintCopy = _fingerprintArray.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setFingerprint:fingerprintCopy];
+            [observer setFingerprint:_fingerprintArray.copy];
         }
     }
 }
@@ -499,9 +490,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         _attributesDictionary[key] = value;
 
-        NSDictionary *attributesCopy = _attributesDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setAttributes:attributesCopy];
+            [observer setAttributes:_attributesDictionary.copy];
         }
     }
 }
@@ -511,9 +501,8 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         [_attributesDictionary removeObjectForKey:key];
 
-        NSDictionary *attributesCopy = _attributesDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setAttributes:attributesCopy];
+            [observer setAttributes:_attributesDictionary.copy];
         }
     }
 }

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -243,8 +243,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary setValue:value forKey:key];
 
+        NSDictionary *contextCopy = _contextDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setContext:_contextDictionary];
+            [observer setContext:contextCopy];
         }
     }
 }
@@ -261,8 +262,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary removeObjectForKey:key];
 
+        NSDictionary *contextCopy = _contextDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setContext:_contextDictionary];
+            [observer setContext:contextCopy];
         }
     }
 }
@@ -279,8 +281,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary setValue:value forKey:key];
 
+        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:_extraDictionary];
+            [observer setExtras:extrasCopy];
         }
     }
 }
@@ -290,8 +293,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary removeObjectForKey:key];
 
+        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:_extraDictionary];
+            [observer setExtras:extrasCopy];
         }
     }
 }
@@ -305,8 +309,9 @@ NS_ASSUME_NONNULL_BEGIN
         [_extraDictionary
             addEntriesFromDictionary:SENTRY_UNWRAP_NULLABLE_DICT(NSString *, id, extras)];
 
+        NSDictionary *extrasCopy = _extraDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:_extraDictionary];
+            [observer setExtras:extrasCopy];
         }
     }
 }
@@ -323,8 +328,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         _tagDictionary[key] = value;
 
+        NSDictionary *tagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:_tagDictionary];
+            [observer setTags:tagsCopy];
         }
     }
 }
@@ -334,8 +340,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary removeObjectForKey:key];
 
+        NSDictionary *tagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:_tagDictionary];
+            [observer setTags:tagsCopy];
         }
     }
 }
@@ -349,8 +356,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary addEntriesFromDictionary:tagsCopy];
 
+        NSDictionary *internalTagsCopy = _tagDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTags:_tagDictionary];
+            [observer setTags:internalTagsCopy];
         }
     }
 }
@@ -400,8 +408,9 @@ NS_ASSUME_NONNULL_BEGIN
                 addObjectsFromArray:SENTRY_UNWRAP_NULLABLE(NSArray<NSString *>, fingerprint)];
         }
 
+        NSArray *fingerprintCopy = _fingerprintArray.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setFingerprint:_fingerprintArray];
+            [observer setFingerprint:fingerprintCopy];
         }
     }
 }
@@ -490,8 +499,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         _attributesDictionary[key] = value;
 
+        NSDictionary *attributesCopy = _attributesDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setAttributes:_attributesDictionary];
+            [observer setAttributes:attributesCopy];
         }
     }
 }
@@ -501,8 +511,9 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         [_attributesDictionary removeObjectForKey:key];
 
+        NSDictionary *attributesCopy = _attributesDictionary.copy;
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setAttributes:_attributesDictionary];
+            [observer setAttributes:attributesCopy];
         }
     }
 }

--- a/Sources/Swift/Integrations/WatchdogTerminations/SentryWatchdogTerminationScopeObserver.swift
+++ b/Sources/Swift/Integrations/WatchdogTerminations/SentryWatchdogTerminationScopeObserver.swift
@@ -3,8 +3,8 @@
 /**
  * This scope observer is used by the Watchdog Termination integration to write breadcrumbs to disk.
  * The overhead is ~0.015 seconds for 1000 breadcrumbs.
- * This class doesn't need to be thread safe as the scope already calls the scope observers in a
- * thread safe manner.
+ * This class doesn't need additional synchronization because the scope copies mutable collections
+ * before passing them to observers, ensuring that the values received here are immutable snapshots.
  */
 class SentryWatchdogTerminationScopeObserver: NSObject, SentryScopeObserver {
     

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -443,7 +443,37 @@ class SentryScopeSwiftTests: XCTestCase {
             scope.serialize()
         })
     }
-    
+
+    func testModifyingFromMultipleThreads_withObserverAsyncDispatch() {
+        // Regression test for https://github.com/getsentry/sentry-react-native/issues/5995
+        // Before the fix, the scope passed mutable collections directly to observers.
+        // Observers like SentryWatchdogTerminationScopeObserver dispatch async work that
+        // iterates the collection after the @synchronized lock is released, causing a
+        // concurrent read+write race (EXC_BAD_ACCESS).
+        let scope = Scope(maxBreadcrumbs: 10)
+        let observer = AsyncIteratingObserver()
+        scope.add(observer)
+
+        testConcurrentModifications(asyncWorkItems: 3, writeLoopCount: 100, writeWork: { i in
+            let key = "key-\(i % 5)"
+
+            scope.setContext(value: ["k": "v-\(i)"], key: key)
+            scope.removeContext(key: "key-\(i % 3)")
+
+            scope.setTag(value: "v-\(i)", key: key)
+            scope.removeTag(key: "key-\(i % 3)")
+            scope.setTags(["a": "1", "b": "2"])
+
+            scope.setExtra(value: i, key: key)
+            scope.removeExtra(key: "key-\(i % 3)")
+            scope.setExtras(["x": 1, "y": 2])
+
+            scope.setFingerprint(["fp-\(i)"])
+        })
+
+        // If the test completes without a crash or TSan error, the fix works.
+    }
+
     func testScopeObserver_setUser() {
         let sut = Scope()
         let observer = fixture.observer
@@ -1013,6 +1043,48 @@ class SentryScopeSwiftTests: XCTestCase {
         func setAttributes(_ attributes: [String: Any]?) {
             self.attributes = attributes
         }
+    }
+
+    /// A scope observer that simulates the behavior of SentryWatchdogTerminationScopeObserver:
+    /// it captures the received collection and iterates it asynchronously on a background queue.
+    /// Before the fix, the scope passed mutable collections directly, so this async iteration
+    /// would race with concurrent mutations — triggering EXC_BAD_ACCESS.
+    private class AsyncIteratingObserver: NSObject, SentryScopeObserver {
+        private let queue = DispatchQueue(label: "AsyncIteratingObserver", attributes: .concurrent)
+
+        func setTags(_ tags: [String: String]?) {
+            guard let tags = tags else { return }
+            queue.async { _ = tags.map { "\($0.key)=\($0.value)" } }
+        }
+
+        func setExtras(_ extras: [String: Any]?) {
+            guard let extras = extras else { return }
+            queue.async { _ = extras.map { "\($0.key)=\($0.value)" } }
+        }
+
+        func setContext(_ context: [String: [String: Any]]?) {
+            guard let context = context else { return }
+            queue.async { _ = context.map { "\($0.key)=\($0.value)" } }
+        }
+
+        func setFingerprint(_ fingerprint: [String]?) {
+            guard let fingerprint = fingerprint else { return }
+            queue.async { _ = fingerprint.joined(separator: ",") }
+        }
+
+        func setAttributes(_ attributes: [String: Any]?) {
+            guard let attributes = attributes else { return }
+            queue.async { _ = attributes.map { "\($0.key)=\($0.value)" } }
+        }
+
+        func setUser(_ user: User?) {}
+        func setDist(_ dist: String?) {}
+        func setEnvironment(_ environment: String?) {}
+        func setLevel(_ level: SentryLevel) {}
+        func setTraceContext(_ traceContext: [String: Any]?) {}
+        func addSerializedBreadcrumb(_ crumb: [String: Any]) {}
+        func clearBreadcrumbs() {}
+        func clear() {}
     }
 }
 

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -474,6 +474,34 @@ class SentryScopeSwiftTests: XCTestCase {
         // If the test completes without a crash or TSan error, the fix works.
     }
 
+    func testScopeObserver_passesDistinctCopyToObservers() {
+        // Verify that observers receive a different object (copy) than the internal
+        // mutable collection, preventing race conditions when observers dispatch async work.
+        let sut = Scope()
+        let observer = IdentityCapturingObserver()
+        sut.add(observer)
+
+        sut.setContext(value: ["k": "v"], key: "key")
+        XCTAssertNotNil(observer.lastContext)
+        XCTAssertFalse(observer.lastContext === sut.contextDictionary,
+            "Observer should receive a copy, not the internal mutable contextDictionary")
+
+        sut.setTag(value: "v", key: "key")
+        XCTAssertNotNil(observer.lastTags)
+        XCTAssertFalse(observer.lastTags === sut.tagDictionary,
+            "Observer should receive a copy, not the internal mutable tagDictionary")
+
+        sut.setExtra(value: 1, key: "key")
+        XCTAssertNotNil(observer.lastExtras)
+        XCTAssertFalse(observer.lastExtras === sut.extraDictionary,
+            "Observer should receive a copy, not the internal mutable extraDictionary")
+
+        sut.setFingerprint(["fp"])
+        XCTAssertNotNil(observer.lastFingerprint)
+        XCTAssertFalse(observer.lastFingerprint === sut.fingerprintArray,
+            "Observer should receive a copy, not the internal mutable fingerprintArray")
+    }
+
     func testScopeObserver_setUser() {
         let sut = Scope()
         let observer = fixture.observer
@@ -1082,6 +1110,40 @@ class SentryScopeSwiftTests: XCTestCase {
         func setEnvironment(_ environment: String?) {}
         func setLevel(_ level: SentryLevel) {}
         func setTraceContext(_ traceContext: [String: Any]?) {}
+        func addSerializedBreadcrumb(_ crumb: [String: Any]) {}
+        func clearBreadcrumbs() {}
+        func clear() {}
+    }
+
+    /// Captures the raw NSDictionary/NSArray references passed to observer methods
+    /// so tests can verify identity (pointer) differs from the internal mutable collection.
+    private class IdentityCapturingObserver: NSObject, SentryScopeObserver {
+        var lastContext: NSDictionary?
+        func setContext(_ context: [String: [String: Any]]?) {
+            lastContext = context as NSDictionary?
+        }
+
+        var lastTags: NSDictionary?
+        func setTags(_ tags: [String: String]?) {
+            lastTags = tags as NSDictionary?
+        }
+
+        var lastExtras: NSDictionary?
+        func setExtras(_ extras: [String: Any]?) {
+            lastExtras = extras as NSDictionary?
+        }
+
+        var lastFingerprint: NSArray?
+        func setFingerprint(_ fingerprint: [String]?) {
+            lastFingerprint = fingerprint as NSArray?
+        }
+
+        func setUser(_ user: User?) {}
+        func setDist(_ dist: String?) {}
+        func setEnvironment(_ environment: String?) {}
+        func setLevel(_ level: SentryLevel) {}
+        func setTraceContext(_ traceContext: [String: Any]?) {}
+        func setAttributes(_ attributes: [String: Any]?) {}
         func addSerializedBreadcrumb(_ crumb: [String: Any]) {}
         func clearBreadcrumbs() {}
         func clear() {}


### PR DESCRIPTION
## :scroll: Description

Copy mutable collections (`_contextDictionary`, `_tagDictionary`, `_extraDictionary`, `_fingerprintArray`, `_attributesDictionary`) before passing them to scope observers in `SentryScope.m`. This prevents a race condition where observers dispatch async work that iterates the collection after the `@synchronized` lock is released, while another thread mutates it concurrently.

Also updates the misleading thread-safety comment in `SentryWatchdogTerminationScopeObserver.swift` to accurately describe the guarantee.

## :bulb: Motivation and Context

Fixes a launch crash (`EXC_BAD_ACCESS` in `objc_msgSend`) reported in getsentry/sentry-react-native#5995 affecting <1% of cold launches on iOS 26+. The crash occurs because `SentryWatchdogTerminationScopeObserver` captures mutable collection references and dispatches async disk writes, racing with concurrent scope mutations.

The public getter methods (`context`, `extras`, `tags`, `fingerprints`, `attributes`) already return `.copy` — this fix makes observer notifications consistent with that pattern.

## :green_heart: How did you test it?

- Added `testModifyingFromMultipleThreads_withObserverAsyncDispatch` — a concurrent stress test that rapidly mutates scope context/tags/extras/fingerprint from multiple threads while an observer with async dispatch is active
- All existing `SentryScopeSwiftTests` (59 tests) pass
- All existing `SentryWatchdogTerminationScopeObserverTests` (18 tests) pass
- `make format`, `make analyze`, `make build-ios` all clean

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.