### PR TITLE
fix(ci): Preserve source SPM products in samples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,15 +116,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # As the DistributionSample project uses local SPM, xcodebuild resolves SPM dependencies for all
-      # sample projects. The Package.swift references binary targets, which in release branch commits points
-      # to non-existent download URLs. This creates chicken-egg failures when building these sample apps for
-      # a release commit build. When building these sample apps for a release commit, xcodebuild tries to
-      # resolve all SPM dependencies, including the binary targets pointing to these non-existent URLs.  The
-      # sample projects don't use SPM for including Sentry. Only the DistributionSample uses local SPM.
-      # Therefore, we only keep the local DistributionSample reference in the Package.swift as a workaround.
-      - name: Only keep distribution lib and target in Package.swift
-        if: matrix.scheme == 'DistributionSample'
+      # Some sample projects use local SPM references. xcodebuild resolves SPM dependencies for the
+      # workspace, so Package.swift binary targets can be resolved even when building another scheme.
+      # On release branches these binary target URLs point to artifacts that do not exist yet, causing
+      # release commit builds to fail before the artifacts are published.
+      - name: Remove binary targets from Package.swift
         run: ./scripts/prepare-package.sh --remove-binary-targets true
 
       - name: Setup Xcode

--- a/scripts/prepare-package.sh
+++ b/scripts/prepare-package.sh
@@ -19,7 +19,7 @@ OPTIONS:
     --remove-duplicate true|false    Strip duplicate variant targets (default: false)
     --change-path true|false         Swap binary URLs for local paths (default: false)
     --remove-binary-targets true|false
-                                     Keep only SentryDistribution (default: false)
+                                     Remove binary targets and keep source-backed products (default: false)
     -h, --help                       Show this help message
 
 EXAMPLES:
@@ -150,7 +150,8 @@ for PACKAGE_FILE in "${PACKAGE_FILES[@]}"; do
     # Remove all binary targets.
     sed -i '' '/^[[:space:]]*\.binaryTarget(/,/^[[:space:]]*),\{0,1\}$/d' "$PACKAGE_FILE"
 
-    # Keep only the SentryDistribution library in the products array.
+    # Keep only source-backed products in the products array. Additional source products can be
+    # appended later in the file, such as SentrySPM and SentryObjC.
     sed -i '' '/^var products: \[Product\] = \[/,/^]/c\
 var products: [Product] = [\
     .library(name: "SentryDistribution", targets: ["SentryDistribution"]),\
@@ -169,9 +170,6 @@ var targets: [Target] = [\
     sed -i '' '/^    dependencies: \[/,/^    ],/c\
     dependencies: [],\
 ' "$PACKAGE_FILE"
-
-    # Remove marker-delimited regions not needed for distribution tests.
-    sed -i '' '/\/\/ BEGIN:OBJC_WRAPPER/,/\/\/ END:OBJC_WRAPPER/d' "$PACKAGE_FILE"
   fi
 
   begin_group "$PACKAGE_FILE (after prepare-package.sh)"


### PR DESCRIPTION
Keep release-branch sample builds from resolving unpublished binary target URLs while preserving the local source package products used by samples.

This is stacked on #7918. That PR adds the iOS-ObjectiveCpp-NoModules sample, which depends on the local SPM product SentryObjC. The existing workflow only ran package prep for DistributionSample, so other sample schemes could still hit Package.swift binary target URLs during workspace package resolution on release branches.

This runs binary target stripping for every sample build and keeps source-backed products appended later in Package.swift, including SentrySPM and SentryObjC.

Verified locally by running prepare-package.sh against a temporary Package.swift copy and parsing the result with swift package dump-package. The generated manifest has no binary targets and still exposes SentryDistribution, SentrySPM, and SentryObjC.

#skip-changelog