### PR TITLE
fix(ci): Stop stripping embedded frameworks from SentryObjC slices

### DIFF
--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -101,25 +101,17 @@ jobs:
         run: ./scripts/build-xcframework-slice.sh "$MATRIX_SDK" "$INPUT_NAME" "$INPUT_SUFFIX" "$INPUT_MACHO_TYPE" "$INPUT_CONFIG_SUFFIX"
         shell: bash
 
-      # Targets that depend on Sentry also build Sentry.framework as a byproduct.
-      # Remove it to avoid downstream assembly tasks from tripping on extra files.
+      # SentrySwiftUI depends on Sentry, which gets built as a byproduct.
+      # Remove it — consumers link Sentry separately.
+      # SentryObjC is NOT included here: it embeds its dependencies inside
+      # the framework bundle and needs them to stay.
       - name: Remove Sentry.framework byproduct
-        if: inputs.name == 'SentrySwiftUI' || inputs.name == 'SentryObjC'
+        if: inputs.name == 'SentrySwiftUI'
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
           find "$GITHUB_WORKSPACE/XCFrameworkBuildPath/archive" -name "Sentry.framework" -print0 | xargs -t0 rm -rf
           find "$GITHUB_WORKSPACE/XCFrameworkBuildPath/archive" -name "Sentry.framework.dSYM" -print0 | xargs -t0 rm -rf
-        shell: bash
-
-      # SentryObjC depends on SentryObjCCompat, which gets built as a byproduct.
-      - name: Remove SentryObjCCompat.framework byproduct
-        if: inputs.name == 'SentryObjC'
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-        run: |
-          find "$GITHUB_WORKSPACE/XCFrameworkBuildPath/archive" -name "SentryObjCCompat.framework" -print0 | xargs -t0 rm -rf
-          find "$GITHUB_WORKSPACE/XCFrameworkBuildPath/archive" -name "SentryObjCCompat.framework.dSYM" -print0 | xargs -t0 rm -rf
         shell: bash
 
       # the upload action broke symlinks in the mac sdk slice's xcarchive


### PR DESCRIPTION
## Summary

The SentryObjC-Dynamic xcframework was shipping as a hollow 103KB binary with only version symbols. The release workflow's byproduct cleanup steps were stripping `Sentry.framework` and `SentryObjCCompat.framework` from the archive — but unlike SentrySwiftUI (where consumers link Sentry separately), SentryObjC embeds these as sub-frameworks inside `SentryObjC.framework/Frameworks/`.

- Restrict `Sentry.framework` removal to SentrySwiftUI only
- Remove the `SentryObjCCompat.framework` cleanup step entirely

## Root Cause

When SentryObjC was added to the CI pipeline (commit `6189f81e2`), the existing SentrySwiftUI cleanup pattern was extended to also cover SentryObjC. This was incorrect because SentryObjC is self-contained — its dependency chain (`SentryObjC → SentryObjCCompat → Sentry`) is embedded inside the framework bundle, not linked separately by consumers.

## How Tested

- Verified locally that `make build-sentryobjc-xcframework-local SDKS=iphonesimulator` produces an xcframework with the full embedded chain:
  - `SentryObjC.framework/Frameworks/SentryObjCCompat.framework` (4MB, wrapper implementations)
  - `SentryObjCCompat.framework/Frameworks/Sentry.framework` (23MB, full SDK)
- Confirmed the release artifact from 9.16.0-alpha.1 has only 2 exported symbols (`_SentryObjCVersionNumber`, `_SentryObjCVersionString`) and an empty `Frameworks/` directory

#skip-changelog