### PR TITLE
fix(build): Fix SentryObjC-Static checksum in release workflow

### DIFF
--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -85,6 +85,7 @@ jobs:
           echo "<FAKE WITHOUT UIKIT OR APPKIT ZIP>" > XCFrameworkBuildPath/Sentry-WithoutUIKitOrAppKit.xcframework.zip
           echo "<FAKE WITHOUT UIKIT OR APPKIT WITH ARM64E ZIP>" > XCFrameworkBuildPath/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip
           echo "<FAKE SENTRYOBJC DYNAMIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Dynamic.xcframework.zip
+          echo "<FAKE SENTRYOBJC STATIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Static.xcframework.zip
 
       - name: Bump version
         run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
@@ -101,6 +102,7 @@ jobs:
             --without-uikit-or-appkit-checksum "c647afe93889063325b5dfcabf43101749f6a8f37008cca858833ed280d2a84e" \
             --without-uikit-or-appkit-with-arm64e-checksum "af5af7edc8e107fe04b905bd23524fdc93914fce8e1bd72ccf281408efff9a47" \
             --sentryobjc-dynamic-checksum "cf74ef3cb789b9cabbd3c366bf717a4f6811ce3ac8b97bc78bb0e210593e4c82" \
+            --sentryobjc-static-checksum "75efb1ba6f25d0f666d07474cf3e35bb56688bb938d04ba48bd42a986f8810a1" \
             --last-release-runid "${{ github.run_id }}"
 
   # This check validates that either version-bump-util passed or was skipped, which allows us

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+> [!NOTE]
+> No documented changes. This is the same as 9.16.0, re-released to fix the SentryObjC-Static SPM checksum.
+
+> [!IMPORTANT]
+> The new SentryObjC SDK introduced in this release should be considered experimental and may be subject to breaking changes.
+
+### Features
+
+- Add SentryObjC wrapper SDK — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). (#7918)
+
+  Ships as a compile-from-source SPM product `SentryObjC`, a static pre-compiled framework `SentryObjC-Static.xcframework.zip` and a dynamic pre-compiled framework `SentryObjC-Dynamic.xcframework.zip`.
+
+  Steps to migrate:
+  - Replace your dependency on the target `Sentry` or `SentrySPM` with `SentryObjC` (or `SentryObjC-Static` / `SentryObjC-Dynamic` if you want to use the precompiled binary targets).
+  - Change `#import <Sentry/Sentry.h>` to `#import <SentryObjC/SentryObjC.h>`
+  - Rename `Sentry`-prefixed types to `SentryObjC` (e.g., `SentrySDK` → `SentryObjCSDK`, `SentryOptions` → `SentryObjCOptions`).
+- `SentrySDK.extendAppLaunch()` now returns the extended app launch span, allowing users to add child spans for granular breakdown of the app start period (#7985)
+
+### Fixes
+
+- Fix crash in `SentryFramesTracker.add/removeListener` when called from a listener's own `init` / `deinit` on a background thread, observed on iOS 26 (#7943)
+- Report only `cold` or `warm` as `start_type` for standalone app starts, removing the `.prewarmed` suffix per sentry-conventions (#7968)
+- Fix reporting arbitrary Objective-C object throws via the C++ exception monitor (#7984)
+
 ## 9.16.0
 
 > [!IMPORTANT]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 
 ## 9.16.0
 
+> [!WARNING]
+> The `SentryObjC-Static` SPM binary target in this release has an incorrect checksum and resolving dependencies might fail, but the release artifacts are not affected.
+
 > [!IMPORTANT]
 > The new SentryObjC SDK introduced in this release should be considered experimental and may be subject to breaking changes.
 

--- a/Package.swift
+++ b/Package.swift
@@ -59,7 +59,7 @@ var targets: [Target] = [
     .binaryTarget(
         name: "SentryObjC-Static",
         url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.16.0/SentryObjC-Static.xcframework.zip",
-        checksum: "a98f93041d6e923bf2d6c87d0fd2126ee98712dda811ca93574bc77f31074e9a" //SentryObjC-Static
+        checksum: "e2392fab2a0924256e29c5157686ad802f7d1b6b2e93748f98536505cf984619" //SentryObjC-Static
     ),
     .target(
         name: "SentrySwiftUI",

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -59,7 +59,7 @@ var targets: [Target] = [
     .binaryTarget(
         name: "SentryObjC-Static",
         url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.16.0/SentryObjC-Static.xcframework.zip",
-        checksum: "a98f93041d6e923bf2d6c87d0fd2126ee98712dda811ca93574bc77f31074e9a" //SentryObjC-Static
+        checksum: "e2392fab2a0924256e29c5157686ad802f7d1b6b2e93748f98536505cf984619" //SentryObjC-Static
     ),
     .target(
         name: "SentrySwiftUI",

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -59,7 +59,7 @@ var targets: [Target] = [
     .binaryTarget(
         name: "SentryObjC-Static",
         url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.16.0/SentryObjC-Static.xcframework.zip",
-        checksum: "a98f93041d6e923bf2d6c87d0fd2126ee98712dda811ca93574bc77f31074e9a" //SentryObjC-Static
+        checksum: "e2392fab2a0924256e29c5157686ad802f7d1b6b2e93748f98536505cf984619" //SentryObjC-Static
     ),
     .target(
         name: "SentrySwiftUI",

--- a/scripts/update-package-sha.sh
+++ b/scripts/update-package-sha.sh
@@ -28,6 +28,7 @@ ZIPS_AND_MARKERS=(
     "Sentry-WithoutUIKitOrAppKit.xcframework.zip|Sentry-WithoutUIKitOrAppKit"
     "Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip|Sentry-WithoutUIKitOrAppKit-WithARM64e"
     "SentryObjC-Dynamic.xcframework.zip|SentryObjC-Dynamic"
+    "SentryObjC-Static.xcframework.zip|SentryObjC-Static"
 )
 
 os=$(uname)

--- a/scripts/verify-package-sha.sh
+++ b/scripts/verify-package-sha.sh
@@ -23,6 +23,7 @@ OPTIONS:
     --without-uikit-or-appkit-checksum <sha256>         Expected Sentry-WithoutUIKitOrAppKit checksum (required)
     --without-uikit-or-appkit-with-arm64e-checksum <sha256>  Expected Sentry-WithoutUIKitOrAppKit-WithARM64e checksum (required)
     --sentryobjc-dynamic-checksum <sha256>               Expected SentryObjC-Dynamic checksum (required)
+    --sentryobjc-static-checksum <sha256>               Expected SentryObjC-Static checksum (required)
     --last-release-runid <id>                           Expected GitHub Actions run ID (required)
 
 EOF
@@ -36,6 +37,7 @@ EXPECTED_DYNAMIC_WITH_ARM64E_CHECKSUM=""
 EXPECTED_WITHOUT_UIKIT_OR_APPKIT_CHECKSUM=""
 EXPECTED_WITHOUT_UIKIT_OR_APPKIT_WITH_ARM64E_CHECKSUM=""
 EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM=""
+EXPECTED_SENTRYOBJC_STATIC_CHECKSUM=""
 EXPECTED_LAST_RELEASE_RUNID=""
 
 while [[ $# -gt 0 ]]; do
@@ -62,6 +64,10 @@ while [[ $# -gt 0 ]]; do
         ;;
     --sentryobjc-dynamic-checksum)
         EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM="$2"
+        shift 2
+        ;;
+    --sentryobjc-static-checksum)
+        EXPECTED_SENTRYOBJC_STATIC_CHECKSUM="$2"
         shift 2
         ;;
     --last-release-runid)
@@ -103,6 +109,11 @@ fi
 
 if [ -z "$EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM" ]; then
     log_error "--sentryobjc-dynamic-checksum is required"
+    usage
+fi
+
+if [ -z "$EXPECTED_SENTRYOBJC_STATIC_CHECKSUM" ]; then
+    log_error "--sentryobjc-static-checksum is required"
     usage
 fi
 
@@ -162,6 +173,13 @@ for package_file in $PACKAGE_FILES; do
     UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Dynamic" "$package_file" | cut -d '"' -f 2)
     if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM" ]; then
         log_error "Expected SentryObjC-Dynamic checksum to be $EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $package_file"
+        exit 1
+    fi
+
+    # Verify SentryObjC-Static checksum
+    UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Static" "$package_file" | cut -d '"' -f 2)
+    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_STATIC_CHECKSUM" ]; then
+        log_error "Expected SentryObjC-Static checksum to be $EXPECTED_SENTRYOBJC_STATIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $package_file"
         exit 1
     fi
 


### PR DESCRIPTION
The `ZIPS_AND_MARKERS` array in `scripts/update-package-sha.sh` was missing the `SentryObjC-Static` entry, so the release workflow never updated its checksum in Package.swift. This meant the 9.16.0 release shipped with the wrong checksum for `SentryObjC-Static.xcframework.zip`.

This PR:
- Adds the missing `SentryObjC-Static.xcframework.zip|SentryObjC-Static` entry to the release script so future releases update it automatically
- Corrects the checksum in all three Package.swift variants to the actual 9.16.0 value

#skip-changelog