### PR TITLE
build: Fix targeted test options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ make analyze
 make build-ios
 
 # 4. Test (targeted — see Tests/AGENTS.md for ONLY_TESTING usage)
-make test-ios ONLY_TESTING=<AffectedTestClass>
+make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests
 
 # 5. If the public API surface changed (Swift/ObjC public headers, @objc/public symbols)
 make generate-public-api  # regenerates sdk_api.json; commit any diff

--- a/Makefile
+++ b/Makefile
@@ -568,6 +568,7 @@ test-ios:
 		--ref $(GIT-REF) \
 		--command test \
 		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
 		--only-testing "$(ONLY_TESTING)"
 
 ## Run macOS tests
@@ -590,6 +591,7 @@ test-macos:
 		--ref $(GIT-REF) \
 		--command test \
 		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
 		--only-testing "$(ONLY_TESTING)"
 
 ## Run Catalyst tests
@@ -611,6 +613,7 @@ test-catalyst:
 		--ref $(GIT-REF) \
 		--command test \
 		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
 		--only-testing "$(ONLY_TESTING)"
 
 ## Run tvOS tests
@@ -633,6 +636,7 @@ test-tvos:
 		--ref $(GIT-REF) \
 		--command test \
 		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
 		--only-testing "$(ONLY_TESTING)"
 
 ## Run visionOS tests
@@ -655,6 +659,7 @@ test-visionos:
 		--ref $(GIT-REF) \
 		--command test \
 		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
 		--only-testing "$(ONLY_TESTING)"
 
 # Note: test-watchos target is not available because watchOS does not support XCTest.

--- a/Makefile
+++ b/Makefile
@@ -550,12 +550,14 @@ test: test-ios test-macos test-catalyst test-tvos test-visionos
 # Runs unit tests for iOS Simulator.
 # Outputs logs and uses xcbeautify for formatted output.
 #
-# Optional: ONLY_TESTING=ClassName to run specific test class(es)
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
 # Examples:
 #   make test-ios
-#   make test-ios ONLY_TESTING=SentryHttpTransportTests
-#   make test-ios ONLY_TESTING=SentryHttpTransportTests,SentryHubTests
-#   make test-ios ONLY_TESTING=SentryHttpTransportTests/testFlush_WhenNoInternet
+#   make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests
+#   make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests,SentryTests/SentryHubTests
+#   make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests/testFlush_WhenNoInternet
+#   make test-ios TEST_SCHEME=SentryObjCTests
 .PHONY: test-ios
 test-ios:
 	@echo "--> Running iOS tests"
@@ -573,10 +575,12 @@ test-ios:
 # Runs unit tests for macOS.
 # Outputs logs and uses xcbeautify for formatted output.
 #
-# Optional: ONLY_TESTING=ClassName to run specific test class(es)
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
 # Examples:
 #   make test-macos
-#   make test-macos ONLY_TESTING=SentryHttpTransportTests
+#   make test-macos ONLY_TESTING=SentryTests/SentryHttpTransportTests
+#   make test-macos TEST_SCHEME=SentryObjCTests
 .PHONY: test-macos
 test-macos:
 	@echo "--> Running macOS tests"
@@ -593,10 +597,11 @@ test-macos:
 # Runs unit tests for Mac Catalyst.
 # Outputs logs and uses xcbeautify for formatted output.
 #
-# Optional: ONLY_TESTING=ClassName to run specific test class(es)
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
 # Examples:
 #   make test-catalyst
-#   make test-catalyst ONLY_TESTING=SentryHttpTransportTests
+#   make test-catalyst ONLY_TESTING=SentryTests/SentryHttpTransportTests
 .PHONY: test-catalyst
 test-catalyst:
 	@echo "--> Running Catalyst tests"
@@ -613,10 +618,11 @@ test-catalyst:
 # Runs unit tests for tvOS Simulator.
 # Outputs logs and uses xcbeautify for formatted output.
 #
-# Optional: ONLY_TESTING=ClassName to run specific test class(es)
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
 # Examples:
 #   make test-tvos
-#   make test-tvos ONLY_TESTING=SentryHttpTransportTests
+#   make test-tvos ONLY_TESTING=SentryTests/SentryHttpTransportTests
 .PHONY: test-tvos
 test-tvos:
 	@echo "--> Running tvOS tests"
@@ -634,10 +640,11 @@ test-tvos:
 # Runs unit tests for visionOS Simulator.
 # Outputs logs and uses xcbeautify for formatted output.
 #
-# Optional: ONLY_TESTING=ClassName to run specific test class(es)
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
 # Examples:
 #   make test-visionos
-#   make test-visionos ONLY_TESTING=SentryHttpTransportTests
+#   make test-visionos ONLY_TESTING=SentryTests/SentryHttpTransportTests
 .PHONY: test-visionos
 test-visionos:
 	@echo "--> Running visionOS tests"
@@ -1166,7 +1173,7 @@ help:
 		echo "📖 Or: make help name=<command>      (e.g., make help name=build-ios)"; \
 		echo ""; \
 	fi
- 
+
 .PHONY: help-% help-target
 help-%:
 	@target="$*"; \

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -8,9 +8,9 @@ Test classes follow naming pattern `<SourceFile>Tests`. Default to iOS (fastest)
 
 ```bash
 make test-ios                                                  # all iOS tests
-make test-ios ONLY_TESTING=SentryHttpTransportTests             # single class
-make test-ios ONLY_TESTING=SentryHttpTransportTests,SentryHubTests  # multiple
-make test-ios ONLY_TESTING=SentryHttpTransportTests/testFlush_WhenNoInternet  # single method
+make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests  # single class
+make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests,SentryTests/SentryHubTests  # multiple
+make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests/testFlush_WhenNoInternet  # single method
 make test                                                      # all platforms
 make test-ui-critical                                          # important UI tests
 ```

--- a/develop-docs/SENTRYCRASH.md
+++ b/develop-docs/SENTRYCRASH.md
@@ -517,8 +517,8 @@ SentryCrash is part of the main SDK targets. Use the same build commands as the 
 
 Run SentryCrash-related tests with the same pattern as other SDK tests. Examples:
 
-- `make test-ios ONLY_TESTING=SentryCrashInstallationTests,SentryCrashWrapperTests`
-- `make test-ios ONLY_TESTING=SentryCrashMonitor_NSException_Tests,SentryCrashMonitor_Signal_Tests`
+- `make test-ios ONLY_TESTING=SentryTests/SentryCrashInstallationTests,SentryTests/SentryCrashWrapperTests`
+- `make test-ios ONLY_TESTING=SentryTests/SentryCrashMonitor_NSException_Tests,SentryTests/SentryCrashMonitor_Signal_Tests`
 
 See AGENTS.md (Testing Instructions) for the convention: test class names follow `<SourceFile>Tests`. The test server is **not** required for most SentryCrash tests; it is only needed for the small set of network integration tests that use the `Sentry_TestServer` xctestplan. See [develop-docs/TEST.md](TEST.md) for general testing practices.
 

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -41,13 +41,14 @@ OPTIONS:
     -D, --derived-data <path>        Derived data path
     -s, --scheme <scheme>            Test scheme (default: Sentry)
     -t, --test-plan <plan>           Test plan name (default: empty)
-    --only-testing <tests>           Comma-separated test classes (default: empty, runs all tests)
+    --only-testing <tests>           Comma-separated test selectors.
+                                      Each selector must be Target/Class or Target/Class/testMethod.
     -R, --result-bundle <path>       Result bundle path (default: results.xcresult)
 
 EXAMPLES:
     $(basename "$0") -p iOS -c test
     $(basename "$0") -p macOS -c build -C Release
-    $(basename "$0") -p iOS -c test --only-testing SentryTests
+    $(basename "$0") -p iOS -c test --only-testing SentryTests/SentrySDKTests
 
 EOF
     exit 1
@@ -220,7 +221,13 @@ ONLY_TESTING_ARGS=()
 if [ -n "$ONLY_TESTING" ]; then
     IFS=',' read -ra TEST_ARRAY <<< "$ONLY_TESTING"
     for test in "${TEST_ARRAY[@]}"; do
-        ONLY_TESTING_ARGS+=("-only-testing:SentryTests/$test")
+        if [[ ! "$test" =~ ^[^/[:space:]]+/[^/[:space:]]+(/[^/[:space:]]+)?$ ]]; then
+            log_error "Invalid --only-testing value: $test"
+            log_error "Use Target/Class or Target/Class/testMethod, for example SentryTests/SentrySDKTests."
+            exit 1
+        fi
+
+        ONLY_TESTING_ARGS+=("-only-testing:$test")
     done
 fi
 


### PR DESCRIPTION
Targeted test runs now require fully qualified `Target/Class` selectors and pass them directly to xcodebuild instead of assuming the `SentryTests` target. The Make test targets also pass `TEST_SCHEME` through to `sentry-xcodebuild.sh`, so documented scheme overrides work across iOS, macOS, Catalyst, tvOS, and visionOS.

**ONLY_TESTING Selectors**

`--only-testing` accepts comma-separated `Target/Class` or `Target/Class/testMethod` selectors and rejects class-only values with a clear error. The Makefile and agent docs now use qualified examples.

**TEST_SCHEME Pass-through**

`make test-* TEST_SCHEME=...` now emits `--scheme` only when the variable is set, preserving the existing default `Sentry` scheme behavior.

Cherry picked from commit ebe080c1a0bd5150123cc99c99f84353cf1fb751 in #7918.

#skip-changelog
