### PR TITLE
ci: extend release issue notification workflow

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -257,6 +257,7 @@ run_release_for_prs: &run_release_for_prs
 
   # GH Actions
   - ".github/workflows/release.yml"
+  - ".github/workflows/release-comment-issues.yml"
   - ".github/workflows/build-xcframework-variant-slices.yml"
   - ".github/workflows/assemble-xcframework-variant.yml"
   - ".github/workflows/ui-tests-common.yml"

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,4 +1,4 @@
-name: 'Automation: Notify issues for release'
+name: "Automation: Notify issues for release"
 on:
   release:
     types:
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release-comment-issues:
     runs-on: ubuntu-24.04
-    name: 'Notify issues'
+    name: "Notify issues"
     steps:
       - name: Get version
         id: get_version

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -9,6 +9,11 @@ on:
         description: Which version to notify issues for
         required: false
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 # This workflow is triggered when a release is published
 jobs:
   release-comment-issues:
@@ -17,17 +22,20 @@ jobs:
     steps:
       - name: Get version
         id: get_version
-        run: echo "version=${VERSION}" >> $GITHUB_OUTPUT
         env:
-          VERSION: ${{ github.event.inputs.version || github.event.release.tag_name }}
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Comment on linked issues that are mentioned in release
         if: |
           steps.get_version.outputs.version != ''
-          && !contains(steps.get_version.outputs.version, 'a')
-          && !contains(steps.get_version.outputs.version, 'b')
-          && !contains(steps.get_version.outputs.version, 'rc')
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
+
         uses: getsentry/release-comment-issues-gh-action@52e08022ca721e701515ede89edd224b63b180eb # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}
+          changelog_pr_mode: SIMPLE_ROUND_BRACKETS

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Comment on linked issues that are mentioned in release
         if: |
           steps.get_version.outputs.version != ''
-          && !contains(steps.get_version.outputs.version, '-beta.')
-          && !contains(steps.get_version.outputs.version, '-alpha.')
-          && !contains(steps.get_version.outputs.version, '-rc.')
+          && !contains(steps.get_version.outputs.version, '-beta')
+          && !contains(steps.get_version.outputs.version, '-alpha')
+          && !contains(steps.get_version.outputs.version, '-rc')
 
         # Pin matches getsentry/release-comment-issues-gh-action@v1 (repo policy: full SHA).
         # changelog_pr_mode: Craft release notes use (#1234); default mode expects markdown PR links.

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,4 +1,4 @@
-name: "Automation: Notify issues for release"
+name: 'Automation: Notify issues for release'
 on:
   release:
     types:
@@ -7,7 +7,7 @@ on:
     inputs:
       version:
         description: Which version to notify issues for
-        required: false
+        required: true
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release-comment-issues:
     runs-on: ubuntu-24.04
-    name: Notify issues
+    name: 'Notify issues'
     steps:
       - name: Get version
         id: get_version
@@ -34,6 +34,8 @@ jobs:
           && !contains(steps.get_version.outputs.version, '-alpha.')
           && !contains(steps.get_version.outputs.version, '-rc.')
 
+        # Pin matches getsentry/release-comment-issues-gh-action@v1 (repo policy: full SHA).
+        # changelog_pr_mode: Craft release notes use (#1234); default mode expects markdown PR links.
         uses: getsentry/release-comment-issues-gh-action@52e08022ca721e701515ede89edd224b63b180eb # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,14 @@ We use [Swiftlint](https://github.com/realm/SwiftLint) and Clang-Format. For Swi
 make lint
 ```
 
+## Changelog entries and linked issues
+
+Changelog entries are generated from merged PRs (see Danger and release tooling). If a PR should
+trigger a comment on a linked issue after a release ships, use a GitHub closing keyword in the PR
+description, such as `Fixes #123`, `Closes #123`, or `Resolves #123`. The release notification
+workflow only comments on issues GitHub recognizes as closed by the released PR; mentioning an issue
+without a closing keyword is not enough.
+
 ## Final Notes
 
 When contributing to the codebase, please make note of the following:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Aligns release issue notification with [getsentry/sentry-dart#3685](https://github.com/getsentry/sentry-dart/pull/3685): same triggers, permissions, pre-release guards, and `workflow_dispatch` input semantics. The action stays pinned to a full SHA per this repo’s policy, and **`changelog_pr_mode: SIMPLE_ROUND_BRACKETS`** is kept because Craft publishes GitHub release notes with `(#1234)` references rather than markdown PR links.

Adds a short **CONTRIBUTING.md** section explaining that issues only get release comments if GitHub links them as closed by the PR (closing keywords).

`run_release_for_prs` in `file-filters.yml` includes this workflow so release CI validates edits.

## Motivation

Team asked to mirror the automation from the Dart/Flutter PR.

## How tested

Not run locally (YAML + docs only). `make format` is not available in this agent environment (`clang-format` missing).

## Checklist

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/G01PW6HRQNN/p1777973293311169?thread_ts=1777973293.311169&cid=G01PW6HRQNN)

<div><a href="https://cursor.com/agents/bc-ceabf5ae-5510-5450-bec3-1b780cdfe1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceabf5ae-5510-5450-bec3-1b780cdfe1f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

