### PR TITLE
feat(objc): support creating envelope items from attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Features
 
-- Add SentryObjC — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). (#7918)
+- Add SentryObjC wrapper SDK — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). (#7918)
 
   Ships as a compile-from-source SPM product `SentryObjC`, a static pre-compiled framework `SentryObjC-Static.xcframework.zip` and a dynamic pre-compiled framework `SentryObjC-Dynamic.xcframework.zip`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Support creating envelope items from attachments via SentryObjC ([#8001](https://github.com/getsentry/sentry-cocoa/pull/8001))
+
 ## 9.16.1
 
 > [!NOTE]
@@ -10,7 +16,7 @@
 
 ### Features
 
-- Add SentryObjC wrapper SDK — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). (#7918)
+- Add SentryObjC — a pure Objective-C interface for projects that cannot enable Clang modules (e.g., ObjC++ with `-fmodules=NO`). (#7918)
 
   Ships as a compile-from-source SPM product `SentryObjC`, a static pre-compiled framework `SentryObjC-Static.xcframework.zip` and a dynamic pre-compiled framework `SentryObjC-Dynamic.xcframework.zip`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Support creating envelope items from attachments via SentryObjC ([#8001](https://github.com/getsentry/sentry-cocoa/pull/8001))
+- Support creating envelope items from attachments via SentryObjC (#8001)
 
 ## 9.16.1
 

--- a/Sources/SentryObjC/Public/SentryObjCEnvelopeItem.h
+++ b/Sources/SentryObjC/Public/SentryObjCEnvelopeItem.h
@@ -5,6 +5,7 @@
 #    import <SentryObjC/SentryObjCDefines.h>
 #endif
 
+@class SentryObjCAttachment;
 @class SentryObjCEvent;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -49,6 +50,14 @@ SENTRY_NO_INIT
  * @param event The event to serialize into the envelope item.
  */
 - (instancetype)initWithEvent:(SentryObjCEvent *)event;
+
+/**
+ * Initializes an envelope item from an attachment.
+ * @param attachment The attachment to serialize into the envelope item.
+ * @param maxAttachmentSize The maximum allowed size in bytes for the attachment payload.
+ */
+- (nullable instancetype)initWithAttachment:(SentryObjCAttachment *)attachment
+                          maxAttachmentSize:(NSUInteger)maxAttachmentSize;
 
 @end
 

--- a/Sources/SentryObjCCompat/SentryObjCEnvelopeItem.swift
+++ b/Sources/SentryObjCCompat/SentryObjCEnvelopeItem.swift
@@ -34,6 +34,13 @@ import Foundation
         self.wrapped = SentryEnvelopeItem(event: event.wrapped)
     }
 
+    @objc public init?(attachment: SentryObjCAttachment, maxAttachmentSize: UInt) {
+        guard let item = SentryEnvelopeItem(attachment: attachment.wrapped, maxAttachmentSize: maxAttachmentSize) else {
+            return nil
+        }
+        self.wrapped = item
+    }
+
     @objc public var data: Data? {
         wrapped.data
     }

--- a/Tests/SentryObjCTests/SentryObjCEnvelopeTests.m
+++ b/Tests/SentryObjCTests/SentryObjCEnvelopeTests.m
@@ -159,6 +159,37 @@
     XCTAssertGreaterThan(item.data.length, 0u);
 }
 
+- (void)testItemInitWithAttachment_shouldSetTypeAndData
+{
+    // -- Arrange --
+    NSData *data = [@"payload" dataUsingEncoding:NSUTF8StringEncoding];
+    SentryObjCAttachment *attachment = [[SentryObjCAttachment alloc] initWithData:data
+                                                                         filename:@"log.txt"];
+
+    // -- Act --
+    SentryObjCEnvelopeItem *item = [[SentryObjCEnvelopeItem alloc] initWithAttachment:attachment
+                                                                    maxAttachmentSize:1024];
+
+    // -- Assert --
+    XCTAssertEqualObjects(item.type, @"attachment");
+    XCTAssertEqualObjects(item.data, data);
+}
+
+- (void)testItemInitWithAttachment_whenPayloadExceedsMaxSize_shouldReturnNil
+{
+    // -- Arrange --
+    NSData *data = [@"payload that is too big" dataUsingEncoding:NSUTF8StringEncoding];
+    SentryObjCAttachment *attachment = [[SentryObjCAttachment alloc] initWithData:data
+                                                                         filename:@"log.txt"];
+
+    // -- Act --
+    SentryObjCEnvelopeItem *item = [[SentryObjCEnvelopeItem alloc] initWithAttachment:attachment
+                                                                    maxAttachmentSize:1];
+
+    // -- Assert --
+    XCTAssertNil(item);
+}
+
 #pragma mark - SentryObjCEnvelope
 
 - (void)testEnvelopeInitWithHeaderAndItems_shouldSetHeaderAndItems

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2595,6 +2595,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "initWithAttachment:maxAttachmentSize:",
+    "parent": "SentryObjCEnvelopeItem",
+    "returnType": "instancetype _Nullable",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "initWithBoolean:",
     "parent": "SentryObjCAttribute",
     "returnType": "instancetype _Nonnull",


### PR DESCRIPTION
This PR adds a new initializer to `SentryObjCEnvelopeItem` that constructs an attachment envelope item directly from a `SentryObjCAttachment`, preserving its filename, content type, and attachment type in the item header.

The existing public initializers on `SentryObjCEnvelopeItem` (`initWithType:data:contentType:itemCount:`, `initWithType:data:addPlatform:`, and `initWithEvent:`) do not allow setting a filename in the item header. As a result, hybrid SDKs (e.g. sentry-unreal) that need to upload an attachment for an already-captured event via `+[SentryObjCPrivateSDKOnly captureEnvelope:]` are forced to either omit the filename or manually serialize envelope bytes.

The new initializer wraps the existing internal `SentryEnvelopeItem(attachment:maxAttachmentSize:)` implementation, ensuring that behavior remains consistent with the SDK's existing attachment handling. This includes size limit enforcement, lazy file reads, and propagation of filename and content type metadata.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1352