### PR TITLE
fix(objc): use conditional import in headers

### DIFF
--- a/Sources/SentryObjC/Public/SentryObjC.h
+++ b/Sources/SentryObjC/Public/SentryObjC.h
@@ -1,83 +1,177 @@
 #import <Foundation/Foundation.h>
 
 // Platform detection and shared macros
-#import <SentryObjC/SentryObjCDefines.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDefines.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#endif
 
 // --- Enums (no dependencies) ---
-#import <SentryObjC/SentryObjCAttachmentType.h>
-#import <SentryObjC/SentryObjCFeedbackSource.h>
-#import <SentryObjC/SentryObjCLastRunStatus.h>
-#import <SentryObjC/SentryObjCLevel.h>
-#import <SentryObjC/SentryObjCLogLevel.h>
-#import <SentryObjC/SentryObjCReplayQuality.h>
-#import <SentryObjC/SentryObjCSampleDecision.h>
-#import <SentryObjC/SentryObjCSpanStatus.h>
-#import <SentryObjC/SentryObjCTransactionNameSource.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCAttachmentType.h"
+#    import "SentryObjCFeedbackSource.h"
+#    import "SentryObjCLastRunStatus.h"
+#    import "SentryObjCLevel.h"
+#    import "SentryObjCLogLevel.h"
+#    import "SentryObjCReplayQuality.h"
+#    import "SentryObjCSampleDecision.h"
+#    import "SentryObjCSpanStatus.h"
+#    import "SentryObjCTransactionNameSource.h"
+#else
+#    import <SentryObjC/SentryObjCAttachmentType.h>
+#    import <SentryObjC/SentryObjCFeedbackSource.h>
+#    import <SentryObjC/SentryObjCLastRunStatus.h>
+#    import <SentryObjC/SentryObjCLevel.h>
+#    import <SentryObjC/SentryObjCLogLevel.h>
+#    import <SentryObjC/SentryObjCReplayQuality.h>
+#    import <SentryObjC/SentryObjCSampleDecision.h>
+#    import <SentryObjC/SentryObjCSpanStatus.h>
+#    import <SentryObjC/SentryObjCTransactionNameSource.h>
+#endif
 
 // --- Data carriers ---
-#import <SentryObjC/SentryObjCAttributeContent.h>
-#import <SentryObjC/SentryObjCMetric.h>
-#import <SentryObjC/SentryObjCMetricValue.h>
-#import <SentryObjC/SentryObjCRedactRegionType.h>
-#import <SentryObjC/SentryObjCUnit.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCAttributeContent.h"
+#    import "SentryObjCMetric.h"
+#    import "SentryObjCMetricValue.h"
+#    import "SentryObjCRedactRegionType.h"
+#    import "SentryObjCUnit.h"
+#else
+#    import <SentryObjC/SentryObjCAttributeContent.h>
+#    import <SentryObjC/SentryObjCMetric.h>
+#    import <SentryObjC/SentryObjCMetricValue.h>
+#    import <SentryObjC/SentryObjCRedactRegionType.h>
+#    import <SentryObjC/SentryObjCUnit.h>
+#endif
 
 // --- Leaf types (no wrapper dependencies) ---
-#import <SentryObjC/SentryObjCDebugMeta.h>
-#import <SentryObjC/SentryObjCFrame.h>
-#import <SentryObjC/SentryObjCGeo.h>
-#import <SentryObjC/SentryObjCHttpStatusCodeRange.h>
-#import <SentryObjC/SentryObjCId.h>
-#import <SentryObjC/SentryObjCMeasurementUnit.h>
-#import <SentryObjC/SentryObjCMechanismContext.h>
-#import <SentryObjC/SentryObjCMessage.h>
-#import <SentryObjC/SentryObjCNSError.h>
-#import <SentryObjC/SentryObjCRequest.h>
-#import <SentryObjC/SentryObjCSpanId.h>
-#import <SentryObjC/SentryObjCTraceHeader.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDebugMeta.h"
+#    import "SentryObjCFrame.h"
+#    import "SentryObjCGeo.h"
+#    import "SentryObjCHttpStatusCodeRange.h"
+#    import "SentryObjCId.h"
+#    import "SentryObjCMeasurementUnit.h"
+#    import "SentryObjCMechanismContext.h"
+#    import "SentryObjCMessage.h"
+#    import "SentryObjCNSError.h"
+#    import "SentryObjCRequest.h"
+#    import "SentryObjCSpanId.h"
+#    import "SentryObjCTraceHeader.h"
+#else
+#    import <SentryObjC/SentryObjCDebugMeta.h>
+#    import <SentryObjC/SentryObjCFrame.h>
+#    import <SentryObjC/SentryObjCGeo.h>
+#    import <SentryObjC/SentryObjCHttpStatusCodeRange.h>
+#    import <SentryObjC/SentryObjCId.h>
+#    import <SentryObjC/SentryObjCMeasurementUnit.h>
+#    import <SentryObjC/SentryObjCMechanismContext.h>
+#    import <SentryObjC/SentryObjCMessage.h>
+#    import <SentryObjC/SentryObjCNSError.h>
+#    import <SentryObjC/SentryObjCRequest.h>
+#    import <SentryObjC/SentryObjCSpanId.h>
+#    import <SentryObjC/SentryObjCTraceHeader.h>
+#endif
 
 // --- Composite types (depend on leaf types) ---
-#import <SentryObjC/SentryObjCAttachment.h>
-#import <SentryObjC/SentryObjCBreadcrumb.h>
-#import <SentryObjC/SentryObjCException.h>
-#import <SentryObjC/SentryObjCMechanism.h>
-#import <SentryObjC/SentryObjCStacktrace.h>
-#import <SentryObjC/SentryObjCThread.h>
-#import <SentryObjC/SentryObjCUser.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCAttachment.h"
+#    import "SentryObjCBreadcrumb.h"
+#    import "SentryObjCException.h"
+#    import "SentryObjCMechanism.h"
+#    import "SentryObjCStacktrace.h"
+#    import "SentryObjCThread.h"
+#    import "SentryObjCUser.h"
+#else
+#    import <SentryObjC/SentryObjCAttachment.h>
+#    import <SentryObjC/SentryObjCBreadcrumb.h>
+#    import <SentryObjC/SentryObjCException.h>
+#    import <SentryObjC/SentryObjCMechanism.h>
+#    import <SentryObjC/SentryObjCStacktrace.h>
+#    import <SentryObjC/SentryObjCThread.h>
+#    import <SentryObjC/SentryObjCUser.h>
+#endif
 
 // --- Span context hierarchy ---
-#import <SentryObjC/SentryObjCSpanContext.h>
-#import <SentryObjC/SentryObjCTransactionContext.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCSpanContext.h"
+#    import "SentryObjCTransactionContext.h"
+#else
+#    import <SentryObjC/SentryObjCSpanContext.h>
+#    import <SentryObjC/SentryObjCTransactionContext.h>
+#endif
 
 // --- Higher-level types ---
-#import <SentryObjC/SentryObjCEvent.h>
-#import <SentryObjC/SentryObjCFeedback.h>
-#import <SentryObjC/SentryObjCSamplingContext.h>
-#import <SentryObjC/SentryObjCScope.h>
-#import <SentryObjC/SentryObjCSpan.h>
-#import <SentryObjC/SentryObjCTraceContext.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCEvent.h"
+#    import "SentryObjCFeedback.h"
+#    import "SentryObjCSamplingContext.h"
+#    import "SentryObjCScope.h"
+#    import "SentryObjCSpan.h"
+#    import "SentryObjCTraceContext.h"
+#else
+#    import <SentryObjC/SentryObjCEvent.h>
+#    import <SentryObjC/SentryObjCFeedback.h>
+#    import <SentryObjC/SentryObjCSamplingContext.h>
+#    import <SentryObjC/SentryObjCScope.h>
+#    import <SentryObjC/SentryObjCSpan.h>
+#    import <SentryObjC/SentryObjCTraceContext.h>
+#endif
 
 // --- Attribute and log types ---
-#import <SentryObjC/SentryObjCAttribute.h>
-#import <SentryObjC/SentryObjCLog.h>
-#import <SentryObjC/SentryObjCLogger.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCAttribute.h"
+#    import "SentryObjCLog.h"
+#    import "SentryObjCLogger.h"
+#else
+#    import <SentryObjC/SentryObjCAttribute.h>
+#    import <SentryObjC/SentryObjCLog.h>
+#    import <SentryObjC/SentryObjCLogger.h>
+#endif
 
 // --- Configuration ---
-#import <SentryObjC/SentryObjCExperimentalOptions.h>
-#import <SentryObjC/SentryObjCOptions.h>
-#import <SentryObjC/SentryObjCReplayOptions.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCExperimentalOptions.h"
+#    import "SentryObjCOptions.h"
+#    import "SentryObjCReplayOptions.h"
+#else
+#    import <SentryObjC/SentryObjCExperimentalOptions.h>
+#    import <SentryObjC/SentryObjCOptions.h>
+#    import <SentryObjC/SentryObjCReplayOptions.h>
+#endif
 
 // --- API surfaces ---
-#import <SentryObjC/SentryObjCFeedbackApi.h>
-#import <SentryObjC/SentryObjCMetricsApi.h>
-#import <SentryObjC/SentryObjCReplayApi.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCFeedbackApi.h"
+#    import "SentryObjCMetricsApi.h"
+#    import "SentryObjCReplayApi.h"
+#else
+#    import <SentryObjC/SentryObjCFeedbackApi.h>
+#    import <SentryObjC/SentryObjCMetricsApi.h>
+#    import <SentryObjC/SentryObjCReplayApi.h>
+#endif
 
 // --- Envelope types (SPI for hybrid SDKs) ---
-#import <SentryObjC/SentryObjCEnvelope.h>
-#import <SentryObjC/SentryObjCEnvelopeHeader.h>
-#import <SentryObjC/SentryObjCEnvelopeItem.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCEnvelope.h"
+#    import "SentryObjCEnvelopeHeader.h"
+#    import "SentryObjCEnvelopeItem.h"
+#else
+#    import <SentryObjC/SentryObjCEnvelope.h>
+#    import <SentryObjC/SentryObjCEnvelopeHeader.h>
+#    import <SentryObjC/SentryObjCEnvelopeItem.h>
+#endif
 
 // --- Entry points ---
-#import <SentryObjC/SentryObjCClient.h>
-#import <SentryObjC/SentryObjCHub.h>
-#import <SentryObjC/SentryObjCPrivateSDKOnly.h>
-#import <SentryObjC/SentryObjCSDK.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCClient.h"
+#    import "SentryObjCHub.h"
+#    import "SentryObjCPrivateSDKOnly.h"
+#    import "SentryObjCSDK.h"
+#else
+#    import <SentryObjC/SentryObjCClient.h>
+#    import <SentryObjC/SentryObjCHub.h>
+#    import <SentryObjC/SentryObjCPrivateSDKOnly.h>
+#    import <SentryObjC/SentryObjCSDK.h>
+#endif

--- a/Sources/SentryObjC/Public/SentryObjC.h
+++ b/Sources/SentryObjC/Public/SentryObjC.h
@@ -1,14 +1,14 @@
 #import <Foundation/Foundation.h>
 
 // Platform detection and shared macros
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDefines.h"
 #else
 #    import <SentryObjC/SentryObjCDefines.h>
 #endif
 
 // --- Enums (no dependencies) ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCAttachmentType.h"
 #    import "SentryObjCFeedbackSource.h"
 #    import "SentryObjCLastRunStatus.h"
@@ -31,7 +31,7 @@
 #endif
 
 // --- Data carriers ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCAttributeContent.h"
 #    import "SentryObjCMetric.h"
 #    import "SentryObjCMetricValue.h"
@@ -46,7 +46,7 @@
 #endif
 
 // --- Leaf types (no wrapper dependencies) ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDebugMeta.h"
 #    import "SentryObjCFrame.h"
 #    import "SentryObjCGeo.h"
@@ -75,7 +75,7 @@
 #endif
 
 // --- Composite types (depend on leaf types) ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCAttachment.h"
 #    import "SentryObjCBreadcrumb.h"
 #    import "SentryObjCException.h"
@@ -94,7 +94,7 @@
 #endif
 
 // --- Span context hierarchy ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCSpanContext.h"
 #    import "SentryObjCTransactionContext.h"
 #else
@@ -103,7 +103,7 @@
 #endif
 
 // --- Higher-level types ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCEvent.h"
 #    import "SentryObjCFeedback.h"
 #    import "SentryObjCSamplingContext.h"
@@ -120,7 +120,7 @@
 #endif
 
 // --- Attribute and log types ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCAttribute.h"
 #    import "SentryObjCLog.h"
 #    import "SentryObjCLogger.h"
@@ -131,7 +131,7 @@
 #endif
 
 // --- Configuration ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCExperimentalOptions.h"
 #    import "SentryObjCOptions.h"
 #    import "SentryObjCReplayOptions.h"
@@ -142,7 +142,7 @@
 #endif
 
 // --- API surfaces ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCFeedbackApi.h"
 #    import "SentryObjCMetricsApi.h"
 #    import "SentryObjCReplayApi.h"
@@ -153,7 +153,7 @@
 #endif
 
 // --- Envelope types (SPI for hybrid SDKs) ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCEnvelope.h"
 #    import "SentryObjCEnvelopeHeader.h"
 #    import "SentryObjCEnvelopeItem.h"
@@ -164,7 +164,7 @@
 #endif
 
 // --- Entry points ---
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCClient.h"
 #    import "SentryObjCHub.h"
 #    import "SentryObjCPrivateSDKOnly.h"

--- a/Sources/SentryObjC/Public/SentryObjCAttachment.h
+++ b/Sources/SentryObjC/Public/SentryObjCAttachment.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCAttachmentType.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCAttachmentType.h"
+#else
+#    import <SentryObjC/SentryObjCAttachmentType.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SentryObjC/Public/SentryObjCAttachment.h
+++ b/Sources/SentryObjC/Public/SentryObjCAttachment.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCAttachmentType.h"
 #else
 #    import <SentryObjC/SentryObjCAttachmentType.h>

--- a/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
+++ b/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCLevel.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCLevel.h"
+#else
+#    import <SentryObjC/SentryObjCLevel.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
+++ b/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCLevel.h"
 #else
 #    import <SentryObjC/SentryObjCLevel.h>

--- a/Sources/SentryObjC/Public/SentryObjCEvent.h
+++ b/Sources/SentryObjC/Public/SentryObjCEvent.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCLevel.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCLevel.h"
+#else
+#    import <SentryObjC/SentryObjCLevel.h>
+#endif
 
 @class SentryObjCBreadcrumb;
 @class SentryObjCDebugMeta;

--- a/Sources/SentryObjC/Public/SentryObjCEvent.h
+++ b/Sources/SentryObjC/Public/SentryObjCEvent.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCLevel.h"
 #else
 #    import <SentryObjC/SentryObjCLevel.h>

--- a/Sources/SentryObjC/Public/SentryObjCFeedback.h
+++ b/Sources/SentryObjC/Public/SentryObjCFeedback.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCFeedbackSource.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCFeedbackSource.h"
+#else
+#    import <SentryObjC/SentryObjCFeedbackSource.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCAttachment;

--- a/Sources/SentryObjC/Public/SentryObjCFeedback.h
+++ b/Sources/SentryObjC/Public/SentryObjCFeedback.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCFeedbackSource.h"
 #else
 #    import <SentryObjC/SentryObjCFeedbackSource.h>

--- a/Sources/SentryObjC/Public/SentryObjCFeedbackApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCFeedbackApi.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDefines.h"
 #else
 #    import <SentryObjC/SentryObjCDefines.h>

--- a/Sources/SentryObjC/Public/SentryObjCFeedbackApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCFeedbackApi.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCDefines.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDefines.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#endif
 
 #if TARGET_OS_IOS && SENTRY_OBJC_HAS_UIKIT
 

--- a/Sources/SentryObjC/Public/SentryObjCLog.h
+++ b/Sources/SentryObjC/Public/SentryObjCLog.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCLogLevel.h"
 #else
 #    import <SentryObjC/SentryObjCLogLevel.h>

--- a/Sources/SentryObjC/Public/SentryObjCLog.h
+++ b/Sources/SentryObjC/Public/SentryObjCLog.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCLogLevel.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCLogLevel.h"
+#else
+#    import <SentryObjC/SentryObjCLogLevel.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCSpanId;

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -1,6 +1,6 @@
 // swiftlint:disable file_length
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDefines.h"
 #    import "SentryObjCLastRunStatus.h"
 #    import "SentryObjCLevel.h"

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -1,8 +1,14 @@
 // swiftlint:disable file_length
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCDefines.h>
-#import <SentryObjC/SentryObjCLastRunStatus.h>
-#import <SentryObjC/SentryObjCLevel.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDefines.h"
+#    import "SentryObjCLastRunStatus.h"
+#    import "SentryObjCLevel.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#    import <SentryObjC/SentryObjCLastRunStatus.h>
+#    import <SentryObjC/SentryObjCLevel.h>
+#endif
 
 @class SentryObjCBreadcrumb;
 @class SentryObjCEvent;

--- a/Sources/SentryObjC/Public/SentryObjCReplayApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCReplayApi.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDefines.h"
 #else
 #    import <SentryObjC/SentryObjCDefines.h>

--- a/Sources/SentryObjC/Public/SentryObjCReplayApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCReplayApi.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCDefines.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDefines.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#endif
 
 #if SENTRY_OBJC_REPLAY_SUPPORTED
 

--- a/Sources/SentryObjC/Public/SentryObjCReplayOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCReplayOptions.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCReplayQuality.h"
 #else
 #    import <SentryObjC/SentryObjCReplayQuality.h>

--- a/Sources/SentryObjC/Public/SentryObjCReplayOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCReplayOptions.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCReplayQuality.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCReplayQuality.h"
+#else
+#    import <SentryObjC/SentryObjCReplayQuality.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -1,7 +1,13 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCDefines.h>
-#import <SentryObjC/SentryObjCFeedbackSource.h>
-#import <SentryObjC/SentryObjCLastRunStatus.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCDefines.h"
+#    import "SentryObjCFeedbackSource.h"
+#    import "SentryObjCLastRunStatus.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#    import <SentryObjC/SentryObjCFeedbackSource.h>
+#    import <SentryObjC/SentryObjCLastRunStatus.h>
+#endif
 
 @class SentryObjCAttachment;
 @class SentryObjCBreadcrumb;

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCDefines.h"
 #    import "SentryObjCFeedbackSource.h"
 #    import "SentryObjCLastRunStatus.h"

--- a/Sources/SentryObjC/Public/SentryObjCScope.h
+++ b/Sources/SentryObjC/Public/SentryObjCScope.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCLevel.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCLevel.h"
+#else
+#    import <SentryObjC/SentryObjCLevel.h>
+#endif
 
 @class SentryObjCAttachment;
 @class SentryObjCBreadcrumb;

--- a/Sources/SentryObjC/Public/SentryObjCScope.h
+++ b/Sources/SentryObjC/Public/SentryObjCScope.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCLevel.h"
 #else
 #    import <SentryObjC/SentryObjCLevel.h>

--- a/Sources/SentryObjC/Public/SentryObjCSpan.h
+++ b/Sources/SentryObjC/Public/SentryObjCSpan.h
@@ -1,6 +1,11 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCSampleDecision.h>
-#import <SentryObjC/SentryObjCSpanStatus.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCSampleDecision.h"
+#    import "SentryObjCSpanStatus.h"
+#else
+#    import <SentryObjC/SentryObjCSampleDecision.h>
+#    import <SentryObjC/SentryObjCSpanStatus.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCMeasurementUnit;

--- a/Sources/SentryObjC/Public/SentryObjCSpan.h
+++ b/Sources/SentryObjC/Public/SentryObjCSpan.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCSampleDecision.h"
 #    import "SentryObjCSpanStatus.h"
 #else

--- a/Sources/SentryObjC/Public/SentryObjCSpanContext.h
+++ b/Sources/SentryObjC/Public/SentryObjCSpanContext.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCSampleDecision.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCSampleDecision.h"
+#else
+#    import <SentryObjC/SentryObjCSampleDecision.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCSpanId;

--- a/Sources/SentryObjC/Public/SentryObjCSpanContext.h
+++ b/Sources/SentryObjC/Public/SentryObjCSpanContext.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCSampleDecision.h"
 #else
 #    import <SentryObjC/SentryObjCSampleDecision.h>

--- a/Sources/SentryObjC/Public/SentryObjCTraceHeader.h
+++ b/Sources/SentryObjC/Public/SentryObjCTraceHeader.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCSampleDecision.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCSampleDecision.h"
+#else
+#    import <SentryObjC/SentryObjCSampleDecision.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCSpanId;

--- a/Sources/SentryObjC/Public/SentryObjCTraceHeader.h
+++ b/Sources/SentryObjC/Public/SentryObjCTraceHeader.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCSampleDecision.h"
 #else
 #    import <SentryObjC/SentryObjCSampleDecision.h>

--- a/Sources/SentryObjC/Public/SentryObjCTransactionContext.h
+++ b/Sources/SentryObjC/Public/SentryObjCTransactionContext.h
@@ -1,7 +1,13 @@
 #import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCSampleDecision.h>
-#import <SentryObjC/SentryObjCSpanContext.h>
-#import <SentryObjC/SentryObjCTransactionNameSource.h>
+#if SWIFT_PACKAGE
+#    import "SentryObjCSampleDecision.h"
+#    import "SentryObjCSpanContext.h"
+#    import "SentryObjCTransactionNameSource.h"
+#else
+#    import <SentryObjC/SentryObjCSampleDecision.h>
+#    import <SentryObjC/SentryObjCSpanContext.h>
+#    import <SentryObjC/SentryObjCTransactionNameSource.h>
+#endif
 
 @class SentryObjCId;
 @class SentryObjCSpanId;

--- a/Sources/SentryObjC/Public/SentryObjCTransactionContext.h
+++ b/Sources/SentryObjC/Public/SentryObjCTransactionContext.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if SWIFT_PACKAGE
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCSampleDecision.h"
 #    import "SentryObjCSpanContext.h"
 #    import "SentryObjCTransactionNameSource.h"


### PR DESCRIPTION
This pull request updates the import logic across all public header files in the `SentryObjC` target to improve compatibility with our different integration setups.

At this point we are building and testing the library both using SPM and Xcode Targets, which are both using either quotation marks or angle bracket imports, hence we need to use the approach of conditional imports.

Note: this approach is not ideal in terms of maintainability and can be refactored in the future, for now it's the quickest way of getting to a working solution.

#skip-changelog