### PR TITLE
fix(session): Prevent SessionTracker crash with profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)
+- Prevent SessionTracker crash with profiling (#7927)
 
 ## 9.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)
 - Prevent SessionTracker crash with profiling (#7927)
+  - Reevaluation of sampling decision is only done for new sessions.
 
 ## 9.13.0
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 		FAAB964C2EA688E50030A2DB /* SentryANRStoppedResultInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = FAAB964B2EA688E40030A2DB /* SentryANRStoppedResultInternal.m */; };
 		FAB359982E05D7E90083D5E3 /* SentryEventSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */; };
 		FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */; };
+		F1A4C0012F5E000100000001 /* SentryProfileConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A4C0002F5E000100000001 /* SentryProfileConfigurationTests.m */; };
 		FAC735232E25AA81006C5A64 /* SentryProfilingSwiftHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAC735222E25AA7A006C5A64 /* SentryProfilingSwiftHelpersTests.m */; };
 		FACEED132E3179A10007B4AC /* SentryOptionsInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = FACEED122E3179A10007B4AC /* SentryOptionsInternal.m */; };
 		FAD882C42EDB3F4C0055AA44 /* SentryCrashAsync.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD882C32EDB3F450055AA44 /* SentryCrashAsync.h */; };
@@ -1139,6 +1140,7 @@
 		FAAB964B2EA688E40030A2DB /* SentryANRStoppedResultInternal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryANRStoppedResultInternal.m; sourceTree = "<group>"; };
 		FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEventSwiftHelper.h; path = include/SentryEventSwiftHelper.h; sourceTree = "<group>"; };
 		FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEventSwiftHelper.m; sourceTree = "<group>"; };
+		F1A4C0002F5E000100000001 /* SentryProfileConfigurationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfileConfigurationTests.m; sourceTree = "<group>"; };
 		FAC735222E25AA7A006C5A64 /* SentryProfilingSwiftHelpersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfilingSwiftHelpersTests.m; sourceTree = "<group>"; };
 		FACEED122E3179A10007B4AC /* SentryOptionsInternal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryOptionsInternal.m; sourceTree = "<group>"; };
 		FAD882C32EDB3F450055AA44 /* SentryCrashAsync.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashAsync.h; path = include/SentryCrashAsync.h; sourceTree = "<group>"; };
@@ -1944,6 +1946,7 @@
 			isa = PBXGroup;
 			children = (
 				D4DEE6582E439B2E00FCA5A9 /* SentryProfileTimeseriesTests.m */,
+				F1A4C0002F5E000100000001 /* SentryProfileConfigurationTests.m */,
 				FAC735222E25AA7A006C5A64 /* SentryProfilingSwiftHelpersTests.m */,
 				849472802971C107002603DE /* SentrySystemWrapperTests.swift */,
 				849472822971C2CD002603DE /* SentryNSProcessInfoWrapperTests.swift */,
@@ -3072,6 +3075,7 @@
 				8431EFE229B27BAD00D8DC56 /* SentryNSTimerFactoryTest.swift in Sources */,
 				8431EFDD29B27B5300D8DC56 /* SentrySamplingProfilerTests.mm in Sources */,
 				8431D4552BE1745A009EAEC1 /* SentryProfileTestFixture.swift in Sources */,
+				F1A4C0012F5E000100000001 /* SentryProfileConfigurationTests.m in Sources */,
 				FAC735232E25AA81006C5A64 /* SentryProfilingSwiftHelpersTests.m in Sources */,
 				8431EFDC29B27B5300D8DC56 /* SentryProfilerTests.mm in Sources */,
 				8431D4562BE1745F009EAEC1 /* SentryContinuousProfilerTests.swift in Sources */,

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -71,10 +71,10 @@ _sentry_hydrateV2Options(NSDictionary<NSString *, NSNumber *> *launchConfigDict,
     profileOptions.profileAppStarts = true;
     profileOptions.sessionSampleRate = samplerDecision.sampleRate.floatValue;
 
-    sentry_profileConfiguration = [[SentryProfileConfiguration alloc]
+    sentry_setProfileConfiguration([[SentryProfileConfiguration alloc]
         initContinuousProfilingV2WaitingForFullDisplay:shouldWaitForFullDisplay
                                        samplerDecision:samplerDecision
-                                        profileOptions:profileOptions];
+                                        profileOptions:profileOptions]);
 }
 
 /**
@@ -353,7 +353,7 @@ sentry_stopAndDiscardLaunchProfileTracer(SentryHubInternal *_Nullable hub)
     SENTRY_LOG_DEBUG(@"Finishing launch tracer.");
     sentry_launchTracer.hub = hub;
     [sentry_launchTracer finish];
-    sentry_profileConfiguration = nil;
+    sentry_setProfileConfiguration(nil);
     sentry_isTracingAppLaunch = NO;
     sentry_launchTracer = nil;
 }

--- a/Sources/Sentry/Profiling/SentryProfileConfiguration.m
+++ b/Sources/Sentry/Profiling/SentryProfileConfiguration.m
@@ -12,6 +12,8 @@
 
 @implementation SentryProfileConfiguration
 
+@synthesize profilerSessionSampleDecision = _profilerSessionSampleDecision;
+
 - (instancetype)initWithProfileOptions:(SentryProfileOptions *)options
 {
     if (!(self = [super init])) {
@@ -45,6 +47,20 @@
     _profilerSessionSampleDecision = decision;
     _isProfilingThisLaunch = YES;
     return self;
+}
+
+- (SentrySamplerDecision *_Nullable)profilerSessionSampleDecision
+{
+    @synchronized(self) {
+        return _profilerSessionSampleDecision;
+    }
+}
+
+- (void)setProfilerSessionSampleDecision:(SentrySamplerDecision *_Nullable)decision
+{
+    @synchronized(self) {
+        _profilerSessionSampleDecision = decision;
+    }
 }
 
 - (void)reevaluateSessionSampleRate

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -121,8 +121,8 @@ SentryId *_Nullable _sentry_startContinuousProfilerV2ForTrace(
         return nil;
     }
 
-    if (sentry_profileConfiguration.profilerSessionSampleDecision.decision
-        != kSentrySampleDecisionYes) {
+    SentryProfileConfiguration *profileConfiguration = sentry_getProfileConfiguration();
+    if (profileConfiguration.profilerSessionSampleDecision.decision != kSentrySampleDecisionYes) {
         return nil;
     }
 
@@ -245,10 +245,11 @@ sentry_stopProfilerDueToFinishedTransaction(SentryHubInternal *hub,
 #    endif // SENTRY_HAS_UIKIT
 )
 {
-    if (sentry_profileConfiguration != nil && sentry_profileConfiguration.isProfilingThisLaunch
-        && sentry_profileConfiguration.profileOptions != nil
-        && sentry_isTraceLifecycle(SENTRY_UNWRAP_NULLABLE(
-            SentryProfileOptions, sentry_profileConfiguration.profileOptions))) {
+    SentryProfileConfiguration *profileConfiguration = sentry_getProfileConfiguration();
+    if (profileConfiguration != nil && profileConfiguration.isProfilingThisLaunch
+        && profileConfiguration.profileOptions != nil
+        && sentry_isTraceLifecycle(
+            SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, profileConfiguration.profileOptions))) {
         SENTRY_LOG_DEBUG(@"Stopping launch UI trace profile.");
         sentry_stopTrackingRootSpanForContinuousProfilerV2();
         // The launch tracer is intentionally discarded by sentry_stopAndDiscardLaunchProfileTracer.
@@ -341,11 +342,12 @@ sentry_stopProfilerDueToFinishedTransaction(SentryHubInternal *hub,
 SentryId *_Nullable sentry_startProfilerForTrace(SentryTracerConfiguration *configuration,
     SentryHubInternal *_Nullable hub, SentryTransactionContext *transactionContext)
 {
-    if (sentry_profileConfiguration.profileOptions != nil) {
+    SentryProfileConfiguration *profileConfiguration = sentry_getProfileConfiguration();
+    if (profileConfiguration.profileOptions != nil) {
         // launch profile; there's no hub to get options from, so they're read from the launch
         // profile config file
         return _sentry_startContinuousProfilerV2ForTrace(
-            sentry_profileConfiguration.profileOptions, transactionContext);
+            profileConfiguration.profileOptions, transactionContext);
     }
     SentryClientInternal *_Nullable client = hub.getClient;
     if (client != nil

--- a/Sources/Sentry/Profiling/SentryProfilingSwiftHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilingSwiftHelpers.m
@@ -231,9 +231,9 @@ sentry_configureContinuousProfiling(SentryOptions *options)
     // help determine when/how to stop the launch profile. otherwise, there won't yet be a
     // SentryProfileConfiguration instance, so we'll instantiate one which will be used to access
     // the profile session sample rate henceforth
-    if (sentry_profileConfiguration == nil) {
-        sentry_profileConfiguration =
-            [[SentryProfileConfiguration alloc] initWithProfileOptions:profilingOptions];
+    if (sentry_getProfileConfiguration() == nil) {
+        sentry_setProfileConfiguration(
+            [[SentryProfileConfiguration alloc] initWithProfileOptions:profilingOptions]);
     }
 
     sentry_reevaluateSessionSampleRate();
@@ -250,7 +250,7 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHubInternal *hub)
 {
     // get the configuration options from the last time the launch config was written; it may be
     // different than the new options the SDK was just started with
-    SentryProfileConfiguration *configurationFromLaunch = sentry_profileConfiguration;
+    SentryProfileConfiguration *configurationFromLaunch = sentry_getProfileConfiguration();
 
     sentry_configureContinuousProfiling(options);
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -29,30 +29,55 @@ using namespace sentry::profiling;
  * The current configuration the profiler operates under for this session. Set when a launch profile
  * runs, and then is updated on SDK start.
  */
-SentryProfileConfiguration *_Nullable sentry_profileConfiguration;
+static SentryProfileConfiguration *_Nullable sentry_profileConfiguration;
 
 namespace {
 
 static const int kSentryProfilerFrequencyHz = 101;
 
+NSObject *
+sentry_profileConfigurationLock()
+{
+    // Function-local static lazily initializes this once and returns the same lock on every call.
+    static NSObject *lock = [[NSObject alloc] init];
+    return lock;
+}
+
 } // namespace
 
 #    pragma mark - Public
 
+SentryProfileConfiguration *_Nullable sentry_getProfileConfiguration(void)
+{
+    @synchronized(sentry_profileConfigurationLock()) {
+        return sentry_profileConfiguration;
+    }
+}
+
+void
+sentry_setProfileConfiguration(SentryProfileConfiguration *_Nullable configuration)
+{
+    @synchronized(sentry_profileConfigurationLock()) {
+        sentry_profileConfiguration = configuration;
+    }
+}
+
 void
 sentry_reevaluateSessionSampleRate()
 {
-    [sentry_profileConfiguration reevaluateSessionSampleRate];
+    SentryProfileConfiguration *configuration = sentry_getProfileConfiguration();
+    [configuration reevaluateSessionSampleRate];
 }
 
 BOOL
 sentry_isLaunchProfileCorrelatedToTraces(void)
 {
-    if (nil == sentry_profileConfiguration) {
+    SentryProfileConfiguration *configuration = sentry_getProfileConfiguration();
+    if (nil == configuration) {
         return NO;
     }
 
-    SentryProfileOptions *_Nullable nullableOptions = sentry_profileConfiguration.profileOptions;
+    SentryProfileOptions *_Nullable nullableOptions = configuration.profileOptions;
     if (nil == nullableOptions) {
         return YES;
     }

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -632,7 +632,8 @@ static NSDate *_Nullable startTimestamp = nil;
             return;
         }
 
-        if (sentry_profileConfiguration.profilerSessionSampleDecision.decision
+        SentryProfileConfiguration *profileConfiguration = sentry_getProfileConfiguration();
+        if (profileConfiguration.profilerSessionSampleDecision.decision
             != kSentrySampleDecisionYes) {
             SENTRY_LOG_DEBUG(
                 @"The profiling session has been sampled out, no profiling will take place.");
@@ -652,8 +653,9 @@ static NSDate *_Nullable startTimestamp = nil;
 {
     // check if we'd be stopping a launch profiler, because then we need to check the hydrated
     // configuration options, not the current ones
-    if (sentry_profileConfiguration.isProfilingThisLaunch) {
-        if (sentry_profileConfiguration.profileOptions == nil) {
+    SentryProfileConfiguration *profileConfiguration = sentry_getProfileConfiguration();
+    if (profileConfiguration.isProfilingThisLaunch) {
+        if (profileConfiguration.profileOptions == nil) {
             SENTRY_LOG_WARN(
                 @"The current profiler was started on app launch and was configured as a "
                 @"transaction profiler, which cannot be stopped manually. Transaction profiling is "
@@ -661,7 +663,7 @@ static NSDate *_Nullable startTimestamp = nil;
             return;
         }
 
-        if (sentry_profileConfiguration.profileOptions.lifecycle == SentryProfileLifecycleTrace) {
+        if (profileConfiguration.profileOptions.lifecycle == SentryProfileLifecycleTrace) {
             SENTRY_LOG_WARN(
                 @"The launch profile lifecycle was set to trace, so you cannot stop profile "
                 @"sessions manually. See SentryProfileLifecycle for more information.");

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -37,7 +37,10 @@ typedef struct {
  */
 SENTRY_EXTERN void sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHubInternal *hub);
 
-SENTRY_EXTERN SentryProfileConfiguration *_Nullable sentry_profileConfiguration;
+SENTRY_EXTERN SentryProfileConfiguration *_Nullable sentry_getProfileConfiguration(void);
+
+SENTRY_EXTERN void sentry_setProfileConfiguration(
+    SentryProfileConfiguration *_Nullable configuration);
 
 SENTRY_EXTERN BOOL sentry_isLaunchProfileCorrelatedToTraces(void);
 

--- a/Sources/Swift/Integrations/Session/SessionTracker.swift
+++ b/Sources/Swift/Integrations/Session/SessionTracker.swift
@@ -164,7 +164,7 @@ final class SessionTracker {
         }
 
         dispatchQueue.dispatchAsync { [weak self] in
-            guard self != nil else { return }
+            guard let self else { return }
             let hub = SentrySDKInternal.currentHub()
             let lastInForeground = SentryDependencyContainerSwiftHelper.readTimestampLastInForeground()
 
@@ -178,6 +178,7 @@ final class SessionTracker {
                     SentrySDKLog.debug("App was in the background for \(secondsInBackground) seconds. Starting a new session.")
                     hub.endSession(withTimestamp: lastInForeground)
                     hub.startSession()
+                    reevaluateProfileSessionSampleRateIfNeeded()
                 } else {
                     SentrySDKLog.debug("App was in the background for \(secondsInBackground) seconds. Not starting a new session.")
                 }
@@ -186,14 +187,9 @@ final class SessionTracker {
                 // wait until the app is in the foreground to start a session.
                 SentrySDKLog.debug("App was in the foreground for the first time. Starting a new session.")
                 hub.startSession()
+                reevaluateProfileSessionSampleRateIfNeeded()
             }
             SentryDependencyContainerSwiftHelper.deleteTimestampLastInForeground()
-
-        #if !(os(watchOS) || os(tvOS) || os(visionOS))
-            if SentryDependencyContainerSwiftHelper.hasProfilingOptions() {
-                sentry_reevaluateSessionSampleRate()
-            }
-        #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         }
     }
 
@@ -224,5 +220,14 @@ final class SessionTracker {
             SentryDependencyContainerSwiftHelper.deleteTimestampLastInForeground()
         }
         wasStartSessionCalled = false
+    }
+
+    // Private helper for profiling session sample-rate reevaluation.
+    private func reevaluateProfileSessionSampleRateIfNeeded() {
+    #if !(os(watchOS) || os(tvOS) || os(visionOS))
+        if SentryDependencyContainerSwiftHelper.hasProfilingOptions() {
+            sentry_reevaluateSessionSampleRate()
+        }
+    #endif // !(os(watchOS) || os(tvOS) || os(visionOS))
     }
 }

--- a/Tests/SentryProfilerTests/SentryProfileConfigurationTests.m
+++ b/Tests/SentryProfilerTests/SentryProfileConfigurationTests.m
@@ -1,0 +1,111 @@
+@import XCTest;
+@import Sentry;
+#import "SentryProfileConfiguration.h"
+#import "SentryProfiler+Private.h"
+#import "SentrySamplerDecision.h"
+
+@interface SentryProfileConfigurationTests : XCTestCase
+@end
+
+@implementation SentryProfileConfigurationTests
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+- (void)tearDown
+{
+    sentry_setProfileConfiguration(nil);
+    [super tearDown];
+}
+
+- (void)testReevaluateSessionSampleRate_whenReadingSampleDecisionConcurrently_shouldNotCrash
+{
+    // -- Arrange --
+    SentryProfileOptions *options = [[SentryProfileOptions alloc] init];
+    options.sessionSampleRate = 1;
+    SentryProfileConfiguration *configuration =
+        [[SentryProfileConfiguration alloc] initWithProfileOptions:options];
+    [configuration reevaluateSessionSampleRate];
+
+    NSUInteger taskCount = 20;
+    NSUInteger loopCount = 1000;
+    XCTestExpectation *expectation =
+        [self expectationWithDescription:@"Concurrent profile configuration access"];
+    expectation.expectedFulfillmentCount = taskCount * 2;
+    expectation.assertForOverFulfill = YES;
+    dispatch_queue_attr_t attributes
+        = dispatch_queue_attr_make_initially_inactive(DISPATCH_QUEUE_CONCURRENT);
+    dispatch_queue_t queue
+        = dispatch_queue_create("io.sentry.profile-configuration-test", attributes);
+
+    // -- Act --
+    for (NSUInteger i = 0; i < taskCount; i++) {
+        dispatch_async(queue, ^{
+            for (NSUInteger j = 0; j < loopCount; j++) {
+                [configuration reevaluateSessionSampleRate];
+            }
+            [expectation fulfill];
+        });
+        dispatch_async(queue, ^{
+            for (NSUInteger j = 0; j < loopCount; j++) {
+                SentrySamplerDecision *decision = configuration.profilerSessionSampleDecision;
+                (void)decision.decision;
+            }
+            [expectation fulfill];
+        });
+    }
+
+    dispatch_activate(queue);
+    [self waitForExpectations:@[ expectation ] timeout:5.0];
+
+    // -- Assert --
+    XCTAssertNotNil(configuration.profilerSessionSampleDecision);
+}
+
+- (void)testReevaluateSessionSampleRate_whenProfileConfigurationChangesConcurrently_shouldNotCrash
+{
+    // -- Arrange --
+    SentryProfileOptions *options = [[SentryProfileOptions alloc] init];
+    options.sessionSampleRate = 1;
+
+    NSUInteger taskCount = 20;
+    NSUInteger loopCount = 1000;
+    dispatch_queue_attr_t attributes
+        = dispatch_queue_attr_make_initially_inactive(DISPATCH_QUEUE_CONCURRENT);
+    dispatch_queue_t queue
+        = dispatch_queue_create("io.sentry.global-profile-configuration-test", attributes);
+    dispatch_group_t group = dispatch_group_create();
+
+    // -- Act --
+    for (NSUInteger i = 0; i < taskCount; i++) {
+        dispatch_group_async(group, queue, ^{
+            for (NSUInteger j = 0; j < loopCount; j++) {
+                SentryProfileConfiguration *configuration =
+                    [[SentryProfileConfiguration alloc] initWithProfileOptions:options];
+                sentry_setProfileConfiguration(configuration);
+                sentry_setProfileConfiguration(nil);
+            }
+        });
+        dispatch_group_async(group, queue, ^{
+            for (NSUInteger j = 0; j < loopCount; j++) {
+                sentry_reevaluateSessionSampleRate();
+            }
+        });
+    }
+
+    dispatch_activate(queue);
+
+    // -- Assert --
+    long waitResult
+        = dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+    XCTAssertEqual(waitResult, 0L);
+    SentryProfileConfiguration *configuration =
+        [[SentryProfileConfiguration alloc] initWithProfileOptions:options];
+    sentry_setProfileConfiguration(configuration);
+    sentry_reevaluateSessionSampleRate();
+    SentryProfileConfiguration *storedConfiguration = sentry_getProfileConfiguration();
+    XCTAssertNotNil(storedConfiguration.profilerSessionSampleDecision);
+}
+
+#endif
+
+@end

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -428,8 +428,9 @@ extension SentryProfilingPublicAPITests {
     }
 
 #if !os(macOS)
-    func testSessionSampleRateReevaluationOnAppBecomingActive() {
+    func testSessionSampleRateReevaluationOnAppBecomingActive_whenNewSessionStarts_shouldReevaluate() {
         // Arrange
+        fixture.options.sessionTrackingIntervalMillis = 10_000
         fixture.options.configureProfiling = {
             $0.sessionSampleRate = 0.5
             $0.lifecycle = .manual
@@ -445,8 +446,8 @@ extension SentryProfilingPublicAPITests {
             notificationCenter: nc,
             dispatchQueue: TestSentryDispatchQueueWrapper()
         )
-        fixture.sessionTracker?.start()
         givenSdkWithHub()
+        fixture.sessionTracker?.start()
 
         // Act
         SentrySDK.startProfiler()
@@ -460,6 +461,7 @@ extension SentryProfilingPublicAPITests {
 
         // Arrange
         fixture.random = TestRandom(value: 1)
+        fixture.currentDate.advance(by: 10)
 
         // Act
         nc.post(Notification(name: UIApplication.didBecomeActiveNotification))
@@ -467,6 +469,49 @@ extension SentryProfilingPublicAPITests {
 
         // Assert
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
+    }
+
+    func testSessionSampleRateReevaluationOnAppBecomingActive_whenSameSession_shouldNotReevaluate() {
+        // Arrange
+        fixture.options.sessionTrackingIntervalMillis = 10_000
+        fixture.options.configureProfiling = {
+            $0.sessionSampleRate = 0.5
+            $0.lifecycle = .manual
+        }
+        fixture.random = TestRandom(value: 0)
+        let container = SentryDependencyContainer.sharedInstance()
+        let nc = container.notificationCenterWrapper
+        let application = container.application()
+        fixture.sessionTracker = SessionTracker(
+            options: fixture.options,
+            applicationProvider: { application },
+            dateProvider: fixture.currentDate,
+            notificationCenter: nc,
+            dispatchQueue: TestSentryDispatchQueueWrapper()
+        )
+        givenSdkWithHub()
+        fixture.sessionTracker?.start()
+
+        // Act
+        SentrySDK.startProfiler()
+
+        // Assert
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
+
+        // Act
+        nc.post(Notification(name: UIApplication.willResignActiveNotification))
+        XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
+
+        // Arrange
+        fixture.random = TestRandom(value: 1)
+        fixture.currentDate.advance(by: 9)
+
+        // Act
+        nc.post(Notification(name: UIApplication.didBecomeActiveNotification))
+        SentrySDK.startProfiler()
+
+        // Assert
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
     }
 #endif // !os(macOS)
 }

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -54,6 +54,9 @@ class SentryProfilingPublicAPITests: XCTestCase {
     }
 
     override func tearDown() {
+        fixture.sessionTracker?.removeObservers()
+        fixture.sessionTracker = nil
+
         super.tearDown()
 
         givenSdkWithHubButNoClient()


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Fixes a crash caused by racing access to the global profiling configuration while reevaluating the profile session sample decision. This was introduced by #7704 because the reevaluation call was done off the main queue.

Initially i just wanted to move reevaluation outside of the async block, but I encountered an additional sampling correctness issue.

Profile session sampling is now reevaluated only when a new Sentry session is started, instead of every time the app returns to the foreground. This matches Android behavior and keeps the sample decision stable for the lifetime of a session.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #7921

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
