### PR TITLE
fix: Handle EOF in sentrycrashfu_readBytesFromFD to prevent infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### Fixes
 
+- Fix infinite loop in `sentrycrashfu_readBytesFromFD` when `read()` returns EOF on a truncated file (#7853)
 - Disable app hang and watchdog termination tracking in Notification Service Extensions (#7818)
 - Fix JSON encoding of infinite numeric values in crash reports (#7802)
 - Fix race condition in `SentryFramesTracker` listeners causing `EXC_BAD_ACCESS` in `NSConcreteHashTable removeItem:` when a listener is deallocated on a background thread (#7839)

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -264,7 +264,12 @@ sentrycrashfu_readBytesFromFD(const int fd, char *const bytes, int length)
         int bytesRead = (int)read(fd, pos, (unsigned)length);
         if (bytesRead == -1) {
             SENTRY_ASYNC_SAFE_LOG_ERROR(
-                "Could not write to fd %d: %s", fd, SENTRY_STRERROR_R(errno));
+                "Could not read from fd %d: %s", fd, SENTRY_STRERROR_R(errno));
+            return false;
+        }
+        if (bytesRead == 0) {
+            SENTRY_ASYNC_SAFE_LOG_ERROR(
+                "Unexpected EOF on fd %d: expected %d more bytes", fd, length);
             return false;
         }
         length -= bytesRead;


### PR DESCRIPTION
## Description

Fix an infinite loop in `sentrycrashfu_readBytesFromFD` when `read()` returns 0 (EOF). The `while (length > 0)` loop never terminates because `length -= 0` makes no progress.

This is reachable when reading a truncated or empty file — callers include `sentrycrashfu_readEntireFile` (crash report loading) and `SentrySessionReplaySyncC` (replay segment state).

Also fixes a copy-paste typo in the error message: "Could not write" → "Could not read".

## How to test

- Existing `SentryCrashFileUtils_Tests` pass (38/38, 0 failures)
- The EOF path is new — previously it was an infinite loop, so no existing test covers it