### PR TITLE
ci: Update craft to c248b38be4dbcdb95ba538f39a2336d7dd12b9f7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
 
       - name: Prepare release
-        uses: getsentry/craft@ba01e596c4a4c07692f0de10b0d4fe05f3dd0292 # v2
+        uses: getsentry/craft@c248b38be4dbcdb95ba538f39a2336d7dd12b9f7 # v2
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
## Summary

- Updates `getsentry/craft` SHA from `ba01e596c4a4c07692f0de10b0d4fe05f3dd0292` to `c248b38be4dbcdb95ba538f39a2336d7dd12b9f7` in `.github/workflows/release.yml`

#skip-changelog