### PR TITLE
chore(ci): Use Xcode 26 for Testflight build

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
-      - run: ./scripts/ci-select-xcode.sh 16.4
+      - run: ./scripts/ci-select-xcode.sh 26.2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
## :scroll: Description

Apple is no longer accepting builds built with Xcode 16

See https://github.com/getsentry/sentry-cocoa/actions/runs/26525305628/job/78137330346
```
17:47:28]: [altool] 2026-05-27 17:47:28.090 ERROR: [altool.6000038681C0] Validation failed SDK version issue. This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution. (ID: 2b5ce19d-c2ff-4569-87b6-22bfc6e64e28) (409)
```

#skip-changelog

## :bulb: Motivation and Context

Enable releases

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
