### PR TITLE
fix: Handle extra length call in SentryInvalidJSONString

### DIFF
--- a/Tests/SentryTests/Helper/SentryInvalidJSONStringTests.swift
+++ b/Tests/SentryTests/Helper/SentryInvalidJSONStringTests.swift
@@ -11,7 +11,6 @@ final class SentryInvalidJSONStringTests: XCTestCase {
     }
     
     func testInitWithInvocations_ReturnsValidJSONUntilInvocationsReached() throws {
-        #if !os(watchOS)
         let sut = SentryInvalidJSONString(lengthInvocationsToBeInvalid: 2)
         
         let array = [sut]
@@ -19,8 +18,5 @@ final class SentryInvalidJSONStringTests: XCTestCase {
         XCTAssertTrue(JSONSerialization.isValidJSONObject(array))
         XCTAssertFalse(JSONSerialization.isValidJSONObject(array))
         XCTAssertFalse(JSONSerialization.isValidJSONObject(array))
-        #else
-        throw XCTSkip("This test fails on CI for watchOS, the reason is still unknown.")
-        #endif
     }
 }

--- a/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
+++ b/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
@@ -34,7 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)length
 {
-    self.lengthInvocations++;
+    // Apple changed the implementation of `__CFStringEncodeByteStream` in some version after iOS26
+    // (and other platforms). Previously `length` was only called from
+    // `-[NSString(NSStringOtherEncodings) dataUsingEncoding:allowLossyConversion:]` but now it is
+    // also called by `__CFStringEncodeByteStream` so to avoid double counting, we ignore it.
+    if ([NSThread.callStackSymbols[1] rangeOfString:@"__CFStringEncodeByteStream"].location
+        == NSNotFound) {
+        self.lengthInvocations++;
+    }
 
     if (self.lengthInvocations > self.lengthInvocationsToBeInvalid) {
         NSMutableString *invalidString = [NSMutableString stringWithString:@"invalid string"];


### PR DESCRIPTION
## Description

Apple changed the implementation of `__CFStringEncodeByteStream` in recent platform versions to additionally call `length` on NSString subclasses. This caused `SentryInvalidJSONString`'s invocation counter to double-count, breaking the test utility's logic.

## Fix

Filter `length` calls by inspecting the call stack — only increment the counter when the call originates from the expected code path (not from `__CFStringEncodeByteStream`). This also fixes the previously-skipped watchOS test, so the `#if !os(watchOS)` / `XCTSkip` guard is removed.

## Test plan

- [x] Existing `SentryInvalidJSONStringTests` pass on all platforms including watchOS

#skip-changelog