### PR TITLE
ci: Migrate macOS 14 workflows to 15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,13 +303,13 @@ jobs:
             platform: "iOS"
 
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
-          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
-          # We are running tests on macOS 14 and later, as there were OS-internal changes introduced in succeeding versions.
+          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 15 is minimal.
+          # We are running tests on macOS 15 and later, as there were OS-internal changes introduced in succeeding versions.
 
-          # macOS 14
-          - name: macOS 14 Sentry
-            runs-on: sonoma
-            xcode: "16"
+          # macOS 15 pinned to Xcode 16.2 to preserve coverage from the retired macOS 14 runner.
+          - name: macOS 15 Compat Sentry
+            runs-on: sequoia
+            xcode: "16.2"
             platform: "macOS"
 
           # macOS 15
@@ -326,10 +326,10 @@ jobs:
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          # In addition we are running tests on macOS 14, as there were OS-internal changes introduced in succeeding versions.
-          - name: Catalyst 14 Sentry
-            runs-on: sonoma
-            xcode: "16"
+          # In addition we run Catalyst with Xcode 16.2 on macOS 15, preserving coverage from the retired macOS 14 runner.
+          - name: Catalyst 15 Compat Sentry
+            runs-on: sequoia
+            xcode: "16.2"
             platform: "Catalyst"
 
           - name: Catalyst 15 Sentry


### PR DESCRIPTION
Migrate the remaining unit-test matrix entries that targeted the macOS 14/Sonoma runner to macOS 15/Sequoia.

Pin the compatibility rows to Xcode 16.2 so they preserve the old macOS 14 image coverage instead of moving to the latest Xcode 16.x, which is already covered by separate macOS 15 rows.

The main reason for this change right now is that the CirrusLabs Runners for macOS-14 were unavailable on June 1st, 2026 while all newer runners were working fine.

#skip-changelog