### PR TITLE
fix: include transaction op in beforeSend context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Populate trace operation and related fields on transaction trace context after the root tracer is detached from the scope so `beforeSend` can inspect the operation
+- Populate trace operation and related fields on transaction trace context after the root tracer is detached from the scope so `beforeSend` can inspect the operation (#7909)
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 
 ## 9.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Populate trace operation and related fields on transaction trace context after the root tracer is detached from the scope so `beforeSend` can inspect the operation
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 
 ## 9.13.0

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -12,6 +12,7 @@
 #import "SentrySpanInternal+Private.h"
 #import "SentrySwift.h"
 #import "SentryTracer.h"
+#import "SentryTransaction.h"
 #import "SentryTransactionContext.h"
 #import "SentryUser.h"
 
@@ -685,7 +686,19 @@ NS_ASSUME_NONNULL_BEGIN
                                       intoDictionary:newContext];
     }
 
-    newContext[@"trace"] = [self buildTraceContext:span];
+    // Transaction payloads carry the root tracer on the event. `captureTransaction` may apply the
+    // scope after the tracer is no longer bound, so using only `scope.span` drops fields like `op`
+    // and falls back to propagation context. Prefer the transaction's tracer when present.
+    id<SentrySpan> traceSpan = span;
+    if ([event.type isEqualToString:SentryEnvelopeItemTypes.transaction] &&
+        [event isKindOfClass:[SentryTransaction class]]) {
+        SentryTracer *transactionTracer = [(SentryTransaction *)event trace];
+        if (transactionTracer != nil) {
+            traceSpan = transactionTracer;
+        }
+    }
+
+    newContext[@"trace"] = [self buildTraceContext:traceSpan];
 
     event.context = newContext;
     return event;

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -233,6 +233,20 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(trace["span_id"] as? String, fixture.transaction.spanId.sentrySpanIdString)
         XCTAssertEqual(trace["status"] as? String, "ok")
     }
+
+    func testApplyToEvent_whenTransactionEventWithoutScopeSpan_shouldPopulateTraceOp() throws {
+        // Mirrors async transaction capture after the tracer is unbound from the scope.
+        fixture.scope.span = nil
+        let tracer = try XCTUnwrap(fixture.transaction as? SentryTracer)
+        let transactionEvent = Transaction(trace: tracer, children: [])
+
+        let actual = fixture.scope.applyTo(event: transactionEvent, maxBreadcrumbs: 10)
+
+        let trace = try XCTUnwrap(actual?.context?["trace"] as? [String: Any])
+        XCTAssertEqual(trace["op"] as? String, fixture.transactionOperation)
+        XCTAssertEqual(trace["trace_id"] as? String, tracer.traceId.sentryIdString)
+        XCTAssertEqual(trace["span_id"] as? String, tracer.spanId.sentrySpanIdString)
+    }
     
     func testApplyToEvent_EventWithDist() {
         let event = fixture.event


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## :scroll: Description

`SentryScope` now builds `event.context[@"trace"]` for transaction events from the transaction’s root tracer when available, instead of relying only on `scope.span`. That restores fields such as `op` for `beforeSend` when `captureTransaction` applies the scope asynchronously after the tracer has been unbound.

## :bulb: Motivation and Context

Resolves missing transaction `op` (and related trace fields) on events passed to `beforeSend` when the root tracer is no longer attached to the scope during async capture.

## :green_heart: How did you test it?

- Added `testApplyToEvent_whenTransactionEventWithoutScopeSpan_shouldPopulateTraceOp` in `SentryScopeSwiftTests.swift`.
- Request running `make format` and `make test-ios ONLY_TESTING=SentryScopeSwiftTests` on a Mac/Xcode host before merge.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

Changelog: unreleased **Fixes** entry links #7909.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f5e2d94-bb15-45b6-8d13-d76ed5d659e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f5e2d94-bb15-45b6-8d13-d76ed5d659e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

