### PR TITLE
fix: report Objective-C object throws via C++ exception monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix reporting arbitrary Objective-C object throws via the C++ exception monitor (#7983)
+
 ## 9.16.0-alpha.2
 
 > [!IMPORTANT]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix reporting arbitrary Objective-C object throws via the C++ exception monitor (#7983)
+- Fix reporting arbitrary Objective-C object throws via the C++ exception monitor (#7984)
 
 ## 9.16.0-alpha.2
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -37,6 +37,7 @@
 #include <cxxabi.h>
 #include <dlfcn.h>
 #include <exception>
+#include <objc/runtime.h>
 #include <ptrauth.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -116,6 +117,35 @@ isObjCException(const std::type_info *tinfo)
         == ptrauth_strip(objc_vtable, ptrauth_key_cxx_vtable_pointer);
 }
 
+struct objc_typeinfo {
+    const void *vtable;
+    const char *name;
+    Class cls;
+};
+
+static Class
+objcExceptionClass(const std::type_info *tinfo)
+{
+    if (!isObjCException(tinfo)) {
+        return Nil;
+    }
+
+    return reinterpret_cast<const objc_typeinfo *>(tinfo)->cls;
+}
+
+static bool
+isNSException(const std::type_info *tinfo)
+{
+    for (Class currentClass = objcExceptionClass(tinfo); currentClass != Nil;
+        currentClass = class_getSuperclass(currentClass)) {
+        const char *className = class_getName(currentClass);
+        if (className != NULL && strcmp(className, "NSException") == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // ============================================================================
 #pragma mark - Callbacks -
 // ============================================================================
@@ -125,8 +155,8 @@ captureStackTrace(void *, std::type_info *tinfo, void (*)(void *)) KEEP_FUNCTION
 {
     SENTRY_ASYNC_SAFE_LOG_TRACE("Entering captureStackTrace");
 
-    // We handle ObjC exceptions (NSException and subclasses) in SentryCrashMonitor_NSException.
-    if (isObjCException(tinfo)) {
+    // We handle NSException and subclasses in SentryCrashMonitor_NSException.
+    if (isNSException(tinfo)) {
         return;
     }
 
@@ -209,14 +239,16 @@ CPPExceptionTerminate(void)
     SENTRY_ASYNC_SAFE_LOG_DEBUG("Trapped c++ exception");
 
     bool isObjCExc = false;
+    bool isNSExceptionExc = false;
     const char *name = NULL;
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
     if (tinfo != NULL) {
         name = tinfo->name();
         isObjCExc = isObjCException(tinfo);
+        isNSExceptionExc = isNSException(tinfo);
     }
 
-    if (!isObjCExc) {
+    if (!isNSExceptionExc) {
         thread_act_array_t threads = NULL;
         mach_msg_type_number_t numThreads = 0;
         // The cxa_throw hook reenters only from other threads. Edge case:
@@ -235,6 +267,11 @@ CPPExceptionTerminate(void)
         if (currException == NULL) {
             SENTRY_ASYNC_SAFE_LOG_DEBUG("Terminate without exception.");
             sentrycrashsc_initSelfThread(&g_stackCursor, 0);
+        } else if (isObjCExc) {
+            // Objective-C object throws that are not NSException won't be handled by
+            // NSSetUncaughtExceptionHandler. Report them via the C++ monitor, but don't rethrow
+            // through the C++ catch list while discovering a C++-style description.
+            description = NULL;
         } else {
 
             // When we reach this point, the stack has already been unwound and the original stack
@@ -300,7 +337,7 @@ CPPExceptionTerminate(void)
         sentrycrashcm_handleException(crashContext);
         sentrycrashmc_resumeEnvironment(threads, numThreads);
     } else {
-        SENTRY_ASYNC_SAFE_LOG_DEBUG("Detected ObjC exception. Letting the current "
+        SENTRY_ASYNC_SAFE_LOG_DEBUG("Detected NSException. Letting the current "
                                     "NSException handler deal with it.");
     }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_CppException_Tests.mm
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_CppException_Tests.mm
@@ -43,6 +43,7 @@ mockTerminationHandler(void)
     if (api != NULL) {
         api->setEnabled(false);
     }
+    sentrycrashcm_resetState();
     sentrycrashcm_setEventCallback(NULL);
     capturedExceptionContextCrashReason = NULL;
     capturedCrashType = (SentryCrashMonitorType)0;
@@ -179,6 +180,24 @@ mockHandleExceptionHandler(struct SentryCrash_MonitorContext *context)
         terminateCalled, "Original terminate handler should be called for ObjC exceptions.");
     XCTAssertNotEqual(capturedCrashType, SentryCrashMonitorTypeCPPException,
         "NSException subclass should NOT be handled by C++ exception handler.");
+}
+
+- (void)testTerminateWithArbitraryObjectiveCObject_HandledByCppHandler
+{
+    // Arrange
+    sentrycrashcm_setEventCallback(mockHandleExceptionHandler);
+    api->setEnabled(true);
+
+    // Act
+    @try {
+        @throw @"Objective-C object exception";
+    } @catch (...) {
+        std::get_terminate()();
+    }
+
+    // Assert
+    XCTAssertEqual(capturedCrashType, SentryCrashMonitorTypeCPPException,
+        "Arbitrary Objective-C object throws are not handled by NSSetUncaughtExceptionHandler.");
 }
 
 - (void)testCallHandler_shouldCaptureExceptionDescription


### PR DESCRIPTION
## :scroll: Description

This is a follow-up fix to #7420. Since that change, the C++ monitor has early-exited on any Objective-C exception, assuming it would be handled by the handler set by `NSSetUncaughtExceptionHandler`. That is, however, only true for `NSException` and its subclasses, but not for arbitrary objects being thrown with `@throw`.

This fix rectifies this by iterating through superclasses of the ABI `Class` of the thrown exception, after verifying that it is an Objective-C exception, and only early-exiting if `NSException` is in the hierarchy.

## :bulb: Motivation and Context

We upstreamed the fix in #7420 to `KSCrash` in https://github.com/kstenerud/KSCrash/pull/845, where the above issue was thankfully raised during the review.

## :green_heart: How did you test it?

Added a test that verifies that an arbitrary thrown object is captured as an `SentryCrashMonitorTypeCPPException`.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
