### PR TITLE
chore(ci): replace Xcode 26.4 with Xcode 26.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
-        run: ./scripts/ci-select-xcode.sh 26.4
+        run: ./scripts/ci-select-xcode.sh 26.4.1
 
       - name: Build macOS-CLI-Xcode sample
         run: |


### PR DESCRIPTION
It started failing here: https://github.com/getsentry/sentry-cocoa/actions/runs/24881281097/job/72852848001?pr=7598

```
> Run ./scripts/ci-select-xcode.sh 26.4
Available Xcode versions:
1) 26.0.1 (17A400)
2) 26.1.1 (17B100)
3) 26.2 (17C52) (Selected)
4) 26.3 (17C529)
5) 26.4.1 (17E202)
6) 26.5 Beta (17F5022i)
Enter the number of the Xcode to select: Not a valid number. Expecting a whole number between 1-6, but given nothing.
```

#skip-changelog