### PR TITLE
docs: Clarify comment resolution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,11 @@ Our different types of reviews:
 3. **Only comments.** You must address all the comments and need another review until you merge.
 4. **Request changes.** Only use if something critical is in the PR that absolutely must be addressed. We usually use `h` comments for that. When someone requests changes, the same person must approve the changes to allow merging. Use this sparingly.
 
+**Comment resolution workflow:**
+
+- `h` (high) comments **must be resolved by the reviewer** who left them — the author should not self-resolve these.
+- `m` (medium) and `l` (low) comments may be resolved by the PR author once they believe the concern has been appropriately addressed.
+
 ### After Addressing PR Feedback
 
 **After addressing PR feedback, request another PR review via GitHub.** This changes the pull request status back from commented/approved to waiting, ensuring maintainers are notified that you've addressed their feedback and the PR is ready for re-review.


### PR DESCRIPTION
## :scroll: Description

Add a small clarification about comment resolution on PRs.

## :bulb: Motivation and Context

This change makes explicit how we want comment resolution to work on PRs after a chat between the team.

#skip-changelog