### PR TITLE
chore(ci): Skip workflows for fork PRs where secrets are unavailable

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       run_benchmarking_for_prs: ${{ steps.changes.outputs.run_benchmarking_for_prs }}
       is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get changed files
@@ -38,8 +39,15 @@ jobs:
     name: Skip Benchmarking for Non-Contributors
     runs-on: ubuntu-latest
     needs: files-changed
-    # Skip for non-contributors, but not for dependabot (handled in build-benchmark-test-target)
-    if: github.event_name == 'pull_request' && needs.files-changed.outputs.run_benchmarking_for_prs == 'true' && !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) && needs.files-changed.outputs.is_dependabot == 'false'
+    # Skip for non-contributors or fork PRs, but not for dependabot (handled in build-benchmark-test-target)
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
+      (
+        !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) ||
+        needs.files-changed.outputs.is_fork == 'true'
+      ) &&
+      needs.files-changed.outputs.is_dependabot == 'false'
     steps:
       - name: Skip Benchmarking for Non-Contributors
         run: |
@@ -51,7 +59,8 @@ jobs:
     # Run for PRs with related changes (including dependabot) or non-PR events.
     if: |
       github.event_name != 'pull_request' || (
-        needs.files-changed.outputs.run_benchmarking_for_prs == 'true' && (
+        needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
+        needs.files-changed.outputs.is_fork != 'true' && (
           contains(
           fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
           github.event.pull_request.author_association
@@ -123,7 +132,8 @@ jobs:
     if: |
       github.event_name != 'pull_request' || (
         needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
-        needs.files-changed.outputs.is_dependabot == 'false'
+        needs.files-changed.outputs.is_dependabot == 'false' &&
+        needs.files-changed.outputs.is_fork != 'true'
       )
     runs-on: ubuntu-latest
     needs: [files-changed, build-benchmark-test-target]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       run_release_for_prs: ${{ steps.changes.outputs.run_release_for_prs }}
       is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get changed files
@@ -298,10 +299,11 @@ jobs:
     name: Collect App Metrics
     runs-on: macos-15
     needs: [files-changed, assemble-xcframework-variant]
-    # Run for PRs with related changes (including dependabot) or non-PR events.
+    # Run for PRs with related changes (including dependabot) or non-PR events. Skip fork PRs (no secrets available).
     if: |
       github.event_name != 'pull_request' || (
-        needs.files-changed.outputs.run_release_for_prs == 'true' && (
+        needs.files-changed.outputs.run_release_for_prs == 'true' &&
+        needs.files-changed.outputs.is_fork != 'true' && (
           contains(
           fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
           github.event.pull_request.author_association

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       run_size_analysis_for_prs: ${{ steps.changes.outputs.run_size_analysis_for_prs }}
       is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get changed files
@@ -36,8 +37,15 @@ jobs:
     name: Skip Size Analysis for Non-Contributors
     runs-on: ubuntu-latest
     needs: files-changed
-    # Skip for non-contributors, but not for dependabot (handled in build)
-    if: github.event_name == 'pull_request' && needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) && needs.files-changed.outputs.is_dependabot == 'false'
+    # Skip for non-contributors or fork PRs, but not for dependabot (handled in build)
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.files-changed.outputs.run_size_analysis_for_prs == 'true' &&
+      (
+        !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) ||
+        needs.files-changed.outputs.is_fork == 'true'
+      ) &&
+      needs.files-changed.outputs.is_dependabot == 'false'
     steps:
       - name: Skip Size Analysis for Non-Contributors
         run: |
@@ -50,7 +58,8 @@ jobs:
     # Run for PRs with related changes (including dependabot) or non-PR events.
     if: |
       github.event_name != 'pull_request' || (
-        needs.files-changed.outputs.run_size_analysis_for_prs == 'true' && (
+        needs.files-changed.outputs.run_size_analysis_for_prs == 'true' &&
+        needs.files-changed.outputs.is_fork != 'true' && (
           contains(
           fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
           github.event.pull_request.author_association

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,6 +28,7 @@ jobs:
       run_testflight_for_pushes: ${{ steps.changes.outputs.run_testflight_for_pushes }}
       is_contributor: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) }}
       is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
+      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get changed files
@@ -41,11 +42,11 @@ jobs:
     name: Skip Testflight for Non-Contributors
     runs-on: ubuntu-latest
     needs: files-changed
-    # Skip for non-contributors, but not for dependabot (handled in upload_to_testflight)
+    # Skip for non-contributors or fork PRs, but not for dependabot (handled in upload_to_testflight)
     if: |
       github.event_name == 'pull_request' &&
       needs.files-changed.outputs.run_testflight_for_prs == 'true' &&
-      needs.files-changed.outputs.is_contributor == 'false' &&
+      (needs.files-changed.outputs.is_contributor == 'false' || needs.files-changed.outputs.is_fork == 'true') &&
       needs.files-changed.outputs.is_dependabot == 'false'
     steps:
       - name: Skip Testflight for Non-Contributors
@@ -61,7 +62,8 @@ jobs:
         needs.files-changed.outputs.run_testflight_for_pushes == 'true'
       ) || (
         github.event_name == 'pull_request' &&
-        needs.files-changed.outputs.run_testflight_for_prs == 'true' && (
+        needs.files-changed.outputs.run_testflight_for_prs == 'true' &&
+        needs.files-changed.outputs.is_fork != 'true' && (
           needs.files-changed.outputs.is_contributor == 'true' ||
           needs.files-changed.outputs.is_dependabot == 'true'
         )


### PR DESCRIPTION
## :scroll: Description

Skips steps which require secrets

## :bulb: Motivation and Context

Some CI jobs require secrets which are not available for forks, making us unable to merge them normally.

## :green_heart: How did you test it?

Here: https://github.com/getsentry/sentry-cocoa/pull/7868

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
