### PR TITLE
feat: Add Set conformance to SentryAttributeValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add Set conformance to SentryAttributeValue (#7876)
+
 ## 9.12.1
 
 ### Fixes
 
 - Prevent memory strings in stack overflow crash reports (#7841)
 - Report crashed thread for null function calls (#7866)
-- Add Set conformance to SentryAttributeValue (#7876)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Prevent memory strings in stack overflow crash reports (#7841)
 - Report crashed thread for null function calls (#7866)
+- Add Set conformance to SentryAttributeValue (#7876)
 
 ### Fixes
 

--- a/Sources/Swift/Protocol/SentryAttributeValue.swift
+++ b/Sources/Swift/Protocol/SentryAttributeValue.swift
@@ -220,7 +220,7 @@ extension Array: SentryAttributeValue {
         guard !values.isEmpty, case .string = values[0].asSentryAttributeContent else {
             return nil
         }
-        
+
         let mappedStringValues = values.compactMap { element -> String? in
             guard case .string(let value) = element.asSentryAttributeContent else {
                 return nil
@@ -231,5 +231,35 @@ extension Array: SentryAttributeValue {
             return nil
         }
         return .stringArray(mappedStringValues)
-    }   
+    }
+}
+
+extension Set: SentryAttributeValue {
+    /// Converts a set to a `SentryAttributeContent` value.
+    ///
+    /// Homogeneous sets of `Bool`, `Double`, `Float`, `Int`, and `String` are converted to
+    /// their corresponding typed array content. For all other element types the set is
+    /// converted to an `Array` and that extension's homogeneous/heterogeneous logic is
+    /// applied, ultimately falling back to a string array if the elements are mixed.
+    ///
+    /// - Note: Sets are unordered, so the resulting array order is not guaranteed to be
+    ///   consistent across calls.
+    public var asSentryAttributeContent: SentryAttributeContent {
+        if Element.self == Bool.self, let values = self as? Set<Bool> {
+            return .booleanArray(Array(values))
+        }
+        if Element.self == Double.self, let values = self as? Set<Double> {
+            return .doubleArray(Array(values))
+        }
+        if Element.self == Float.self, let values = self as? Set<Float> {
+            return .doubleArray(Array(values).map(Double.init))
+        }
+        if Element.self == Int.self, let values = self as? Set<Int> {
+            return .integerArray(Array(values))
+        }
+        if Element.self == String.self, let values = self as? Set<String> {
+            return .stringArray(Array(values))
+        }
+        return Array(self).asSentryAttributeContent
+    }
 }

--- a/Sources/Swift/Protocol/SentryAttributeValue.swift
+++ b/Sources/Swift/Protocol/SentryAttributeValue.swift
@@ -245,21 +245,6 @@ extension Set: SentryAttributeValue {
     /// - Note: Sets are unordered, so the resulting array order is not guaranteed to be
     ///   consistent across calls.
     public var asSentryAttributeContent: SentryAttributeContent {
-        if Element.self == Bool.self, let values = self as? Set<Bool> {
-            return .booleanArray(Array(values))
-        }
-        if Element.self == Double.self, let values = self as? Set<Double> {
-            return .doubleArray(Array(values))
-        }
-        if Element.self == Float.self, let values = self as? Set<Float> {
-            return .doubleArray(Array(values).map(Double.init))
-        }
-        if Element.self == Int.self, let values = self as? Set<Int> {
-            return .integerArray(Array(values))
-        }
-        if Element.self == String.self, let values = self as? Set<String> {
-            return .stringArray(Array(values))
-        }
         return Array(self).asSentryAttributeContent
     }
 }

--- a/Tests/SentryTests/Protocol/SentryAttributeValuableTests.swift
+++ b/Tests/SentryTests/Protocol/SentryAttributeValuableTests.swift
@@ -545,12 +545,12 @@ final class SentryAttributeValueTests: XCTestCase {
                 return .string("custom")
             }
         }
-        
+
         let array: [CustomStringType] = []
-        
+
         // -- Act --
         let result = array.asSentryAttributeContent
-        
+
         // -- Assert --
         // Empty arrays of custom SentryAttributeValue types cannot determine the intended type,
         // so they should default to stringArray as a safe fallback
@@ -558,5 +558,177 @@ final class SentryAttributeValueTests: XCTestCase {
             return XCTFail("Expected .stringArray case for empty custom array (should not be booleanArray)")
         }
         XCTAssertEqual(value, [])
+    }
+
+    // MARK: - Set Extension Tests
+
+    func testAsSentryAttributeContent_whenStringSet_shouldReturnStringArrayCase() {
+        // -- Arrange --
+        let set: Set<String> = ["hello", "world", "test"]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .stringArray(let value) = result else {
+            return XCTFail("Expected .stringArray case")
+        }
+        XCTAssertEqual(Set(value), set)
+    }
+
+    func testAsSentryAttributeContent_whenEmptyStringSet_shouldReturnStringArrayCase() {
+        // -- Arrange --
+        let set: Set<String> = []
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .stringArray(let value) = result else {
+            return XCTFail("Expected .stringArray case")
+        }
+        XCTAssertEqual(value, [])
+    }
+
+    func testAsSentryAttributeContent_whenBooleanSet_shouldReturnBooleanArrayCase() {
+        // -- Arrange --
+        let set: Set<Bool> = [true, false]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .booleanArray(let value) = result else {
+            return XCTFail("Expected .booleanArray case")
+        }
+        XCTAssertEqual(Set(value), set)
+    }
+
+    func testAsSentryAttributeContent_whenEmptyBooleanSet_shouldReturnBooleanArrayCase() {
+        // -- Arrange --
+        let set: Set<Bool> = []
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .booleanArray(let value) = result else {
+            return XCTFail("Expected .booleanArray case")
+        }
+        XCTAssertEqual(value, [])
+    }
+
+    func testAsSentryAttributeContent_whenIntegerSet_shouldReturnIntegerArrayCase() {
+        // -- Arrange --
+        let set: Set<Int> = [1, 2, 3, 42]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .integerArray(let value) = result else {
+            return XCTFail("Expected .integerArray case")
+        }
+        XCTAssertEqual(Set(value), set)
+    }
+
+    func testAsSentryAttributeContent_whenEmptyIntegerSet_shouldReturnIntegerArrayCase() {
+        // -- Arrange --
+        let set: Set<Int> = []
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .integerArray(let value) = result else {
+            return XCTFail("Expected .integerArray case")
+        }
+        XCTAssertEqual(value, [])
+    }
+
+    func testAsSentryAttributeContent_whenDoubleSet_shouldReturnDoubleArrayCase() {
+        // -- Arrange --
+        let set: Set<Double> = [1.1, 2.2, 3.14159]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .doubleArray(let value) = result else {
+            return XCTFail("Expected .doubleArray case")
+        }
+        XCTAssertEqual(Set(value), set)
+    }
+
+    func testAsSentryAttributeContent_whenEmptyDoubleSet_shouldReturnDoubleArrayCase() {
+        // -- Arrange --
+        let set: Set<Double> = []
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .doubleArray(let value) = result else {
+            return XCTFail("Expected .doubleArray case")
+        }
+        XCTAssertEqual(value, [])
+    }
+
+    func testAsSentryAttributeContent_whenFloatSet_shouldReturnDoubleArrayCase() {
+        // -- Arrange --
+        let set: Set<Float> = [Float(1.1), Float(2.2), Float(3.14159)]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .doubleArray(let value) = result else {
+            return XCTFail("Expected .doubleArray case (Float set converted to Double array)")
+        }
+        
+        let doubleSet = Set<Double>(set.map { Double($0) })
+        XCTAssertEqual(Set(value), doubleSet)
+    }
+
+    func testAsSentryAttributeContent_whenEmptyFloatSet_shouldReturnDoubleArrayCase() {
+        // -- Arrange --
+        let set: Set<Float> = []
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .doubleArray(let value) = result else {
+            return XCTFail("Expected .doubleArray case (Float set converted to Double array)")
+        }
+        XCTAssertEqual(value, [])
+    }
+
+    func testAsSentryAttributeContent_whenSingleElementStringSet_shouldReturnStringArrayCase() {
+        // -- Arrange --
+        let set: Set<String> = ["single"]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .stringArray(let value) = result else {
+            return XCTFail("Expected .stringArray case")
+        }
+        XCTAssertEqual(value, ["single"])
+    }
+
+    func testAsSentryAttributeContent_whenHeterogeneousAnyHashableSet_shouldReturnStringArrayCase() {
+        // -- Arrange --
+        let set: Set<AnyHashable> = ["hello", 42]
+
+        // -- Act --
+        let result = set.asSentryAttributeContent
+
+        // -- Assert --
+        guard case .stringArray(let value) = result else {
+            return XCTFail("Expected .stringArray case for heterogeneous AnyHashable set")
+        }
+        XCTAssertEqual(value.sorted(), ["42", "hello"])
     }
 }

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -67661,6 +67661,363 @@
       {
         "children": [
           {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryAttributeContent",
+                    "printedName": "Sentry.SentryAttributeContent",
+                    "usr": "s:6Sentry0A16AttributeContentO"
+                  }
+                ],
+                "declKind": "Accessor",
+                "genericSig": "<Element where Element : Swift.Hashable>",
+                "isFromExtension": true,
+                "kind": "Accessor",
+                "mangledName": "$sSh6SentryE02asA16AttributeContentAA0acD0Ovg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "s:Sh6SentryE02asA16AttributeContentAA0acD0Ovg"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryAttributeContent",
+                "printedName": "Sentry.SentryAttributeContent",
+                "usr": "s:6Sentry0A16AttributeContentO"
+              }
+            ],
+            "declKind": "Var",
+            "isFromExtension": true,
+            "kind": "Var",
+            "mangledName": "$sSh6SentryE02asA16AttributeContentAA0acD0Ovp",
+            "moduleName": "Sentry",
+            "name": "asSentryAttributeContent",
+            "printedName": "asSentryAttributeContent",
+            "usr": "s:Sh6SentryE02asA16AttributeContentAA0acD0Ovp"
+          }
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss7CVarArgP",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "GenericTypeParam",
+                        "printedName": "Element"
+                      }
+                    ],
+                    "kind": "TypeNameAlias",
+                    "name": "Element",
+                    "printedName": "Swift.Set<Element>.Element"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Index",
+                    "printedName": "Swift.Set<Element>.Index",
+                    "usr": "s:Sh5IndexV"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Index",
+                "printedName": "Index"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "GenericTypeParam",
+                                "printedName": "Element"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Set",
+                            "printedName": "Swift.Set<Element>",
+                            "usr": "s:Sh"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "DefaultIndices",
+                        "printedName": "Swift.DefaultIndices<Swift.Set<Element>>",
+                        "usr": "s:SI"
+                      }
+                    ],
+                    "kind": "TypeNameAlias",
+                    "name": "Indices",
+                    "printedName": "Swift.Set<Element>.Indices"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Indices",
+                "printedName": "Indices"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Iterator",
+                    "printedName": "Swift.Set<Element>.Iterator",
+                    "usr": "s:Sh8IteratorV"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Iterator",
+                "printedName": "Iterator"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "GenericTypeParam",
+                                "printedName": "Element"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Set",
+                            "printedName": "Swift.Set<Element>",
+                            "usr": "s:Sh"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Slice",
+                        "printedName": "Swift.Slice<Swift.Set<Element>>",
+                        "usr": "s:s5SliceV"
+                      }
+                    ],
+                    "kind": "TypeNameAlias",
+                    "name": "SubSequence",
+                    "printedName": "Swift.Set<Element>.SubSequence"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "SubSequence",
+                "printedName": "SubSequence"
+              }
+            ],
+            "kind": "Conformance",
+            "mangledName": "$sSl",
+            "name": "Collection",
+            "printedName": "Collection",
+            "usr": "s:Sl"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss8CopyableP",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss28CustomDebugStringConvertibleP",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss17CustomReflectableP",
+            "name": "CustomReflectable",
+            "printedName": "CustomReflectable",
+            "usr": "s:s17CustomReflectableP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss23CustomStringConvertibleP",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$sSe",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$sSE",
+            "name": "Encodable",
+            "printedName": "Encodable",
+            "usr": "s:SE"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$sSQ",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss9EscapableP",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "GenericTypeParam",
+                        "printedName": "Element"
+                      }
+                    ],
+                    "kind": "TypeNameAlias",
+                    "name": "ArrayLiteralElement",
+                    "printedName": "Swift.Set<Element>.ArrayLiteralElement"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "ArrayLiteralElement",
+                "printedName": "ArrayLiteralElement"
+              }
+            ],
+            "kind": "Conformance",
+            "mangledName": "$ss25ExpressibleByArrayLiteralP",
+            "name": "ExpressibleByArrayLiteral",
+            "printedName": "ExpressibleByArrayLiteral",
+            "usr": "s:s25ExpressibleByArrayLiteralP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$sSH",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$ss8SendableP",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "mangledName": "$s6Sentry0A14AttributeValueP",
+            "name": "SentryAttributeValue",
+            "printedName": "SentryAttributeValue",
+            "usr": "s:6Sentry0A14AttributeValueP"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "GenericTypeParam",
+                    "printedName": "Element"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Iterator",
+                    "printedName": "Swift.Set<Element>.Iterator",
+                    "usr": "s:Sh8IteratorV"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Iterator",
+                "printedName": "Iterator"
+              }
+            ],
+            "kind": "Conformance",
+            "mangledName": "$sST",
+            "name": "Sequence",
+            "printedName": "Sequence",
+            "usr": "s:ST"
+          },
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "GenericTypeParam",
+                        "printedName": "Element"
+                      }
+                    ],
+                    "kind": "TypeNameAlias",
+                    "name": "Element",
+                    "printedName": "Swift.Set<Element>.Element"
+                  }
+                ],
+                "kind": "TypeWitness",
+                "name": "Element",
+                "printedName": "Element"
+              }
+            ],
+            "kind": "Conformance",
+            "mangledName": "$ss10SetAlgebraP",
+            "name": "SetAlgebra",
+            "printedName": "SetAlgebra",
+            "usr": "s:s10SetAlgebraP"
+          }
+        ],
+        "declAttributes": [
+          "EagerMove",
+          "Frozen"
+        ],
+        "declKind": "Struct",
+        "genericSig": "<Element where Element : Swift.Hashable>",
+        "isExternal": true,
+        "kind": "TypeDecl",
+        "mangledName": "$sSh",
+        "moduleName": "Swift",
+        "name": "Set",
+        "printedName": "Set",
+        "usr": "s:Sh"
+      },
+      {
+        "children": [
+          {
             "children": [
               {
                 "children": [


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->
Extend Set to conform to `SentryAttributeValue` (see #7842). Fall back to the extension of Array when the Set contains mixed types so not duplicate logic. 

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows consumers to use `Set` types in Metric Attributes

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
