### PR TITLE
docs: Add doc link to Session Replay network capture changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 - Make feature Metrics generally available, moving experimental options to top-level options (#7843)
 - Add Session Replay network details capture, including request/response headers and bodies extraction (#7580, #7582, #7584, #7585, #7588, #7590, #7854)
+  - Find more details [here](https://docs.sentry.dev/platforms/apple/guides/ios/session-replay/configuration/).
 
 ### Fixes
 


### PR DESCRIPTION
## :scroll: Description

Adds a link to the related Session Replay docs in the CHANGELOG

#skip-changelog

Depends on https://github.com/getsentry/sentry-docs/pull/17668 