### PR TITLE
fix: Call `SentrySessionListener` on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)
+- Call SentrySessionListener on main thread (#7917)
 
 ## 9.13.0
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -86,6 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startSession
 {
     SentrySession *lastSession = nil;
+    SentrySession *newSession = nil;
     SentryScope *scope = self.scope;
     SentryOptions *options = [self.client options];
     if (options == nil) {
@@ -97,6 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
             @"Release name of the options of the client is nil. Not starting a session.");
         return;
     }
+    NSString *releaseName = SENTRY_UNWRAP_NULLABLE(NSString, options.releaseName);
 
     @synchronized(_sessionLock) {
         if (_session != nil) {
@@ -106,28 +108,28 @@ NS_ASSUME_NONNULL_BEGIN
         NSString *distinctId =
             [SentryInstallation idWithCacheDirectoryPath:options.cacheDirectoryPath];
 
-        _session = [[SentrySession alloc]
-            initWithReleaseName:SENTRY_UNWRAP_NULLABLE(NSString, options.releaseName)
-                     distinctId:distinctId];
+        SentrySession *session = [[SentrySession alloc] initWithReleaseName:releaseName
+                                                                 distinctId:distinctId];
+        _session = session;
 
         if (_errorsBeforeSession > 0 && options.enableAutoSessionTracking == YES) {
-            _session.errors = _errorsBeforeSession;
+            session.errors = _errorsBeforeSession;
             _errorsBeforeSession = 0;
         }
 
-        _session.environment = options.environment;
+        session.environment = options.environment;
 
-        [scope applyToSession:SENTRY_UNWRAP_NULLABLE(SentrySession, _session)];
+        [scope applyToSession:session];
 
-        [self storeCurrentSession:SENTRY_UNWRAP_NULLABLE(SentrySession, _session)];
-        [self captureSession:SENTRY_UNWRAP_NULLABLE(SentrySession, _session)];
+        [self storeCurrentSession:session];
+        [self captureSession:session];
+        newSession = session;
     }
     [lastSession
         endSessionExitedWithTimestamp:[SentryDependencyContainer.sharedInstance.dateProvider date]];
     [self captureSession:lastSession];
 
-    [_sessionListener
-        sentrySessionStartedWithSession:SENTRY_UNWRAP_NULLABLE(SentrySession, _session)];
+    [self notifySessionStarted:newSession];
 }
 
 - (void)endSession
@@ -152,7 +154,35 @@ NS_ASSUME_NONNULL_BEGIN
     [currentSession endSessionExitedWithTimestamp:timestamp];
     [self captureSession:currentSession];
 
-    [_sessionListener sentrySessionEndedWithSession:currentSession];
+    [self notifySessionEnded:currentSession];
+}
+
+- (void)notifySessionStarted:(SentrySession *)session
+{
+    id<SentrySessionListener> listener = self.sessionListener;
+    if (listener == nil) {
+        return;
+    }
+
+    [self.dispatchQueue dispatchAsyncOnMainQueueIfNotMainThread:^{
+        if (self.sessionListener == listener) {
+            [listener sentrySessionStartedWithSession:session];
+        }
+    }];
+}
+
+- (void)notifySessionEnded:(SentrySession *)session
+{
+    id<SentrySessionListener> listener = self.sessionListener;
+    if (listener == nil) {
+        return;
+    }
+
+    [self.dispatchQueue dispatchAsyncOnMainQueueIfNotMainThread:^{
+        if (self.sessionListener == listener) {
+            [listener sentrySessionEndedWithSession:session];
+        }
+    }];
 }
 
 - (void)storeCurrentSession:(SentrySession *)session

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionListener.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionListener.swift
@@ -1,7 +1,9 @@
 // swiftlint:disable missing_docs
 @objc
 @_spi(Private) public protocol SentrySessionListener {
+    /// Called on the main thread when a session ends.
     @objc(sentrySessionEndedWithSession:) func sentrySessionEnded(session: SentrySession)
+    /// Called on the main thread when a session starts.
     @objc(sentrySessionStartedWithSession:) func sentrySessionStarted(session: SentrySession)
 }
 // swiftlint:enable missing_docs

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -66,6 +66,19 @@ class SentryHubTests: XCTestCase {
             return hub
         }
     }
+
+    private class TestSessionListener: NSObject, SentrySessionListener {
+        let startedSessions = Invocations<SentrySession>()
+        let endedSessions = Invocations<SentrySession>()
+
+        func sentrySessionStarted(session: SentrySession) {
+            startedSessions.record(session)
+        }
+
+        func sentrySessionEnded(session: SentrySession) {
+            endedSessions.record(session)
+        }
+    }
     
     private var fixture: Fixture!
     private lazy var sut = fixture.getSut()
@@ -966,6 +979,38 @@ class SentryHubTests: XCTestCase {
         // Assert
         let session = try XCTUnwrap(sut.session)
         XCTAssertEqual(session.errors, UInt(captureCount))
+    }
+
+    func testStartSession_NotifiesSessionListenerOnMainQueue() {
+        let listener = TestSessionListener()
+        sut.registerSessionListener(listener)
+        fixture.dispatchQueueWrapper.blockBeforeMainBlock = { false }
+
+        sut.startSession()
+
+        XCTAssertEqual(1, fixture.dispatchQueueWrapper.blockOnMainInvocations.count)
+        XCTAssertEqual(0, listener.startedSessions.count)
+
+        fixture.dispatchQueueWrapper.blockOnMainInvocations.last?()
+
+        XCTAssertEqual(1, listener.startedSessions.count)
+    }
+
+    func testEndSession_NotifiesSessionListenerOnMainQueue() {
+        sut.startSession()
+
+        let listener = TestSessionListener()
+        sut.registerSessionListener(listener)
+        fixture.dispatchQueueWrapper.blockBeforeMainBlock = { false }
+
+        sut.endSession()
+
+        XCTAssertEqual(1, fixture.dispatchQueueWrapper.blockOnMainInvocations.count)
+        XCTAssertEqual(0, listener.endedSessions.count)
+
+        fixture.dispatchQueueWrapper.blockOnMainInvocations.last?()
+
+        XCTAssertEqual(1, listener.endedSessions.count)
     }
 
     func testCaptureEventIncrementingSessionErrorCount_WithStartedSession_OnlySendsSessionInit() {


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Ensure SentrySessionListener callbacks for session start/end are delivered on the main thread. This fixes Session Replay lifecycle callbacks being invoked from the session-tracker background queue, while preserving async delivery.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/getsentry/sentry-cocoa/pull/7912

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
