### PR TITLE
feat: add appStartSampleRate to experimental options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `appStartSampleRate` to experimental options for overriding `tracesSampleRate` on standalone app start transactions (#7235)
+- Add `appStartSampleRate` to experimental options for overriding `tracesSampleRate` on standalone app start transactions (#7931)
 - Add standalone app start tracing as an experimental option (#7660), enable it via `options.experimental.enableStandaloneAppStartTracing = true`
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add `appStartSampleRate` to experimental options for overriding `tracesSampleRate` on standalone app start transactions (#7235)
 - Add standalone app start tracing as an experimental option (#7660), enable it via `options.experimental.enableStandaloneAppStartTracing = true`
 
 ### Fixes

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -94,6 +94,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case disableUITracing                   = "--io.sentry.performance.disable-ui-tracing"
         case disablePrewarmedAppStartTracing    = "--io.sentry.performance.disable-prewarmed-app-start-tracing"
         case enableStandaloneAppStartTracing    = "--io.sentry.performance.enable-standalone-app-start-tracing"
+        case appStartSampleRate                 = "--io.sentry.performance.appStartSampleRate"
         case disablePerformanceTracing          = "--io.sentry.performance.disable-auto-performance-tracing"
         case sessionTrackingIntervalMillis      = "--io.sentry.performance.sessionTrackingIntervalMillis"
     }
@@ -314,6 +315,7 @@ extension SentrySDKOverrides.Performance {
     public var overrideType: OverrideType {
         switch self {
         case .disableTimeToFullDisplayTracing, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .enableStandaloneAppStartTracing, .disablePerformanceTracing: return .boolean
+        case .appStartSampleRate: return .float
         case .sessionTrackingIntervalMillis: return .string
         }
     }
@@ -410,7 +412,7 @@ extension SentrySDKOverrides.Performance {
     public var ignoresDisableEverything: Bool {
         switch self {
         case .disableTimeToFullDisplayTracing, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .enableStandaloneAppStartTracing, .disablePerformanceTracing: return false
-        case .sessionTrackingIntervalMillis: return true
+        case .appStartSampleRate, .sessionTrackingIntervalMillis: return true
         }
     }
 }

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -125,6 +125,7 @@ public struct SentrySDKWrapper {
 
         options.enablePreWarmedAppStartTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disablePrewarmedAppStartTracing.boolValue
         options.experimental.enableStandaloneAppStartTracing = SentrySDKOverrides.Performance.enableStandaloneAppStartTracing.boolValue
+        options.experimental.appStartSampleRate = SentrySDKOverrides.Performance.appStartSampleRate.floatValue.map { NSNumber(value: $0) }
         options.enableUIViewControllerTracing = !SentrySDKOverrides.Performance.disableUIVCTracing.boolValue
 
         // -- Screenshot Options --

--- a/Sources/Sentry/SentrySampling.m
+++ b/Sources/Sentry/SentrySampling.m
@@ -3,6 +3,7 @@
 #import "SentrySampleDecision.h"
 #import "SentrySamplerDecision.h"
 #import "SentrySamplingContext.h"
+#import "SentrySpanOperation.h"
 #import "SentrySwift.h"
 #import "SentryTransactionContext.h"
 
@@ -63,6 +64,12 @@ sentry_sampleTrace(SentrySamplingContext *context, SentryOptions *_Nullable opti
             [[SentrySamplerDecision alloc] initWithDecision:context.transactionContext.sampled
                                               forSampleRate:context.transactionContext.sampleRate
                                              withSampleRand:context.transactionContext.sampleRand];
+    }
+
+    NSNumber *appStartRate = options.experimental.appStartSampleRate;
+    if (appStartRate != nil &&
+        [context.transactionContext.operation isEqualToString:SentrySpanOperationAppStart]) {
+        return _sentry_calcSampleFromNumericalRate(appStartRate);
     }
 
     NSNumber *callbackRate = _sentry_samplerCallbackRate(options.tracesSampler, context, 0);

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -32,6 +32,37 @@ public final class SentryExperimentalOptions: NSObject {
      */
     public var enableStandaloneAppStartTracing = false
 
+    /**
+     * The sample rate for standalone app start transactions, overriding `tracesSampleRate`.
+     *
+     * When set, standalone app start transactions use this rate instead of
+     * `tracesSampleRate`. A custom `tracesSampler` callback still takes precedence.
+     *
+     * Requires `enableStandaloneAppStartTracing` to be `true`.
+     *
+     * - Note: Specifying `nil` falls back to `tracesSampleRate`. Specifying `0` discards all
+     *   app start transactions, `1.0` collects all of them.
+     * - Note: The value needs to be >= 0.0 and <= 1.0. When setting a value out of range
+     *   the SDK sets it to the default of `0`.
+     */
+    public var appStartSampleRate: NSNumber? {
+        set {
+            guard let newValue else {
+                _appStartSampleRate = nil
+                return
+            }
+            if newValue.isValidSampleRate() {
+                _appStartSampleRate = newValue
+            } else {
+                _appStartSampleRate = 0
+            }
+        }
+        get {
+            _appStartSampleRate
+        }
+    }
+    private var _appStartSampleRate: NSNumber?
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) public func validateOptions(_ options: [String: Any]?) {
     }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -458,7 +458,60 @@ class SentryHubTests: XCTestCase {
         let span = hub.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation)
         XCTAssertEqual(span.sampled, .no)
     }
-    
+
+    func testStartTransaction_AppStartSampleRate_UsedForAppStartOperation() {
+        fixture.options.tracesSampleRate = 0
+        fixture.options.experimental.appStartSampleRate = 1.0
+
+        let hub = fixture.getSut()
+        let span = hub.startTransaction(
+            transactionContext: TransactionContext(name: "App Start", operation: "app.start"),
+            customSamplingContext: [:]
+        )
+
+        XCTAssertEqual(span.sampled, .yes)
+    }
+
+    func testStartTransaction_AppStartSampleRate_NotUsedForOtherOperations() {
+        fixture.options.tracesSampleRate = 0
+        fixture.options.experimental.appStartSampleRate = 1.0
+
+        let hub = fixture.getSut()
+        let span = hub.startTransaction(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation
+        )
+
+        XCTAssertEqual(span.sampled, .no)
+    }
+
+    func testStartTransaction_AppStartSampleRate_NilFallsBackToTracesSampleRate() {
+        fixture.options.tracesSampleRate = 0.50
+        fixture.options.experimental.appStartSampleRate = nil
+
+        let hub = fixture.getSut()
+        let span = hub.startTransaction(
+            transactionContext: TransactionContext(name: "App Start", operation: "app.start"),
+            customSamplingContext: [:]
+        )
+
+        XCTAssertEqual(span.sampled, .yes)
+    }
+
+    func testStartTransaction_AppStartSampleRate_SetsCorrectSampleRate() {
+        fixture.options.tracesSampleRate = 0.1
+        fixture.options.experimental.appStartSampleRate = 0.75
+
+        let hub = fixture.getSut()
+        let span = hub.startTransaction(
+            transactionContext: TransactionContext(name: "App Start", operation: "app.start"),
+            customSamplingContext: [:]
+        )
+
+        let context = (span as? SentryTracer)?.transactionContext
+        XCTAssertEqual(context?.sampleRate, 0.75)
+    }
+
     func testCaptureTransaction_CapturesEventAsync() throws {
         let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes, sampleRate: nil, sampleRand: nil))
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1122,6 +1122,52 @@ typedef SentryLog *_Nullable (^SentryBeforeSendLogCallback)(SentryLog *_Nonnull 
     XCTAssertTrue(options.isTracingEnabled);
 }
 
+- (void)testDefaultAppStartSampleRate
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    XCTAssertNil(options.experimental.appStartSampleRate);
+}
+
+- (void)testAppStartSampleRate_SetToNil
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.experimental.appStartSampleRate = @0.5;
+    options.experimental.appStartSampleRate = nil;
+    XCTAssertNil(options.experimental.appStartSampleRate);
+}
+
+- (void)testAppStartSampleRateLowerBound
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.experimental.appStartSampleRate = @0.5;
+
+    NSNumber *lowerBound = @0;
+    options.experimental.appStartSampleRate = lowerBound;
+    XCTAssertEqual(lowerBound, options.experimental.appStartSampleRate);
+
+    options.experimental.appStartSampleRate = @0.5;
+
+    NSNumber *tooLow = @-0.01;
+    options.experimental.appStartSampleRate = tooLow;
+    XCTAssertEqual(options.experimental.appStartSampleRate.doubleValue, 0);
+}
+
+- (void)testAppStartSampleRateUpperBound
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.experimental.appStartSampleRate = @0.5;
+
+    NSNumber *upperBound = @1;
+    options.experimental.appStartSampleRate = upperBound;
+    XCTAssertEqual(upperBound, options.experimental.appStartSampleRate);
+
+    options.experimental.appStartSampleRate = @0.5;
+
+    NSNumber *tooHigh = @1.01;
+    options.experimental.appStartSampleRate = tooHigh;
+    XCTAssertEqual(options.experimental.appStartSampleRate.doubleValue, 0);
+}
+
 - (void)testInAppIncludes
 {
     NSArray<NSString *> *expected = @[ @"iOS-Swift", @"BusinessLogic" ];

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -36845,6 +36845,103 @@
                 "accessorKind": "get",
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "NSNumber",
+                        "printedName": "Foundation.NSNumber",
+                        "usr": "c:objc(cs)NSNumber"
+                      }
+                    ],
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Foundation.NSNumber?",
+                    "usr": "s:Sq"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry0A19ExperimentalOptionsC18appStartSampleRateSo8NSNumberCSgvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)appStartSampleRate"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "NSNumber",
+                        "printedName": "Foundation.NSNumber",
+                        "usr": "c:objc(cs)NSNumber"
+                      }
+                    ],
+                    "kind": "TypeNominal",
+                    "name": "Optional",
+                    "printedName": "Foundation.NSNumber?",
+                    "usr": "s:Sq"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry0A19ExperimentalOptionsC18appStartSampleRateSo8NSNumberCSgvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "objc_name": "setAppStartSampleRate:",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setAppStartSampleRate:"
+              }
+            ],
+            "children": [
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "NSNumber",
+                    "printedName": "Foundation.NSNumber",
+                    "usr": "c:objc(cs)NSNumber"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Foundation.NSNumber?",
+                "usr": "s:Sq"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "kind": "Var",
+            "mangledName": "$s6Sentry0A19ExperimentalOptionsC18appStartSampleRateSo8NSNumberCSgvp",
+            "moduleName": "Sentry",
+            "name": "appStartSampleRate",
+            "printedName": "appStartSampleRate",
+            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)appStartSampleRate"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
                     "kind": "TypeNominal",
                     "name": "Bool",
                     "printedName": "Swift.Bool",


### PR DESCRIPTION
## :scroll: Description

Add `experimental.appStartSampleRate` to override `tracesSampleRate` for standalone app start transactions. When set, the sampling logic uses this rate instead of `tracesSampleRate` for transactions with the `app.start` operation. A custom `tracesSampler` callback still takes precedence.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-cocoa/issues/7235

Users can set a global sample rate or use a custom sampler, but there isn't a clear way to set a sample rate specifically for app launches. A reasonable global sample rate might greatly reduce the number of app launch spans even though they are arguably the most important spans. This provides a simple dedicated API for that.

## :green_heart: How did you test it?

- Added unit tests for the new option property (default, nil, bounds validation)
- Added sampling behavior tests in `SentryHubTests` covering:
  - `appStartSampleRate` is used for `app.start` operation
  - `appStartSampleRate` is NOT used for other operations
  - `tracesSampler` callback takes precedence
  - `nil` falls back to `tracesSampleRate`
  - Correct sample rate is propagated to the transaction context
- Added sample app test override (`SentrySDKOverrides.Performance.appStartSampleRate`)
- Regenerated `sdk_api.json`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.