### PR TITLE
fix: Init vars before task_threads and vm_deallocate

### DIFF
--- a/Sources/Sentry/SentrySystemWrapper.mm
+++ b/Sources/Sentry/SentrySystemWrapper.mm
@@ -44,8 +44,8 @@
 
 - (NSNumber *)cpuUsageWithError:(NSError **)error
 {
-    mach_msg_type_number_t count;
-    thread_act_array_t list;
+    mach_msg_type_number_t count = 0;
+    thread_act_array_t list = nullptr;
 
     const auto taskThreadsStatus = task_threads(mach_task_self(), &list, &count);
     if (taskThreadsStatus != KERN_SUCCESS) {
@@ -53,8 +53,6 @@
             *error = NSErrorFromSentryErrorWithKernelError(
                 kSentryErrorKernel, @"task_threads reported an error.", taskThreadsStatus);
         }
-        vm_deallocate(
-            mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count);
         return nil;
     }
 
@@ -98,8 +96,8 @@
         if (error) {
             *error = NSErrorFromSentryErrorWithKernelError(
                 kSentryErrorKernel, @"Error with task_info(…TASK_POWER_INFO_V2…).", kr);
-            ;
         }
+        return nil;
     }
     return @(powerInfo.task_energy);
 }

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -45,8 +45,8 @@ namespace profiling {
     ThreadHandle::all() noexcept
     {
         std::vector<std::unique_ptr<ThreadHandle>> threads;
-        mach_msg_type_number_t count;
-        thread_act_array_t list;
+        mach_msg_type_number_t count = 0;
+        thread_act_array_t list = nullptr;
         if (SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(task_threads(mach_task_self(), &list, &count))
             == KERN_SUCCESS) {
             for (decltype(count) i = 0; i < count; i++) {
@@ -54,9 +54,9 @@ namespace profiling {
                 threads.push_back(std::unique_ptr<ThreadHandle>(
                     new ThreadHandle(thread, true /* isOwnedPort */)));
             }
+            SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(vm_deallocate(
+                mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count));
         }
-        SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(vm_deallocate(
-            mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count));
         return threads;
     }
 
@@ -64,8 +64,8 @@ namespace profiling {
     ThreadHandle::allExcludingCurrent() noexcept
     {
         std::vector<std::unique_ptr<ThreadHandle>> threads;
-        mach_msg_type_number_t count;
-        thread_act_array_t list;
+        mach_msg_type_number_t count = 0;
+        thread_act_array_t list = nullptr;
         auto current = ThreadHandle::current();
         if (SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(task_threads(mach_task_self(), &list, &count))
             == KERN_SUCCESS) {
@@ -79,9 +79,9 @@ namespace profiling {
                         mach_port_deallocate(mach_task_self(), thread));
                 }
             }
+            SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(vm_deallocate(
+                mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count));
         }
-        SENTRY_ASYNC_SAFE_LOG_KERN_RETURN(vm_deallocate(
-            mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count));
         return std::make_pair(std::move(threads), std::move(current));
     }
 

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -7,18 +7,43 @@ class SentrySystemWrapperTests: XCTestCase {
     }
     lazy private var fixture = Fixture()
 
-    func testCPUUsageReportsData() throws {
-        XCTAssertNoThrow({
-            let cpuUsage = try XCTUnwrap(self.fixture.systemWrapper.cpuUsage())
-            XCTAssertTrue((0.0 ... 100.0).contains(cpuUsage.doubleValue))
-        })
+    // MARK: - cpuUsageWithError
+
+    func testCPUUsage_shouldReturnNonNilValue() throws {
+        let cpuUsage = try XCTUnwrap(fixture.systemWrapper.cpuUsage())
+        XCTAssertGreaterThanOrEqual(cpuUsage.floatValue, 0.0)
     }
 
-    func testMemoryFootprint() {
-        let error: NSErrorPointer = nil
-        let memoryFootprint = fixture.systemWrapper.memoryFootprintBytes(error)
-        XCTAssertNil(error?.pointee)
-        XCTAssertTrue((0...UINT64_MAX).contains(memoryFootprint))
+    func testCPUUsage_shouldNotThrow() throws {
+        XCTAssertNotNil(try fixture.systemWrapper.cpuUsage())
     }
+
+    // Error path for cpuUsageWithError: untestable — task_threads uses hardcoded
+    // mach_task_self() which cannot be made to fail without resource exhaustion.
+
+    // MARK: - memoryFootprintBytes
+
+    func testMemoryFootprint_shouldReturnPositiveValue() {
+        var error: NSError?
+        let memoryFootprint = fixture.systemWrapper.memoryFootprintBytes(&error)
+        XCTAssertNil(error)
+        XCTAssertGreaterThan(memoryFootprint, 0)
+    }
+
+    // MARK: - cpuEnergyUsageWithError
+
+#if arch(arm64)
+    func testCPUEnergyUsage_shouldReturnNonNilValue() throws {
+        let energyUsage = try XCTUnwrap(fixture.systemWrapper.cpuEnergyUsage())
+        XCTAssertGreaterThanOrEqual(energyUsage.uint64Value, 0)
+    }
+
+    func testCPUEnergyUsage_shouldNotThrow() throws {
+        XCTAssertNotNil(try fixture.systemWrapper.cpuEnergyUsage())
+    }
+
+    // Error path for cpuEnergyUsageWithError: untestable — task_info uses hardcoded
+    // mach_task_self() which cannot be made to fail without resource exhaustion.
+#endif // arch(arm64)
 }
 #endif // os(iOS) || os(macOS)


### PR DESCRIPTION
## Description

Fix uninitialized variables and incorrect error-path control flow in thread/task enumeration code in `SentryThreadHandle.cpp` and `SentrySystemWrapper.mm`.

It also moves the `vm_deallocate()` inside the success branch so it only runs when `task_threads` returned valid data.

## Motivation

If `task_threads()` or `task_info()` fails (e.g. under resource pressure), uninitialized `list`/`count` would be passed to `vm_deallocate`, potentially unmapping valid memory. The energy usage method would return data from a partially-initialized struct on failure.

## How Tested

- `make build-ios` and `make analyze` pass
- `SentrySystemWrapperTests` — 5 tests pass (added coverage for `cpuEnergyUsage`, improved existing tests)
- `SentryThreadHandleTests` — 7 tests pass
- Error paths are untestable (kernel calls with hardcoded `mach_task_self()` cannot be reliably made to fail)

#skip-changelog