### PR TITLE
fix: Use port 8081 for test server

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -12,7 +12,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
     func testGetRequest_SpanCreatedAndBaggageHeaderAdded() throws {
         try ensureTestServerIsRunning()
 
-        let testBaggageURL = try XCTUnwrap(URL(string: "http://localhost:8080/echo-baggage-header"))
+        let testBaggageURL = try XCTUnwrap(URL(string: "http://localhost:8081/echo-baggage-header"))
 
         startSDK()
 
@@ -53,7 +53,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
     func testGetRequest_CompareSentryTraceHeader() throws {
         try ensureTestServerIsRunning()
 
-        let testTraceURL = try XCTUnwrap(URL(string: "http://localhost:8080/echo-sentry-trace"))
+        let testTraceURL = try XCTUnwrap(URL(string: "http://localhost:8081/echo-sentry-trace"))
 
         startSDK()
 
@@ -88,7 +88,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
     func testGetCaptureFailedRequestsEnabled() throws {
         try ensureTestServerIsRunning()
 
-        let clientErrorTraceURL = try XCTUnwrap(URL(string: "http://localhost:8080/http-client-error"))
+        let clientErrorTraceURL = try XCTUnwrap(URL(string: "http://localhost:8081/http-client-error"))
 
         let expect = expectation(description: "Request completed")
         expect.expectedFulfillmentCount = 2
@@ -138,7 +138,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
     // If a XCTestExpectation times out, the test would fail.
     // swiftlint:disable avoid_dispatch_groups_in_tests
     private func ensureTestServerIsRunning() throws {
-        let testUrl = try XCTUnwrap(URL(string: "http://localhost:8080/"))
+        let testUrl = try XCTUnwrap(URL(string: "http://localhost:8081/"))
 
         let session = URLSession(configuration: URLSessionConfiguration.default)
         let attempts = 20

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class SentryNetworkTrackerIntegrationTests: XCTestCase {
     
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentryNetworkTrackerIntegrationTests")
-    private static let testBaggageURL = URL(string: "http://localhost:8080/echo-baggage-header")!
+    private static let testBaggageURL = URL(string: "http://localhost:8081/echo-baggage-header")!
     private static let transactionName = "TestTransaction"
     private static let transactionOperation = "Test"
     

--- a/scripts/start-test-server.sh
+++ b/scripts/start-test-server.sh
@@ -31,7 +31,7 @@ log_info "Making test server executable"
 chmod +x ./test-server-exec
 
 log_info "Start the test server in the background"
-./test-server-exec &
+./test-server-exec serve --port 8081 &
 
 log_info "Waiting up to 20 seconds for the test server to respond"
 

--- a/scripts/start-test-server.sh
+++ b/scripts/start-test-server.sh
@@ -11,7 +11,7 @@ usage() {
 Usage: $(basename "$0")
 
 Start the test server (./test-server-exec) in the background and wait
-up to 20 seconds for it to respond on http://localhost:8080.
+up to 20 seconds for it to respond on http://localhost:8081.
 
 EOF
     exit 1
@@ -22,7 +22,7 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
 fi
 
 is_server_running() {
-    curl -s http://localhost:8080/echo-baggage-header > /dev/null 2>&1
+    curl -s http://localhost:8081/echo-baggage-header > /dev/null 2>&1
 }
 
 begin_group "Starting test server"
@@ -60,7 +60,7 @@ done
 end_group
 
 if [ "$server_started" = true ]; then
-    log_info "Test server successfully started and is responding at http://localhost:8080"
+    log_info "Test server successfully started and is responding at http://localhost:8081"
 else
     log_error "Test server failed to start or is not responding after 20 seconds"
     exit 1


### PR DESCRIPTION
## Description

Change the test server port from 8080 to 8081 across all test files and the server startup script.

## Motivation

Bitrise runs a service on port 8080, causing conflicts with our test server and leading to flaky/failing CI tests.

## How tested

- Verified all references to port 8080 in test server code are updated to 8081
- Tests use the same port as the startup script

#skip-changelog