### PR TITLE
ci: Bump iOS 26 test runner to 26.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,7 +293,7 @@ jobs:
           - name: iOS 26 Sentry
             runs-on: tahoe
             xcode: "26.3"
-            test-destination-os: "26.3"
+            test-destination-os: "26.4"
             platform: "iOS"
             device: "iPhone 17 Pro"
 


### PR DESCRIPTION
## Summary
- Bumps the iOS 26 unit test runner from 26.3 to 26.4
- Reproduces a Foundation behavior change where `JSONSerialization.isValidJSONObject` calls `NSString.length` twice per invocation (was once in 26.3), which breaks `SentryInvalidJSONStringTests`

## Context
`SentryInvalidJSONString` counts `length` invocations to flip from valid to invalid JSON. iOS 26.4 changed the internal call pattern, exhausting the threshold earlier than expected. This PR is intentionally expected to fail to confirm the issue in CI before applying a fix.

#skip-changelog