### PR TITLE
feat(objc): Add missing SentryObjC public APIs

### DIFF
--- a/Sources/SentryObjC/Public/SentryObjCMetric.h
+++ b/Sources/SentryObjC/Public/SentryObjCMetric.h
@@ -21,6 +21,27 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryObjCMetric : NSObject
 SENTRY_NO_INIT
 
+/**
+ * Creates a new metric with the given parameters.
+ * @param timestamp The timestamp when the metric was recorded.
+ * @param traceId The trace ID to associate this metric with distributed tracing.
+ * @param name The name of the metric (e.g., "api.response_time", "db.query.duration").
+ * @param value The numeric value of the metric. Counters use integer values, distributions and
+ * gauges use double values.
+ * @param unit The unit of measurement for the metric value (optional). Examples: "millisecond",
+ * "byte", "connection", "request". This helps provide context for the metric value when viewing in
+ * Sentry.
+ * @param attributes A dictionary of structured attributes added to the metric. Attributes provide
+ * additional context and can be used
+ */
+- (instancetype)initWithTimestamp:(NSDate *)timestamp
+                          traceId:(SentryObjCId *)traceId
+                             name:(NSString *)name
+                            value:(SentryObjCMetricValue *)value
+                             unit:(nullable SentryObjCUnit *)unit
+                       attributes:
+                           (NSDictionary<NSString *, SentryObjCAttributeContent *> *)attributes;
+
 /// The timestamp when the metric was recorded.
 @property (nonatomic, strong) NSDate *timestamp;
 

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -14,6 +14,8 @@
 @class SentryObjCEvent;
 @class SentryObjCExperimentalOptions;
 @class SentryObjCHttpStatusCodeRange;
+@class SentryObjCLog;
+@class SentryObjCMetric;
 @class SentryObjCReplayOptions;
 @class SentryObjCSamplingContext;
 @class SentryObjCScope;
@@ -119,6 +121,15 @@ NS_ASSUME_NONNULL_BEGIN
 /// This block can be used to modify the breadcrumb before it will be serialized and sent.
 @property (nonatomic, copy, nullable) SentryObjCBreadcrumb *_Nullable (^beforeBreadcrumb)
     (SentryObjCBreadcrumb *);
+
+/// This block can be used to modify or drop a log before it will be sent. Return @c nil to drop the
+/// log.
+@property (nonatomic, copy, nullable) SentryObjCLog *_Nullable (^beforeSendLog)(SentryObjCLog *);
+
+/// This block can be used to modify or drop a metric before it will be sent. Return @c nil to drop
+/// the metric.
+@property (nonatomic, copy, nullable) SentryObjCMetric *_Nullable (^beforeSendMetric)
+    (SentryObjCMetric *);
 
 /**
  * You can use this callback to decide if the SDK should capture a screenshot or not.

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -15,6 +15,7 @@
 @class SentryObjCFeedbackApi;
 @class SentryObjCId;
 @class SentryObjCLogger;
+@class SentryObjCMetricsApi;
 @class SentryObjCOptions;
 @class SentryObjCReplayApi;
 @class SentryObjCScope;
@@ -38,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// API to access Sentry logs.
 @property (class, nonatomic, readonly) SentryObjCLogger *logger;
+
+/// API to record metrics (counters, distributions, gauges).
+@property (class, nonatomic, readonly) SentryObjCMetricsApi *metrics;
 
 /**
  * Returns the crash status of the last program execution.

--- a/Sources/SentryObjC/Public/SentryObjCScope.h
+++ b/Sources/SentryObjC/Public/SentryObjCScope.h
@@ -7,6 +7,7 @@
 
 @class SentryObjCAttachment;
 @class SentryObjCBreadcrumb;
+@class SentryObjCSpan;
 @class SentryObjCUser;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -109,6 +110,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Clears all attachments in the scope.
 - (void)clearAttachments;
+
+/// The current Span or Transaction bound to the scope.
+@property (nullable, nonatomic, strong) SentryObjCSpan *span;
+
+/// Serializes the scope to a dictionary.
+- (NSDictionary<NSString *, id> *)serialize;
 
 /// Clears the current scope.
 - (void)clear;

--- a/Sources/SentryObjCCompat/SentryObjCMetric.swift
+++ b/Sources/SentryObjCCompat/SentryObjCMetric.swift
@@ -13,6 +13,24 @@ import Foundation
         self.wrapped = wrapped
     }
 
+    @objc public init(
+        timestamp: Date,
+        traceId: SentryObjCId,
+        name: String,
+        value: SentryObjCMetricValue,
+        unit: SentryObjCUnit?,
+        attributes: [String: SentryObjCAttributeContent]
+    ) {
+        self.wrapped = SentryMetric(
+            timestamp: timestamp,
+            traceId: traceId.wrapped,
+            name: name,
+            value: value.toMetricValue(),
+            unit: unit?.toSentryUnit(),
+            attributes: attributes.mapValues { $0.toAttributeContent() }
+        )
+    }
+
     @objc public var timestamp: Date {
         get { wrapped.timestamp }
         set { wrapped.timestamp = newValue }

--- a/Sources/SentryObjCCompat/SentryObjCOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCOptions.swift
@@ -135,6 +135,32 @@ import Foundation
         }
     }
 
+    @objc public var beforeSendLog: ((SentryObjCLog) -> SentryObjCLog?)? {
+        didSet {
+            if let beforeSendLog = beforeSendLog {
+                wrapped.beforeSendLog = { log in
+                    guard let result = beforeSendLog(SentryObjCLog(log)) else { return nil }
+                    return result.wrapped
+                }
+            } else {
+                wrapped.beforeSendLog = nil
+            }
+        }
+    }
+
+    @objc public var beforeSendMetric: ((SentryObjCMetric) -> SentryObjCMetric?)? {
+        didSet {
+            if let beforeSendMetric = beforeSendMetric {
+                wrapped.beforeSendMetric = { metric in
+                    guard let result = beforeSendMetric(SentryObjCMetric(metric)) else { return nil }
+                    return result.wrapped
+                }
+            } else {
+                wrapped.beforeSendMetric = nil
+            }
+        }
+    }
+
     @objc public var beforeCaptureScreenshot: ((SentryObjCEvent) -> Bool)? {
         didSet {
             if let beforeCaptureScreenshot = beforeCaptureScreenshot {

--- a/Sources/SentryObjCCompat/SentryObjCSDK.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDK.swift
@@ -27,6 +27,10 @@ import Foundation
         SentryObjCLogger(SentrySDK.logger)
     }
 
+    @objc public static var metrics: SentryObjCMetricsApi {
+        SentryObjCMetricsApi(SentrySDK.metrics)
+    }
+
     #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
     @objc public static var feedback: SentryObjCFeedbackApi {
         SentryObjCFeedbackApi(SentrySDK.feedback)

--- a/Sources/SentryObjCCompat/SentryObjCScope.swift
+++ b/Sources/SentryObjCCompat/SentryObjCScope.swift
@@ -110,6 +110,15 @@ import Foundation
         wrapped.clearAttachments()
     }
 
+    @objc public var span: SentryObjCSpan? {
+        get { wrapped.span.map { SentryObjCSpan($0) } }
+        set { wrapped.span = newValue?.wrapped }
+    }
+
+    @objc public func serialize() -> [String: Any] {
+        wrapped.serialize()
+    }
+
     @objc public func clear() {
         wrapped.clear()
     }

--- a/Sources/Swift/Protocol/SentryMetric.swift
+++ b/Sources/Swift/Protocol/SentryMetric.swift
@@ -65,7 +65,7 @@ public struct SentryMetric {
     ///   - value: The numeric value of the metric
     ///   - unit: The unit of measurement for the metric value (optional)
     ///   - attributes: A dictionary of structured attributes to add to the metric
-    internal init(
+    @_spi(Private) public init(
         timestamp: Date,
         traceId: SentryId,
         name: String,

--- a/Tests/SentryObjCCompatTests/SentryObjCCompatMetricConversionTests.swift
+++ b/Tests/SentryObjCCompatTests/SentryObjCCompatMetricConversionTests.swift
@@ -56,6 +56,60 @@ final class SentryObjCCompatMetricConversionTests: XCTestCase {
         XCTAssertNotNil(objcMetric.spanId)
     }
 
+    func testMetricPublicInit_shouldCreateWrappedMetric() {
+        // -- Arrange --
+        let timestamp = Date(timeIntervalSince1970: 789)
+        let traceId = SentryObjCId()
+        let value = SentryObjCMetricValue.distribution(42.5)
+        let unit = SentryObjCUnit.millisecond
+        let attributes: [String: SentryObjCAttributeContent] = [
+            "source": .string("swift"),
+            "count": .integer(3)
+        ]
+
+        // -- Act --
+        let metric = SentryObjCMetric(
+            timestamp: timestamp,
+            traceId: traceId,
+            name: "api.latency",
+            value: value,
+            unit: unit,
+            attributes: attributes
+        )
+
+        // -- Assert --
+        XCTAssertEqual(metric.timestamp, timestamp)
+        XCTAssertEqual(metric.name, "api.latency")
+        XCTAssertTrue(metric.value.isDistribution)
+        XCTAssertEqual(metric.value.distributionValue, 42.5, accuracy: 0.001)
+        XCTAssertEqual(metric.unit?.rawValue, "millisecond")
+        XCTAssertEqual(metric.attributes.count, 2)
+
+        XCTAssertEqual(metric.wrapped.timestamp, timestamp)
+        XCTAssertEqual(metric.wrapped.name, "api.latency")
+        XCTAssertEqual(metric.wrapped.value, .distribution(42.5))
+        XCTAssertEqual(metric.wrapped.unit?.rawValue, "millisecond")
+        XCTAssertEqual(metric.wrapped.attributes.count, 2)
+    }
+
+    func testMetricPublicInit_whenNilUnit_shouldCreateWithNilUnit() {
+        // -- Act --
+        let metric = SentryObjCMetric(
+            timestamp: Date(),
+            traceId: SentryObjCId(),
+            name: "events",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Assert --
+        XCTAssertNil(metric.unit)
+        XCTAssertNil(metric.wrapped.unit)
+        XCTAssertTrue(metric.value.isCounter)
+        XCTAssertEqual(metric.value.counterValue, 1)
+    }
+
     func testMetricWrapping_whenModified_shouldUpdateWrapped() {
         // -- Arrange --
         let objcMetric = SentryObjCMetric(SentryMetric(

--- a/Tests/SentryObjCTests/SentryObjCMetricTests.m
+++ b/Tests/SentryObjCTests/SentryObjCMetricTests.m
@@ -1,0 +1,225 @@
+@import SentryObjC;
+@import XCTest;
+
+@interface SentryObjCMetricTests : XCTestCase
+@end
+
+@implementation SentryObjCMetricTests
+
+#pragma mark - Init
+
+- (void)testInitWithAllParameters_shouldSetProperties
+{
+    // -- Arrange --
+    NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:123];
+    SentryObjCId *traceId = [[SentryObjCId alloc] init];
+    SentryObjCMetricValue *value = [SentryObjCMetricValue distribution:4.25];
+    SentryObjCUnit *unit = SentryObjCUnit.millisecond;
+    NSDictionary<NSString *, SentryObjCAttributeContent *> *attributes =
+        @{ @"source" : [SentryObjCAttributeContent string:@"test"] };
+
+    // -- Act --
+    SentryObjCMetric *metric = [[SentryObjCMetric alloc] initWithTimestamp:timestamp
+                                                                   traceId:traceId
+                                                                      name:@"api.response_time"
+                                                                     value:value
+                                                                      unit:unit
+                                                                attributes:attributes];
+
+    // -- Assert --
+    XCTAssertNotNil(metric);
+    XCTAssertEqualObjects(metric.timestamp, timestamp);
+    XCTAssertEqualObjects(metric.traceId.sentryIdString, traceId.sentryIdString);
+    XCTAssertEqualObjects(metric.name, @"api.response_time");
+    XCTAssertTrue(metric.value.isDistribution);
+    XCTAssertEqualWithAccuracy(metric.value.distributionValue, 4.25, 0.001);
+    XCTAssertEqualObjects(metric.unit.rawValue, @"millisecond");
+    XCTAssertEqual(metric.attributes.count, 1u);
+}
+
+- (void)testInitWithNilUnit_shouldSetUnitToNil
+{
+    // -- Arrange --
+    NSDate *timestamp = [NSDate date];
+    SentryObjCId *traceId = [[SentryObjCId alloc] init];
+    SentryObjCMetricValue *value = [SentryObjCMetricValue counter:1];
+
+    // -- Act --
+    SentryObjCMetric *metric = [[SentryObjCMetric alloc] initWithTimestamp:timestamp
+                                                                   traceId:traceId
+                                                                      name:@"events"
+                                                                     value:value
+                                                                      unit:nil
+                                                                attributes:@{ }];
+
+    // -- Assert --
+    XCTAssertNotNil(metric);
+    XCTAssertNil(metric.unit);
+    XCTAssertTrue(metric.value.isCounter);
+    XCTAssertEqual(metric.value.counterValue, 1u);
+}
+
+- (void)testInitWithEmptyAttributes_shouldSetEmptyAttributes
+{
+    // -- Arrange --
+    NSDate *timestamp = [NSDate date];
+    SentryObjCId *traceId = [[SentryObjCId alloc] init];
+    SentryObjCMetricValue *value = [SentryObjCMetricValue gauge:99.5];
+
+    // -- Act --
+    SentryObjCMetric *metric = [[SentryObjCMetric alloc] initWithTimestamp:timestamp
+                                                                   traceId:traceId
+                                                                      name:@"cpu"
+                                                                     value:value
+                                                                      unit:SentryObjCUnit.percent
+                                                                attributes:@{ }];
+
+    // -- Assert --
+    XCTAssertNotNil(metric);
+    XCTAssertEqual(metric.attributes.count, 0u);
+    XCTAssertTrue(metric.value.isGauge);
+    XCTAssertEqualWithAccuracy(metric.value.gaugeValue, 99.5, 0.001);
+}
+
+#pragma mark - Properties
+
+- (void)testTimestamp_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    NSDate *newTimestamp = [NSDate dateWithTimeIntervalSince1970:999];
+
+    // -- Act --
+    metric.timestamp = newTimestamp;
+
+    // -- Assert --
+    XCTAssertEqualObjects(metric.timestamp, newTimestamp);
+}
+
+- (void)testName_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+
+    // -- Act --
+    metric.name = @"updated.metric";
+
+    // -- Assert --
+    XCTAssertEqualObjects(metric.name, @"updated.metric");
+}
+
+- (void)testTraceId_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    SentryObjCId *newTraceId = [[SentryObjCId alloc] init];
+
+    // -- Act --
+    metric.traceId = newTraceId;
+
+    // -- Assert --
+    XCTAssertEqualObjects(metric.traceId.sentryIdString, newTraceId.sentryIdString);
+}
+
+- (void)testSpanId_whenDefault_shouldBeNil
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+
+    // -- Assert --
+    XCTAssertNil(metric.spanId);
+}
+
+- (void)testSpanId_whenSet_shouldReturnValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] init];
+
+    // -- Act --
+    metric.spanId = spanId;
+
+    // -- Assert --
+    XCTAssertNotNil(metric.spanId);
+}
+
+- (void)testSpanId_whenSetToNil_shouldReturnNil
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    metric.spanId = [[SentryObjCSpanId alloc] init];
+
+    // -- Act --
+    metric.spanId = nil;
+
+    // -- Assert --
+    XCTAssertNil(metric.spanId);
+}
+
+- (void)testValue_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+
+    // -- Act --
+    metric.value = [SentryObjCMetricValue gauge:7.5];
+
+    // -- Assert --
+    XCTAssertTrue(metric.value.isGauge);
+    XCTAssertEqualWithAccuracy(metric.value.gaugeValue, 7.5, 0.001);
+}
+
+- (void)testUnit_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+
+    // -- Act --
+    metric.unit = SentryObjCUnit.byte;
+
+    // -- Assert --
+    XCTAssertEqualObjects(metric.unit.rawValue, @"byte");
+}
+
+- (void)testUnit_whenSetToNil_shouldReturnNil
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    metric.unit = SentryObjCUnit.millisecond;
+
+    // -- Act --
+    metric.unit = nil;
+
+    // -- Assert --
+    XCTAssertNil(metric.unit);
+}
+
+- (void)testAttributes_whenSet_shouldReturnNewValue
+{
+    // -- Arrange --
+    SentryObjCMetric *metric = [self createDefaultMetric];
+    NSDictionary<NSString *, SentryObjCAttributeContent *> *newAttributes = @{
+        @"key1" : [SentryObjCAttributeContent string:@"val1"],
+        @"key2" : [SentryObjCAttributeContent integer:42]
+    };
+
+    // -- Act --
+    metric.attributes = newAttributes;
+
+    // -- Assert --
+    XCTAssertEqual(metric.attributes.count, 2u);
+}
+
+#pragma mark - Helpers
+
+- (SentryObjCMetric *)createDefaultMetric
+{
+    return [[SentryObjCMetric alloc] initWithTimestamp:[NSDate date]
+                                               traceId:[[SentryObjCId alloc] init]
+                                                  name:@"test.metric"
+                                                 value:[SentryObjCMetricValue counter:1]
+                                                  unit:nil
+                                            attributes:@{ }];
+}
+
+@end

--- a/Tests/SentryObjCTests/SentryObjCOptionsTests.m
+++ b/Tests/SentryObjCTests/SentryObjCOptionsTests.m
@@ -746,6 +746,62 @@
     XCTAssertNil(options.beforeBreadcrumb);
 }
 
+- (void)testBeforeSendLog_whenSetBlock_shouldReturnNotNil
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+
+    // -- Act --
+    options.beforeSendLog = ^SentryObjCLog *_Nullable(SentryObjCLog *log) { return log; };
+
+    // -- Assert --
+    XCTAssertNotNil(options.beforeSendLog);
+}
+
+- (void)testBeforeSendLog_whenSetNil_shouldReturnNil
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+    options.beforeSendLog = ^SentryObjCLog *_Nullable(SentryObjCLog *log) { return log; };
+
+    // -- Act --
+    options.beforeSendLog = nil;
+
+    // -- Assert --
+    XCTAssertNil(options.beforeSendLog);
+}
+
+- (void)testBeforeSendMetric_whenSetBlock_shouldReturnNotNil
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+
+    // -- Act --
+    options.beforeSendMetric = ^SentryObjCMetric *_Nullable(SentryObjCMetric *metric)
+    {
+        return metric;
+    };
+
+    // -- Assert --
+    XCTAssertNotNil(options.beforeSendMetric);
+}
+
+- (void)testBeforeSendMetric_whenSetNil_shouldReturnNil
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+    options.beforeSendMetric = ^SentryObjCMetric *_Nullable(SentryObjCMetric *metric)
+    {
+        return metric;
+    };
+
+    // -- Act --
+    options.beforeSendMetric = nil;
+
+    // -- Assert --
+    XCTAssertNil(options.beforeSendMetric);
+}
+
 - (void)testBeforeCaptureScreenshot_whenSetBlock_shouldReturnNotNil
 {
     // -- Arrange --

--- a/Tests/SentryObjCTests/SentryObjCSDKTests.m
+++ b/Tests/SentryObjCTests/SentryObjCSDKTests.m
@@ -117,6 +117,15 @@
     XCTAssertNotNil(logger);
 }
 
+- (void)testMetrics_shouldReturnMetricsApi
+{
+    // -- Arrange & Act --
+    SentryObjCMetricsApi *metrics = SentryObjCSDK.metrics;
+
+    // -- Assert --
+    XCTAssertNotNil(metrics);
+}
+
 #pragma mark - Capture Event
 
 - (void)testCaptureEvent_shouldReturnNonEmptyId

--- a/Tests/SentryObjCTests/SentryObjCScopeTests.m
+++ b/Tests/SentryObjCTests/SentryObjCScopeTests.m
@@ -315,6 +315,76 @@
     XCTAssertNil(scope.attributes[@"attrKey"]);
 }
 
+- (void)testSpan_whenDefault_shouldBeNil
+{
+    // -- Arrange --
+    SentryObjCScope *scope = [[SentryObjCScope alloc] init];
+
+    // -- Assert --
+    XCTAssertNil(scope.span);
+}
+
+- (void)testSpan_whenSetToNil_shouldReturnNil
+{
+    // -- Arrange --
+    SentryObjCScope *scope = [[SentryObjCScope alloc] init];
+
+    // -- Act --
+    scope.span = nil;
+
+    // -- Assert --
+    XCTAssertNil(scope.span);
+}
+
+- (void)testSpan_whenSetToSpan_shouldReturnSpan
+{
+    // -- Arrange --
+    [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+        options.dsn = @"https://key@sentry.io/123";
+        options.enableCrashHandler = NO;
+        options.tracesSampleRate = @1.0;
+    }];
+    SentryObjCSpan *transaction = [SentryObjCSDK startTransactionWithName:@"test" operation:@"op"];
+    SentryObjCScope *scope = [[SentryObjCScope alloc] init];
+
+    // -- Act --
+    scope.span = transaction;
+
+    // -- Assert --
+    XCTAssertNotNil(scope.span);
+
+    // -- Cleanup --
+    [transaction finish];
+    [SentryObjCSDK close];
+}
+
+- (void)testSerialize_whenDefault_shouldReturnDictionary
+{
+    // -- Arrange --
+    SentryObjCScope *scope = [[SentryObjCScope alloc] init];
+
+    // -- Act --
+    NSDictionary<NSString *, id> *result = [scope serialize];
+
+    // -- Assert --
+    XCTAssertNotNil(result);
+}
+
+- (void)testSerialize_whenTagsSet_shouldIncludeTagsInResult
+{
+    // -- Arrange --
+    SentryObjCScope *scope = [[SentryObjCScope alloc] init];
+    [scope setTagValue:@"val" forKey:@"key"];
+
+    // -- Act --
+    NSDictionary<NSString *, id> *result = [scope serialize];
+
+    // -- Assert --
+    XCTAssertNotNil(result);
+    NSDictionary *tags = result[@"tags"];
+    XCTAssertEqualObjects(tags[@"key"], @"val");
+}
+
 - (void)testClear_whenCalled_shouldNotCrash
 {
     // -- Arrange --

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -754,6 +754,20 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "beforeSendLog",
+    "parent": "SentryObjCOptions",
+    "returnType": "SentryObjCLog * _Nullable (^ _Nullable)(SentryObjCLog * _Nonnull)",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "beforeSendMetric",
+    "parent": "SentryObjCOptions",
+    "returnType": "SentryObjCMetric * _Nullable (^ _Nullable)(SentryObjCMetric * _Nonnull)",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "beforeSendSpan",
     "parent": "SentryObjCOptions",
     "returnType": "SentryObjCSpan * _Nullable (^ _Nullable)(SentryObjCSpan * _Nonnull)",
@@ -2903,6 +2917,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "initWithTimestamp:traceId:name:value:unit:attributes:",
+    "parent": "SentryObjCMetric",
+    "returnType": "instancetype _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "initWithTraceId:spanId:parentId:operation:sampled:",
     "parent": "SentryObjCSpanContext",
     "returnType": "instancetype _Nonnull",
@@ -3334,6 +3355,13 @@
     "parent": "SentryObjCRequest",
     "returnType": "NSString * _Nullable",
     "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "metrics",
+    "parent": "SentryObjCSDK",
+    "returnType": "SentryObjCMetricsApi * _Nonnull",
+    "instance": false
   },
   {
     "kind": "ObjCMethodDecl",
@@ -4240,6 +4268,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "serialize",
+    "parent": "SentryObjCScope",
+    "returnType": "NSDictionary<NSString *,id> * _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "serverName",
     "parent": "SentryObjCEvent",
     "returnType": "NSString * _Nullable",
@@ -4360,6 +4395,20 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "setBeforeSend:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setBeforeSendLog:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setBeforeSendMetric:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
     "instance": true
@@ -5619,6 +5668,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setSpan:",
+    "parent": "SentryObjCScope",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setSpanDescription:",
     "parent": "SentryObjCSpan",
     "returnType": "void",
@@ -6071,6 +6127,13 @@
     "parent": "SentryObjCSDK",
     "returnType": "SentryObjCSpan * _Nullable",
     "instance": false
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "span",
+    "parent": "SentryObjCScope",
+    "returnType": "SentryObjCSpan * _Nullable",
+    "instance": true
   },
   {
     "kind": "ObjCMethodDecl",
@@ -6909,6 +6972,18 @@
     "name": "beforeSend",
     "parent": "SentryObjCOptions",
     "type": "SentryObjCEvent * _Nullable (^ _Nullable)(SentryObjCEvent * _Nonnull)"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "beforeSendLog",
+    "parent": "SentryObjCOptions",
+    "type": "SentryObjCLog * _Nullable (^ _Nullable)(SentryObjCLog * _Nonnull)"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "beforeSendMetric",
+    "parent": "SentryObjCOptions",
+    "type": "SentryObjCMetric * _Nullable (^ _Nullable)(SentryObjCMetric * _Nonnull)"
   },
   {
     "kind": "ObjCPropertyDecl",
@@ -7926,6 +8001,12 @@
   },
   {
     "kind": "ObjCPropertyDecl",
+    "name": "metrics",
+    "parent": "SentryObjCSDK",
+    "type": "SentryObjCMetricsApi * _Nonnull"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
     "name": "microsecond",
     "parent": "SentryObjCMeasurementUnit",
     "type": "SentryObjCMeasurementUnit * _Nonnull"
@@ -8504,6 +8585,12 @@
     "kind": "ObjCPropertyDecl",
     "name": "span",
     "parent": "SentryObjCSDK",
+    "type": "SentryObjCSpan * _Nullable"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "span",
+    "parent": "SentryObjCScope",
     "type": "SentryObjCSpan * _Nullable"
   },
   {


### PR DESCRIPTION
## Description

Expose APIs that were present on `SentryScope`/`SentrySDK`/`SentryOptions` but missing from the SentryObjC wrapper:

- **SentryObjCScope**: `span` property, `serialize` method
- **SentryObjCSDK**: `metrics` property
- **SentryObjCOptions**: `beforeSendLog`, `beforeSendMetric` callbacks
- **SentryObjCMetric**: public initializer with required fields (needed by sentry-unreal for unit tests)
- **SentryMetric**: `@_spi(Private) public init(...)` so ObjC compat layer can construct instances

Discovered while migrating sentry-unreal from `Sentry.framework` to `SentryObjC.framework`.

#skip-changelog

## How to Test

- Added `SentryObjCMetricTests` for metric initializer and property wrapping
- Added scope tests for `span` and `serialize`
- Added SDK tests for `metrics`
- Added options tests for `beforeSendLog` and `beforeSendMetric`
- Added compat conversion tests for metric round-tripping