### PR TITLE
chore(dx): add and remove default .agents skills

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.XcodeBuildMCP]
+command = "npx"
+args = [ "-y", "xcodebuildmcp@2.0.7", "mcp" ]
+
+[mcp_servers.sentry]
+url = "https://mcp.sentry.dev/mcp/sentry-sdks/sentry-cocoa"

--- a/agents.toml
+++ b/agents.toml
@@ -1,9 +1,5 @@
 version = 1
-agents = ["claude", "cursor"]
-
-[[skills]]
-name = "*"
-source = "getsentry/dotagents"
+agents = ["claude", "codex", "cursor"]
 
 [[mcp]]
 name = "XcodeBuildMCP"
@@ -13,3 +9,15 @@ args = ["-y", "xcodebuildmcp@2.0.7", "mcp"]
 [[mcp]]
 name = "sentry"
 url = "https://mcp.sentry.dev/mcp/sentry-sdks/sentry-cocoa"
+
+[[skills]]
+name = "*"
+source = "getsentry/dotagents"
+
+[[skills]]
+name = "*"
+source = "obra/superpowers"
+
+[[skills]]
+name = "*"
+source = "getsentry/sentry-skills"


### PR DESCRIPTION
- Adds `codex` to the list of agents set up by `npx @sentry/dotagents install`
- Adds `obra/superpowers` and `getsentry/sentry-skills` to the list of skills

#skip-changelog