### PR TITLE
Adopt .editorconfig for style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,63 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+# Swift — matches existing source files
+[*.swift]
+indent_size = 4
+
+# Objective-C, C, C++ — matches .clang-format (IndentWidth: 4)
+[*.{m,h,c,mm,cpp,cc,hpp}]
+indent_size = 4
+
+# Ruby — standard Ruby convention
+[*.{rb,podspec}]
+indent_size = 2
+
+[{Gemfile,Fastfile,Matchfile,Appfile,Deliverfile}]
+indent_size = 2
+
+# Shell — matches existing scripts
+[*.sh]
+indent_size = 4
+
+# Python — PEP 8
+[*.py]
+indent_size = 4
+
+# YAML — matches dprint.json (indentWidth: 2)
+[*.{yml,yaml}]
+indent_size = 2
+
+# JSON — matches dprint.json (indentWidth: 2)
+[*.json]
+indent_size = 2
+
+# TOML
+[*.toml]
+indent_size = 2
+
+# Markdown — matches existing files
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Makefiles require tabs
+[{Makefile,GNUmakefile,*.mk}]
+indent_style = tab
+
+# Xcode project/workspace files - align with Xcode defaults
+[*.{pbxproj,xcscheme,xcsettings}]
+indent_style = tab
+
+# XML / Interface Builder - align with Xcode defaults
+[*.{xml,xib,storyboard}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,7 +22,7 @@ indent_size = 4
 [*.{rb,podspec}]
 indent_size = 2
 
-[{Gemfile,Fastfile,Matchfile,Appfile,Deliverfile}]
+[{Gemfile,Fastfile,Matchfile,Appfile}]
 indent_size = 2
 
 # Shell — matches existing scripts
@@ -41,23 +41,6 @@ indent_size = 2
 [*.json]
 indent_size = 2
 
-# TOML
-[*.toml]
-indent_size = 2
-
-# Markdown — matches existing files
-[*.md]
-indent_size = 2
-trim_trailing_whitespace = false
-
 # Makefiles require tabs
-[{Makefile,GNUmakefile,*.mk}]
+[Makefile]
 indent_style = tab
-
-# Xcode project/workspace files - align with Xcode defaults
-[*.{pbxproj,xcscheme,xcsettings}]
-indent_style = tab
-
-# XML / Interface Builder - align with Xcode defaults
-[*.{xml,xib,storyboard}]
-indent_size = 2


### PR DESCRIPTION
## :scroll: Description

This change adds an [`.editorconfig`](https://editorconfig.org/) file which codifies some of the in-use or declared code/file styles. 

This is particularly useful if, like me, you prefer things like tabs instead of spaces and are constantly having to fix up files to align with the project. With this config, your IDE (sometimes automatically, sometimes with an extension or setting) will pick up the projects preferred styling and override your global IDE settings to use the values in this file.

## :bulb: Motivation and Context

This helps align style across the project and alleviates the need for the developer to manually change their settings to achieve it. 

## :green_heart: How did you test it?

Not a code change - so no tests required :) 

#skip-changelog