### PR TITLE
ci: fix RN Sentry podspec rewrite

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -101,7 +101,11 @@ jobs:
         run: yarn install
 
       - name: Remove fixed version of Sentry Dependency from RNSentry.podspec
-        run: sed -E -i '' "s/s.dependency 'Sentry', '[0-9]*\.[0-9]*\.[0-9]*(-[a-z]+\.[0-9]+)?'/s.dependency 'Sentry'/" sentry-react-native/packages/core/RNSentry.podspec
+        run: |
+          sed -E -i '' \
+            -e "s/s.dependency 'Sentry', '[0-9]+\.[0-9]+\.[0-9]+(-[[:alnum:].-]+)?'/s.dependency 'Sentry'/" \
+            -e "s/s.dependency 'Sentry', sentry_cocoa_version/s.dependency 'Sentry'/" \
+            sentry-react-native/packages/core/RNSentry.podspec
 
       - name: Add Sentry Dependency with path to Sentry Cocoa SDK to RNSentryCocoaTester/Podfile
         run: sed -i '' -e "s/RNSentry.podspec'/RNSentry.podspec'\\n  pod 'Sentry', :path => '..\/..\/..\/..\/sentry-cocoa'/" sentry-react-native/packages/core/RNSentryCocoaTester/Podfile


### PR DESCRIPTION
Fix the React Native cross-platform workflow RNSentry.podspec rewrite to strip both the old literal Sentry version constraint and the current sentry_cocoa_version variable form.

This keeps the local sentry-cocoa path injection from conflicting with RNSentry pinned CocoaPods dependency when sentry-react-native trails this branch Sentry version.

Stacked on #7918.

#skip-changelog