### PR TITLE
ref(ci): consolidate ci-diagnostics into a composite action

### DIFF
--- a/.github/actions/ci-diagnostics/action.yml
+++ b/.github/actions/ci-diagnostics/action.yml
@@ -1,0 +1,10 @@
+name: "CI Diagnostics"
+description: >-
+  Captures Xcode/macOS environment diagnostics for failure investigation.
+  Intended to be called with `if: failure()` (or similar) at the end of a job.
+runs:
+  using: "composite"
+  steps:
+    - name: Run CI Diagnostics
+      shell: bash
+      run: "${{ github.action_path }}/../../../scripts/ci-diagnostics.sh"

--- a/.github/workflows/analyze-language-trends.yml
+++ b/.github/workflows/analyze-language-trends.yml
@@ -54,9 +54,8 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/api-stability.yml
+++ b/.github/workflows/api-stability.yml
@@ -87,9 +87,8 @@ jobs:
             cat sentryswiftui_result.json
             exit 1
           fi
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either all API stability checks passed or were skipped, which allows us
   # to make API stability checks a required check with only running the API stability checks when required.

--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -177,6 +177,5 @@ jobs:
           name: xcframework-${{github.sha}}-${{inputs.override-name || inputs.variant-id}}
           if-no-files-found: error
           path: ${{ env.XCFRAMEWORK_NAME }}.xcframework.zip
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh

--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -114,9 +114,8 @@ jobs:
           sign-commits: true
           base: main
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either auto-update-tools passed or was skipped, which allows us
   # to make auto-update-tools a required check with only running the auto-update-tools when required.

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -113,9 +113,8 @@ jobs:
             **/Debug-iphoneos/iOS-Swift.app
             **/Debug-iphoneos/iOS-Benchmarking-Runner.app
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   run-ui-tests-with-sauce:
     name: Run Benchmarks ${{matrix.suite}}
@@ -213,9 +212,8 @@ jobs:
             --tags benchmark \
             --verbose
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   benchmarking-required-check:
     needs:

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -137,6 +137,5 @@ jobs:
           path: |
             *.log
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,8 @@ jobs:
         # We only need to archive, not package the IPA, so we skip codesigning.
         run: bundle exec fastlane build_ios_swift_without_codesigning
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   build-sample:
     name: Sample ${{ matrix.scheme }} ${{ matrix.config }}
@@ -143,9 +142,8 @@ jobs:
           path: |
             raw-build-output.log
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   build-sample-spm:
     name: Sample SPM ${{ matrix.name }}
@@ -183,9 +181,8 @@ jobs:
           IOS_SIMULATOR_OS: latest
           IOS_DEVICE_NAME: iPhone 17 Pro
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-macOS-CLI-Xcode-no-UI-framework:
     name: macOS CLI (NoUIFramework) builds and has no AppKit/UIKit
@@ -215,9 +212,8 @@ jobs:
       - name: Ensure CLI binary does not link UIKit
         run: ./scripts/check-ui-framework-linkage.sh --configuration Debug --derived-data "$GITHUB_WORKSPACE/cli-xcode-build" --linkage unlinked --module macOS-CLI-Xcode --framework UIKit
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   build-distribution:
     name: Build the distribution framework
@@ -281,9 +277,8 @@ jobs:
             raw-build-output-spm-watchos.log
             raw-build-output-spm-iphoneos.log
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-debug-without-UIKit:
     name: Check no UIKit linkage (DebugWithoutUIKit)
@@ -310,9 +305,8 @@ jobs:
       - name: Ensure UIKit is not linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration DebugWithoutUIKit --derived-data uikit-check-build --linkage unlinked --module SentryWithoutUIKit
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-release-without-UIKit:
     name: Check no UIKit linkage (ReleaseWithoutUIKit)
@@ -339,9 +333,8 @@ jobs:
       - name: Ensure UIKit is not linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration ReleaseWithoutUIKit --derived-data uikit-check-build --linkage unlinked --module SentryWithoutUIKit
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-debug-with-UIKit:
     name: Check UIKit linkage (Debug)
@@ -368,9 +361,8 @@ jobs:
       - name: Ensure UIKit is linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration Debug --derived-data uikit-check-build --linkage linked --module Sentry
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-release-with-UIKit:
     name: Check UIKit linkage (Release)
@@ -397,9 +389,8 @@ jobs:
       - name: Ensure UIKit is linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration Release --derived-data uikit-check-build --linkage linked --module Sentry
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-release-with-AppKit:
     name: Check AppKit linkage (Release)
@@ -425,9 +416,8 @@ jobs:
       - name: Ensure AppKit is linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration Release --derived-data appkit-check-build --linkage linked --module Sentry --framework AppKit
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   check-release-without-AppKit:
     name: Check no AppKit linkage (ReleaseWithoutUIKit)
@@ -453,9 +443,8 @@ jobs:
       - name: Ensure AppKit is not linked
         run: ./scripts/check-ui-framework-linkage.sh --configuration ReleaseWithoutUIKit --derived-data no-appkit-check-build --linkage unlinked --module SentryWithoutUIKit --framework AppKit
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
     # The compiler only evaluates SentryAsyncSafeLogs that get printed based on the SENTRY_ASYNC_SAFE_LOG_LEVEL.
     # So if the level is set to error, which is the default, and a SENTRY_ASYNC_SAFE_LOG_DEBUG has a compiler error,
@@ -491,9 +480,8 @@ jobs:
             --device "iPhone 16 Pro" \
             --configuration Debug
 
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   build-required-check:
     needs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,9 +72,8 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@256d634097be96e792d6764f9edaefc4320557b1 # v4
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either analyze passed or was skipped, which allows us
   # to make CodeQL analysis a required check with only running the analysis when required.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -60,10 +60,8 @@ jobs:
           name: integration-test-iOS-Cocoapods-Swift6.xcresult
           path: Samples/iOS-Cocoapods-Swift6/fastlane/test_results/results.xcresult
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        shell: bash
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either all integration tests passed or were skipped, which allows us
   # to make integration tests a required check with only running the integration tests when required.

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -63,9 +63,8 @@ jobs:
             echo "✅ All code is formatted correctly."
           fi
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   lint_clang_formatting-required-check:
     needs: [files-changed, lint]

--- a/.github/workflows/lint-cocoapods-specs.yml
+++ b/.github/workflows/lint-cocoapods-specs.yml
@@ -59,9 +59,8 @@ jobs:
       - name: Validate Podspec
         #  Use --allow-warnings because cocoapods gives warnings like "warning: using '@_implementationOnly' without enabling library evolution for 'Sentry' may lead to instability during execution"
         run: ./scripts/pod-lib-lint.sh ${{ matrix.platform }} ${{ matrix.podspec}} ${{ matrix.library_type}} --allow-warnings
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   lint_cocoapods_Specs-required-check:
     needs:

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -58,9 +58,8 @@ jobs:
           else
             echo "✅ All code is formatted correctly."
           fi
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   lint_swift_formatting-required-check:
     needs:

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -46,9 +46,8 @@ jobs:
       - run: swiftlint --version
       - name: Run SwiftLint
         run: swiftlint --strict
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either lint passed or was skipped, which allows us
   # to make lint-swiftlint a required check with only running the lint when required.

--- a/.github/workflows/lint-xcode-analyze.yml
+++ b/.github/workflows/lint-xcode-analyze.yml
@@ -44,9 +44,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: ./scripts/ci-select-xcode.sh 16.4
       - run: make analyze
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   lint_xcode_analyze-required-check:
     needs:

--- a/.github/workflows/objc-conversion-analysis.yml
+++ b/.github/workflows/objc-conversion-analysis.yml
@@ -78,9 +78,8 @@ jobs:
             SwiftConversion/objc_dependencies_topo.svg
           retention-days: 30
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either all Objective-C conversion analysis passed or was skipped, which allows us
   # to make the analysis a required check with only running the analysis when required.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,9 +138,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: make strip-xcframework-expected-signature
       - run: make build-xcframework-sample
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # Use github.event.pull_request.head.sha instead of github.sha when available as
   # the github.sha is be the pre merge commit id for PRs.
@@ -175,9 +174,8 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.4
       - run: swift build
         working-directory: Samples/macOS-SPM-CommandLine
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   validate-spm-dynamic:
     name: Validate SPM Dynamic
@@ -209,9 +207,8 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.4
       - run: swift build
         working-directory: Samples/SPM-Dynamic
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   swift-build:
     name: Build Swift Static
@@ -242,9 +239,8 @@ jobs:
             --change-path true
       - run: ./scripts/ci-select-xcode.sh 16.4
       - run: swift build --target SentrySwiftUI
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   validate-spm-visionos:
     name: Validate SPM Static visionOS
@@ -276,9 +272,8 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.4
       - run: set -o pipefail &&xcodebuild build -scheme visionOS-SPM -sdk xros -destination 'generic/platform=xros' | tee raw-build-output-spm-visionOS.log | xcbeautify
         working-directory: Samples/visionOS-SPM
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   duplication-tests:
     name: Test Sentry Duplication V4 # Up the version with every change to keep track of flaky tests
@@ -359,9 +354,8 @@ jobs:
         if: needs.files-changed.outputs.is_dependabot == 'true'
         run: |
           echo "::warning::App metrics collection was SKIPPED ON PURPOSE for dependabot PR. Code signing secrets are not available for dependabot PRs."
-      - name: Debug Xcode environment
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
   job_release:
     runs-on: ubuntu-latest
@@ -420,9 +414,8 @@ jobs:
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   release-required-check:
     needs:

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -94,10 +94,8 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        shell: bash
-        run: ./scripts/ci-diagnostics.sh
 
   build-required-check:
     needs:

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -111,9 +111,8 @@ jobs:
           name: raw-output-${{matrix.integration_dir}}-integration
           path: |
             3rd-party-integrations/${{matrix.integration_dir}}/.build/**/*.log
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   unit-tests-required-check:
     needs:

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -126,9 +126,8 @@ jobs:
             -destination "$DESTINATION" \
             test SWIFT_ACTIVE_COMPILATION_CONDITIONS=CROSS_PLATFORM_TEST GCC_PREPROCESSOR_DEFINITIONS"=CROSS_PLATFORM_TEST=1" | xcbeautify
 
-      - name: Run CI Diagnostics
+      - uses: ./sentry-cocoa/.github/actions/ci-diagnostics
         if: failure()
-        run: ./sentry-cocoa/scripts/ci-diagnostics.sh
 
   test_cross_platform-required-check:
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,8 @@ jobs:
             test-server-build-intel.log
             test-server-build-arm64.log
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   distribution-tests:
     name: Distribution Tests
@@ -240,9 +239,8 @@ jobs:
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
-        run: ./scripts/ci-diagnostics.sh
 
       - name: Store screenshot
         uses: ./.github/actions/capture-screenshot

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -132,9 +132,8 @@ jobs:
             ${{ github.workspace }}/*.dSYM.zip
             ${{ github.workspace }}/dSYMs/
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either upload_to_testflight passed or was skipped, which allows us
   # to make testflight a required check with only running the upload_to_testflight when required.

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -184,6 +184,5 @@ jobs:
         with:
           suffix: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -136,9 +136,8 @@ jobs:
           name: swiftui-crash-test-log.logarchive
           path: swiftui-crash-test-log.logarchive
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
   # This check validates that either all UI tests critical passed or were skipped, which allows us
   # to make UI tests critical a required check with only running the UI tests critical when required.

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -266,9 +266,8 @@ jobs:
           name: sentry-cocoa-unit-tests
           flags: unittests-${{ inputs.platform }}-${{ inputs.xcode }}-${{ inputs.test-destination-os }}, unittests
 
-      - name: Run CI Diagnostics
+      - uses: ./.github/actions/ci-diagnostics
         if: failure()
-        run: ./scripts/ci-diagnostics.sh
 
       - name: Store screenshot
         uses: ./.github/actions/capture-screenshot


### PR DESCRIPTION
## Summary

Replace the repeated `Run CI Diagnostics` block in 23 workflow files with a single `uses: ./.github/actions/ci-diagnostics`.

## Motivation

The diagnostics step was repeated ~26 times across workflows in 3-4-line blocks. A composite action gives us a single source of truth so any future change (e.g. uploading the captured environment as a job artifact) lands in one place rather than all callers.

## Checklist

- [x] No public API or behaviour changes
- [x] No new compiler warnings

#skip-changelog