### PR TITLE
test: Fix SentryDistributionTests when running with 'swift test'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           PLATFORM: "iOS"
         run: ./scripts/ci-ensure-runtime-loaded.sh --os-version "$OS_VERSION" --platform "$PLATFORM"
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
-      - run: set -o pipefail && NSUnbufferedIO=YES SKIP_BINARIES=1 xcodebuild test -scheme Sentry-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' | tee raw-test-output-distribution.log | xcbeautify --preserve-unbeautified
+      - run: set -o pipefail && NSUnbufferedIO=YES xcodebuild test -scheme Sentry-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro' | tee raw-test-output-distribution.log | xcbeautify --preserve-unbeautified
         shell: sh
       - name: Upload Distribution Test Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Sources/SentryDistributionTests/BinaryParserTests.swift
+++ b/Sources/SentryDistributionTests/BinaryParserTests.swift
@@ -1,7 +1,16 @@
 @testable import SentryDistribution
 import Testing
 
-@Test func testBinaryParserGetsCorrectUUID() throws {
+// Distribution is only supported on iOS and the binary parser
+// does not support non-iOS apps.
+@Test("Binary Parser", .enabled(if: {
+    #if os(iOS)
+    return true
+    #else
+    return false
+    #endif
+}()))
+func testBinaryParserGetsCorrectUUID() throws {
   let uuid = BinaryParser.getMainBinaryUUID { _, ptr in
     let mutable = UnsafeMutableRawPointer(mutating: ptr)
     for i in 0..<16 {

--- a/Sources/SentryDistributionTests/UpdaterTests.swift
+++ b/Sources/SentryDistributionTests/UpdaterTests.swift
@@ -22,7 +22,12 @@ import Testing
 }
 
 @Test func testSuccessfullUpdateRequest() async throws {
-  let params = CheckForUpdateParams(accessToken: "token", organization: "org", project: "project")
+  let params = CheckForUpdateParams(
+    accessToken: "token",
+    organization: "org",
+    project: "project",
+    // App id override is provided so this test can run with `swift test`
+    appIdOverride: "")
   let configuration = URLSessionConfiguration.default
   configuration.protocolClasses = [MockURLProtocol.self]
   let session = URLSession(configuration: configuration)


### PR DESCRIPTION
Updated this test to work with `swift test` in preparation for some questions about swift testing at WWDC