### PR TITLE
ref: End standalone app start at didFinishLaunching

### DIFF
--- a/Sources/Sentry/SentryBuildAppStartSpans.m
+++ b/Sources/Sentry/SentryBuildAppStartSpans.m
@@ -130,14 +130,15 @@ sentryBuildAppStartSpansInternal(SentryTracer *tracer,
     }
     [appStartSpans addObject:didFinishLaunching];
 
-    id<SentrySpan> frameRenderSpan
-        = sentryBuildAppStartSpan(tracer, appStartSpanParentId, operation, @"Initial Frame Render");
-    [frameRenderSpan setStartTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
-    [frameRenderSpan setTimestamp:appStartEndTimestamp];
-    if (isStandalone && startType != nil) {
-        [frameRenderSpan setDataValue:startType forKey:SentrySpanDataKeyAppVitalsStartType];
+    // Standalone app starts end at didFinishLaunching, so the frame render span
+    // does not apply. Non-standalone starts still end at the first frame render.
+    if (!isStandalone) {
+        id<SentrySpan> frameRenderSpan = sentryBuildAppStartSpan(
+            tracer, appStartSpanParentId, operation, @"Initial Frame Render");
+        [frameRenderSpan setStartTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
+        [frameRenderSpan setTimestamp:appStartEndTimestamp];
+        [appStartSpans addObject:frameRenderSpan];
     }
-    [appStartSpans addObject:frameRenderSpan];
 
     return appStartSpans;
 }

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -74,7 +74,9 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
 
         super.init()
 
-        framesTracker.addListener(self)
+        if !enableStandaloneAppStartTracing {
+            framesTracker.addListener(self)
+        }
     }
 
     deinit {
@@ -133,7 +135,9 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
             object: nil
         )
 
-        framesTracker.removeListener(self)
+        if !(reportingStrategy is StandaloneTransactionStrategy) {
+            framesTracker.removeListener(self)
+        }
         SentryAppStartMeasurementProvider.setAppStartTrace(nil)
 
         #if SENTRY_TEST || SENTRY_TEST_CI || DEBUG

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -105,6 +105,12 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
             object: nil
         )
 
+        // Standalone app starts rely on didFinishLaunchingNotification to trigger the
+        // measurement. If the SDK is initialized after that notification has already been 
+        // posted, the notification is never received and no app start is
+        // measured. 
+        // There is no reliable way to detect if the notification was already posted.
+        // UIApplication.applicationState may be .active in SwiftUI apps during App.init(),
         if reportingStrategy is StandaloneTransactionStrategy {
             let traceId = SentryId()
             appStartTraceId = traceId

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -304,6 +304,9 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
     @objc
     private func didFinishLaunching() {
         didFinishLaunchingTimestamp = dateProvider.date()
+        if reportingStrategy is StandaloneTransactionStrategy {
+            buildAppStartMeasurement(didFinishLaunchingTimestamp)
+        }
     }
 
     @objc

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
@@ -324,16 +324,16 @@ class AppStartReportingStrategyTests: XCTestCase {
         let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
         let spans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
 
-        // Warm non-prewarmed standalone: no grouping span, includes pre-runtime spans → 5 child spans
-        XCTAssertEqual(spans.count, 5)
+        // Warm non-prewarmed standalone: no grouping span, includes pre-runtime spans,
+        // no "Initial Frame Render" (standalone ends at didFinishLaunching) → 4 child spans
+        XCTAssertEqual(spans.count, 4)
 
         let descriptions = spans.compactMap { $0["description"] as? String }
         XCTAssertEqual(descriptions, [
             "Pre Runtime Init",
             "Runtime Init to Pre Main Initializers",
             "UIKit Init",
-            "Application Init",
-            "Initial Frame Render"
+            "Application Init"
         ])
 
         let operations = Set(spans.compactMap { $0["op"] as? String })
@@ -357,10 +357,6 @@ class AppStartReportingStrategyTests: XCTestCase {
         assertSpanTimestamps(spans[3],
                              expectedStart: appStartInterval + 0.15,
                              expectedEnd: appStartInterval + 0.3)
-        // Initial Frame Render: didFinishLaunching → appStart + duration
-        assertSpanTimestamps(spans[4],
-                             expectedStart: appStartInterval + 0.3,
-                             expectedEnd: appStartInterval + 0.5)
     }
 
     // MARK: - StandaloneAppStartTransactionHelper

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -405,13 +405,14 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         // The global static must not be set — standalone bypasses it.
         XCTAssertNil(SentrySDKInternal.getAppStartMeasurement())
 
-        // Verify the transaction contains app start child spans (standalone = no grouping span).
+        // Verify the transaction contains app start child spans (standalone = no grouping span,
+        // no "Initial Frame Render" since standalone ends at didFinishLaunching).
         let spans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
-        XCTAssertEqual(spans.count, 5)
+        XCTAssertEqual(spans.count, 4)
 
         let descriptions = spans.compactMap { $0["description"] as? String }
         XCTAssertTrue(descriptions.contains("Pre Runtime Init"))
-        XCTAssertTrue(descriptions.contains("Initial Frame Render"))
+        XCTAssertTrue(descriptions.contains("Application Init"))
 
         // Verify the app start vitals are set as span data.
         let extra = try XCTUnwrap(serialized["extra"] as? [String: Any])

--- a/Tests/SentryTests/Transaction/SentryBuildAppStartSpansTests.swift
+++ b/Tests/SentryTests/Transaction/SentryBuildAppStartSpansTests.swift
@@ -44,7 +44,7 @@ class SentryBuildAppStartSpansTests: XCTestCase {
 
         let result = sentryBuildStandaloneAppStartSpans(tracer, appStartMeasurement)
 
-        XCTAssertEqual(result.count, 5, "Standalone uses unified app.start op regardless of type")
+        XCTAssertEqual(result.count, 4, "Standalone uses unified app.start op regardless of type, no Initial Frame Render")
     }
 
     func testSentryBuildAppStartSpans_appStartMeasurementIsNotColdOrWarm_shouldNotReturnAnySpans() {
@@ -255,8 +255,9 @@ class SentryBuildAppStartSpansTests: XCTestCase {
         // Act
         let result = sentryBuildStandaloneAppStartSpans(tracer, appStartMeasurement)
 
-        // Assert — no intermediate "Cold Start" span, all 5 children parent to tracer
-        XCTAssertEqual(result.count, 5, "Number of spans do not match")
+        // Assert — no intermediate "Cold Start" span, no "Initial Frame Render" (standalone
+        // ends at didFinishLaunching), all 4 children parent to tracer
+        XCTAssertEqual(result.count, 4, "Number of spans do not match")
         assertSpan(
             span: result[0],
             expectedTraceId: tracer.traceId.sentryIdString,
@@ -297,16 +298,6 @@ class SentryBuildAppStartSpansTests: XCTestCase {
             expectedEndTimestamp: Date(timeIntervalSince1970: 1_600),
             expectedSampled: tracer.sampled
         )
-        assertSpan(
-            span: result[4],
-            expectedTraceId: tracer.traceId.sentryIdString,
-            expectedParentSpanId: tracer.spanId.sentrySpanIdString,
-            expectedOperation: "app.start",
-            expectedDescription: "Initial Frame Render",
-            expectedStartTimestamp: Date(timeIntervalSince1970: 1_600),
-            expectedEndTimestamp: Date(timeIntervalSince1970: 1_935),
-            expectedSampled: tracer.sampled
-        )
     }
 
     func testBuildStandaloneAppStartSpans_whenPrewarmed_shouldNotIncludeGroupingSpan() {
@@ -328,8 +319,9 @@ class SentryBuildAppStartSpansTests: XCTestCase {
         // Act
         let result = sentryBuildStandaloneAppStartSpans(tracer, appStartMeasurement)
 
-        // Assert — no grouping span, no pre-runtime spans, all 3 children parent to tracer
-        XCTAssertEqual(result.count, 3, "Number of spans do not match")
+        // Assert — no grouping span, no pre-runtime spans, no "Initial Frame Render"
+        // (standalone ends at didFinishLaunching), all 2 children parent to tracer
+        XCTAssertEqual(result.count, 2, "Number of spans do not match")
         assertSpan(
             span: result[0],
             expectedTraceId: tracer.traceId.sentryIdString,
@@ -348,16 +340,6 @@ class SentryBuildAppStartSpansTests: XCTestCase {
             expectedDescription: "Application Init",
             expectedStartTimestamp: Date(timeIntervalSince1970: 1_500),
             expectedEndTimestamp: Date(timeIntervalSince1970: 1_600),
-            expectedSampled: tracer.sampled
-        )
-        assertSpan(
-            span: result[2],
-            expectedTraceId: tracer.traceId.sentryIdString,
-            expectedParentSpanId: tracer.spanId.sentrySpanIdString,
-            expectedOperation: "app.start",
-            expectedDescription: "Initial Frame Render",
-            expectedStartTimestamp: Date(timeIntervalSince1970: 1_600),
-            expectedEndTimestamp: Date(timeIntervalSince1970: 1_935),
             expectedSampled: tracer.sampled
         )
     }

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -999,7 +999,7 @@ class SentryTracerTests: XCTestCase {
         // Standalone transactions have no intermediate grouping span, so 5 child spans
         // (not 6) for a non-prewarmed cold start.
         let spans = try XCTUnwrap(serializedTransaction["spans"] as? [[String: Any]])
-        XCTAssertEqual(spans.count, 5)
+        XCTAssertEqual(spans.count, 4)
 
         let spanDescriptions = spans.compactMap { $0["description"] as? String }
         let spanOperations = spans.compactMap { $0["op"] as? String }
@@ -1008,8 +1008,7 @@ class SentryTracerTests: XCTestCase {
             "Pre Runtime Init",
             "Runtime Init to Pre Main Initializers",
             "UIKit Init",
-            "Application Init",
-            "Initial Frame Render"
+            "Application Init"
         ])
         XCTAssertEqual(Set(spanOperations), ["app.start"])
     }


### PR DESCRIPTION
## Summary

- Standalone app start transactions now end when `UIApplication.didFinishLaunchingNotification` is posted instead of waiting for the first frame render
- The "Initial Frame Render" child span is no longer emitted for standalone transactions since it does not apply
- Non-standalone (attach-to-transaction) behavior is unchanged

Decided to do this change on standalone app starts since it is still experimental and thus we can make "breaking changes"

Fixes #6883

## Test plan

- [x] All existing `AppStartReportingStrategyTests`, `SentryAppStartTrackerTests`, and `SentryBuildAppStartSpansTests` updated and passing
- [ ] Test with sample app: enable `enable-standalone-app-start-tracing`, verify app start transaction ends at didFinishLaunching and has no "Initial Frame Render" span

#skip-changelog