### PR TITLE
fix: Fix format string argument order in SentryCrashReportStore

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -286,7 +286,7 @@ sentrycrashcrs_addUserReport(const char *report, int reportLength)
         goto done;
     } else if (bytesWritten < reportLength) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("Expected to write %d bytes to file %s, but only wrote %d",
-            crashReportPath, reportLength, bytesWritten);
+            reportLength, crashReportPath, bytesWritten);
     }
 
 done:


### PR DESCRIPTION
## Description

Fix mismatched format string arguments in the `SENTRY_ASYNC_SAFE_LOG_ERROR` call within `sentrycrashcrs_addUserReport` (partial write error path).

The format string `"Expected to write %d bytes to file %s, but only wrote %d"` expected `(int, char*, int)` but received `(char*, int, int)`. This caused `%s` to dereference `reportLength` (a small integer) as a memory address, resulting in a segfault when a partial write occurs (e.g., disk full).

## How to test

- The fix is a trivial argument reorder — verified by reading the format string and matching specifiers to arguments.

#skip-changelog