### PR TITLE
fix: handle Apple & Homebrew LLVM vended clang-format versions in tooling scripts

### DIFF
--- a/scripts/check-tooling-versions.sh
+++ b/scripts/check-tooling-versions.sh
@@ -10,7 +10,14 @@ cd "${0%/*}"
 # -- Begin Script --
 
 REMOTE_CLANG_FORMAT_VERSION=$(cat .clang-format-version)
-LOCAL_CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
+CLANG_FORMAT_VERSION_STR=$(clang-format --version)
+
+# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that mean we need to extract the version from the 4th field
+# we need to extract the version from the 4th field
+case "$CLANG_FORMAT_VERSION_STR" in
+    Apple\ *|Homebrew\ *) LOCAL_CLANG_FORMAT_VERSION=$(echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $4}') ;;
+    *)                    LOCAL_CLANG_FORMAT_VERSION=$(echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $3}') ;;
+esac
 
 REMOTE_SWIFTLINT_VERSION=$(cat .swiftlint-version)
 LOCAL_SWIFTLINT_VERSION=$(swiftlint version)

--- a/scripts/check-tooling-versions.sh
+++ b/scripts/check-tooling-versions.sh
@@ -12,7 +12,7 @@ cd "${0%/*}"
 REMOTE_CLANG_FORMAT_VERSION=$(cat .clang-format-version)
 CLANG_FORMAT_VERSION_STR=$(clang-format --version)
 
-# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that mean we need to extract the version from the 4th field
+# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that means
 # we need to extract the version from the 4th field
 case "$CLANG_FORMAT_VERSION_STR" in
     Apple\ *|Homebrew\ *) LOCAL_CLANG_FORMAT_VERSION=$(echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $4}') ;;

--- a/scripts/update-tooling-versions.sh
+++ b/scripts/update-tooling-versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euox pipefail
+set -euo pipefail
 
 # Store current working directory
 pushd "$(pwd)" > /dev/null
@@ -10,7 +10,7 @@ cd "${0%/*}"
 # -- Begin Script --
 
 CLANG_FORMAT_VERSION_STR=$(clang-format --version)
-# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that mean
+# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that means
 # we need to extract the version from the 4th field
 case "$CLANG_FORMAT_VERSION_STR" in
     Apple\ *|Homebrew\ *) echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $4}' > .clang-format-version ;;

--- a/scripts/update-tooling-versions.sh
+++ b/scripts/update-tooling-versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 # Store current working directory
 pushd "$(pwd)" > /dev/null
@@ -9,7 +9,14 @@ cd "${0%/*}"
 
 # -- Begin Script --
 
-clang-format --version | awk '{print $3}' > .clang-format-version
+CLANG_FORMAT_VERSION_STR=$(clang-format --version)
+# Xcode's clang-format & Homebrew's LLVM clang-format have prefixes that mean
+# we need to extract the version from the 4th field
+case "$CLANG_FORMAT_VERSION_STR" in
+    Apple\ *|Homebrew\ *) echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $4}' > .clang-format-version ;;
+    *)                    echo "$CLANG_FORMAT_VERSION_STR" | awk '{print $3}' > .clang-format-version ;;
+esac
+
 swiftlint version > .swiftlint-version
 
 # -- End Script --


### PR DESCRIPTION
## :scroll: Description

Adds support for Apple & Homebrew LLVM versions of clang-format in the tooling version scripts.

## :bulb: Motivation and Context

Homebrew LLVM and Apple vended versions of clang-format have an additional prefix:

```sh
➜ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-format --version
Apple clang-format version 21.0.0 (clang-2100.1.1.101)

➜ /opt/homebrew/opt/llvm/bin/clang-format --version
Homebrew clang-format version 22.1.6
```

This differs to the often installed Homebrew version of `clang-format`:

```sh
➜ /opt/homebrew/bin/clang-format --version
clang-format version 22.1.6
```

This caused the tooling scripts (which selected the 3rd item in the output) to select the string 'version' instead of the actual version.

I did consider iterating through each item in the output and looking for something that came after the word "version" or looked like a version number, but decided instead to be more specific on the variants of tooling that I know exist to keep the code as small and as simple as possible.

## :green_heart: How did you test it?

Ran with all three variants of clang-format and ensured it chose the right output.

#skip-changelog