### PR TITLE
fix(ci): Remove duplicate brew update from auto-update-tools.yml

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -73,8 +73,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ github.event_name != 'pull_request' && steps.app_token.outputs.token || github.token }}
-      - name: Update Homebrew
-        run: brew update
 
       - name: Install Tools
         run: make init


### PR DESCRIPTION
Fixes the broken workflow like [here](https://github.com/getsentry/sentry-cocoa/actions/runs/25027140751/job/73300680184). Most likely caused by issues in GitHub Actions runner image. 

#skip-changelog