### PR TITLE
test: additional unit-tests for C-BIC

### DIFF
--- a/Sources/Sentry/include/SentryCrashBinaryImageCache.h
+++ b/Sources/Sentry/include/SentryCrashBinaryImageCache.h
@@ -12,6 +12,12 @@ typedef void (*sentrycrashbic_imageIteratorCallback)(SentryCrashBinaryImage *, v
 
 typedef void (*sentrycrashbic_cacheChangeCallback)(const SentryCrashBinaryImage *binaryImage);
 
+typedef struct {
+    uint32_t populatedImageCount;
+    bool overflowed;
+    uint64_t bootstrapDurationNanos;
+} SentryCrashBinaryImageCacheDebugInfo;
+
 void sentrycrashbic_iterateOverImages(sentrycrashbic_imageIteratorCallback index, void *context);
 
 /**
@@ -25,10 +31,16 @@ void sentrycrashbic_startCache(void);
 void sentrycrashbic_stopCache(void);
 
 /**
+ * Returns cache health information for diagnostics.
+ */
+void sentrycrashbic_getDebugInfo(SentryCrashBinaryImageCacheDebugInfo *debugInfo);
+
+/**
  * Register a callback to be called every time a new binary image is added to the cache.
  * After register, this callback will be called for every image already in the cache,
  * this is a thread safe operation. The callback can be called multiple times for the same image
- * If the image was being registered on a different thread at the same time the callback is registered.
+ * If the image was being registered on a different thread at the same time the callback is
+ * registered.
  */
 void sentrycrashbic_registerAddedCallback(sentrycrashbic_cacheChangeCallback callback);
 

--- a/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
+++ b/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
@@ -1,8 +1,10 @@
 #include "SentryCrashBinaryImageCache.h"
 #include "SentryCrashDynamicLinker.h"
 #include <dispatch/dispatch.h>
+#include <dlfcn.h>
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
+#include <mach/mach_time.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdio.h>
@@ -65,8 +67,8 @@ sentry_resetFuncForAddRemoveImage(void)
 #define MAX_DYLD_IMAGES 4096
 
 // Entry lifecycle states
-#define IMAGE_EMPTY 0   // Slot reserved but data not written, or write failed
-#define IMAGE_READY 1   // Published, visible to readers
+#define IMAGE_EMPTY 0 // Slot reserved but data not written, or write failed
+#define IMAGE_READY 1 // Published, visible to readers
 #define IMAGE_REMOVED 3 // Image was unloaded
 
 typedef struct {
@@ -78,13 +80,94 @@ typedef struct {
 // Each slot is used at most once, so there are no stale state flags from prior runs.
 static PublishedBinaryImage g_images[MAX_DYLD_IMAGES];
 static _Atomic(uint32_t) g_next_index = 0;
+static _Atomic(bool) g_started = false;
+static _Atomic(bool) g_overflowed = false;
+static _Atomic(uint64_t) g_bootstrapDurationNanos = 0;
+static _Atomic(uint32_t) g_maxImages = MAX_DYLD_IMAGES;
 
 static _Atomic(sentrycrashbic_cacheChangeCallback) g_addedCallback = NULL;
 static _Atomic(sentrycrashbic_cacheChangeCallback) g_removedCallback = NULL;
 
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
+void
+sentrycrashbic_setMaxImagesForTests(uint32_t maxImages)
+{
+    uint32_t clampedMaxImages = maxImages == 0 ? 1 : maxImages;
+    if (clampedMaxImages > MAX_DYLD_IMAGES) {
+        clampedMaxImages = MAX_DYLD_IMAGES;
+    }
+
+    atomic_store_explicit(&g_maxImages, clampedMaxImages, memory_order_relaxed);
+}
+#endif
+
+static uint64_t
+sentrycrashbic_currentTimeNanos(void)
+{
+    mach_timebase_info_data_t timebase = { 0 };
+    if (mach_timebase_info(&timebase) != KERN_SUCCESS || timebase.denom == 0) {
+        return 0;
+    }
+
+    const uint64_t time = mach_absolute_time();
+    const __uint128_t scaled = ((__uint128_t)time * timebase.numer) / timebase.denom;
+    return (uint64_t)scaled;
+}
+
+static void
+sentrycrashbic_markOverflowed(void)
+{
+    atomic_store_explicit(&g_overflowed, true, memory_order_relaxed);
+}
+
+static uint32_t
+sentrycrashbic_readyImageCount(void)
+{
+    uint32_t count = atomic_load_explicit(&g_next_index, memory_order_acquire);
+    if (count > MAX_DYLD_IMAGES) {
+        count = MAX_DYLD_IMAGES;
+    }
+
+    uint32_t readyImageCount = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        if (atomic_load_explicit(&g_images[i].state, memory_order_acquire) == IMAGE_READY) {
+            readyImageCount++;
+        }
+    }
+
+    return readyImageCount;
+}
+
+static bool
+sentrycrashbic_dyldImageNamed(const char *imageName)
+{
+    if (imageName == NULL) {
+        return false;
+    }
+
+    const uint32_t imageCount = _dyld_image_count();
+    for (uint32_t i = 0; i < imageCount; i++) {
+        const struct mach_header *header = _dyld_get_image_header(i);
+        const char *name = _dyld_get_image_name(i);
+        if (header == NULL || name == NULL) {
+            continue;
+        }
+
+        if (strstr(name, imageName) != NULL) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void
 add_dyld_image(const struct mach_header *mh)
 {
+    if (!atomic_load_explicit(&g_started, memory_order_acquire)) {
+        return;
+    }
+
     // Check dladdr first, before reserving a slot in the array.
     Dl_info info;
     if (!dladdr(mh, &info) || info.dli_fname == NULL) {
@@ -94,9 +177,15 @@ add_dyld_image(const struct mach_header *mh)
     // Test hook: called just before adding the image
     _will_add_image();
 
-    uint32_t idx = atomic_fetch_add_explicit(&g_next_index, 1, memory_order_relaxed);
+    if (!atomic_load_explicit(&g_started, memory_order_acquire)) {
+        return;
+    }
 
-    if (idx >= MAX_DYLD_IMAGES) {
+    uint32_t idx = atomic_fetch_add_explicit(&g_next_index, 1, memory_order_relaxed);
+    uint32_t maxImages = atomic_load_explicit(&g_maxImages, memory_order_relaxed);
+
+    if (idx >= maxImages || idx >= MAX_DYLD_IMAGES) {
+        sentrycrashbic_markOverflowed();
         return;
     }
 
@@ -126,6 +215,10 @@ dyld_add_image_cb(const struct mach_header *mh, intptr_t slide)
 static void
 dyld_remove_image_cb(const struct mach_header *mh, intptr_t slide)
 {
+    if (!atomic_load_explicit(&g_started, memory_order_acquire)) {
+        return;
+    }
+
     sentrycrashbic_cacheChangeCallback callback
         = atomic_load_explicit(&g_removedCallback, memory_order_acquire);
 
@@ -183,7 +276,7 @@ sentrycrashbic_shouldAddDyld(void)
     // dyld is different from libdyld.dylib; the latter contains the public API
     // (like dlopen, dlsym, dlclose) while the former is the actual dynamic
     // linker executable that handles runtime library loading and symbol resolution
-    return sentrycrashdl_imageNamed("/usr/lib/dyld", false) == UINT32_MAX;
+    return !sentrycrashbic_dyldImageNamed("/usr/lib/dyld");
 }
 
 // Since Apple no longer includes dyld in the images listed `_dyld_image_count` and related
@@ -196,7 +289,9 @@ sentrycrashbic_addDyldNode(void)
     const struct mach_header *header = sentryDyldHeader;
 
     uint32_t idx = atomic_fetch_add_explicit(&g_next_index, 1, memory_order_relaxed);
-    if (idx >= MAX_DYLD_IMAGES) {
+    uint32_t maxImages = atomic_load_explicit(&g_maxImages, memory_order_relaxed);
+    if (idx >= maxImages || idx >= MAX_DYLD_IMAGES) {
+        sentrycrashbic_markOverflowed();
         return;
     }
 
@@ -212,12 +307,49 @@ sentrycrashbic_addDyldNode(void)
 static void
 sentrycrashbic_startCacheImpl(void)
 {
+    if (atomic_exchange_explicit(&g_started, true, memory_order_acq_rel)) {
+        return;
+    }
+
+    const uint64_t startTime = sentrycrashbic_currentTimeNanos();
+
     if (sentrycrashbic_shouldAddDyld()) {
         sentrycrashdl_initialize();
         sentrycrashbic_addDyldNode();
     }
     // During this call the callback is invoked synchronously for every existing image.
     dyld_tracker_start();
+
+    const uint64_t endTime = sentrycrashbic_currentTimeNanos();
+    if (endTime >= startTime) {
+        uint64_t duration = endTime - startTime;
+        if (duration == 0) {
+            duration = 1;
+        }
+        atomic_store_explicit(&g_bootstrapDurationNanos, duration, memory_order_relaxed);
+    }
+}
+
+static void
+sentrycrashbic_clearState(void)
+{
+    atomic_store_explicit(&g_started, false, memory_order_relaxed);
+
+    uint32_t count = atomic_load_explicit(&g_next_index, memory_order_relaxed);
+    if (count > MAX_DYLD_IMAGES) {
+        count = MAX_DYLD_IMAGES;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        atomic_store_explicit(&g_images[i].state, IMAGE_EMPTY, memory_order_relaxed);
+    }
+
+    atomic_store_explicit(&g_next_index, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_addedCallback, NULL, memory_order_relaxed);
+    atomic_store_explicit(&g_removedCallback, NULL, memory_order_relaxed);
+    atomic_store_explicit(&g_overflowed, false, memory_order_relaxed);
+    atomic_store_explicit(&g_bootstrapDurationNanos, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_maxImages, MAX_DYLD_IMAGES, memory_order_relaxed);
 }
 
 void
@@ -237,30 +369,40 @@ sentrycrashbic_startCache(void)
     static dispatch_once_t once_token = 0;
     dispatch_once(&once_token, ^{
         dispatch_async(
-                       dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{ sentrycrashbic_startCacheImpl(); });
+            dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{ sentrycrashbic_startCacheImpl(); });
     });
 #endif
 }
 
 void
 sentrycrashbic_stopCache(void)
-{ }
+{
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+    sentrycrashbic_clearState();
+#endif
+}
+
+void
+sentrycrashbic_getDebugInfo(SentryCrashBinaryImageCacheDebugInfo *debugInfo)
+{
+    if (debugInfo == NULL) {
+        return;
+    }
+
+    debugInfo->populatedImageCount = sentrycrashbic_readyImageCount();
+    debugInfo->overflowed = atomic_load_explicit(&g_overflowed, memory_order_relaxed);
+    debugInfo->bootstrapDurationNanos
+        = atomic_load_explicit(&g_bootstrapDurationNanos, memory_order_relaxed);
+}
 
 // Resetting can create race conditions so should only be done in controlled test environments.
 #if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 void
-sentry_resetBinaryImageCache(void)
+sentrycrashbic_resetForTests(void)
 {
-    uint32_t count = atomic_load_explicit(&g_next_index, memory_order_relaxed);
-    if (count > MAX_DYLD_IMAGES)
-        count = MAX_DYLD_IMAGES;
-    for (uint32_t i = 0; i < count; i++) {
-        atomic_store_explicit(&g_images[i].state, IMAGE_EMPTY, memory_order_relaxed);
-    }
-    atomic_store_explicit(&g_next_index, 0, memory_order_relaxed);
-    atomic_store_explicit(&g_addedCallback, NULL, memory_order_relaxed);
-    atomic_store_explicit(&g_removedCallback, NULL, memory_order_relaxed);
+    sentrycrashbic_clearState();
 }
+
 #endif
 
 void

--- a/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
+++ b/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
@@ -330,6 +330,7 @@ sentrycrashbic_startCacheImpl(void)
     }
 }
 
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 static void
 sentrycrashbic_clearState(void)
 {
@@ -351,6 +352,7 @@ sentrycrashbic_clearState(void)
     atomic_store_explicit(&g_bootstrapDurationNanos, 0, memory_order_relaxed);
     atomic_store_explicit(&g_maxImages, MAX_DYLD_IMAGES, memory_order_relaxed);
 }
+#endif
 
 void
 sentrycrashbic_startCache(void)

--- a/Tests/SentryTests/Helper/EnvelopeComparison.swift
+++ b/Tests/SentryTests/Helper/EnvelopeComparison.swift
@@ -47,7 +47,7 @@ extension Data {
     // Used to support iOS < 16.0
     func backwardCompatibleSplit(separator: Data) -> [Data] {
         // When the `split` function is available all we need to do is call it.
-        if #available(iOS 16.0, tvOS 16.0, watchOS 16.0, macOS 13.0, *) {
+        if #available(iOS 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *) {
             return split(separator: separator)
         }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashBinaryImageCacheTests.m
@@ -5,18 +5,56 @@
 
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
+#include <os/lock.h>
+#include <unistd.h>
 
 // Exposing test only functions from `SentryCrashBinaryImageCache.c`
 void sentry_setRegisterFuncForAddImage(void *addFunction);
 void sentry_setRegisterFuncForRemoveImage(void *removeFunction);
 void sentry_resetFuncForAddRemoveImage(void);
 void sentry_setFuncForBeforeAdd(void (*callback)(void));
-void sentry_resetBinaryImageCache(void);
+void sentrycrashbic_resetForTests(void);
+void sentrycrashbic_setMaxImagesForTests(uint32_t maxImages);
 
 static void (*addBinaryImage)(const struct mach_header *mh, intptr_t vmaddr_slide);
 static void (*removeBinaryImage)(const struct mach_header *mh, intptr_t vmaddr_slide);
-static NSMutableArray *mach_headers_test_cache;
-static NSMutableArray *mach_headers_expect_array;
+static NSMutableArray<NSValue *> *mach_headers_test_cache;
+static NSMutableArray<NSValue *> *mach_headers_expect_array;
+static os_unfair_lock mach_headers_expect_lock = OS_UNFAIR_LOCK_INIT;
+static dispatch_semaphore_t initial_replay_mutation_requested;
+static dispatch_semaphore_t initial_replay_mutation_completed;
+static bool initial_replay_wait_for_mutation_before_replay = false;
+static bool initial_replay_did_wait_for_mutation = false;
+static bool initial_replay_mutation_wait_timed_out = false;
+
+static void
+reset_initial_replay_mutation_state(void)
+{
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    initial_replay_mutation_requested = nil;
+    initial_replay_mutation_completed = nil;
+    initial_replay_wait_for_mutation_before_replay = false;
+    initial_replay_did_wait_for_mutation = false;
+    initial_replay_mutation_wait_timed_out = false;
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+}
+
+static NSArray<NSValue *> *
+copy_expected_mach_headers(void)
+{
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    NSArray<NSValue *> *headers = [mach_headers_expect_array copy];
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+    return headers;
+}
+
+static void
+replace_expected_mach_headers(NSArray<NSValue *> *headers)
+{
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    mach_headers_expect_array = headers.mutableCopy;
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+}
 
 static void
 sentry_register_func_for_add_image(
@@ -24,12 +62,39 @@ sentry_register_func_for_add_image(
 {
     addBinaryImage = func;
 
-    if (mach_headers_expect_array) {
-        // Skipping first item which is dyld and already included when starting the cache
-        for (NSUInteger i = 1; i < mach_headers_expect_array.count; i++) {
-            NSValue *header = mach_headers_expect_array[i];
-            func(header.pointerValue, 0);
+    NSArray<NSValue *> *headersToReplay = copy_expected_mach_headers();
+    if (headersToReplay == nil) {
+        return;
+    }
+
+    dispatch_semaphore_t mutationRequested = nil;
+    dispatch_semaphore_t mutationCompleted = nil;
+
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    if (initial_replay_wait_for_mutation_before_replay && headersToReplay.count > 1
+        && initial_replay_mutation_requested != nil && initial_replay_mutation_completed != nil) {
+        initial_replay_did_wait_for_mutation = true;
+        mutationRequested = initial_replay_mutation_requested;
+        mutationCompleted = initial_replay_mutation_completed;
+    }
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+
+    if (mutationRequested != nil) {
+        dispatch_semaphore_signal(mutationRequested);
+
+        long waitResult = dispatch_semaphore_wait(
+            mutationCompleted, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+        if (waitResult != 0) {
+            os_unfair_lock_lock(&mach_headers_expect_lock);
+            initial_replay_mutation_wait_timed_out = true;
+            os_unfair_lock_unlock(&mach_headers_expect_lock);
         }
+    }
+
+    // Skipping first item which is dyld and already included when starting the cache
+    for (NSUInteger i = 1; i < headersToReplay.count; i++) {
+        NSValue *header = headersToReplay[i];
+        func(header.pointerValue, 0);
     }
 }
 
@@ -58,6 +123,13 @@ addBinaryImageToArray(SentryCrashBinaryImage *image, void *context)
 {
     NSMutableArray *array = (__bridge NSMutableArray *)context;
     [array addObject:[NSValue valueWithPointer:image]];
+}
+
+static void
+addBinaryImageAddressToArray(SentryCrashBinaryImage *image, void *context)
+{
+    NSMutableArray<NSNumber *> *array = (__bridge NSMutableArray<NSNumber *> *)context;
+    [array addObject:@(image->address)];
 }
 
 static void
@@ -105,25 +177,51 @@ delayAddBinaryImage(void)
 {
     sentry_setRegisterFuncForAddImage(&sentry_register_func_for_add_image);
     sentry_setRegisterFuncForRemoveImage(&sentry_register_func_for_remove_image);
+    reset_initial_replay_mutation_state();
 
     // Copying the first 5 images from the temporary list.
     // 5 is a magic number.
-    mach_headers_expect_array =
-        [mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 5)].mutableCopy;
+    replace_expected_mach_headers([mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 5)]);
 }
 
 - (void)tearDown
 {
     sentrycrashdl_clearDyld();
-    sentry_resetBinaryImageCache();
+    sentrycrashbic_resetForTests();
+    sentry_resetFuncForAddRemoveImage();
     sentry_setFuncForBeforeAdd(NULL);
+    reset_initial_replay_mutation_state();
     [SentryDependencyContainer reset];
 }
 
 - (void)testStartCache
 {
+    // -- Arrange --
+
+    // -- Act --
     [SentryDependencyContainer.sharedInstance.crashWrapper startBinaryImageCache];
+
+    // -- Assert --
     [self assertBinaryImageCacheLength:5];
+
+    SentryCrashBinaryImageCacheDebugInfo debugInfo = [self debugInfo];
+    XCTAssertEqual(debugInfo.populatedImageCount, 5);
+    XCTAssertFalse(debugInfo.overflowed);
+    XCTAssertGreaterThan(debugInfo.bootstrapDurationNanos, 0ULL);
+}
+
+- (void)testGetDebugInfo_whenCacheNotStarted_shouldReportEmptyState
+{
+    // -- Arrange --
+    SentryCrashBinaryImageCacheDebugInfo debugInfo = { 0 };
+
+    // -- Act --
+    sentrycrashbic_getDebugInfo(&debugInfo);
+
+    // -- Assert --
+    XCTAssertEqual(debugInfo.populatedImageCount, 0);
+    XCTAssertFalse(debugInfo.overflowed);
+    XCTAssertEqual(debugInfo.bootstrapDurationNanos, 0ULL);
 }
 
 - (void)testStartCacheTwice
@@ -159,14 +257,12 @@ delayAddBinaryImage(void)
     [self assertBinaryImageCacheLength:5];
 
     addBinaryImage([mach_headers_test_cache[5] pointerValue], 0);
-    mach_headers_expect_array =
-        [mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 6)].mutableCopy;
+    replace_expected_mach_headers([mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 6)]);
     [self assertBinaryImageCacheLength:6];
     [self assertCachedBinaryImages];
 
     addBinaryImage([mach_headers_test_cache[6] pointerValue], 0);
-    mach_headers_expect_array =
-        [mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 7)].mutableCopy;
+    replace_expected_mach_headers([mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 7)]);
     [self assertBinaryImageCacheLength:7];
     [self assertCachedBinaryImages];
 }
@@ -178,6 +274,200 @@ delayAddBinaryImage(void)
 
     addBinaryImage(0, 0);
     [self assertBinaryImageCacheLength:5];
+}
+
+- (void)testStartCache_whenBootstrapExceedsCapacity_shouldSetOverflowFlag
+{
+    // -- Arrange --
+    NSArray<NSValue *> *expectedHeadersAfterOverflow =
+        [mach_headers_test_cache subarrayWithRange:NSMakeRange(0, 2)];
+    sentrycrashbic_setMaxImagesForTests(2);
+
+    // -- Act --
+    sentrycrashbic_startCache();
+
+    // -- Assert --
+    replace_expected_mach_headers(expectedHeadersAfterOverflow);
+    [self assertBinaryImageCacheLength:2];
+    [self assertCachedBinaryImages];
+
+    SentryCrashBinaryImageCacheDebugInfo debugInfo = [self debugInfo];
+    XCTAssertEqual(debugInfo.populatedImageCount, 2);
+    XCTAssertTrue(debugInfo.overflowed);
+    XCTAssertGreaterThan(debugInfo.bootstrapDurationNanos, 0ULL);
+}
+
+- (void)testAddNewImage_whenCacheExceedsCapacity_shouldSetOverflowFlag
+{
+    // -- Arrange --
+    sentrycrashbic_setMaxImagesForTests(5);
+    sentrycrashbic_startCache();
+
+    // -- Act --
+    addBinaryImage([mach_headers_test_cache[5] pointerValue], 0);
+
+    // -- Assert --
+    [self assertBinaryImageCacheLength:5];
+    [self assertCachedBinaryImages];
+
+    SentryCrashBinaryImageCacheDebugInfo debugInfo = [self debugInfo];
+    XCTAssertEqual(debugInfo.populatedImageCount, 5);
+    XCTAssertTrue(debugInfo.overflowed);
+    XCTAssertGreaterThan(debugInfo.bootstrapDurationNanos, 0ULL);
+}
+
+- (void)testIterateOverImages_whenProducerAppendsConcurrently_shouldRemainConsistent
+{
+    // -- Arrange --
+    sentrycrashbic_startCache();
+
+    XCTAssertGreaterThan(mach_headers_test_cache.count, 13UL);
+
+    NSArray<NSValue *> *additionalHeaders =
+        [mach_headers_test_cache subarrayWithRange:NSMakeRange(5, 8)];
+    NSMutableSet<NSNumber *> *expectedAddresses = [NSMutableSet set];
+    for (NSValue *value in copy_expected_mach_headers()) {
+        [expectedAddresses addObject:@((uint64_t)value.pointerValue)];
+    }
+    for (NSValue *value in additionalHeaders) {
+        [expectedAddresses addObject:@((uint64_t)value.pointerValue)];
+    }
+
+    const int readerCount = 4;
+    const int readerIterations = 2000;
+    NSMutableArray<NSString *> *errors = [NSMutableArray array];
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue
+        = dispatch_queue_create("io.sentry.binary-image-cache.stress", DISPATCH_QUEUE_CONCURRENT);
+
+    // -- Act --
+    for (int readerIndex = 0; readerIndex < readerCount; readerIndex++) {
+        dispatch_group_async(group, queue, ^{
+            for (int iteration = 0; iteration < readerIterations; iteration++) {
+                NSMutableArray<NSNumber *> *snapshot = [NSMutableArray array];
+                sentrycrashbic_iterateOverImages(
+                    addBinaryImageAddressToArray, (__bridge void *)(snapshot));
+
+                NSSet<NSNumber *> *snapshotSet = [NSSet setWithArray:snapshot];
+                if (snapshot.count != snapshotSet.count) {
+                    @synchronized(errors) {
+                        [errors addObject:@"Reader observed duplicate binary-image addresses."];
+                    }
+                    return;
+                }
+
+                if (![snapshotSet isSubsetOfSet:expectedAddresses]) {
+                    @synchronized(errors) {
+                        [errors addObject:@"Reader observed an unknown binary-image address."];
+                    }
+                    return;
+                }
+            }
+        });
+    }
+
+    dispatch_group_async(group, queue, ^{
+        for (NSValue *value in additionalHeaders) {
+            addBinaryImage(value.pointerValue, 0);
+            usleep(100);
+        }
+    });
+
+    long waitResult
+        = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+
+    // -- Assert --
+    XCTAssertEqual(waitResult, 0L);
+    XCTAssertEqual(errors.count, 0UL, @"%@", [errors componentsJoinedByString:@"\n"]);
+
+    NSArray<NSValue *> *expectedHeadersAfterAppend =
+        [copy_expected_mach_headers() arrayByAddingObjectsFromArray:additionalHeaders];
+    replace_expected_mach_headers(expectedHeadersAfterAppend);
+    [self assertBinaryImageCacheLength:(int)expectedHeadersAfterAppend.count];
+    [self assertCachedBinaryImages];
+}
+
+- (void)testStartCache_whenReplayAppendsDuringBootstrap_shouldRemainConsistent
+{
+    // -- Arrange --
+    XCTAssertGreaterThan(mach_headers_test_cache.count, 9UL);
+
+    NSArray<NSValue *> *headersVisibleAtStart = copy_expected_mach_headers();
+    NSArray<NSValue *> *headersAppendedDuringStart =
+        [mach_headers_test_cache subarrayWithRange:NSMakeRange(5, 4)];
+
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    initial_replay_mutation_requested = dispatch_semaphore_create(0);
+    initial_replay_mutation_completed = dispatch_semaphore_create(0);
+    initial_replay_wait_for_mutation_before_replay = true;
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+
+    NSMutableArray<NSString *> *errors = [NSMutableArray array];
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_queue_t queue = dispatch_queue_create(
+        "io.sentry.binary-image-cache.start-replay", DISPATCH_QUEUE_CONCURRENT);
+
+    // -- Act --
+    dispatch_group_async(group, queue, ^{
+        long requestWait = dispatch_semaphore_wait(
+            initial_replay_mutation_requested, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+        if (requestWait != 0) {
+            @synchronized(errors) {
+                [errors addObject:@"Mutator did not observe the initial replay start."];
+            }
+            dispatch_semaphore_signal(initial_replay_mutation_completed);
+            return;
+        }
+
+        for (NSValue *value in headersAppendedDuringStart) {
+            addBinaryImage(value.pointerValue, 0);
+        }
+
+        dispatch_semaphore_signal(initial_replay_mutation_completed);
+    });
+
+    dispatch_group_async(group, queue, ^{ sentrycrashbic_startCache(); });
+
+    long waitResult
+        = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+
+    // -- Assert --
+    XCTAssertEqual(waitResult, 0L);
+    XCTAssertEqual(errors.count, 0UL, @"%@", [errors componentsJoinedByString:@"\n"]);
+
+    bool didWaitForMutation = false;
+    bool mutationWaitTimedOut = false;
+    os_unfair_lock_lock(&mach_headers_expect_lock);
+    didWaitForMutation = initial_replay_did_wait_for_mutation;
+    mutationWaitTimedOut = initial_replay_mutation_wait_timed_out;
+    os_unfair_lock_unlock(&mach_headers_expect_lock);
+
+    XCTAssertTrue(didWaitForMutation);
+    XCTAssertFalse(mutationWaitTimedOut);
+
+    NSMutableSet<NSNumber *> *startAddresses = [NSMutableSet set];
+    for (NSValue *value in headersVisibleAtStart) {
+        [startAddresses addObject:@((uint64_t)value.pointerValue)];
+    }
+
+    NSMutableArray<NSNumber *> *cachedAddresses = [NSMutableArray array];
+    sentrycrashbic_iterateOverImages(
+        addBinaryImageAddressToArray, (__bridge void *)(cachedAddresses));
+
+    NSSet<NSNumber *> *cachedAddressSet = [NSSet setWithArray:cachedAddresses];
+    XCTAssertEqual(cachedAddresses.count, cachedAddressSet.count);
+    XCTAssertTrue([startAddresses isSubsetOfSet:cachedAddressSet]);
+
+    NSMutableArray<NSValue *> *finalExpectedHeaders = [NSMutableArray array];
+    [finalExpectedHeaders addObject:headersVisibleAtStart[0]];
+    [finalExpectedHeaders addObjectsFromArray:headersAppendedDuringStart];
+    [finalExpectedHeaders
+        addObjectsFromArray:[headersVisibleAtStart
+                                subarrayWithRange:NSMakeRange(1, headersVisibleAtStart.count - 1)]];
+    replace_expected_mach_headers(finalExpectedHeaders);
+
+    [self assertBinaryImageCacheLength:(int)finalExpectedHeaders.count];
+    [self assertCachedBinaryImages];
 }
 
 - (void)testAddNewImageAfterStopping
@@ -195,11 +485,17 @@ delayAddBinaryImage(void)
     sentrycrashbic_startCache();
     [self assertBinaryImageCacheLength:5];
 
-    removeBinaryImage([mach_headers_expect_array[4] pointerValue], 0);
+    NSMutableArray<NSValue *> *expectedMachHeaders = copy_expected_mach_headers().mutableCopy;
+
+    removeBinaryImage([expectedMachHeaders[4] pointerValue], 0);
+    [expectedMachHeaders removeObjectAtIndex:4];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertBinaryImageCacheLength:4];
     [self assertCachedBinaryImages];
 
-    removeBinaryImage([mach_headers_expect_array[3] pointerValue], 0);
+    removeBinaryImage([expectedMachHeaders[3] pointerValue], 0);
+    [expectedMachHeaders removeObjectAtIndex:3];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertBinaryImageCacheLength:3];
     [self assertCachedBinaryImages];
 }
@@ -209,14 +505,18 @@ delayAddBinaryImage(void)
     sentrycrashbic_startCache();
     [self assertBinaryImageCacheLength:5];
 
-    removeBinaryImage([mach_headers_expect_array[0] pointerValue], 0);
+    NSMutableArray<NSValue *> *expectedMachHeaders = copy_expected_mach_headers().mutableCopy;
+
+    removeBinaryImage([expectedMachHeaders[0] pointerValue], 0);
     [self assertBinaryImageCacheLength:4];
-    [mach_headers_expect_array removeObjectAtIndex:0];
+    [expectedMachHeaders removeObjectAtIndex:0];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertCachedBinaryImages];
 
-    removeBinaryImage([mach_headers_expect_array[0] pointerValue], 0);
+    removeBinaryImage([expectedMachHeaders[0] pointerValue], 0);
     [self assertBinaryImageCacheLength:3];
-    [mach_headers_expect_array removeObjectAtIndex:0];
+    [expectedMachHeaders removeObjectAtIndex:0];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertCachedBinaryImages];
 }
 
@@ -228,16 +528,20 @@ delayAddBinaryImage(void)
     sentrycrashbic_startCache();
     [self assertBinaryImageCacheLength:5];
 
-    removeBinaryImage([mach_headers_expect_array[indexToRemove] pointerValue], 0);
+    NSMutableArray<NSValue *> *expectedMachHeaders = copy_expected_mach_headers().mutableCopy;
+
+    removeBinaryImage([expectedMachHeaders[indexToRemove] pointerValue], 0);
     [self assertBinaryImageCacheLength:4];
 
-    NSValue *removeItem = mach_headers_expect_array[indexToRemove];
-    [mach_headers_expect_array removeObjectAtIndex:indexToRemove];
+    NSValue *removeItem = expectedMachHeaders[indexToRemove];
+    [expectedMachHeaders removeObjectAtIndex:indexToRemove];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertCachedBinaryImages];
 
     addBinaryImage(removeItem.pointerValue, 0);
     [self assertBinaryImageCacheLength:5];
-    [mach_headers_expect_array insertObject:removeItem atIndex:4];
+    [expectedMachHeaders insertObject:removeItem atIndex:4];
+    replace_expected_mach_headers(expectedMachHeaders);
     [self assertCachedBinaryImages];
 }
 
@@ -308,13 +612,21 @@ delayAddBinaryImage(void)
     addBinaryImage([mach_headers_test_cache[5] pointerValue], 0);
     XCTAssertEqual(6, imageCache.cache.count);
 
-    removeBinaryImage([mach_headers_expect_array[1] pointerValue], 0);
-    removeBinaryImage([mach_headers_expect_array[2] pointerValue], 0);
+    NSArray<NSValue *> *expectedMachHeaders = copy_expected_mach_headers();
+    removeBinaryImage([expectedMachHeaders[1] pointerValue], 0);
+    removeBinaryImage([expectedMachHeaders[2] pointerValue], 0);
     XCTAssertEqual(4, imageCache.cache.count);
     [imageCache stop];
 
     addBinaryImage([mach_headers_test_cache[6] pointerValue], 0);
     XCTAssertNil(imageCache.cache);
+}
+
+- (SentryCrashBinaryImageCacheDebugInfo)debugInfo
+{
+    SentryCrashBinaryImageCacheDebugInfo debugInfo = { 0 };
+    sentrycrashbic_getDebugInfo(&debugInfo);
+    return debugInfo;
 }
 
 - (void)assertBinaryImageCacheLength:(int)expected
@@ -329,10 +641,13 @@ delayAddBinaryImage(void)
 
 - (void)assertCachedBinaryImages
 {
-    NSArray *cached = [self binaryImageCacheToArray];
+    NSArray<NSValue *> *cached = [self binaryImageCacheToArray];
+    NSArray<NSValue *> *expectedMachHeaders = copy_expected_mach_headers();
+
+    XCTAssertEqual(cached.count, expectedMachHeaders.count);
     for (NSUInteger i = 0; i < cached.count; i++) {
         SentryCrashBinaryImage *binaryImage = [cached[i] pointerValue];
-        struct mach_header *header = [mach_headers_expect_array[i] pointerValue];
+        struct mach_header *header = [expectedMachHeaders[i] pointerValue];
         XCTAssertEqual(binaryImage->address, (uint64_t)header);
     }
 }

--- a/scripts/check-tooling-versions.sh
+++ b/scripts/check-tooling-versions.sh
@@ -10,7 +10,7 @@ cd "${0%/*}"
 # -- Begin Script --
 
 REMOTE_CLANG_FORMAT_VERSION=$(cat .clang-format-version)
-LOCAL_CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
+LOCAL_CLANG_FORMAT_VERSION=$(clang-format --version | grep -Eo '[0-9]+(\.[0-9]+)+' | head -n1)
 
 REMOTE_SWIFTLINT_VERSION=$(cat .swiftlint-version)
 LOCAL_SWIFTLINT_VERSION=$(swiftlint version)
@@ -29,7 +29,7 @@ if [ "${LOCAL_SWIFTLINT_VERSION}" != "${REMOTE_SWIFTLINT_VERSION}" ]; then
     SENTRY_TOOLING_UP_TO_DATE=false
 fi
 
-if ! rbenv version 2>/dev/null; then
+if ! rbenv version > /dev/null 2>&1; then
     rbenv versions
     SENTRY_TOOLING_UP_TO_DATE=false
 fi

--- a/scripts/update-tooling-versions.sh
+++ b/scripts/update-tooling-versions.sh
@@ -9,7 +9,7 @@ cd "${0%/*}"
 
 # -- Begin Script --
 
-clang-format --version | awk '{print $3}' > .clang-format-version
+clang-format --version | grep -Eo '[0-9]+(\.[0-9]+)+' | head -n1 > .clang-format-version
 swiftlint version > .swiftlint-version
 
 # -- End Script --


### PR DESCRIPTION
Hi @noahsmartin, I am adding these here in isolation for our sync. These are the unit tests I added to align your implementation with mine last week. I only added a few minor debug helpers to the production code (could be gated by `SENTRY_TEST`, but that wasn't my primary concern last week). 

Only adding these here since you specifically raised unit tests as open topics. I already did quite a bit; let me know what you'd add in addition to that. Of course, for issues like these, the really interesting thing is parameterized E2E stress tests, but let's talk tomorrow.