### PR TITLE
chore: add SentryObjC wrapper reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@ You have to check all boxes before merging:
 - [ ] Review from the native team if needed.
 - [ ] No breaking change or entry added to the changelog.
 - [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
+- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ make test-sample-iOS-Swift-ui  # if UI behavior changed
 ```
 
 - **Public API regeneration is mandatory** for any PR that adds, removes, or renames `public` Swift symbols, `@objc` properties/methods, or ObjC public headers. The `api-stability` CI check diffs `sdk_api.json` against the committed file and fails the PR otherwise. Run `make generate-public-api` and commit the resulting `sdk_api.json` (and `sdk_api_sentryswiftui.json` if it changes) in the same PR. The script auto-locates Xcode 16 if it isn't the active toolchain.
+- **SentryObjC wrapper** — any new public API must also be exposed in the ObjC wrapper SDK (`SentryObjC` / `SentryObjCCompat`). See [`develop-docs/SENTRY-OBJC.md`](develop-docs/SENTRY-OBJC.md) for the wrapper pattern: add a header in `Sources/SentryObjC/Public/` and a wrapper in `Sources/SentryObjCCompat/`.
 
 ### Platform Decision Tree
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ make test-sample-iOS-Swift-ui  # if UI behavior changed
 ```
 
 - **Public API regeneration is mandatory** for any PR that adds, removes, or renames `public` Swift symbols, `@objc` properties/methods, or ObjC public headers. The `api-stability` CI check diffs `sdk_api.json` against the committed file and fails the PR otherwise. Run `make generate-public-api` and commit the resulting `sdk_api.json` (and `sdk_api_sentryswiftui.json` if it changes) in the same PR. The script auto-locates Xcode 16 if it isn't the active toolchain.
-- **SentryObjC wrapper** — any new public API must also be exposed in the ObjC wrapper SDK (`SentryObjC` / `SentryObjCCompat`). See [`develop-docs/SENTRY-OBJC.md`](develop-docs/SENTRY-OBJC.md) for the wrapper pattern: add a header in `Sources/SentryObjC/Public/` and a wrapper in `Sources/SentryObjCCompat/`.
+- **SentryObjC wrapper** — any new public API must also be exposed in the ObjC wrapper SDK (`SentryObjC` / `SentryObjCCompat`). See [`develop-docs/SENTRY-OBJC.md`](develop-docs/SENTRY-OBJC.md) for the wrapper pattern: add a header in `Sources/SentryObjC/Public/` and a wrapper in `Sources/SentryObjCCompat/`. Reference example: [#7996](https://github.com/getsentry/sentry-cocoa/pull/7996).
 
 ### Platform Decision Tree
 

--- a/REVIEWS.md
+++ b/REVIEWS.md
@@ -23,6 +23,7 @@ In order of importance:
 - **C/C++ code** (SentryCrash) — buffer overflows, null pointer dereferences, signal safety
 - **Session Replay** — privacy-sensitive; verify redaction/masking logic
 - **Envelope serialization** — correct byte ordering, length prefixes, JSON encoding
+- **SentryObjC wrapper** — any new public API must also be exposed in `SentryObjC` / `SentryObjCCompat`; see [`develop-docs/SENTRY-OBJC.md`](develop-docs/SENTRY-OBJC.md) for the wrapper pattern and naming convention
 
 ## Conventions to Enforce
 


### PR DESCRIPTION
## Description

Adds a reminder for contributors to expose new public APIs in the SentryObjC wrapper SDK.

## Motivation and Context

Since we now have a SentryObjC wrapper SDK, new public API additions could easily be missed in the wrapper. This adds guardrails so we don't forget.

## Changes

- **PR template**: new checklist item — "If I added a new public API, I also added it to the SentryObjC wrapper"
- **AGENTS.md**: documents the SentryObjC wrapper requirement in the verification loop section

#skip-changelog