### PR TITLE
fix(ci): update RN integration test sed pattern

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -101,7 +101,7 @@ jobs:
         run: yarn install
 
       - name: Remove fixed version of Sentry Dependency from RNSentry.podspec
-        run: sed -E -i '' "s/s.dependency 'Sentry', '[0-9]*\.[0-9]*\.[0-9]*(-[a-z]+\.[0-9]+)?'/s.dependency 'Sentry'/" sentry-react-native/packages/core/RNSentry.podspec
+        run: sed -E -i '' "s/s.dependency 'Sentry', sentry_cocoa_version/s.dependency 'Sentry'/" sentry-react-native/packages/core/RNSentry.podspec
 
       - name: Add Sentry Dependency with path to Sentry Cocoa SDK to RNSentryCocoaTester/Podfile
         run: sed -i '' -e "s/RNSentry.podspec'/RNSentry.podspec'\\n  pod 'Sentry', :path => '..\/..\/..\/..\/sentry-cocoa'/" sentry-react-native/packages/core/RNSentryCocoaTester/Podfile


### PR DESCRIPTION
## Summary
- The `sentry-react-native` repo changed `RNSentry.podspec` to use a Ruby variable (`sentry_cocoa_version`) instead of an inline version string for the Sentry dependency ([getsentry/sentry-react-native@853723c](https://github.com/getsentry/sentry-react-native/commit/853723c6cd192e3b1fec329fea461b3d4d8df8af))
- Our `test-cross-platform` CI workflow's `sed` pattern no longer matches, breaking the React Native integration test
- Updated the sed to match the new `s.dependency 'Sentry', sentry_cocoa_version` format

## Test plan
- [x] `test-react-native` job in `test-cross-platform` workflow passes

#skip-changelog