### PR TITLE
feat(metrics)!: Promote experimental options to be generally available

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,15 @@ make build-ios
 # 4. Test (targeted — see Tests/AGENTS.md for ONLY_TESTING usage)
 make test-ios ONLY_TESTING=<AffectedTestClass>
 
-# 5. If samples changed
+# 5. If the public API surface changed (Swift/ObjC public headers, @objc/public symbols)
+make generate-public-api  # regenerates sdk_api.json; commit any diff
+
+# 6. If samples changed
 make build-sample-iOS-Swift
 make test-sample-iOS-Swift-ui  # if UI behavior changed
 ```
+
+- **Public API regeneration is mandatory** for any PR that adds, removes, or renames `public` Swift symbols, `@objc` properties/methods, or ObjC public headers. The `api-stability` CI check diffs `sdk_api.json` against the committed file and fails the PR otherwise. Run `make generate-public-api` and commit the resulting `sdk_api.json` (and `sdk_api_sentryswiftui.json` if it changes) in the same PR. The script auto-locates Xcode 16 if it isn't the active toolchain.
 
 ### Platform Decision Tree
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+> [!WARNING]
+> This release promotes Metrics out of experimental and **removes** `options.experimental.enableMetrics` and `options.experimental.beforeSendMetric`. If you set either of these, your app will fail to compile after upgrading.
+> Migrate to `options.enableMetrics` and `options.beforeSendMetric` (top-level on `Options`) — the defaults and behavior are unchanged.
+
+### Features
+
+- Metrics: Move options out of experimental (#7843)
+  - **Breaking**: `options.experimental.enableMetrics` and `options.experimental.beforeSendMetric` are removed. Use `options.enableMetrics` and `options.beforeSendMetric` instead.
+
 ### Fixes
 
 - Fix JSON encoding of infinite numeric values in crash reports (#7802)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Features
 
-- Metrics: Move options out of experimental (#7843)
-  - **Breaking**: `options.experimental.enableMetrics` and `options.experimental.beforeSendMetric` are removed. Use `options.enableMetrics` and `options.beforeSendMetric` instead.
+- Make feature Metrics generally available, moving experimental options to top-level options (#7843)
 
 ### Fixes
 

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -192,8 +192,8 @@ public struct SentrySDKWrapper {
         options.enableLogs = true
 
         // Integration: Metrics
-        options.experimental.enableMetrics = SentrySDKOverrides.Metrics.enable.boolValue
-        options.experimental.beforeSendMetric = { metric in
+        options.enableMetrics = SentrySDKOverrides.Metrics.enable.boolValue
+        options.beforeSendMetric = { metric in
             // Modify the metric in the callback
             var modifiedMetric = metric
 

--- a/SentryTestUtils/Sources/TestOptions.swift
+++ b/SentryTestUtils/Sources/TestOptions.swift
@@ -21,7 +21,8 @@ public extension Options {
         attachViewHierarchy = false
         enableUIViewControllerTracing = false
         #endif
-        experimental.enableMetrics = false
+        enableMetrics = false
+        beforeSendMetric = { metric in metric }
     }
 
     static func noIntegrations() -> Options {

--- a/Sources/Sentry/SentryOptionsInternal.m
+++ b/Sources/Sentry/SentryOptionsInternal.m
@@ -95,6 +95,9 @@
 
     [self setBool:options[@"enableLogs"] block:^(BOOL value) { sentryOptions.enableLogs = value; }];
 
+    [self setBool:options[@"enableMetrics"]
+            block:^(BOOL value) { sentryOptions.enableMetrics = value; }];
+
     [self setBool:options[@"enableNetworkBreadcrumbs"]
             block:^(BOOL value) { sentryOptions.enableNetworkBreadcrumbs = value; }];
 

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -46,7 +46,7 @@ import Foundation
         if options.experimental.enableUnhandledCPPExceptionsV2 {
             features.append("unhandledCPPExceptionsV2")
         }
-        if options.experimental.enableMetrics {
+        if options.enableMetrics {
             features.append("metrics")
         }
 

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -72,18 +72,11 @@ import Foundation
     ///
     /// ## Requirements
     ///
-    /// Metrics are enabled by default even though it is an experimental feature, because you must still
-    /// manually call the API methods (``SentryMetricsApiProtocol/count(key:value:attributes:)``,
-    /// ``SentryMetricsApiProtocol/gauge(key:value:unit:attributes:)``, or
-    /// ``SentryMetricsApiProtocol/distribution(key:value:unit:attributes:)``) to use it.
+    /// To disable metrics, set ``Options/enableMetrics`` to `false`.
     ///
-    /// To disable metrics, set ``Options/experimental`` ``SentryExperimentalOptions/enableMetrics`` to `false`.
-    ///
-    /// - Note: This feature is currently in open beta.
-    ///
-    /// - Important: The Metrics API has been designed and optimized for Swift. Objective-C support is not
-    ///   currently available. If you need Objective-C support, please open an issue at
-    ///   https://github.com/getsentry/sentry-cocoa/issues to show demand for this feature.
+    /// - Important: The Metrics API has been designed and optimized for Swift. Objective-C support is
+    ///   currently not available. If you need Objective-C support, please see the issue
+    ///   https://github.com/getsentry/sentry-cocoa/issues/6342 for progress.
     ///
     /// - SeeAlso: For complete documentation, visit https://docs.sentry.io/platforms/apple/metrics/
     public static var metrics: SentryMetricsApiProtocol = SentryMetricsApi(dependencies: SentryDependencyContainer.sharedInstance())

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
@@ -44,7 +44,7 @@ struct SentryMetricsApi<Dependencies: SentryMetricsApiDependencies>: SentryMetri
             return
         }
         guard let integration = dependencies.metricsIntegration else {
-            SentrySDKLog.warning("Metric '\(name)' was not captured because metrics are disabled. Enable metrics by setting 'options.experimental.enableMetrics = true' when starting the SDK.")
+            SentrySDKLog.warning("Metric '\(name)' was not captured because metrics are disabled. Enable metrics by setting 'options.enableMetrics = true' when starting the SDK.")
             return
         }
 

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -12,7 +12,7 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     private let beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
 
     init?(with options: Options, dependencies _: Dependencies) {
-        guard options.experimental.enableMetrics else { return nil }
+        guard options.enableMetrics else { return nil }
 
         self.scopeMetaData = SentryDefaultScopeApplyingMetadata(
             environment: options.environment,
@@ -21,7 +21,7 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
             sendDefaultPii: options.sendDefaultPii
         )
 
-        self.beforeSendMetric = options.experimental.beforeSendMetric
+        self.beforeSendMetric = options.beforeSendMetric
 
         super.init()
     }

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -694,6 +694,17 @@
     
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public static let defaultEnvironment = "production"
+
+    // MARK: - Integration: Metrics
+
+    /// When enabled, the SDK sends metrics to Sentry. Metrics can be captured using the ``SentrySDK/metrics``
+    /// API, which allows you to send, view and query counters, gauges and measurements.
+    /// @note Default value is @c true.
+    @objc public var enableMetrics: Bool = true
+
+    /// Use this callback to drop or modify a metric before the SDK sends it to Sentry. Return nil to
+    /// drop the metric.
+    public var beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
 }
 
 extension NSNumber {

--- a/Sources/Swift/Protocol/SentryAttributeContent.swift
+++ b/Sources/Swift/Protocol/SentryAttributeContent.swift
@@ -10,14 +10,11 @@ internal enum SentryAttributeType: String {
     case doubleArray = "double[]"
 }
 
-/// A type-safe representation of attribute values used by structured logging.
+/// A type-safe representation of attribute values used by structured logging and metrics.
 ///
 /// `SentryAttributeContent` provides a strongly-typed enum for representing various attribute types
 /// including strings, booleans, integers, doubles, and their array variants. This enum conforms to
 /// `Equatable`, `Hashable`, and `Encodable` for use in structured data contexts.
-///
-/// - Warning: **Experimental API** - This API is experimental and will be used by the upcoming
-///   experimental Metrics product. The API may change in future releases.
 public enum SentryAttributeContent: Equatable, Hashable {
     case string(String)
     case boolean(Bool)

--- a/Sources/Swift/Protocol/SentryAttributeValue.swift
+++ b/Sources/Swift/Protocol/SentryAttributeValue.swift
@@ -1,7 +1,4 @@
-/// A protocol that represents values that can be used as structured logging attributes.
-///
-/// - Warning: **Experimental API** - This API is experimental and will be used by the upcoming
-///   experimental Metrics product. The API may change in future releases.
+/// A protocol that represents values that can be used as structured logging and metric attributes.
 ///
 /// `SentryAttributeValue` provides a protocol-oriented approach for accepting attribute values
 /// in public APIs. This allows APIs to accept a wide variety of types without requiring a concrete

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -30,15 +30,6 @@ public final class SentryExperimentalOptions: NSObject {
      */
     public var enableSessionReplayInUnreliableEnvironment = false
 
-    /// When enabled, the SDK sends metrics to Sentry. Metrics can be captured using the SentrySDK.metrics
-    /// API, which allows you to send, view and query counters, gauges and measurements.
-    /// @note Default value is @c true.
-    @objc public var enableMetrics: Bool = true
-
-    /// Use this callback to drop or modify a metric before the SDK sends it to Sentry. Return nil to
-    /// drop the metric.
-    public var beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
-    
     /// When enabled, the SDK uses a more efficient mechanism for detecting watchdog terminations.
     public var enableWatchdogTerminationsV2 = false
 

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -174,7 +174,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         // -- Arrange --
         let options = Options()
 
-        options.experimental.enableMetrics = true
+        options.enableMetrics = true
 
         // -- Act --
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
@@ -187,7 +187,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         // -- Arrange --
         let options = Options()
 
-        options.experimental.enableMetrics = false
+        options.enableMetrics = false
 
         // -- Act --
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -260,7 +260,7 @@ class SentryMetricsApiE2ETests: XCTestCase {
         let options = Options()
         options.dsn = TestConstants.dsnForTestCase(type: Self.self)
         options.removeAllIntegrations()
-        options.experimental.enableMetrics = isMetricsEnabled
+        options.enableMetrics = isMetricsEnabled
 
         let client = try XCTUnwrap(E2EMetricsTestClient(options: options))
         let hub = SentryHubInternal(

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -102,7 +102,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         // -- Arrange --
         var beforeSendCalled = false
         let client = try givenSdkWithHub { options in
-            options.experimental.beforeSendMetric = { metric in
+            options.beforeSendMetric = { metric in
                 beforeSendCalled = true
 
                 XCTAssertEqual(metric.name, "test.metric")
@@ -142,7 +142,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         // -- Arrange --
         var beforeSendCalled = false
         let client = try givenSdkWithHub { options in
-            options.experimental.beforeSendMetric = { _ in
+            options.beforeSendMetric = { _ in
                 beforeSendCalled = true
                 return nil // Drop the metric
             }
@@ -171,7 +171,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
     func testAddMetric_beforeSendMetricNotSet_metricCapturedUnmodified() throws {
         // -- Arrange --
         let client = try givenSdkWithHub { options in
-            options.experimental.beforeSendMetric = nil
+            options.beforeSendMetric = nil
         }
 
         let integration = try getSut()
@@ -202,7 +202,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         var beforeSendCalled = false
         try givenSdkWithHub { options in
             options.environment = "test"
-            options.experimental.beforeSendMetric = { metric in
+            options.beforeSendMetric = { metric in
                 beforeSendCalled = true
 
                 // Verify that scope attributes were already applied before the callback runs
@@ -270,7 +270,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
             $0.dsn = TestConstants.dsnForTestCase(type: Self.self)
             $0.removeAllIntegrations()
 
-            $0.experimental.enableMetrics = isEnabled
+            $0.enableMetrics = isEnabled
 
             configure?($0)
         }
@@ -281,7 +281,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         let options = Options()
         options.dsn = TestConstants.dsnForTestCase(type: Self.self)
         options.removeAllIntegrations()
-        options.experimental.enableMetrics = true
+        options.enableMetrics = true
 
         configure?(options)
 

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -25,7 +25,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableAppHangTracking = false
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
-        options.experimental.enableMetrics = false
+        options.enableMetrics = false
         
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)
@@ -53,7 +53,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableAppHangTracking = false
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
-        options.experimental.enableMetrics = false
+        options.enableMetrics = false
 
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)

--- a/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
+++ b/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
@@ -20,7 +20,9 @@ final class SentryOptionsDocumentationSyncTests: XCTestCase {
             "onLastRunStatusDetermined",
             "strictTraceContinuation", // Docs PR: https://github.com/getsentry/sentry-docs/pull/16983
             "orgId", // Docs PR: https://github.com/getsentry/sentry-docs/pull/16983
-            "effectiveOrgId" // @_spi(Private) - internal computed property, not a user-facing option
+            "effectiveOrgId", // @_spi(Private) - internal computed property, not a user-facing option
+            "enableMetrics", // Promoted to GA in https://github.com/getsentry/sentry-cocoa/pull/7843; docs update pending
+            "beforeSendMetric" // Promoted to GA in https://github.com/getsentry/sentry-cocoa/pull/7843; docs update pending
         ]
         
         #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -207,6 +207,11 @@
     [self testBooleanField:@"enableLogs" defaultValue:NO];
 }
 
+- (void)testEnableMetrics
+{
+    [self testBooleanField:@"enableMetrics" defaultValue:YES];
+}
+
 - (void)testEnableAutoBreadcrumbTracking
 {
     [self testBooleanField:@"enableAutoBreadcrumbTracking"];

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -820,6 +820,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Breadcrumb",
+                "printedName": "Sentry.Breadcrumb",
+                "usr": "c:objc(cs)SentryBreadcrumb"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -832,20 +838,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Breadcrumb?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Breadcrumb",
-                    "printedName": "Sentry.Breadcrumb",
-                    "usr": "c:objc(cs)SentryBreadcrumb"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Breadcrumb)",
-                "usr": "c:objc(cs)SentryBreadcrumb"
               }
             ],
             "kind": "TypeFunc",
@@ -871,17 +863,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -908,17 +892,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -939,6 +915,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Event",
+                "printedName": "Sentry.Event",
+                "usr": "c:objc(cs)SentryEvent"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -951,20 +933,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Event?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
-                "usr": "c:objc(cs)SentryEvent"
               }
             ],
             "kind": "TypeFunc",
@@ -998,17 +966,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
-                    "usr": "c:objc(pl)SentrySpan"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(any Sentry.Span)",
+                "name": "Span",
+                "printedName": "any Sentry.Span",
                 "usr": "c:objc(pl)SentrySpan"
               }
             ],
@@ -1059,23 +1019,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryAppStartMeasurement",
-                        "printedName": "Sentry.SentryAppStartMeasurement",
-                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                    "usr": "s:Sq"
+                    "name": "SentryAppStartMeasurement",
+                    "printedName": "Sentry.SentryAppStartMeasurement",
+                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                "name": "Optional",
+                "printedName": "Sentry.SentryAppStartMeasurement?",
                 "usr": "s:Sq"
               }
             ],
@@ -1108,17 +1060,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1153,23 +1097,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Error",
-                        "printedName": "any Swift.Error",
-                        "usr": "s:s5ErrorP"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "(any Swift.Error)?",
-                    "usr": "s:Sq"
+                    "name": "Error",
+                    "printedName": "any Swift.Error",
+                    "usr": "s:s5ErrorP"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "((any Swift.Error)?)",
+                "name": "Optional",
+                "printedName": "(any Swift.Error)?",
                 "usr": "s:Sq"
               }
             ],
@@ -1326,17 +1262,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SamplingContext",
-                    "printedName": "Sentry.SamplingContext",
-                    "usr": "c:objc(cs)SentrySamplingContext"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SamplingContext)",
+                "name": "SamplingContext",
+                "printedName": "Sentry.SamplingContext",
                 "usr": "c:objc(cs)SentrySamplingContext"
               }
             ],
@@ -1369,17 +1297,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryUserFeedbackConfiguration",
-                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1518,6 +1438,22 @@
         "name": "char32_t",
         "printedName": "char32_t",
         "usr": "c:@T@char32_t"
+      },
+      {
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "UInt8",
+            "printedName": "Swift.UInt8",
+            "usr": "s:s5UInt8V"
+          }
+        ],
+        "declKind": "TypeAlias",
+        "kind": "TypeAlias",
+        "moduleName": "Sentry",
+        "name": "char8_t",
+        "printedName": "char8_t",
+        "usr": "c:@T@char8_t"
       },
       {
         "children": [
@@ -16055,22 +15991,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16101,22 +16030,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16147,22 +16069,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16193,22 +16108,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16278,22 +16186,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16324,22 +16225,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -20345,6 +20239,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20357,20 +20257,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20412,6 +20298,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20424,20 +20316,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20483,6 +20361,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Breadcrumb",
+                            "printedName": "Sentry.Breadcrumb",
+                            "usr": "c:objc(cs)SentryBreadcrumb"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -20495,20 +20379,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Breadcrumb?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Breadcrumb)",
-                            "usr": "c:objc(cs)SentryBreadcrumb"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -20560,17 +20430,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20619,17 +20481,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20682,17 +20536,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -20745,17 +20591,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20804,17 +20642,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20867,17 +20697,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -20924,6 +20746,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20936,20 +20764,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20991,6 +20805,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21003,20 +20823,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21062,6 +20868,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
+                            "usr": "c:objc(cs)SentryEvent"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -21074,20 +20886,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Event?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
-                            "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -21145,23 +20943,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21205,23 +20995,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21269,23 +21051,15 @@
                         "usr": "s:Sq"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
-                            "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog)",
+                        "name": "SentryLog",
+                        "printedName": "Sentry.SentryLog",
                         "usr": "c:@M@Sentry@objc(cs)SentryLog"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21321,6 +21095,167 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryMetric?",
+                            "usr": "s:Sq"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
+                            "usr": "s:6Sentry0A6MetricV"
+                          }
+                        ],
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                      }
+                    ],
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declAttributes": [
+                  "Final"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "s:6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvg"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryMetric?",
+                            "usr": "s:Sq"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
+                            "usr": "s:6Sentry0A6MetricV"
+                          }
+                        ],
+                        "kind": "TypeFunc",
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                      }
+                    ],
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "s:6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvs"
+              }
+            ],
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
+                            "usr": "s:6Sentry0A6MetricV"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Optional",
+                        "printedName": "Sentry.SentryMetric?",
+                        "usr": "s:Sq"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryMetric",
+                        "printedName": "Sentry.SentryMetric",
+                        "usr": "s:6Sentry0A6MetricV"
+                      }
+                    ],
+                    "kind": "TypeFunc",
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
+                "usr": "s:Sq"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasInitialValue",
+              "HasStorage"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvp",
+            "moduleName": "Sentry",
+            "name": "beforeSendMetric",
+            "printedName": "beforeSendMetric",
+            "usr": "s:6Sentry7OptionsC16beforeSendMetricAA0aE0VSgAFcSgvp"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21335,17 +21270,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21402,17 +21329,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21473,17 +21392,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
-                                "usr": "c:objc(pl)SentrySpan"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Sentry.Span)",
+                            "name": "Span",
+                            "printedName": "any Sentry.Span",
                             "usr": "c:objc(pl)SentrySpan"
                           }
                         ],
@@ -21616,23 +21527,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21673,23 +21576,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21735,23 +21630,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
-                            "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions)",
+                        "name": "SentryProfileOptions",
+                        "printedName": "Sentry.SentryProfileOptions",
                         "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21794,23 +21681,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21851,23 +21730,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21913,23 +21784,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                        "name": "SentryUserFeedbackConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -23364,6 +23227,82 @@
             "name": "enableMetricKitRawPayload",
             "printedName": "enableMetricKitRawPayload",
             "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableMetricKitRawPayload"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableMetrics"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableMetrics:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvp",
+            "moduleName": "Sentry",
+            "name": "enableMetrics",
+            "printedName": "enableMetrics",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableMetrics"
           },
           {
             "accessors": [
@@ -24917,17 +24856,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -24961,17 +24892,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25009,17 +24932,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   },
                   {
@@ -25345,17 +25260,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -25410,17 +25317,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -25479,17 +25378,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -25576,8 +25467,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25647,8 +25538,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25722,8 +25613,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -27224,17 +27115,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27291,17 +27174,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27362,17 +27237,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
-                                "usr": "c:objc(cs)SentrySamplingContext"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SamplingContext)",
+                            "name": "SamplingContext",
+                            "printedName": "Sentry.SamplingContext",
                             "usr": "c:objc(cs)SentrySamplingContext"
                           }
                         ],
@@ -27516,17 +27383,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -27555,17 +27414,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -29360,17 +29211,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.String)",
+                    "name": "String",
+                    "printedName": "Swift.String",
                     "usr": "s:SS"
                   }
                 ],
@@ -30164,23 +30007,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30251,23 +30086,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30324,23 +30151,15 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
@@ -32251,22 +32070,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32297,22 +32109,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32343,22 +32148,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32389,22 +32187,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32474,22 +32265,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33180,22 +32964,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33265,22 +33042,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33311,22 +33081,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33602,22 +33365,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33687,22 +33443,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34670,17 +34419,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -34697,22 +34438,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34737,23 +34471,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Bool",
-                                "printedName": "Swift.Bool",
-                                "usr": "s:Sb"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Bool]",
-                            "usr": "s:Sa"
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Bool])",
+                        "name": "Array",
+                        "printedName": "[Swift.Bool]",
                         "usr": "s:Sa"
                       },
                       {
@@ -34770,22 +34496,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34808,17 +34527,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -34835,22 +34546,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34875,23 +34579,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Double",
-                                "printedName": "Swift.Double",
-                                "usr": "s:Sd"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Double]",
-                            "usr": "s:Sa"
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Double])",
+                        "name": "Array",
+                        "printedName": "[Swift.Double]",
                         "usr": "s:Sa"
                       },
                       {
@@ -34908,22 +34604,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34983,17 +34672,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Int",
-                            "printedName": "Swift.Int",
-                            "usr": "s:Si"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Int)",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
                         "usr": "s:Si"
                       },
                       {
@@ -35010,22 +34691,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35050,23 +34724,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Int",
-                                "printedName": "Swift.Int",
-                                "usr": "s:Si"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Int]",
-                            "usr": "s:Sa"
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Int])",
+                        "name": "Array",
+                        "printedName": "[Swift.Int]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35083,22 +34749,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35121,24 +34780,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryAttributeContent",
                         "printedName": "Sentry.SentryAttributeContent",
                         "usr": "s:6Sentry0A16AttributeContentO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -35148,22 +34799,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35188,23 +34832,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.String]",
-                            "usr": "s:Sa"
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String])",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35221,22 +34857,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -36524,22 +36153,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36570,22 +36192,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36616,22 +36231,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36662,22 +36270,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36708,22 +36309,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36754,22 +36348,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36800,22 +36387,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36846,22 +36426,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36931,22 +36504,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -36977,22 +36543,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -37023,22 +36582,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -37171,267 +36723,6 @@
             "overriding": true,
             "printedName": "init()",
             "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)init"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryMetric?",
-                            "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
-                        "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
-                      }
-                    ],
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declAttributes": [
-                  "Final"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "s:6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvg"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryMetric?",
-                            "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
-                        "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
-                      }
-                    ],
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
-                    "usr": "s:Sq"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "s:6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvs"
-              }
-            ],
-            "children": [
-              {
-                "children": [
-                  {
-                    "children": [
-                      {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Optional",
-                        "printedName": "Sentry.SentryMetric?",
-                        "usr": "s:Sq"
-                      },
-                      {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryMetric)",
-                        "usr": "s:6Sentry0A6MetricV"
-                      }
-                    ],
-                    "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)?",
-                "usr": "s:Sq"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasInitialValue",
-              "HasStorage"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvp",
-            "moduleName": "Sentry",
-            "name": "beforeSendMetric",
-            "printedName": "beforeSendMetric",
-            "usr": "s:6Sentry0A19ExperimentalOptionsC16beforeSendMetricAA0aF0VSgAFcSgvp"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC13enableMetricsSbvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)enableMetrics"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC13enableMetricsSbvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setEnableMetrics:"
-              }
-            ],
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasStorage",
-              "ObjC"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC13enableMetricsSbvp",
-            "moduleName": "Sentry",
-            "name": "enableMetrics",
-            "printedName": "enableMetrics",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)enableMetrics"
           },
           {
             "accessors": [
@@ -37797,22 +37088,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -37843,22 +37127,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -37928,22 +37205,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -37974,22 +37244,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38294,22 +37557,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -38415,22 +37671,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -38814,22 +38063,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38899,22 +38141,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39081,22 +38316,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39127,22 +38355,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39173,22 +38394,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39219,22 +38433,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39265,22 +38472,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39311,22 +38511,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39396,22 +38589,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39963,17 +39149,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -41076,22 +40254,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41123,22 +40294,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41207,22 +40371,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41386,22 +40543,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41471,22 +40621,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41517,22 +40660,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41563,22 +40699,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41609,22 +40738,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41694,22 +40816,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42092,22 +41207,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -42139,22 +41247,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -42186,22 +41287,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -42233,22 +41327,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -42317,22 +41404,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -42401,22 +41481,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45798,24 +44871,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "UInt",
-                            "printedName": "Swift.UInt",
-                            "usr": "s:Su"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.UInt)",
-                        "usr": "s:Su"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryMetricValue",
                         "printedName": "Sentry.SentryMetricValue",
                         "usr": "s:6Sentry0A11MetricValueO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "UInt",
+                        "printedName": "Swift.UInt",
+                        "usr": "s:Su"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45825,22 +44890,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -45863,17 +44921,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -45890,22 +44940,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -45928,17 +44971,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -45955,22 +44990,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -46811,22 +45839,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46896,22 +45917,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47103,22 +46117,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -47187,22 +46194,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -48146,22 +47146,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -48190,22 +47183,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -48234,22 +47220,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -48315,22 +47294,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -48359,22 +47331,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -50175,22 +49140,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -50222,22 +49180,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -50269,22 +49220,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -52197,22 +51141,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52243,22 +51180,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52289,22 +51219,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52510,22 +51433,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52595,22 +51511,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53759,17 +52668,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -53928,17 +52829,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -54097,17 +52990,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -54295,17 +53180,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -54418,17 +53295,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -54656,17 +53525,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Options",
-                        "printedName": "Sentry.Options",
-                        "usr": "c:@M@Sentry@objc(cs)SentryOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Options)",
+                    "name": "Options",
+                    "printedName": "Sentry.Options",
                     "usr": "c:@M@Sentry@objc(cs)SentryOptions"
                   }
                 ],
@@ -55463,17 +54324,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Span",
-                            "printedName": "any Sentry.Span",
-                            "usr": "c:objc(pl)SentrySpan"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Sentry.Span)",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
                         "usr": "c:objc(pl)SentrySpan"
                       }
                     ],
@@ -55501,17 +54354,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.Span)",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -55669,22 +54514,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -55754,22 +54592,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -55800,22 +54631,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56614,22 +55438,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56660,22 +55477,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56706,22 +55516,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56752,22 +55555,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56798,22 +55594,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56844,22 +55633,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56890,22 +55672,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56936,22 +55711,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56982,22 +55750,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57028,22 +55789,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57074,22 +55828,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57120,22 +55867,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57205,22 +55945,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57251,22 +55984,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57297,22 +56023,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57343,22 +56062,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57389,22 +56101,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57435,22 +56140,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59049,17 +57747,11 @@
               }
             ],
             "declAttributes": [
-              "Available",
-              "Available",
-              "Available",
               "Available"
             ],
             "declKind": "TypeAlias",
             "genericSig": "<Content where Content : SwiftUI.View>",
             "intro_Macosx": "10.15",
-            "intro_iOS": "13.0",
-            "intro_tvOS": "13.0",
-            "intro_watchOS": "6.0",
             "kind": "TypeAlias",
             "mangledName": "$s6Sentry0A10TracedViewV4Bodya",
             "moduleName": "Sentry",
@@ -59256,22 +57948,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59304,22 +57989,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59389,22 +58067,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59437,22 +58108,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59485,22 +58149,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59533,22 +58190,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59922,22 +58572,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59966,22 +58609,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60010,22 +58646,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60054,22 +58683,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60098,22 +58720,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60142,24 +58757,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUnit",
                         "printedName": "Sentry.SentryUnit",
                         "usr": "s:6Sentry0A4UnitO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -60169,22 +58776,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -60207,22 +58807,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60251,22 +58844,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60295,22 +58881,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60339,22 +58918,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60383,22 +58955,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60427,22 +58992,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60471,22 +59029,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60515,22 +59066,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60559,22 +59103,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60603,22 +59140,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60647,22 +59177,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60691,22 +59214,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60735,22 +59251,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60779,22 +59288,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60823,22 +59325,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60906,22 +59401,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60950,22 +59438,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60994,22 +59475,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61038,22 +59512,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61328,17 +59795,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "NSRegularExpression",
-                            "printedName": "Foundation.NSRegularExpression",
-                            "usr": "c:objc(cs)NSRegularExpression"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Foundation.NSRegularExpression)",
+                        "name": "NSRegularExpression",
+                        "printedName": "Foundation.NSRegularExpression",
                         "usr": "c:objc(cs)NSRegularExpression"
                       },
                       {
@@ -61355,22 +59814,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -61393,24 +59845,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUrlMatcher",
                         "printedName": "Sentry.SentryUrlMatcher",
                         "usr": "s:6Sentry0A10UrlMatcherO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -61420,22 +59864,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -61601,23 +60038,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -61658,23 +60087,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -61722,23 +60143,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                        "name": "SentryUserFeedbackThemeConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -61781,23 +60194,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -61839,23 +60244,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -61901,23 +60298,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                        "name": "SentryUserFeedbackFormConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -61963,23 +60352,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62021,23 +60402,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62083,23 +60456,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                        "name": "SentryUserFeedbackThemeConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -62145,23 +60510,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackWidgetConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                            "name": "SentryUserFeedbackWidgetConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62203,23 +60560,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackWidgetConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                            "name": "SentryUserFeedbackWidgetConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62265,23 +60614,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackWidgetConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                        "name": "SentryUserFeedbackWidgetConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -62434,8 +60775,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62483,8 +60824,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62536,8 +60877,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -62589,8 +60930,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62638,8 +60979,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62691,8 +61032,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -62738,23 +61079,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62796,23 +61129,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62858,23 +61183,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
-                            "usr": "s:s5ErrorP"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Swift.Error)",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
                         "usr": "s:s5ErrorP"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((any Swift.Error) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(any Swift.Error) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -62922,34 +61239,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -62993,34 +61302,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -63068,34 +61369,26 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
-                            "usr": "s:SD"
+                            "name": "ProtocolComposition",
+                            "printedName": "Any"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String : Any])",
+                        "name": "Dictionary",
+                        "printedName": "[Swift.String : Any]",
                         "usr": "s:SD"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "([Swift.String : Any]) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -65328,17 +63621,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -65372,17 +63657,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -65420,17 +63697,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
-                        "usr": "s:Sb"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.Bool)",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
                     "usr": "s:Sb"
                   },
                   {
@@ -75388,17 +73657,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryRedactOptions",
-                        "printedName": "any Sentry.SentryRedactOptions",
-                        "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.SentryRedactOptions)",
+                    "name": "SentryRedactOptions",
+                    "printedName": "any Sentry.SentryRedactOptions",
                     "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
                   }
                 ],


### PR DESCRIPTION
Promote `enableMetrics` and `beforeSendMetric` from `SentryExperimentalOptions` to top-level `Options`. Metrics has been stable for long enough that the experimental gate is no longer warranted — this matches the same move done previously for Structured Logs (#6359) and the swizzling options (#6592).

`enableMetrics` is also wired through `SentryOptionsInternal` dict-init so hybrid SDKs can toggle metrics on/off. `beforeSendMetric` stays Swift-only, since `SentryMetric` is a Swift struct and can't be bridged to ObjC; full ObjC support remains tracked in #6342.

Stale "experimental Metrics product" wording on `SentryAttributeValue` and `SentryAttributeContent` is removed — both are used by Logs (already GA) and Metrics. The `SentrySDK.metrics` headerdoc no longer claims "open beta" / "experimental".

#### Breaking change

`options.experimental.enableMetrics` and `options.experimental.beforeSendMetric` are removed with no deprecation shim. Use `options.enableMetrics` and `options.beforeSendMetric` instead. This matches how prior moves out of experimental were handled.

#### Notes

- `sdk_api.json` regenerated via `make generate-public-api`.
- Docs update for `docs.sentry.io/platforms/apple/metrics/` will land in a separate PR against `getsentry/sentry-docs`.
- Second commit (`docs(agents): ...`) updates `AGENTS.md` to require `make generate-public-api` on any PR touching the public API surface — independent of this change but small enough to ride along.