### PR TITLE
fix: Thread-safe scope observer iteration and propagation context locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix race conditions in scope observer iteration and propagation context locking (#7897)
+
 ## 9.13.0
 
 ### Fixes

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -34,9 +34,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryScope {
     NSObject *_spanLock;
+    NSObject *_observersLock;
+    NSObject *_propagationContextLock;
 }
 
 @synthesize span = _span;
+@synthesize propagationContext = _propagationContext;
 
 #pragma mark Initializer
 
@@ -53,6 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
         self.fingerprintArray = [[NSMutableArray alloc] init];
         self.attributesDictionary = [[NSMutableDictionary alloc] init];
         _spanLock = [[NSObject alloc] init];
+        _observersLock = [[NSObject alloc] init];
+        _propagationContextLock = [[NSObject alloc] init];
         self.observers = [[NSMutableArray alloc] init];
         self.propagationContext = [[SentryPropagationContext alloc] init];
     }
@@ -116,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Serializing is expensive. Only do it once.
         NSDictionary<NSString *, id> *serializedBreadcrumb = [crumb serialize];
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer addSerializedBreadcrumb:serializedBreadcrumb];
         }
     }
@@ -127,20 +132,28 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_spanLock) {
         _span = span;
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setTraceContext:[self buildTraceContext:span]];
         }
     }
 }
 
+- (SentryPropagationContext *)propagationContext
+{
+    @synchronized(_propagationContextLock) {
+        return _propagationContext;
+    }
+}
+
 - (void)setPropagationContext:(SentryPropagationContext *)propagationContext
 {
-    @synchronized(_propagationContext) {
+    @synchronized(_propagationContextLock) {
         _propagationContext = propagationContext;
 
-        if (self.observers.count > 0) {
-            NSDictionary *traceContext = [self.propagationContext traceContextForEvent];
-            for (id<SentryScopeObserver> observer in self.observers) {
+        NSArray<id<SentryScopeObserver>> *observers = [self observerSnapshot];
+        if (observers.count > 0) {
+            NSDictionary *traceContext = [propagationContext traceContextForEvent];
+            for (id<SentryScopeObserver> observer in observers) {
                 [observer setTraceContext:traceContext];
             }
         }
@@ -203,7 +216,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.environmentString = nil;
     self.levelEnum = kSentryLevelNone;
 
-    for (id<SentryScopeObserver> observer in self.observers) {
+    for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
         [observer clear];
     }
 }
@@ -214,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
         _currentBreadcrumbIndex = 0;
         [_breadcrumbArray removeAllObjects];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer clearBreadcrumbs];
         }
     }
@@ -243,7 +256,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary setValue:value forKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setContext:_contextDictionary.copy];
         }
     }
@@ -261,7 +274,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_contextDictionary) {
         [_contextDictionary removeObjectForKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setContext:_contextDictionary.copy];
         }
     }
@@ -279,7 +292,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary setValue:value forKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setExtras:_extraDictionary.copy];
         }
     }
@@ -290,7 +303,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_extraDictionary) {
         [_extraDictionary removeObjectForKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setExtras:_extraDictionary.copy];
         }
     }
@@ -305,7 +318,7 @@ NS_ASSUME_NONNULL_BEGIN
         [_extraDictionary
             addEntriesFromDictionary:SENTRY_UNWRAP_NULLABLE_DICT(NSString *, id, extras)];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setExtras:_extraDictionary.copy];
         }
     }
@@ -323,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         _tagDictionary[key] = value;
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setTags:_tagDictionary.copy];
         }
     }
@@ -334,7 +347,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary removeObjectForKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setTags:_tagDictionary.copy];
         }
     }
@@ -349,7 +362,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_tagDictionary) {
         [_tagDictionary addEntriesFromDictionary:tagsCopy];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setTags:_tagDictionary.copy];
         }
     }
@@ -367,7 +380,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(self) {
         self.userObject = user;
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setUser:user];
         }
     }
@@ -377,7 +390,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     self.distString = dist;
 
-    for (id<SentryScopeObserver> observer in self.observers) {
+    for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
         [observer setDist:dist];
     }
 }
@@ -386,7 +399,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     self.environmentString = environment;
 
-    for (id<SentryScopeObserver> observer in self.observers) {
+    for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
         [observer setEnvironment:environment];
     }
 }
@@ -400,7 +413,7 @@ NS_ASSUME_NONNULL_BEGIN
                 addObjectsFromArray:SENTRY_UNWRAP_NULLABLE(NSArray<NSString *>, fingerprint)];
         }
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setFingerprint:_fingerprintArray.copy];
         }
     }
@@ -418,7 +431,7 @@ NS_ASSUME_NONNULL_BEGIN
     _currentScreen = currentScreen;
 
     SEL setCurrentScreen = @selector(setCurrentScreen:);
-    for (id<SentryScopeObserver> observer in self.observers) {
+    for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
         if ([observer respondsToSelector:setCurrentScreen]) {
             [observer setCurrentScreen:currentScreen];
         }
@@ -429,7 +442,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     self.levelEnum = level;
 
-    for (id<SentryScopeObserver> observer in self.observers) {
+    for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
         [observer setLevel:level];
     }
 }
@@ -490,7 +503,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         _attributesDictionary[key] = value;
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setAttributes:_attributesDictionary.copy];
         }
     }
@@ -501,7 +514,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_attributesDictionary) {
         [_attributesDictionary removeObjectForKey:key];
 
-        for (id<SentryScopeObserver> observer in self.observers) {
+        for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer setAttributes:_attributesDictionary.copy];
         }
     }
@@ -706,7 +719,16 @@ NS_ASSUME_NONNULL_BEGIN
     SENTRY_ASSERT(conformsToScopeObserver,
         @"Observer must be an instance conforming to SentryScopeObserver protocol")
     if (conformsToScopeObserver) {
-        [self.observers addObject:observer];
+        @synchronized(_observersLock) {
+            [self.observers addObject:observer];
+        }
+    }
+}
+
+- (NSArray<id<SentryScopeObserver>> *)observerSnapshot
+{
+    @synchronized(_observersLock) {
+        return [self.observers copy];
     }
 }
 

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -474,6 +474,27 @@ class SentryScopeSwiftTests: XCTestCase {
         // If the test completes without a crash or TSan error, the fix works.
     }
 
+    func testAddObserverWhileEnumeratingObservers() {
+        // Regression test for https://github.com/getsentry/sentry-react-native/issues/6131
+        // addScopeObserver: mutates the observers array, which can race with
+        // observer enumeration in setter methods, causing EXC_BREAKPOINT.
+        let scope = Scope(maxBreadcrumbs: 10)
+
+        testConcurrentModifications(asyncWorkItems: 5, writeLoopCount: 200, writeWork: { i in
+            scope.setTag(value: "v-\(i)", key: "key-\(i % 5)")
+            scope.setExtra(value: i, key: "key-\(i % 5)")
+            scope.setContext(value: ["k": "v-\(i)"], key: "ctx-\(i % 5)")
+            scope.setUser(User(userId: "user-\(i)"))
+            scope.setDist("dist-\(i)")
+            scope.setEnvironment("env-\(i)")
+            scope.addBreadcrumb(self.fixture.breadcrumb)
+
+            if i % 10 == 0 {
+                scope.add(AsyncIteratingObserver())
+            }
+        })
+    }
+
     func testScopeObserver_passesDistinctCopyToObservers() {
         // Verify that observers receive a different object (copy) than the internal
         // mutable collection, preventing race conditions when observers dispatch async work.


### PR DESCRIPTION
## :scroll: Description

Fixes race conditions in `SentryScope` that cause `EXC_BREAKPOINT` crashes during concurrent scope observer enumeration and mutation.

**SentryScope.m:**
1. **`_observersLock` + `observerSnapshot`** — Adds a dedicated lock and snapshot method returning `[self.observers copy]`. All 21 observer iteration sites are migrated from `self.observers` to `[self observerSnapshot]`, eliminating mutation-during-enumeration on the `NSMutableArray`. `addScopeObserver:` is also protected by the same lock.
2. **`_propagationContextLock`** — Replaces `@synchronized(_propagationContext)` which locked on the ivar value itself — a bug since the ivar is reassigned inside the block, allowing concurrent calls to lock on different objects. Adds explicit `@synthesize` + manual getter/setter with a stable lock object.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-react-native/issues/6131

A similar fix was applied with https://github.com/getsentry/sentry-cocoa/pull/7807 but didn't cover the observer array or propagation context.

## :green_heart: How did you test it?

- Added `testAddObserverWhileEnumeratingObservers` — stress test that exercises the exact crash scenario: concurrent `addScopeObserver:` calls while other threads iterate observers via scope setters.
- All existing scope tests pass, including:
  - `testModifyingFromMultipleThreads`
  - `testModifyingFromMultipleThreads_withObserverAsyncDispatch`
  - `testScopeObserver_passesDistinctCopyToObservers`
  - `testScopeObserver_setPropagationContext_UpdatesTraceContext`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.