### PR TITLE
fix(samples): remove invalid button and fix attachments

### DIFF
--- a/Samples/iOS-ObjectiveC/App/Resources/Base.lproj/Main.storyboard
+++ b/Samples/iOS-ObjectiveC/App/Resources/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,13 +18,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sentry Test App (Objective-C)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Si0-bZ-rNR">
-                                <rect key="frame" x="92" y="92" width="230" height="20.5"/>
+                                <rect key="frame" x="92" y="140" width="230" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="AVC-4r-eVc">
-                                <rect key="frame" x="8" y="120.5" width="398" height="300"/>
+                                <rect key="frame" x="8" y="168.5" width="398" height="270"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rUC-at-hwU">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -40,57 +41,50 @@
                                             <action selector="captureMessage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="DCQ-8y-GOx"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bD3-Kg-hld">
-                                        <rect key="frame" x="0.0" y="60" width="398" height="30"/>
-                                        <state key="normal" title="captureUserFeedback"/>
-                                        <connections>
-                                            <action selector="captureUserFeedback:" destination="BYZ-38-t0r" eventType="touchUpInside" id="PfT-MW-tlq"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GFX-14-5JR">
-                                        <rect key="frame" x="0.0" y="90" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="60" width="398" height="30"/>
                                         <state key="normal" title="captureUserFeedbackV2"/>
                                         <connections>
                                             <action selector="captureUserFeedbackV2:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Teu-9p-m5v"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G9Q-jA-9Nd">
-                                        <rect key="frame" x="0.0" y="120" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="90" width="398" height="30"/>
                                         <state key="normal" title="captureNSError"/>
                                         <connections>
                                             <action selector="captureError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Btq-8D-8N6"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ugR-6E-UFA">
-                                        <rect key="frame" x="0.0" y="150" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="120" width="398" height="30"/>
                                         <state key="normal" title="captureNSException"/>
                                         <connections>
                                             <action selector="captureException:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ezD-qB-SSr"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I9B-iL-of0">
-                                        <rect key="frame" x="0.0" y="180" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="150" width="398" height="30"/>
                                         <state key="normal" title="captureTransaction"/>
                                         <connections>
                                             <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uaN-VO-vJA"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PFR-up-CPy">
-                                        <rect key="frame" x="0.0" y="210" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="180" width="398" height="30"/>
                                         <state key="normal" title="crash"/>
                                         <connections>
                                             <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6xT-zA-EZI"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eUX-Yi-7fo">
-                                        <rect key="frame" x="0.0" y="240" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="210" width="398" height="30"/>
                                         <state key="normal" title="sigsevCrash"/>
                                         <connections>
                                             <action selector="sigsevCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Z0n-Rw-Tpu"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7cg-k4-wJ5" userLabel="oomCrash">
-                                        <rect key="frame" x="0.0" y="270" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="240" width="398" height="30"/>
                                         <state key="normal" title="OOM Crash"/>
                                         <connections>
                                             <action selector="oomCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6Eb-uS-ljp"/>

--- a/Samples/iOS-ObjectiveC/App/Sources/ViewController.m
+++ b/Samples/iOS-ObjectiveC/App/Sources/ViewController.m
@@ -65,9 +65,9 @@
 - (IBAction)captureUserFeedbackV2:(id)sender
 {
     NSData *data = [NSData dataWithContentsOfURL:BundleResourceProvider.screenshotURL];
-    NSArray<NSData *> *attachments = nil;
+    NSArray<SentryAttachment *> *attachments = nil;
     if (data != nil) {
-        attachments = @[ data ];
+        attachments = @[ [[SentryAttachment alloc] initWithData:data filename:@"screenshot.png"] ];
     }
     SentryId *errorEventID =
         [SentrySDK captureError:[NSError errorWithDomain:@"test-error.user-feedback.iOS-ObjectiveC"


### PR DESCRIPTION
- The Objective-C sample project contained a button in the UI with a broken IBAction, removed it
- The usage of SentryAttachment was incorrect.

Extracted from #7598

#skip-changelog