### PR TITLE
fix: Defensive type checks for malformed recrash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Prevent crash-loop from malformed recrash reports (#7888)
+
 ### Features
 
 - Add Set conformance to SentryAttributeValue (#7876)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Prevent crash-loop from malformed recrash reports (#7888)
+- Prevent crash-loop from malformed recrash reports (#7892)
 
 ### Features
 

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -56,15 +56,18 @@
         self.userContext = userContextMerged;
 
         NSDictionary *crashContext;
-        // This is an incomplete crash report
-        if (nil != report[@"recrash_report"][@"crash"]) {
-            crashContext = report[@"recrash_report"][@"crash"];
+        id recrashReport = report[@"recrash_report"];
+        NSDictionary *recrashDict =
+            [recrashReport isKindOfClass:[NSDictionary class]] ? recrashReport : nil;
+
+        if (nil != recrashDict[@"crash"]) {
+            crashContext = recrashDict[@"crash"];
         } else {
             crashContext = report[@"crash"];
         }
 
-        if (nil != report[@"recrash_report"][@"binary_images"]) {
-            self.binaryImages = report[@"recrash_report"][@"binary_images"];
+        if (nil != recrashDict[@"binary_images"]) {
+            self.binaryImages = recrashDict[@"binary_images"];
         } else {
             self.binaryImages = report[@"binary_images"];
         }

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -443,15 +443,18 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
 - (void)doctorReport:(NSMutableDictionary *)report
 {
-    NSMutableDictionary *crashReport = report[@SentryCrashField_Crash];
-    if (crashReport != nil) {
-        crashReport[@SentryCrashField_Diagnosis] =
-            [[SentryCrashDoctor doctor] diagnoseCrash:report];
+    id crashField = report[@SentryCrashField_Crash];
+    if ([crashField isKindOfClass:[NSMutableDictionary class]]) {
+        crashField[@SentryCrashField_Diagnosis] = [[SentryCrashDoctor doctor] diagnoseCrash:report];
     }
-    crashReport = report[@SentryCrashField_RecrashReport][@SentryCrashField_Crash];
-    if (crashReport != nil) {
-        crashReport[@SentryCrashField_Diagnosis] =
-            [[SentryCrashDoctor doctor] diagnoseCrash:report];
+
+    id recrashField = report[@SentryCrashField_RecrashReport];
+    if ([recrashField isKindOfClass:[NSDictionary class]]) {
+        id recrashCrashField = recrashField[@SentryCrashField_Crash];
+        if ([recrashCrashField isKindOfClass:[NSMutableDictionary class]]) {
+            recrashCrashField[@SentryCrashField_Diagnosis] =
+                [[SentryCrashDoctor doctor] diagnoseCrash:report];
+        }
     }
 }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -13,6 +13,8 @@
 
 - (NSArray *)getAttachmentPaths:(int64_t)reportID;
 
+- (void)doctorReport:(NSMutableDictionary *)report;
+
 @end
 
 @implementation SentryCrashTests
@@ -96,6 +98,64 @@
         fileExistsAtPath:[installPath stringByAppendingPathComponent:@"Data"]]);
     XCTAssertTrue([NSFileManager.defaultManager
         fileExistsAtPath:[installPath stringByAppendingPathComponent:@"Data/CrashState.json"]]);
+}
+
+// GH-7888: doctorReport must not crash when recrash_report is an unexpected type.
+- (void)test_doctorReport_recrashReportIsArray_doesNotCrash
+{
+    SentryCrash *sentryCrash = [[SentryCrash alloc]
+        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+
+    NSMutableDictionary *report = [@{
+        @"crash" : [@{
+            @"error" : @ { @"type" : @"mach" },
+        } mutableCopy],
+        @"recrash_report" : @[ @"garbage", @"data" ],
+    } mutableCopy];
+
+    XCTAssertNoThrow([sentryCrash doctorReport:report]);
+}
+
+- (void)test_doctorReport_recrashReportCrashFieldIsArray_doesNotCrash
+{
+    SentryCrash *sentryCrash = [[SentryCrash alloc]
+        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+
+    NSMutableDictionary *report = [@{
+        @"crash" : [@{
+            @"error" : @ { @"type" : @"mach" },
+        } mutableCopy],
+        @"recrash_report" : @ { @"crash" : @[ @"not", @"a", @"dict" ] },
+    } mutableCopy];
+
+    XCTAssertNoThrow([sentryCrash doctorReport:report]);
+}
+
+- (void)test_doctorReport_crashFieldIsArray_doesNotCrash
+{
+    SentryCrash *sentryCrash = [[SentryCrash alloc]
+        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+
+    NSMutableDictionary *report = [@{
+        @"crash" : @[ @"not", @"a", @"dict" ],
+    } mutableCopy];
+
+    XCTAssertNoThrow([sentryCrash doctorReport:report]);
+}
+
+- (void)test_doctorReport_recrashReportIsString_doesNotCrash
+{
+    SentryCrash *sentryCrash = [[SentryCrash alloc]
+        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+
+    NSMutableDictionary *report = [@{
+        @"crash" : [@{
+            @"error" : @ { @"type" : @"mach" },
+        } mutableCopy],
+        @"recrash_report" : @"unexpected_string",
+    } mutableCopy];
+
+    XCTAssertNoThrow([sentryCrash doctorReport:report]);
 }
 
 - (void)initReport:(uint64_t)reportId withScreenshots:(int)amount

--- a/Tests/SentryTests/SentryCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryCrashReportConverterTests.m
@@ -131,6 +131,47 @@
     XCTAssertEqual(21, thread.stacktrace.registers.count);
 }
 
+// GH-7888: Converter must not crash when recrash_report is a non-dictionary type.
+- (void)testRecrashReport_WithArrayInsteadOfDict_doesNotCrash
+{
+    NSDictionary *report = @{
+        @"crash" : @ {
+            @"error" :
+                @ { @"type" : @"mach", @"mach" : @ { @"exception_name" : @"EXC_BAD_ACCESS" } },
+            @"threads" : @[ @{ @"crashed" : @YES, @"backtrace" : @ { @"contents" : @[] } } ],
+        },
+        @"binary_images" : @[],
+        @"recrash_report" : @[ @"malformed", @"array" ],
+    };
+
+    SentryCrashReportConverter *reportConverter =
+        [[SentryCrashReportConverter alloc] initWithReport:report inAppLogic:self.inAppLogic];
+    SentryEvent *event = [reportConverter convertReportToEvent];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqual(1, event.exceptions.count);
+}
+
+- (void)testRecrashReport_WithStringInsteadOfDict_doesNotCrash
+{
+    NSDictionary *report = @{
+        @"crash" : @ {
+            @"error" :
+                @ { @"type" : @"mach", @"mach" : @ { @"exception_name" : @"EXC_BAD_ACCESS" } },
+            @"threads" : @[ @{ @"crashed" : @YES, @"backtrace" : @ { @"contents" : @[] } } ],
+        },
+        @"binary_images" : @[],
+        @"recrash_report" : @"unexpected_string",
+    };
+
+    SentryCrashReportConverter *reportConverter =
+        [[SentryCrashReportConverter alloc] initWithReport:report inAppLogic:self.inAppLogic];
+    SentryEvent *event = [reportConverter convertReportToEvent];
+
+    XCTAssertNotNil(event);
+    XCTAssertEqual(1, event.exceptions.count);
+}
+
 - (void)testRawWithCrashReport
 {
     NSDictionary *rawCrash = [self getCrashReport:@"Resources/raw-crash"];


### PR DESCRIPTION
## Summary
- Add `isKindOfClass:` type guards in `doctorReport:` (`SentryCrash.m`) and `initWithReport:` (`SentryCrashReportConverter.m`) before subscripting the `recrash_report` field
- SentryCrash can produce structurally malformed recrash reports during signal handler execution (known issue — see existing defensive check in `initThreads:`). When `recrash_report` is a non-dictionary type (e.g. `NSArray`), the chained keyed subscript throws `NSInvalidArgumentException`, crashing the app on every launch in a permanent crash-loop
- The corrupted report is never deleted because the exception fires before `sendAllReportsWithCompletion:` reaches its cleanup handler

## Test plan
- [x] `make build-ios` passes
- [x] `SentryCrashTests` — 4 new tests covering `doctorReport:` with array, string, and nested-array malformed inputs
- [x] `SentryCrashReportConverterTests` — 2 new tests covering converter with array and string `recrash_report`
- [x] All existing tests pass (11 SentryCrashTests, 52 SentryCrashReportConverterTests)

Fixes #7888