### PR TITLE
ci: Disable parallel Sentry scheme builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Features
 
-- Add SentryObjC wrapper SDK — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). Ships as `SentryObjC-Dynamic.xcframework.zip` and as a compile-from-source SPM product. (#6342)
+- Add SentryObjC wrapper SDK — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). Ships as `SentryObjC-Dynamic.xcframework.zip` and as a compile-from-source SPM product. (#7919)
   Steps to migrate:
   - Replace your dependency on `Sentry` with `SentryObjC` (SPM product or xcframework)
   - Change `#import <Sentry/Sentry.h>` to `#import <SentryObjC/SentryObjC.h>`

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1400"
    version = "1.7">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry


### PR DESCRIPTION
Serialize the Sentry scheme build graph by setting `parallelizeBuildables` to `NO`.

This is a diagnostic stacked PR on top of #7918 to test whether the CI module-cache signature mismatch is caused by parallel target builds within a fresh ephemeral runner.

If this makes the affected unit jobs stable, it confirms the failure is an intra-build scheduling/module-cache interaction rather than stale state from previous CI runs.

#skip-changelog