### PR TITLE
feat: skip max app start duration limit for standalone tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Feature
+
+- Skip max app start duration limit for standalone app start tracing (#7949)
+
 ## 9.14.0
 
 ### Features
@@ -8,7 +14,6 @@
 
 ### Fixes
 
-- Skip max app start duration limit for standalone app start tracing (#7949)
 - Defer Session Replay startup until a foreground window is available (#7928)
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Skip max app start duration limit for standalone app start tracing (#7949)
 - Defer Session Replay startup until a foreground window is available (#7928)
 - Fix race conditions in scope observer iteration and propagation context locking (#7897)
 - Support stack traces for standalone clients (#7817)

--- a/Sources/Swift/Integrations/AppStartTracking/AppStartReportingStrategy.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/AppStartReportingStrategy.swift
@@ -5,12 +5,17 @@
 /// Determines how a completed app start measurement is reported to Sentry.
 protocol AppStartReportingStrategy {
     func report(_ measurement: SentryAppStartMeasurement, traceId: SentryId)
+    func shouldSkipMaxAppStartDurationLimit() -> Bool
 }
 
 /// Attaches app start data to the first UIViewController transaction (default behavior).
 struct AttachToTransactionStrategy: AppStartReportingStrategy {
     func report(_ measurement: SentryAppStartMeasurement, traceId: SentryId) {
         SentrySDKInternal.setAppStartMeasurement(measurement)
+    }
+
+    func shouldSkipMaxAppStartDurationLimit() -> Bool {
+        return false
     }
 }
 
@@ -56,6 +61,10 @@ struct StandaloneTransactionStrategy: AppStartReportingStrategy {
         tracer.setData(value: "launch", key: SentrySpanDataKeyAppVitalsStartReason)
 
         tracer.finish()
+    }
+
+    func shouldSkipMaxAppStartDurationLimit() -> Bool {
+        return true
     }
 }
 

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -209,7 +209,7 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
                 appStartTimestamp = sysctl.processStartTimestamp
             }
 
-            if !(self.reportingStrategy is StandaloneTransactionStrategy) && appStartDuration >= Self.maxAppStartDuration {
+            if !self.reportingStrategy.shouldSkipMaxAppStartDurationLimit() && appStartDuration >= Self.maxAppStartDuration {
                 SentrySDKLog.info("The app start exceeded the max duration of \(Self.maxAppStartDuration) seconds. Not measuring app start.")
                 return
             }

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -23,6 +23,7 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
     /// multiple stages during the launch we pick a higher threshold. This threshold also prevents
     /// reporting way too long app starts, since we can't always reliably detect prewarming, for example.
     /// It is a safety guard to discard suspiciously long app starts to avoid reporting false app starts.
+    /// When using standalone app start tracing, this limit is not applied.
     private static let maxAppStartDuration: TimeInterval = 180.0
 
     // MARK: - Instance Properties
@@ -208,8 +209,7 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
                 appStartTimestamp = sysctl.processStartTimestamp
             }
 
-            // Safety check to not report app starts that are completely off.
-            if appStartDuration >= Self.maxAppStartDuration {
+            if !(self.reportingStrategy is StandaloneTransactionStrategy) && appStartDuration >= Self.maxAppStartDuration {
                 SentrySDKLog.info("The app start exceeded the max duration of \(Self.maxAppStartDuration) seconds. Not measuring app start.")
                 return
             }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -273,15 +273,15 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
     
     func testAppLaunches_MaximumAppStartDuration_NoAppStart() {
         let processStartTime = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(-180)
-        startApp(processStartTimeStamp: processStartTime)
-        
+        startApp(processStartTimeStamp: processStartTime, callDisplayLink: true)
+
         assertNoAppStartUp()
     }
-    
+
     func testAppLaunches_OSAlmostPrewarmedProcess_AppStartUp() {
         let processStartTime = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(-179)
         startApp(processStartTimeStamp: processStartTime, callDisplayLink: true)
-        
+
         assertValidStart(type: .cold, expectedDuration: 179.45)
     }
     
@@ -361,12 +361,18 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         XCTAssertNil(SentryAppStartMeasurementProvider.appStartTraceId())
     }
 
-    func testMaxDurationExceeded_whenStandalone_shouldClearAppStartTraceId() {
+    func testLongDuration_whenStandalone_shouldNotDropAppStart() throws {
+        fixture.options.tracesSampleRate = 1
+        let client = TestClient(options: fixture.options)
+        let hub = TestHub(client: client, andScope: Scope())
+        SentrySDKInternal.setCurrentHub(hub)
+
         fixture.enableStandaloneAppStartTracing = true
         let processStartTime = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(-180)
         startApp(processStartTimeStamp: processStartTime, callDisplayLink: true)
 
-        assertNoAppStartUp()
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        XCTAssertEqual(serialized["transaction"] as? String, "App Start")
         XCTAssertNil(SentryAppStartMeasurementProvider.appStartTraceId())
     }
 


### PR DESCRIPTION
## Description

The 180s `maxAppStartDuration` safety guard that drops suspiciously long app starts now only applies to the attach-to-transaction strategy. When standalone app start tracing is enabled (`options.experimental.enableStandaloneAppStartTracing`), the limit is bypassed.

Closes #7427

## Changes

- **`SentryAppStartTracker.swift`**: The `maxAppStartDuration` check now skips when using `StandaloneTransactionStrategy`
- **`SentryAppStartTrackerTests.swift`**:
  - Fixed `testAppLaunches_MaximumAppStartDuration_NoAppStart` to fire the display link so it actually exercises the duration check
  - Replaced `testMaxDurationExceeded_whenStandalone_shouldClearAppStartTraceId` with `testLongDuration_whenStandalone_shouldNotDropAppStart` which verifies the "App Start" transaction is captured

## How to test

- Run `make test-ios ONLY_TESTING=SentryAppStartTrackerTests`