### PR TITLE
chore(deps): replace codecov/test-results-action with codecov/codecov-action

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -153,9 +153,10 @@ jobs:
 
       - name: Codecov test analytics
         if: ${{ !cancelled() && inputs.codecov_test_analytics }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # pin@v1.2.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # pin@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           verbose: true
           name: sentry-cocoa-unit-tests
           flags: ui-tests-${{ inputs.fastlane_command }}-${{ inputs.xcode_version }}, ui-tests

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -284,9 +284,10 @@ jobs:
 
       - name: Codecov test analytics
         if: ${{ !cancelled() && !contains(github.ref, 'release') && github.event.schedule == '' }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # pin@v1.2.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # pin@v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           verbose: true
           name: sentry-cocoa-unit-tests
           flags: unittests-${{ inputs.platform }}-${{ inputs.xcode }}-${{ steps.resolve-test-destination.outputs.TEST_OS }}, unittests


### PR DESCRIPTION
## Summary
- Replace `codecov/test-results-action@v1.2.1` (Node 20) with `codecov/codecov-action@v6.0.1` using `report_type: test_results`

## How tested
- CI workflows will validate on this PR

#skip-changelog