### PR TITLE
fix(replay): Defer startup until window exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Defer Session Replay startup until a foreground window is available (#7928)
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)
 - Prevent SessionTracker crash with profiling (#7927)

--- a/Sources/Swift/Helper/SentryApplicationExtensions.swift
+++ b/Sources/Swift/Helper/SentryApplicationExtensions.swift
@@ -40,6 +40,8 @@ extension SentryApplication {
         var windows = Set<UIWindow>()
         Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({ [weak self] in
             guard let self else { return }
+
+            // For each active scene we get the window
             let scenes = self.connectedScenes
             for scene in scenes {
                 if scene.activationState == .foregroundActive {
@@ -53,10 +55,16 @@ extension SentryApplication {
                 }
             }
 
-            if let window = self.delegate?.window {
-                if let window {
-                    windows.insert(window)
-                }
+            // If no scenes are given, we try to find the window of the application delegate
+            guard let delegate else {
+                SentrySDKLog.debug("No application delegate found.")
+                return
+            }
+
+            // If scenes are not used, we fallback to the default UIApplicationDelegate.window.
+            // The property is of type UIWindow?? so we need to unwrap both optional layers.
+            if let optionalWindow = delegate.window, let window = optionalWindow {
+                windows.insert(window)
             }
         }, timeout: 0.01)
         return Array(windows)

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
@@ -23,7 +23,6 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     private let replayOptions: SentryReplayOptions
     private let rateLimits: RateLimits
     private let random: SentryRandomProtocol
-    private let application: SentryApplication?
     private var startedAsFullSession = false
     private let experimentalOptions: SentryExperimentalOptions
     private let notificationCenter: SentryNSNotificationCenterWrapper
@@ -34,11 +33,25 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     private let crashWrapper: SentryCrashReporter
     private let replayFileManager: SessionReplayFileManager
     private var replayRecovery: SessionReplayRecovery?
-    
+
+    /// Getter to get the current application at runtime
+    ///
+    /// When initializing the Sentry SDK from ``SwiftUI/App.init`` the ``UIKit/UIApplication.shared`` returns `nil`, therefore we need to
+    /// dynamically get it later, even if the application is not changing during the life-time of the app
+    private let getApplication: () -> SentryApplication?
+
     /// We need to use this variable to identify whether rate limiting was ever activated for session replay
     /// in this session, instead of always looking for the rate status in `SentryRateLimits`. This is the
     /// easiest way to ensure segment 0 will always reach the server, because session replay needs segment 0.
     private var rateLimited = false
+
+    /// Indicates that session replay should start once the SDK can resolve a usable application
+    /// window. This is needed because SDK startup can run before `UIApplication.shared` or a
+    /// foreground scene window is available; lifecycle notifications should retry startup while this
+    /// flag is set. Clear it when the pending start is no longer valid, such as on session end,
+    /// manual stop, or replay rate limiting.
+    private var isPendingStart = false
+
     @objc public static var name: String { "SentrySessionReplayIntegration" }
 
     // MARK: - Initialization
@@ -55,9 +68,11 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     @objc
     public convenience init(forManualUseWith options: Options, dependencies: SentryDependencyContainer) {
         self.init(nonOptionalWith: options, dependencies: dependencies)
-        startWithOptions(options.sessionReplay,
-                         experimentalOptions: options.experimental,
-                         fullSession: true)
+        startWithOptions(
+            options.sessionReplay,
+            experimentalOptions: options.experimental,
+            fullSession: true
+        )
     }
     
     init(nonOptionalWith options: Options, dependencies: SessionReplayIntegrationScope) {
@@ -68,8 +83,8 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         self.dateProvider = dependencies.dateProvider
         self.random = dependencies.random
         self.crashWrapper = dependencies.crashWrapper
-        self.application = dependencies.application()
-        
+        self.getApplication = dependencies.application
+
         self.replayFileManager = SessionReplayFileManager(
             fileManager: dependencies.fileManager,
             sharedDispatchQueue: dependencies.dispatchQueueWrapper
@@ -95,10 +110,16 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         
         SentrySDKInternal.currentHub().registerSessionListener(self)
         dependencies.reachability.add(self)
+
+        // Create observers of the application lifecycle for UIKit and SwiftUI
+        notificationCenter.addObserver(self, selector: #selector(applicationDidBecomeActiveHandler), name: UIApplication.didBecomeActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(sceneDidActivateHandler), name: UIScene.didActivateNotification, object: nil)
     }
 
     public func uninstall() {
         SentrySDKLog.debug("[Session Replay] Uninstalling")
+        notificationCenter.removeObserver(self, name: UIScene.didActivateNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
         SentrySDKInternal.currentHub().unregisterSessionListener(self)
         touchTracker = nil
         pause()
@@ -175,44 +196,93 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         SentrySDKLog.debug("[Session Replay] Starting session")
         sessionReplay?.pause()
         startedAsFullSession = random.nextNumber() < Double(replayOptions.sessionSampleRate)
-        
+
         if !startedAsFullSession && replayOptions.onErrorSampleRate == 0 {
             SentrySDKLog.debug("[Session Replay] Not full session and onErrorSampleRate is 0, not starting session")
             return
         }
-        
+
+        isPendingStart = true
         runReplayForAvailableWindow()
     }
 
     private func runReplayForAvailableWindow() {
-        if let windowCount = application?.getWindows()?.count, windowCount > 0 {
-            SentrySDKLog.debug("[Session Replay] Running replay for available window")
-            // If a window its already available start replay right away
-            startWithOptions(replayOptions, experimentalOptions: experimentalOptions, fullSession: startedAsFullSession)
-        } else {
-            SentrySDKLog.debug("[Session Replay] Waiting for a scene to be available to started the replay")
-            // Wait for a scene to be available to started the replay
-            notificationCenter.addObserver(self, selector: #selector(newSceneActivate), name: UIScene.didActivateNotification, object: nil)
+        // Lifecycle notifications are long-lived retry triggers, so only act when a sampled or
+        // manual start request explicitly marked replay startup as pending.
+        guard isPendingStart else {
+            return
         }
+        // If replay already started between the pending request and this retry, clear the pending
+        // state so later lifecycle notifications do not create another replay instance.
+        guard sessionReplay == nil else {
+            isPendingStart = false
+            return
+        }
+        // SwiftUI can initialize the SDK before UIApplication.shared is available, so resolve the
+        // application lazily on every retry instead of keeping the value from integration init.
+        guard let application = getApplication() else {
+            return SentrySDKLog.debug("[Session Replay] Cannot get application, not starting replay")
+        }
+        // getWindows() centralizes the foreground scene and app delegate fallback logic. If no
+        // window exists yet, keep the pending start and wait for the next lifecycle notification.
+        guard let window = application.getWindows()?.first else {
+            SentrySDKLog.debug("[Session Replay] Waiting for a window to be available to start replay")
+            return
+        }
+        // Clear before starting so any synchronous callbacks or later lifecycle notifications cannot
+        // re-enter this path and create a second replay for the same pending request.
+        isPendingStart = false
+
+        SentrySDKLog.debug("[Session Replay] Running replay for available window")
+        startReplayForWindow(window: window)
     }
 
-    @objc private func newSceneActivate() {
+    private func startReplayForWindow(window: UIWindow) {
+        startWithOptions(
+            replayOptions: replayOptions,
+            experimentalOptions: experimentalOptions,
+            screenshotProvider: currentScreenshotProvider ?? viewPhotographer,
+            breadcrumbConverter: currentBreadcrumbConverter ?? SentrySRDefaultBreadcrumbConverter(),
+            fullSession: startedAsFullSession,
+            rootView: window
+        )
+    }
+
+    @objc private func applicationDidBecomeActiveHandler(_ notification: Notification) {
+        SentrySDKLog.debug("[Session Replay] Application did become active, starting replay")
+        runReplayForAvailableWindow()
+    }
+
+    @objc private func sceneDidActivateHandler(_ notification: Notification) {
         SentrySDKLog.debug("[Session Replay] Scene is available, starting replay")
-        notificationCenter.removeObserver(self, name: UIScene.didActivateNotification, object: nil)
-        startWithOptions(replayOptions, experimentalOptions: experimentalOptions, fullSession: startedAsFullSession)
+        runReplayForAvailableWindow()
     }
 
     // MARK: - Session Replay Setup
 
     func startWithOptions(_ replayOptions: SentryReplayOptions, experimentalOptions: SentryExperimentalOptions, fullSession: Bool) {
-        startWithOptions(replayOptions, experimentalOptions: experimentalOptions,
-                        screenshotProvider: currentScreenshotProvider ?? viewPhotographer,
-                        breadcrumbConverter: currentBreadcrumbConverter ?? SentrySRDefaultBreadcrumbConverter(),
-                        fullSession: fullSession)
+        guard let rootView = getApplication()?.getWindows()?.first else {
+            SentrySDKLog.warning("Failed to start session replay, no root window found")
+            return
+        }
+        startWithOptions(
+            replayOptions: replayOptions,
+            experimentalOptions: experimentalOptions,
+            screenshotProvider: currentScreenshotProvider ?? viewPhotographer,
+            breadcrumbConverter: currentBreadcrumbConverter ?? SentrySRDefaultBreadcrumbConverter(),
+            fullSession: fullSession,
+            rootView: rootView
+        )
     }
 
-    private func startWithOptions(_ replayOptions: SentryReplayOptions, experimentalOptions: SentryExperimentalOptions,
-                                  screenshotProvider: SentryViewScreenshotProvider, breadcrumbConverter: SentryReplayBreadcrumbConverter, fullSession: Bool) {
+    private func startWithOptions(
+        replayOptions: SentryReplayOptions,
+        experimentalOptions: SentryExperimentalOptions,
+        screenshotProvider: SentryViewScreenshotProvider,
+        breadcrumbConverter: SentryReplayBreadcrumbConverter,
+        fullSession: Bool,
+        rootView: UIView
+    ) {
         SentrySDKLog.debug("[Session Replay] Starting session")
         guard let sessionDocs = replayFileManager.createSessionDirectory() else {
             SentrySDKLog.warning("[Session Replay] Failed to create session direcotry, cancelling starting session")
@@ -226,7 +296,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
             dateProvider: dateProvider, delegate: self, displayLinkWrapper: SentryDisplayLinkWrapper())
 
         self.sessionReplay = newSessionReplay
-        newSessionReplay.start(rootView: application?.getWindows()?.first, fullSession: fullSession)
+        newSessionReplay.start(rootView: rootView, fullSession: fullSession)
         addBackgroundForegroundObservers()
         
         if let replayId = newSessionReplay.sessionReplayId {
@@ -283,6 +353,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
             return
         }
         startedAsFullSession = true
+        isPendingStart = true
         runReplayForAvailableWindow()
     }
 
@@ -320,7 +391,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
             SentrySDKLog.debug("[Session Replay] No tracing is active, not showing mask preview")
             return 
         }
-        guard let window = application?.getWindows()?.first else { 
+        guard let window = getApplication()?.getWindows()?.first else {
             SentrySDKLog.debug("[Session Replay] No UIWindow available to display preview")
             return 
         }
@@ -374,7 +445,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     }
 
     public func currentScreenNameForSessionReplay() -> String? {
-        SentrySDKInternal.currentHub().scope.currentScreen ?? application?.relevantViewControllersNames()?.first
+        SentrySDKInternal.currentHub().scope.currentScreen ?? getApplication()?.relevantViewControllersNames()?.first
     }
 
     // MARK: - SentryReachabilityObserver

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
@@ -33,6 +33,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     private let crashWrapper: SentryCrashReporter
     private let replayFileManager: SessionReplayFileManager
     private var replayRecovery: SessionReplayRecovery?
+    private var backgroundForegroundObserver: SentrySessionReplayBackgroundForegroundObserver?
 
     /// Getter to get the current application at runtime
     ///
@@ -94,6 +95,8 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         (self.replayProcessingQueue, self.replayAssetWorkerQueue) = Self.createDispatchQueues(dependencies: dependencies)
         
         super.init()
+
+        self.backgroundForegroundObserver = SentrySessionReplayBackgroundForegroundObserver(integration: self)
         
         self.replayRecovery = SessionReplayRecovery(
             replayOptions: replayOptions,
@@ -118,11 +121,12 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
 
     public func uninstall() {
         SentrySDKLog.debug("[Session Replay] Uninstalling")
+        isPendingStart = false
         notificationCenter.removeObserver(self, name: UIScene.didActivateNotification, object: nil)
         notificationCenter.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
         SentrySDKInternal.currentHub().unregisterSessionListener(self)
         touchTracker = nil
-        pause()
+        stopCurrentReplay()
     }
 
     deinit {
@@ -187,18 +191,17 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
 
     public func sentrySessionEnded(session: SentrySession) {
         SentrySDKLog.debug("[Session Replay] Session ended")
-        pause()
-        removeBackgroundForegroundObservers()
-        sessionReplay = nil
+        cancelPendingStartAndStopCurrentReplay()
     }
 
     private func startSession() {
         SentrySDKLog.debug("[Session Replay] Starting session")
-        sessionReplay?.pause()
+        stopCurrentReplay()
         startedAsFullSession = random.nextNumber() < Double(replayOptions.sessionSampleRate)
 
         if !startedAsFullSession && replayOptions.onErrorSampleRate == 0 {
             SentrySDKLog.debug("[Session Replay] Not full session and onErrorSampleRate is 0, not starting session")
+            isPendingStart = false
             return
         }
 
@@ -319,13 +322,39 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
     // MARK: - Notification Observers
     
     private func addBackgroundForegroundObservers() {
-        notificationCenter.addObserver(self, selector: #selector(pause), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(resume), name: UIApplication.didBecomeActiveNotification, object: nil)
+        guard let observer = backgroundForegroundObserver else {
+            return
+        }
+
+        // The deferred-start retry observers are registered on `self` in init and intentionally
+        // live until uninstall. Session replay also needs a `didBecomeActive` observer for
+        // pause/resume, but `removeObserver(observer, name:object:)` removes every selector
+        // registered for that observer and notification name. Use a separate observer identity for
+        // replay-lifetime pause/resume so removing it cannot unregister the pending-start retry
+        // path on `self`.
+        removeBackgroundForegroundObservers()
+        notificationCenter.addObserver(observer, selector: #selector(SentrySessionReplayBackgroundForegroundObserver.pause(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.addObserver(observer, selector: #selector(SentrySessionReplayBackgroundForegroundObserver.resume(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
     
     private func removeBackgroundForegroundObservers() {
-        notificationCenter.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-        notificationCenter.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        guard let observer = backgroundForegroundObserver else {
+            return
+        }
+
+        notificationCenter.removeObserver(observer, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.removeObserver(observer, name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    private func cancelPendingStartAndStopCurrentReplay() {
+        isPendingStart = false
+        stopCurrentReplay()
+    }
+
+    private func stopCurrentReplay() {
+        sessionReplay?.pause()
+        removeBackgroundForegroundObservers()
+        sessionReplay = nil
     }
 
     // MARK: - API Exposed to ObjC
@@ -359,8 +388,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
 
     @objc public func stop() {
         SentrySDKLog.debug("[Session Replay] Stopping session")
-        sessionReplay?.pause()
-        sessionReplay = nil 
+        cancelPendingStartAndStopCurrentReplay()
     }
 
     @objc @discardableResult public func captureReplay() -> Bool {
@@ -433,6 +461,7 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
 
     public func sessionReplayEnded() {
         SentrySDKLog.debug("[Session Replay] Session replay ended")
+        isPendingStart = false
         SentrySDKInternal.currentHub().configureScope { scope in scope.replayId = nil }
         removeBackgroundForegroundObservers()
         sessionReplay = nil
@@ -470,6 +499,26 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
 #endif
 }
 // swiftlint:enable type_body_length
+
+// NotificationCenter selector observers are removed by observer object and notification name, not by
+// selector. Keep replay pause/resume observers on a dedicated object so removing them does not also
+// remove `SentrySessionReplayIntegration`'s persistent deferred-start lifecycle observers.
+private final class SentrySessionReplayBackgroundForegroundObserver: NSObject {
+    weak var integration: SentrySessionReplayIntegration?
+
+    init(integration: SentrySessionReplayIntegration) {
+        self.integration = integration
+        super.init()
+    }
+
+    @objc func pause(_ notification: Notification) {
+        integration?.pause()
+    }
+
+    @objc func resume(_ notification: Notification) {
+        integration?.resume()
+    }
+}
 
 #endif // (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
 // swiftlint:enable missing_docs file_length

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -115,6 +115,18 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
     }
+
+    func testLifecycleNotificationDoesNotStartReplayWhenStartIsNotPending() throws {
+        SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
+        startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
+
+        let sut = try getSut()
+        XCTAssertNil(sut.sessionReplay)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertNil(sut.sessionReplay)
+    }
     
     func testInstallFullSessionReplayBecauseOfRandom() throws {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.1)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -116,15 +116,18 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertNil(sut.sessionReplay)
     }
 
-    func testLifecycleNotificationDoesNotStartReplayWhenStartIsNotPending() throws {
+    func testApplicationDidBecomeActive_whenStartIsNotPending_shouldNotStartReplay() throws {
+        // -- Arrange --
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
         startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
 
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
 
+        // -- Act --
         NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
+        // -- Assert --
         XCTAssertNil(sut.sessionReplay)
     }
     
@@ -154,6 +157,44 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertNil(sut.sessionReplay)
         uiApplication.windows = [UIWindow()]
         NotificationCenter.default.post(name: UIScene.didActivateNotification, object: nil)
+        XCTAssertNotNil(sut.sessionReplay)
+    }
+
+    func testRunReplayForAvailableWindow_whenPendingStartAndSessionEnds_shouldNotStartAfterLifecycleNotification() throws {
+        // -- Arrange --
+        uiApplication.windows = nil
+        startSDK(sessionSampleRate: 1, errorSampleRate: 0)
+
+        let sut = try getSut()
+        XCTAssertNil(sut.sessionReplay)
+
+        // -- Act --
+        SentrySDKInternal.currentHub().endSession()
+        uiApplication.windows = [UIWindow()]
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIScene.didActivateNotification, object: nil)
+
+        // -- Assert --
+        XCTAssertNil(sut.sessionReplay)
+    }
+
+    func testApplicationDidBecomeActive_whenSessionRestartWasDelayed_shouldStartReplay() throws {
+        // -- Arrange --
+        startSDK(sessionSampleRate: 1, errorSampleRate: 0)
+
+        let sut = try getSut()
+        XCTAssertNotNil(sut.sessionReplay)
+        SentrySDKInternal.currentHub().endSession()
+        XCTAssertNil(sut.sessionReplay)
+        uiApplication.windows = nil
+        SentrySDKInternal.currentHub().startSession()
+        XCTAssertNil(sut.sessionReplay)
+
+        // -- Act --
+        uiApplication.windows = [UIWindow()]
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        // -- Assert --
         XCTAssertNotNil(sut.sessionReplay)
     }
     


### PR DESCRIPTION
Session Replay startup now stays pending until the SDK can resolve a foreground window. This handles apps that initialize Sentry before UIApplication or scene windows are available, while keeping lifecycle notifications from starting replay unless sampling or manual start requested it.

**Pending Startup Gate**

Replay startup is retried from app and scene activation notifications only while isPendingStart is true, and the flag is cleared before creating the replay instance.

**Lazy Window Lookup**

The integration resolves the application at retry time and uses getWindows() to share foreground scene and app delegate fallback logic.