### PR TITLE
chore: Add fix message to v9.12.0 and v9.12.1 for #7886

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ## 9.12.1
 
 > [!WARNING]
-> ⚠️ **Known Issue:** Sentry Cocoa **9.12.0+** crashes apps using `AVAssetDownloadURLSession`. Pin to **9.11.x** until a fix ships. ([#7886](https://github.com/getsentry/sentry-cocoa/issues/7886))
+> ⚠️ **Known Issue:** Sentry Cocoa **9.12.0+** crashes apps using `AVAssetDownloadURLSession` ([#7886](https://github.com/getsentry/sentry-cocoa/issues/7886)). Fixed in [**9.13.0**](https://github.com/getsentry/sentry-cocoa/releases/tag/9.13.0).
 
 ### Fixes
 
@@ -43,7 +43,7 @@
 ## 9.12.0
 
 > [!WARNING]
-> ⚠️ **Known Issue:** Sentry Cocoa **9.12.0+** crashes apps using `AVAssetDownloadURLSession`. Pin to **9.11.x** until a fix ships. ([#7886](https://github.com/getsentry/sentry-cocoa/issues/7886))
+> ⚠️ **Known Issue:** Sentry Cocoa **9.12.0+** crashes apps using `AVAssetDownloadURLSession` ([#7886](https://github.com/getsentry/sentry-cocoa/issues/7886)). Fixed in [**9.13.0**](https://github.com/getsentry/sentry-cocoa/releases/tag/9.13.0).
 
 > [!WARNING]
 > This release promotes Metrics out of experimental and **removes** `options.experimental.enableMetrics` and `options.experimental.beforeSendMetric`. If you set either of these, your app will fail to compile after upgrading.


### PR DESCRIPTION
Updated known issue notice for Sentry Cocoa 9.12.0 and added migration instructions for metrics options.

#skip-changelog