### PR TITLE
ref: move version bump from Makefile to scripts

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -452,6 +452,8 @@ run_version_bump_util_for_prs: &run_version_bump_util_for_prs
 
   # Scripts
   - "scripts/bump.sh"
+  - "scripts/bump-version.sh"
+  - "scripts/verify-version.sh"
 
   # Version-related source files
   - "Sources/Sentry/SentryMeta.m"

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Bump version
         env:
           VERSION: ${{ env.VERSION }}
-        run: make bump-version TO=$VERSION
+        run: ./scripts/bump-version.sh --version "$VERSION"
 
       - name: Build ${{inputs.name}}${{inputs.suffix}} XCFramework slice for ${{matrix.sdk}}
         env:

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -37,8 +37,7 @@ jobs:
   run-version-bump:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_version_bump_util_for_prs == 'true'
     needs: files-changed
-    # The release workflow uses the Makefile to bump the version so it needs to be tested.
-    name: Run Version Bump (Makefile)
+    name: Run Version Bump (Scripts)
     # We intentionally run this on ubuntu because the release workflow also runs on ubuntu, which uses the version bump util.
     runs-on: ubuntu-latest
     steps:
@@ -49,8 +48,8 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           echo "VERSION=100.0.$TIMESTAMP" >> $GITHUB_OUTPUT
       # We don't care which version we bump to, as long as it's a valid semver
-      - run: make bump-version TO=${{ steps.generate-version-number.outputs.VERSION }}
-      - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}
+      - run: ./scripts/bump-version.sh --version "${{ steps.generate-version-number.outputs.VERSION }}"
+      - run: ./scripts/verify-version.sh --version "${{ steps.generate-version-number.outputs.VERSION }}"
 
   run-version-bump-script:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_version_bump_util_for_prs == 'true'
@@ -90,7 +89,7 @@ jobs:
         run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
 
       - name: Verify outputs of bump.sh
-        run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}
+        run: ./scripts/verify-version.sh --version "${{ steps.generate-version-number.outputs.NEW_VERSION }}"
 
       - name: Verify outputs of update-package-sha.sh
         run: |

--- a/Makefile
+++ b/Makefile
@@ -925,50 +925,6 @@ generate-public-api:
 strip-xcframework-expected-signature:
 	sed -i '' 's/expectedSignature = "[^"]*"; //g' Samples/XCFramework-Validation/XCFramework.xcodeproj/project.pbxproj
 
-## Bump version to specified version
-#
-# Updates the version across all project files.
-# Usage: make bump-version TO=5.0.0-rc.0
-.PHONY: bump-version
-bump-version: clean-version-bump
-	@echo "--> Bumping version to ${TO}"
-	./Utils/VersionBump/.build/debug/VersionBump --update ${TO}
-
-## Verify version matches specified version
-#
-# Verifies that the version matches the specified version across all project files.
-# Usage: make verify-version TO=5.0.0-rc.0
-.PHONY: verify-version
-verify-version: clean-version-bump
-	@echo "--> Verifying version ${TO}"
-	./Utils/VersionBump/.build/debug/VersionBump --verify ${TO}
-
-## Clean and build VersionBump tool
-#
-# Cleans and rebuilds the VersionBump utility tool.
-.PHONY: clean-version-bump
-clean-version-bump:
-	@echo "--> Clean VersionBump"
-	cd Utils/VersionBump && rm -rf .build && swift build
-
-## Release new version
-#
-# Bumps version, commits changes, creates tag, and pushes to remote.
-# Usage: make release TO=5.0.0-rc.0
-.PHONY: release
-release: bump-version git-commit-add
-
-## Commit version changes and create tag
-#
-# Commits version changes, creates git tag, and pushes to remote.
-# Usage: make git-commit-add TO=5.0.0-rc.0
-.PHONY: git-commit-add
-git-commit-add:
-	@echo "\n\n\n--> Committing git ${TO}"
-	git commit -am "release: ${TO}"
-	git tag ${TO}
-	git push
-	git push --tags
 
 # ============================================================================
 # VALIDATION

--- a/develop-docs/BUILD.md
+++ b/develop-docs/BUILD.md
@@ -24,7 +24,7 @@ This feature is experimental and is currently not compatible with SPM.
 ```bash
 make build-xcframework     # Build XCFramework for distribution
 make pod-lint              # Validate CocoaPods specs
-make bump-version TO=X.Y.Z # Bump version (requires TO parameter)
+./scripts/bump-version.sh --version X.Y.Z # Bump version
 ```
 
 ## Platform-Specific Build Notes

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+VERSION=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --version <version>
+
+Build the VersionBump utility and update the version across all source files.
+
+OPTIONS:
+    --version <version>     Target version string, e.g. 9.13.0 (required)
+
+EXAMPLES:
+    $(basename "$0") --version 9.13.0
+    $(basename "$0") --version 9.13.0-rc.0
+
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version) VERSION="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) log_error "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    log_error "--version is required"
+    usage
+fi
+
+begin_group "Build VersionBump"
+cd "$SCRIPT_DIR/../Utils/VersionBump" && swift build
+cd "$SCRIPT_DIR/.."
+end_group
+
+begin_group "Bump version to ${VERSION}"
+./Utils/VersionBump/.build/debug/VersionBump --update "${VERSION}"
+end_group
+
+log_info "Version bump to ${VERSION} completed successfully"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 # shellcheck source=./ci-utils.sh disable=SC1091
 source "$SCRIPT_DIR/ci-utils.sh"
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
-set -eux
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/.."
+set -euo pipefail
 
-# Disable SC1091 because it won't work with pre-commit
-# shellcheck source=./scripts/ci-utils.sh disable=SC1091
-source "${SCRIPT_DIR}/ci-utils.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
 
 usage() {
     cat <<EOF
 Usage: $(basename "$0") <old_version> <new_version>
 
 Bump the SDK version across all source files and update the package SHA.
+This is the entry point used by Craft during releases.
+
+Accepts positional parameters for Craft compatibility.
 
 ARGUMENTS:
     old_version     Current version string (e.g., 9.12.0)
@@ -40,17 +41,10 @@ log_info "Bumping version:"
 log_info "  Old version: $OLD_VERSION"
 log_info "  New version: $NEW_VERSION"
 
-begin_group "Build VersionBump"
-cd Utils/VersionBump && swift build
-cd "$SCRIPT_DIR/.."
-end_group
-
-begin_group "Bump version from ${OLD_VERSION} to ${NEW_VERSION}"
-./Utils/VersionBump/.build/debug/VersionBump --update "${NEW_VERSION}"
-end_group
+"$SCRIPT_DIR/bump-version.sh" --version "${NEW_VERSION}"
 
 begin_group "Update package SHA"
-./scripts/update-package-sha.sh
+"$SCRIPT_DIR/update-package-sha.sh"
 end_group
 
 log_info "Version bump from ${OLD_VERSION} to ${NEW_VERSION} completed successfully"

--- a/scripts/verify-version.sh
+++ b/scripts/verify-version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+VERSION=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --version <version>
+
+Build the VersionBump utility and verify the version across all source files.
+
+OPTIONS:
+    --version <version>     Expected version string, e.g. 9.13.0 (required)
+
+EXAMPLES:
+    $(basename "$0") --version 9.13.0
+    $(basename "$0") --version 9.13.0-rc.0
+
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version) VERSION="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) log_error "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    log_error "--version is required"
+    usage
+fi
+
+begin_group "Build VersionBump"
+cd "$SCRIPT_DIR/../Utils/VersionBump" && swift build
+cd "$SCRIPT_DIR/.."
+end_group
+
+begin_group "Verify version ${VERSION}"
+./Utils/VersionBump/.build/debug/VersionBump --verify "${VERSION}"
+end_group
+
+log_info "Version verification for ${VERSION} completed successfully"


### PR DESCRIPTION
Consolidates version bump infrastructure by replacing Makefile targets with dedicated shell scripts that follow the repo's named-parameter conventions. This eliminates the mixed Makefile/script approach and removes dead targets (`release`, `git-commit-add`).

**New scripts with named parameters**

`scripts/bump-version.sh --version <v>` builds VersionBump and runs `--update`. `scripts/verify-version.sh --version <v>` builds VersionBump and runs `--verify`. Both follow the repo's script template with `usage()`, `ci-utils.sh` logging, and `set -euo pipefail`.

**`bump.sh` delegates instead of reimplementing**

`bump.sh` keeps positional parameters for Craft compatibility but now delegates to `bump-version.sh` instead of duplicating the VersionBump build-and-run logic. It remains the entry point for `.craft.yml`'s `preReleaseCommand`.

**Removed Makefile targets**

`bump-version`, `verify-version`, `clean-version-bump`, `release`, and `git-commit-add` are removed. `release`/`git-commit-add` were unused in CI — Craft owns the release flow.

#skip-changelog
Fixes #5285