### PR TITLE
chore: Track SentryObjC adoption

### DIFF
--- a/Sources/SentryObjCCompat/SentryObjCSDK.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDK.swift
@@ -34,10 +34,12 @@ import Foundation
     #endif
 
     @objc public static func start(options: SentryObjCOptions) {
+        SentryObjCSDKTracking.markStartedThroughObjCWrapper()
         SentrySDK.start(options: options.wrapped)
     }
 
     @objc public static func start(configureOptions: @escaping (SentryObjCOptions) -> Void) {
+        SentryObjCSDKTracking.markStartedThroughObjCWrapper()
         SentrySDK.start { options in
             configureOptions(SentryObjCOptions(options))
         }
@@ -232,6 +234,7 @@ import Foundation
 
     @objc public static func close() {
         SentrySDK.close()
+        SentryObjCSDKTracking.markClosedThroughObjCWrapper()
     }
 
     #if !(os(watchOS) || os(tvOS) || os(visionOS))

--- a/Sources/SentryObjCCompat/SentryObjCSDKTracking.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDKTracking.swift
@@ -1,0 +1,30 @@
+#if SWIFT_PACKAGE
+internal import SentrySwift
+#else
+internal import Sentry
+#endif
+
+enum SentryObjCSDKTracking {
+    private static let baseSDKName = "sentry.cocoa"
+    static let objcSDKName = "sentry.cocoa.objc"
+    private static var didSetObjCSDKName = false
+
+    static func markStartedThroughObjCWrapper() {
+        guard PrivateSentrySDKOnly.getSdkName() == baseSDKName else {
+            return
+        }
+
+        PrivateSentrySDKOnly.setSdkName(objcSDKName)
+        didSetObjCSDKName = true
+    }
+
+    static func markClosedThroughObjCWrapper() {
+        guard didSetObjCSDKName,
+              PrivateSentrySDKOnly.getSdkName() == objcSDKName else {
+            return
+        }
+
+        PrivateSentrySDKOnly.setSdkName(baseSDKName)
+        didSetObjCSDKName = false
+    }
+}

--- a/Tests/SentryObjCCompatTests/SentryObjCCompatSDKTrackingTests.swift
+++ b/Tests/SentryObjCCompatTests/SentryObjCCompatSDKTrackingTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+#if SWIFT_PACKAGE
+@_spi(Private) @testable import SentrySwift
+#else
+@_spi(Private) @testable import Sentry
+#endif
+
+@testable import SentryObjCCompat
+import XCTest
+
+final class SentryObjCCompatSDKTrackingTests: XCTestCase {
+
+    override func tearDown() {
+        SentryObjCSDK.close()
+        super.tearDown()
+    }
+
+    func testEnvelopeHeaderAfterObjCStart_usesObjCSdkName() throws {
+        SentryObjCSDK.start { options in
+            options.dsn = "https://key@sentry.io/123"
+            options.enableCrashHandler = false
+        }
+
+        let envelope = SentryEnvelope(id: SentryId(), items: [])
+        let data = try XCTUnwrap(SentrySerializationSwift.data(with: envelope))
+        let headerLine = try XCTUnwrap(
+            String(data: data, encoding: .utf8)?
+                .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+                .first
+        )
+        let header = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(headerLine.utf8)) as? [String: Any]
+        )
+        let sdk = try XCTUnwrap(header["sdk"] as? [String: Any])
+
+        XCTAssertEqual(sdk["name"] as? String, "sentry.cocoa.objc")
+    }
+}

--- a/Tests/SentryObjCTests/SentryObjCSDKTests.m
+++ b/Tests/SentryObjCTests/SentryObjCSDKTests.m
@@ -36,6 +36,60 @@
     [SentryObjCSDK startWithOptions:options];
 }
 
+- (void)testStartWithOptions_shouldSetObjCSdkNameOnEvent
+{
+    // -- Arrange --
+    [SentryObjCSDK close];
+    __block NSDictionary<NSString *, id> *capturedSdk = nil;
+
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+    options.dsn = @"https://key@sentry.io/123";
+    options.enableCrashHandler = NO;
+    options.beforeSend = ^SentryObjCEvent *_Nullable(SentryObjCEvent *event)
+    {
+        capturedSdk = event.sdk;
+        return event;
+    };
+
+    // -- Act --
+    [SentryObjCSDK startWithOptions:options];
+    [SentryObjCSDK captureEvent:[[SentryObjCEvent alloc] init]];
+
+    // -- Assert --
+    XCTAssertEqualObjects(capturedSdk[@"name"], @"sentry.cocoa.objc");
+}
+
+- (void)testStartWithConfigureOptions_shouldSetObjCSdkNameOnEvent
+{
+    // -- Arrange --
+    [SentryObjCSDK close];
+    __block NSDictionary<NSString *, id> *capturedSdk = nil;
+
+    // -- Act --
+    [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+        options.dsn = @"https://key@sentry.io/123";
+        options.enableCrashHandler = NO;
+        options.beforeSend = ^SentryObjCEvent *_Nullable(SentryObjCEvent *event)
+        {
+            capturedSdk = event.sdk;
+            return event;
+        };
+    }];
+    [SentryObjCSDK captureEvent:[[SentryObjCEvent alloc] init]];
+
+    // -- Assert --
+    XCTAssertEqualObjects(capturedSdk[@"name"], @"sentry.cocoa.objc");
+}
+
+- (void)testClose_shouldRestoreBaseSdkName
+{
+    // -- Act --
+    [SentryObjCSDK close];
+
+    // -- Assert --
+    XCTAssertEqualObjects([SentryObjCPrivateSDKOnly getSdkName], @"sentry.cocoa");
+}
+
 - (void)testIsEnabled_whenStarted_shouldReturnTrue
 {
     // -- Arrange & Act --


### PR DESCRIPTION
Mark Sentry events and envelope headers produced through `SentryObjCSDK`
with the SDK name `sentry.cocoa.objc`.

This lets Sentry measure adoption of the ObjC wrapper while reusing the
existing SDK Interface `sdk.name` field. The marker only applies when the
current SDK name is the base Cocoa name and restores `sentry.cocoa` when the
ObjC wrapper closes after setting it.

#skip-changelog
