### PR TITLE
ci: bump build workflow runners to macos-26 and Xcode 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
     name: Sample ${{ matrix.scheme }} ${{ matrix.config }}
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
       - run: make init-ci-build
       - run: make xcode-ci
 
@@ -278,7 +278,7 @@ jobs:
 
   build-distribution:
     name: Build the distribution framework
-    runs-on: macos-15
+    runs-on: macos-26
     # Don't run this on release branches, cause the SPM Package.swift points to the unreleased versions.
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
@@ -287,7 +287,7 @@ jobs:
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
       - run: |
@@ -307,7 +307,7 @@ jobs:
 
   build-spm:
     name: Build with SPM
-    runs-on: macos-15
+    runs-on: macos-26
     # Don't run this on release branches, cause the SPM Package.swift points to the unreleased versions.
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
@@ -316,7 +316,7 @@ jobs:
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
       - run: |
           set -o pipefail && NSUnbufferedIO=YES xcodebuild \
@@ -350,14 +350,14 @@ jobs:
     name: Check no UIKit linkage (DebugWithoutUIKit)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -391,14 +391,14 @@ jobs:
     name: Check no UIKit linkage (ReleaseWithoutUIKit)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -432,14 +432,14 @@ jobs:
     name: Check UIKit linkage (Debug)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -473,14 +473,14 @@ jobs:
     name: Check UIKit linkage (Release)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -514,14 +514,14 @@ jobs:
     name: Check AppKit linkage (Release)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -552,14 +552,14 @@ jobs:
     name: Check no AppKit linkage (ReleaseWithoutUIKit)
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Xcode
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination
@@ -594,7 +594,7 @@ jobs:
     name: Check compiling Async Safe Logs
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
@@ -610,7 +610,7 @@ jobs:
         id: setup-xcode
         uses: ./.github/actions/setup-xcode
         with:
-          version: "16"
+          version: "26"
 
       - name: Resolve test destination
         id: resolve-test-destination


### PR DESCRIPTION
Bumps all remaining `macos-15` / Xcode 16 runners in the build workflow to `macos-26` / Xcode 26.

Several jobs (`ios-swift-release`, `build-sample-binary`, `build-sample-spm`, `check-macOS-CLI-Xcode-no-UI-framework`) were already on `macos-26`. This updates the rest:

- `build-sample`
- `build-distribution`
- `build-spm`
- `check-debug-without-UIKit`
- `check-release-without-UIKit`
- `check-debug-with-UIKit`
- `check-release-with-UIKit`
- `check-release-with-AppKit`
- `check-release-without-AppKit`
- `check-compiling-async-safe-logs`

#skip-changelog