### PR TITLE
ref(samples): Organize SDK override flags

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -18,9 +18,7 @@ public protocol SentrySDKOverride: RawRepresentable, CaseIterable where Self.Raw
     var stringValue: String? { get set }
 }
 
-/// This enum contains nested enums, to group feature flags by any kind of category you choose, whether it's feature area, or just a kitchen sink of otherwise unclassifiable flags (like Special/Other).
-///
-/// The parent enum has a case for each child enum type, to help dynamically access them when driving a table view (see
+/// This enum contains nested enums, grouped by the SDK integration or option area they configure.
 public enum SentrySDKOverrides: String, CaseIterable {
     public static func resetDefaults() {
         for override in SentrySDKOverrides.allCases {
@@ -38,16 +36,33 @@ public enum SentrySDKOverrides: String, CaseIterable {
     var featureFlags: [any SentrySDKOverride] {
         switch self {
         case .special: return SentrySDKOverrides.Special.allCases
-        case .feedback: return SentrySDKOverrides.Feedback.allCases
-        case .performance: return SentrySDKOverrides.Performance.allCases
-        case .sessionReplay: return SentrySDKOverrides.SessionReplay.allCases
-        case .screenshot: return SentrySDKOverrides.Screenshot.allCases
         case .events: return SentrySDKOverrides.Events.allCases
-        case .other: return SentrySDKOverrides.Other.allCases
-        case .tracing: return SentrySDKOverrides.Tracing.allCases
+        case .performance: return SentrySDKOverrides.Performance.allCases
+        case .appStart: return SentrySDKOverrides.AppStart.allCases
+        case .session: return SentrySDKOverrides.Session.allCases
+        case .replay: return SentrySDKOverrides.Replay.allCases
+        case .screenshot: return SentrySDKOverrides.Screenshot.allCases
+        case .viewHierarchy: return SentrySDKOverrides.ViewHierarchy.allCases
+        case .feedback: return SentrySDKOverrides.Feedback.allCases
         case .profiling: return SentrySDKOverrides.Profiling.allCases
-        case .networking: return SentrySDKOverrides.Networking.allCases
+        case .networkTracking: return SentrySDKOverrides.NetworkTracking.allCases
+        case .uiEventTracking: return SentrySDKOverrides.UIEventTracking.allCases
+        case .uiViewControllerTracing: return SentrySDKOverrides.UIViewControllerTracing.allCases
+        case .fileIO: return SentrySDKOverrides.FileIO.allCases
+        case .coreData: return SentrySDKOverrides.CoreData.allCases
+        case .appHangs: return SentrySDKOverrides.AppHangs.allCases
+        case .watchdogTerminations: return SentrySDKOverrides.WatchdogTerminations.allCases
+        case .breadcrumbs: return SentrySDKOverrides.Breadcrumbs.allCases
+        case .crash: return SentrySDKOverrides.Crash.allCases
+        case .metricKit: return SentrySDKOverrides.MetricKit.allCases
         case .metrics: return SentrySDKOverrides.Metrics.allCases
+        case .logs: return SentrySDKOverrides.Logs.allCases
+        case .spotlight: return SentrySDKOverrides.Spotlight.allCases
+        case .swizzling: return SentrySDKOverrides.Swizzling.allCases
+        case .transport: return SentrySDKOverrides.Transport.allCases
+        case .attachments: return SentrySDKOverrides.Attachments.allCases
+        case .spans: return SentrySDKOverrides.Spans.allCases
+        case .scope: return SentrySDKOverrides.Scope.allCases
         }
     }
 
@@ -60,62 +75,54 @@ public enum SentrySDKOverrides: String, CaseIterable {
     }
     case special = "Special"
 
-    public enum Feedback: String, SentrySDKOverride {
-        case allDefaults                = "--io.sentry.feedback.all-defaults"
-        case disableAutoInject          = "--io.sentry.feedback.no-auto-inject-widget"
-        case noWidgetText               = "--io.sentry.feedback.no-widget-text"
-        case noWidgetIcon               = "--io.sentry.feedback.no-widget-icon"
-        case noUserInjection            = "--io.sentry.feedback.dont-use-sentry-user"
-        case requireEmail               = "--io.sentry.feedback.require-email"
-        case requireName                = "--io.sentry.feedback.require-name"
-        case noAnimations               = "--io.sentry.feedback.no-animations"
-        case injectScreenshot           = "--io.sentry.feedback.inject-screenshot"
-        case useCustomFeedbackButton    = "--io.sentry.feedback.use-custom-feedback-button"
-        case noScreenshots              = "--io.sentry.feedback.no-screenshots"
-        case noShakeGesture             = "--io.sentry.feedback.no-shake-gesture"
-    }
-    case feedback = "Feedback"
-
     public enum Events: String, SentrySDKOverride {
-        case sampleRate        = "--io.sentry.events.sampleRate"
-        case rejectAll         = "--io.sentry.events.reject-all"
-        case attachAllThreads  = "--io.sentry.events.attach-all-threads"
+        case sampleRate       = "--io.sentry.events.sample-rate"
+        case rejectAll        = "--io.sentry.events.reject-all"
+        case attachAllThreads = "--io.sentry.events.attach-all-threads"
     }
     case events = "Events"
 
     public enum Performance: String, SentrySDKOverride {
-        case disableTimeToFullDisplayTracing    = "--io.sentry.performance.disable-time-to-full-display-tracing"
-        case disableSessionTracking             = "--io.sentry.performance.disable-automatic-session-tracking"
-        case disableFileIOTracing               = "--io.sentry.performance.disable-file-io-tracing"
-        case disableUIVCTracing                 = "--io.sentry.performance.disable-uiviewcontroller-tracing"
-        case disableCoreDataTracing             = "--io.sentry.performance.disable-core-data-tracing"
-        case disableANRTracking                 = "--io.sentry.performance.disable-anr-tracking"
-        case disableWatchdogTracking            = "--io.sentry.performance.disable-watchdog-tracking"
-        case disableUITracing                   = "--io.sentry.performance.disable-ui-tracing"
-        case disablePrewarmedAppStartTracing    = "--io.sentry.performance.disable-prewarmed-app-start-tracing"
-        case enableStandaloneAppStartTracing    = "--io.sentry.performance.enable-standalone-app-start-tracing"
-        case extendAppLaunchDelay               = "--io.sentry.performance.extend-app-launch-delay"
-        case disablePerformanceTracing          = "--io.sentry.performance.disable-auto-performance-tracing"
-        case sessionTrackingIntervalMillis      = "--io.sentry.performance.sessionTrackingIntervalMillis"
+        case sampleRate                       = "--io.sentry.performance.traces-sample-rate"
+        case samplerValue                     = "--io.sentry.performance.traces-sampler-value"
+        case disableTracing                   = "--io.sentry.performance.disable-tracing"
+        case disableAutoTracing               = "--io.sentry.performance.disable-auto-tracing"
+        case disableTimeToFullDisplayTracing  = "--io.sentry.performance.disable-time-to-full-display-tracing"
     }
     case performance = "Performance"
 
-    public enum SessionReplay: String, SentrySDKOverride {
-        case disable = "--io.sentry.session-replay.disable"
-        
-        case onErrorSampleRate = "--io.sentry.session-replay.on-error-sample-rate"
-        case sessionSampleRate = "--io.sentry.session-replay.session-sample-rate"
-        case quality = "--io.sentry.session-replay.quality"
-        
-        case disableViewRendererV2 = "--io.sentry.session-replay.disable-view-renderer-v2"
-        case enableFastViewRendering = "--io.sentry.session-replay.enable-fast-view-rendering"
-        
-        case disableMaskAllImages = "--io.sentry.session-replay.disable-mask-all-images"
-        case disableMaskAllText = "--io.sentry.session-replay.disable-mask-all-text"
+    public enum AppStart: String, SentrySDKOverride {
+        case disablePrewarmedTracing = "--io.sentry.app-start.disable-prewarmed-tracing"
+        case enableStandaloneTracing = "--io.sentry.app-start.enable-standalone-tracing"
+        case extendLaunchDelay       = "--io.sentry.app-start.extend-launch-delay"
     }
-    case sessionReplay = "Session Replay"
+    case appStart = "App Start"
+
+    public enum Session: String, SentrySDKOverride {
+        case disableTracking        = "--io.sentry.session.disable-tracking"
+        case trackingIntervalMillis = "--io.sentry.session.tracking-interval-millis"
+    }
+    case session = "Session"
+
+    public enum Replay: String, SentrySDKOverride {
+        case disable = "--io.sentry.replay.disable"
+
+        case onErrorSampleRate = "--io.sentry.replay.on-error-sample-rate"
+        case sessionSampleRate = "--io.sentry.replay.session-sample-rate"
+        case quality = "--io.sentry.replay.quality"
+
+        case disableViewRendererV2 = "--io.sentry.replay.disable-view-renderer-v2"
+        case enableFastViewRendering = "--io.sentry.replay.enable-fast-view-rendering"
+
+        case disableMaskAllImages = "--io.sentry.replay.disable-mask-all-images"
+        case disableMaskAllText = "--io.sentry.replay.disable-mask-all-text"
+        case disableNetworkDetailsCapturing = "--io.sentry.replay.disable-network-details-capturing"
+    }
+    case replay = "Replay"
 
     public enum Screenshot: String, SentrySDKOverride {
+        case disableAttachment = "--io.sentry.screenshot.disable-attachment"
+        case rejectInBeforeCapture = "--io.sentry.screenshot.reject-in-before-capture"
         case disableViewRendererV2 = "--io.sentry.screenshot.disable-view-renderer-v2"
         case enableFastViewRendering = "--io.sentry.screenshot.enable-fast-view-rendering"
         case disableMaskAllImages = "--io.sentry.screenshot.disable-mask-all-images"
@@ -123,57 +130,140 @@ public enum SentrySDKOverrides: String, CaseIterable {
     }
     case screenshot = "Screenshot"
 
-    public enum Networking: String, SentrySDKOverride {
-        case disableBreadcrumbs            = "--io.sentry.networking.disable-breadcrumbs"
-        case disablePerformanceTracking    = "--io.sentry.networking.disable-tracking"
-        case disableFailedRequestTracking  = "--io.sentry.networking.disable-failed-request-tracking"
+    public enum ViewHierarchy: String, SentrySDKOverride {
+        case disableAttachment = "--io.sentry.view-hierarchy.disable-attachment"
+        case rejectInBeforeCapture = "--io.sentry.view-hierarchy.reject-in-before-capture"
     }
-    case networking = "Networking"
+    case viewHierarchy = "View Hierarchy"
 
-    public enum Other: String, SentrySDKOverride {
-        case disableAttachScreenshot        = "--io.sentry.other.disable-attach-screenshot"
-        case disableAttachViewHierarchy     = "--io.sentry.other.disable-attach-view-hierarchy"
-        case rejectAllSpans                 = "--io.sentry.other.reject-all-spans"
-        case rejectScreenshots              = "--io.sentry.other.reject-screenshots-in-before-capture-screenshot"
-        case rejectViewHierarchy            = "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy"
-        case disableMetricKit               = "--io.sentry.other.disable-metrickit-integration"
-        case disableMetricKitRawPayloads    = "--io.sentry.other.disable-metrickit-raw-payloads"
-        case disableBreadcrumbs             = "--io.sentry.other.disable-automatic-breadcrumbs"
-        case disableSwizzling               = "--io.sentry.other.disable-swizzling"
-        case disableCrashHandling           = "--io.sentry.other.disable-crash-handler"
-        case disableSpotlight               = "--io.sentry.other.disable-spotlight"
-        case disableFileManagerSwizzling    = "--io.sentry.other.disable-filemanager-swizzling"
-        case base64AttachmentData           = "--io.sentry.other.base64-attachment-data"
-        case disableHttpTransport           = "--io.sentry.other.disable-http-transport"
-        case username                       = "--io.sentry.scope.user.username"
-        case userFullName                   = "--io.sentry.scope.user.name"
-        case userEmail                      = "--io.sentry.scope.user.email"
-        case userID                         = "--io.sentry.scope.user.id"
-        case environment                    = "--io.sentry.scope.sdk-environment"
+    public enum Feedback: String, SentrySDKOverride {
+        case allDefaults             = "--io.sentry.feedback.all-defaults"
+        case disableAutoInject       = "--io.sentry.feedback.no-auto-inject-widget"
+        case noWidgetText            = "--io.sentry.feedback.no-widget-text"
+        case noWidgetIcon            = "--io.sentry.feedback.no-widget-icon"
+        case noUserInjection         = "--io.sentry.feedback.dont-use-sentry-user"
+        case requireEmail            = "--io.sentry.feedback.require-email"
+        case requireName             = "--io.sentry.feedback.require-name"
+        case noAnimations            = "--io.sentry.feedback.no-animations"
+        case injectScreenshot        = "--io.sentry.feedback.inject-screenshot"
+        case useCustomFeedbackButton = "--io.sentry.feedback.use-custom-feedback-button"
+        case noScreenshots           = "--io.sentry.feedback.no-screenshots"
+        case noShakeGesture          = "--io.sentry.feedback.no-shake-gesture"
     }
-    case other = "Other"
-
-    public enum Tracing: String, SentrySDKOverride {
-        case sampleRate      = "--io.sentry.tracing.tracesSampleRate"
-        case samplerValue    = "--io.sentry.tracing.tracesSamplerValue"
-        case disableTracing  = "--io.sentry.tracing.disable-tracing"
-    }
-    case tracing = "Tracing"
+    case feedback = "User Feedback"
 
     public enum Profiling: String, SentrySDKOverride {
-        case disableAppStartProfiling   = "--io.sentry.profiling.disable-app-start-profiling"
-        case manualLifecycle            = "--io.sentry.profiling.profile-lifecycle-manual"
-        case sessionSampleRate          = "--io.sentry.profiling.profile-session-sample-rate"
-        case disableUIProfiling         = "--io.sentry.profiling.disable-ui-profiling"
-        case slowLoadMethod             = "--io.sentry.profiling.slow-load-method"
-        case immediateStop              = "--io.sentry.profiling.continuous-profiler-immediate-stop"
+        case disableAppStartProfiling = "--io.sentry.profiling.disable-app-start-profiling"
+        case manualLifecycle          = "--io.sentry.profiling.profile-lifecycle-manual"
+        case sessionSampleRate        = "--io.sentry.profiling.profile-session-sample-rate"
+        case disableUIProfiling       = "--io.sentry.profiling.disable-ui-profiling"
+        case slowLoadMethod           = "--io.sentry.profiling.slow-load-method"
+        case immediateStop            = "--io.sentry.profiling.continuous-profiler-immediate-stop"
     }
     case profiling = "Profiling"
+
+    public enum NetworkTracking: String, SentrySDKOverride {
+        case disableBreadcrumbs           = "--io.sentry.network.disable-breadcrumbs"
+        case disablePerformanceTracking   = "--io.sentry.network.disable-tracking"
+        case disableFailedRequestTracking = "--io.sentry.network.disable-failed-request-tracking"
+    }
+    case networkTracking = "Network Tracking"
+
+    public enum UIEventTracking: String, SentrySDKOverride {
+        case disableTracing = "--io.sentry.ui-events.disable-tracing"
+    }
+    case uiEventTracking = "UI Event Tracking"
+
+    public enum UIViewControllerTracing: String, SentrySDKOverride {
+        case disable = "--io.sentry.uiviewcontroller-tracing.disable"
+    }
+    case uiViewControllerTracing = "UIViewController Tracing"
+
+    public enum FileIO: String, SentrySDKOverride {
+        case disableTracing = "--io.sentry.file-io.disable-tracing"
+        case disableFileManagerSwizzling = "--io.sentry.file-io.disable-file-manager-swizzling"
+    }
+    case fileIO = "File IO"
+
+    public enum CoreData: String, SentrySDKOverride {
+        case disableTracing = "--io.sentry.core-data.disable-tracing"
+    }
+    case coreData = "Core Data"
+
+    public enum AppHangs: String, SentrySDKOverride {
+        case disableTracking = "--io.sentry.app-hangs.disable-tracking"
+    }
+    case appHangs = "App Hangs"
+
+    public enum WatchdogTerminations: String, SentrySDKOverride {
+        case disableTracking = "--io.sentry.watchdog-terminations.disable-tracking"
+        case disableV2       = "--io.sentry.watchdog-terminations.disable-v2"
+    }
+    case watchdogTerminations = "Watchdog Terminations"
+
+    public enum Breadcrumbs: String, SentrySDKOverride {
+        case disableAutomatic = "--io.sentry.breadcrumbs.disable-automatic"
+    }
+    case breadcrumbs = "Breadcrumbs"
+
+    public enum Crash: String, SentrySDKOverride {
+        case disableHandler = "--io.sentry.crash.disable-handler"
+        case disablePersistingTracesWhenCrashing = "--io.sentry.crash.disable-persisting-traces"
+        case disableUnhandledCPPExceptionsV2     = "--io.sentry.crash.disable-unhandled-cpp-exceptions-v2"
+        case disableUncaughtNSExceptionReporting = "--io.sentry.crash.disable-uncaught-ns-exception-reporting"
+    }
+    case crash = "Crash"
+
+    public enum MetricKit: String, SentrySDKOverride {
+        case disable = "--io.sentry.metric-kit.disable"
+        case disableRawPayloads = "--io.sentry.metric-kit.disable-raw-payloads"
+    }
+    case metricKit = "MetricKit"
 
     public enum Metrics: String, SentrySDKOverride {
         case enable = "--io.sentry.metrics.enable"
     }
     case metrics = "Metrics"
+
+    public enum Logs: String, SentrySDKOverride {
+        case disable = "--io.sentry.logs.disable"
+    }
+    case logs = "Logs"
+
+    public enum Spotlight: String, SentrySDKOverride {
+        case disable = "--io.sentry.spotlight.disable"
+        case enable = "--io.sentry.spotlight.enable"
+    }
+    case spotlight = "Spotlight"
+
+    public enum Swizzling: String, SentrySDKOverride {
+        case disable = "--io.sentry.swizzling.disable"
+    }
+    case swizzling = "Swizzling"
+
+    public enum Transport: String, SentrySDKOverride {
+        case disableHttpTransport = "--io.sentry.transport.disable-http"
+    }
+    case transport = "Transport"
+
+    public enum Attachments: String, SentrySDKOverride {
+        case base64Data = "--io.sentry.attachments.base64-data"
+    }
+    case attachments = "Attachments"
+
+    public enum Spans: String, SentrySDKOverride {
+        case rejectAll = "--io.sentry.spans.reject-all"
+    }
+    case spans = "Spans"
+
+    public enum Scope: String, SentrySDKOverride {
+        case username     = "--io.sentry.scope.user.username"
+        case userFullName = "--io.sentry.scope.user.name"
+        case userEmail    = "--io.sentry.scope.user.email"
+        case userID       = "--io.sentry.scope.user.id"
+        case environment  = "--io.sentry.scope.sdk-environment"
+    }
+    case scope = "Scope"
 }
 
 // MARK: Public flag/variable value access
@@ -182,7 +272,7 @@ public extension SentrySDKOverride {
     var boolValue: Bool {
         get {
             guard overrideType == .boolean else { fatalError("Unsupported bool override: \(self.rawValue)") }
-            
+
             if !ignoresDisableEverything {
                 return Self.getBoolOverride(for: SentrySDKOverrides.Special.disableEverything.rawValue) || Self.getBoolOverride(for: rawValue)
             }
@@ -266,28 +356,11 @@ private extension SentrySDKOverride {
 
 // These are listed exhaustively, without using default cases, so that when new cases are added to the enums above, the compiler helps remind you to annotate what type it is down here.
 
-extension SentrySDKOverrides.Profiling {
+extension SentrySDKOverrides.Special {
     public var overrideType: OverrideType {
         switch self {
-        case .sessionSampleRate: return .float
-        case .disableAppStartProfiling, .manualLifecycle, .disableUIProfiling, .slowLoadMethod, .immediateStop: return .boolean
-        }
-    }
-}
-
-extension SentrySDKOverrides.Tracing {
-    public var overrideType: OverrideType {
-        switch self {
-        case .sampleRate, .samplerValue: return .float
-        case .disableTracing: return .boolean
-        }
-    }
-}
-
-extension SentrySDKOverrides.Networking {
-    public var overrideType: OverrideType {
-        switch self {
-        case .disableBreadcrumbs, .disablePerformanceTracking, .disableFailedRequestTracking: return .boolean
+        case .wipeDataOnLaunch, .disableEverything, .skipSDKInit, .disableDebugMode: return .boolean
+        case .dsn: return .string
         }
     }
 }
@@ -299,32 +372,41 @@ extension SentrySDKOverrides.Events {
         case .sampleRate: return .float
         }
     }
-
-}
-
-extension SentrySDKOverrides.Other {
-    public var overrideType: OverrideType {
-        switch self {
-        case .disableAttachScreenshot, .disableAttachViewHierarchy, .rejectScreenshots, .rejectViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .rejectAllSpans, .base64AttachmentData, .disableHttpTransport: return .boolean
-        case .username, .userFullName, .userEmail, .userID, .environment: return .string
-        }
-    }
 }
 
 extension SentrySDKOverrides.Performance {
     public var overrideType: OverrideType {
         switch self {
-        case .disableTimeToFullDisplayTracing, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .enableStandaloneAppStartTracing, .disablePerformanceTracing: return .boolean
-        case .extendAppLaunchDelay: return .float
-        case .sessionTrackingIntervalMillis: return .string
+        case .disableTracing, .disableAutoTracing, .disableTimeToFullDisplayTracing: return .boolean
+        case .sampleRate, .samplerValue: return .float
         }
     }
 }
 
-extension SentrySDKOverrides.SessionReplay {
+extension SentrySDKOverrides.AppStart {
     public var overrideType: OverrideType {
         switch self {
-        case .disable, .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText, .disableMaskAllImages: return .boolean
+        case .disablePrewarmedTracing, .enableStandaloneTracing: return .boolean
+        case .extendLaunchDelay: return .float
+        }
+    }
+}
+
+extension SentrySDKOverrides.Session {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracking: return .boolean
+        case .trackingIntervalMillis: return .string
+        }
+    }
+}
+
+extension SentrySDKOverrides.Replay {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable, .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText,
+             .disableMaskAllImages, .disableNetworkDetailsCapturing:
+            return .boolean
         case .onErrorSampleRate, .sessionSampleRate: return .float
         case .quality: return .string
         }
@@ -334,7 +416,17 @@ extension SentrySDKOverrides.SessionReplay {
 extension SentrySDKOverrides.Screenshot {
     public var overrideType: OverrideType {
         switch self {
-        case .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText, .disableMaskAllImages: return .boolean
+        case .disableAttachment, .rejectInBeforeCapture, .disableViewRendererV2,
+             .enableFastViewRendering, .disableMaskAllText, .disableMaskAllImages:
+            return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.ViewHierarchy {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableAttachment, .rejectInBeforeCapture: return .boolean
         }
     }
 }
@@ -342,16 +434,104 @@ extension SentrySDKOverrides.Screenshot {
 extension SentrySDKOverrides.Feedback {
     public var overrideType: OverrideType {
         switch self {
-        case .allDefaults, .disableAutoInject, .noWidgetText, .noWidgetIcon, .noUserInjection, .requireEmail, .requireName, .noAnimations, .injectScreenshot, .useCustomFeedbackButton, .noScreenshots, .noShakeGesture: return .boolean
+        case .allDefaults, .disableAutoInject, .noWidgetText, .noWidgetIcon, .noUserInjection,
+             .requireEmail, .requireName, .noAnimations, .injectScreenshot,
+             .useCustomFeedbackButton, .noScreenshots, .noShakeGesture:
+            return .boolean
         }
     }
 }
 
-extension SentrySDKOverrides.Special {
+extension SentrySDKOverrides.Profiling {
     public var overrideType: OverrideType {
         switch self {
-        case .wipeDataOnLaunch, .disableEverything, .skipSDKInit, .disableDebugMode: return .boolean
-        case .dsn: return .string
+        case .sessionSampleRate: return .float
+        case .disableAppStartProfiling, .manualLifecycle, .disableUIProfiling, .slowLoadMethod,
+             .immediateStop:
+            return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.NetworkTracking {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableBreadcrumbs, .disablePerformanceTracking, .disableFailedRequestTracking:
+            return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.UIEventTracking {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracing: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.UIViewControllerTracing {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.FileIO {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracing, .disableFileManagerSwizzling: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.CoreData {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracing: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.AppHangs {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracking: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.WatchdogTerminations {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableTracking, .disableV2: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Breadcrumbs {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableAutomatic: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Crash {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableHandler, .disablePersistingTracesWhenCrashing,
+             .disableUnhandledCPPExceptionsV2, .disableUncaughtNSExceptionReporting:
+            return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.MetricKit {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable, .disableRawPayloads: return .boolean
         }
     }
 }
@@ -364,30 +544,73 @@ extension SentrySDKOverrides.Metrics {
     }
 }
 
+extension SentrySDKOverrides.Logs {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Spotlight {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable, .enable: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Swizzling {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Transport {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableHttpTransport: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Attachments {
+    public var overrideType: OverrideType {
+        switch self {
+        case .base64Data: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Spans {
+    public var overrideType: OverrideType {
+        switch self {
+        case .rejectAll: return .boolean
+        }
+    }
+}
+
+extension SentrySDKOverrides.Scope {
+    public var overrideType: OverrideType {
+        switch self {
+        case .username, .userFullName, .userEmail, .userID, .environment: return .string
+        }
+    }
+}
+
 // MARK: Disable Everything Helper
 
 // These are listed exhaustively, without using default cases, so that when new cases are added to the enums above, the compiler helps remind you to annotate what type it is down here.
 
-extension SentrySDKOverrides.Profiling {
+extension SentrySDKOverrides.Special {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .sessionSampleRate, .manualLifecycle, .slowLoadMethod, .immediateStop: return true
-        case .disableAppStartProfiling, .disableUIProfiling: return false
+        case .wipeDataOnLaunch, .disableEverything, .skipSDKInit, .disableDebugMode, .dsn:
+            return true
         }
     }
-}
-
-extension SentrySDKOverrides.Tracing {
-    public var ignoresDisableEverything: Bool {
-        switch self {
-        case .sampleRate, .samplerValue: return false
-        case .disableTracing: return true
-        }
-    }
-}
-
-extension SentrySDKOverrides.Networking {
-    public var ignoresDisableEverything: Bool { return false }
 }
 
 extension SentrySDKOverrides.Events {
@@ -399,29 +622,41 @@ extension SentrySDKOverrides.Events {
     }
 }
 
-extension SentrySDKOverrides.Other {
-    public var ignoresDisableEverything: Bool {
-        switch self {
-        case .rejectScreenshots, .rejectViewHierarchy, .rejectAllSpans, .username, .userFullName, .userEmail, .userID, .environment, .base64AttachmentData: return true
-        case .disableAttachScreenshot, .disableAttachViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .disableHttpTransport: return false
-        }
-    }
-}
-
 extension SentrySDKOverrides.Performance {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .disableTimeToFullDisplayTracing, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .enableStandaloneAppStartTracing, .extendAppLaunchDelay, .disablePerformanceTracing: return false
-        case .sessionTrackingIntervalMillis: return true
+        case .sampleRate, .samplerValue, .disableTracing: return true
+        case .disableAutoTracing, .disableTimeToFullDisplayTracing: return false
         }
     }
 }
 
-extension SentrySDKOverrides.SessionReplay {
+extension SentrySDKOverrides.AppStart {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .disablePrewarmedTracing: return false
+        case .enableStandaloneTracing, .extendLaunchDelay: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.Session {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .disableTracking: return false
+        case .trackingIntervalMillis: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.Replay {
     public var ignoresDisableEverything: Bool {
         switch self {
         case .disable: return false
-        case .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText, .disableMaskAllImages, .onErrorSampleRate, .sessionSampleRate, .quality: return true
+        case .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText,
+             .disableMaskAllImages, .onErrorSampleRate, .sessionSampleRate, .quality,
+             .disableNetworkDetailsCapturing:
+            return true
         }
     }
 }
@@ -429,7 +664,19 @@ extension SentrySDKOverrides.SessionReplay {
 extension SentrySDKOverrides.Screenshot {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText, .disableMaskAllImages: return false
+        case .disableAttachment, .disableViewRendererV2, .disableMaskAllText,
+             .disableMaskAllImages:
+            return false
+        case .rejectInBeforeCapture, .enableFastViewRendering: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.ViewHierarchy {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .disableAttachment: return false
+        case .rejectInBeforeCapture: return true
         }
     }
 }
@@ -437,17 +684,62 @@ extension SentrySDKOverrides.Screenshot {
 extension SentrySDKOverrides.Feedback {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .allDefaults, .disableAutoInject, .noWidgetText, .noWidgetIcon, .noUserInjection, .requireEmail, .requireName, .noAnimations, .injectScreenshot, .useCustomFeedbackButton, .noScreenshots, .noShakeGesture: return true
+        case .allDefaults, .disableAutoInject, .noWidgetText, .noWidgetIcon, .noUserInjection,
+             .requireEmail, .requireName, .noAnimations, .injectScreenshot,
+             .useCustomFeedbackButton, .noScreenshots, .noShakeGesture:
+            return true
         }
     }
 }
 
-extension SentrySDKOverrides.Special {
+extension SentrySDKOverrides.Profiling {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .wipeDataOnLaunch, .disableEverything, .skipSDKInit, .disableDebugMode, .dsn: return true
+        case .sessionSampleRate, .manualLifecycle, .slowLoadMethod, .immediateStop:
+            return true
+        case .disableAppStartProfiling, .disableUIProfiling: return false
         }
     }
+}
+
+extension SentrySDKOverrides.NetworkTracking {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.UIEventTracking {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.UIViewControllerTracing {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.FileIO {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.CoreData {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.AppHangs {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.WatchdogTerminations {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Breadcrumbs {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Crash {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.MetricKit {
+    public var ignoresDisableEverything: Bool { return false }
 }
 
 extension SentrySDKOverrides.Metrics {
@@ -456,5 +748,46 @@ extension SentrySDKOverrides.Metrics {
         case .enable: return true
         }
     }
+}
+
+extension SentrySDKOverrides.Logs {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Spotlight {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .disable: return false
+        case .enable: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.Swizzling {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Transport {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Attachments {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .base64Data: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.Spans {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .rejectAll: return true
+        }
+    }
+}
+
+extension SentrySDKOverrides.Scope {
+    public var ignoresDisableEverything: Bool { return true }
 }
 // swiftlint:enable file_length

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -34,7 +34,7 @@ public struct SentrySDKWrapper {
         }
 
 #if os(iOS) || os(tvOS) || os(visionOS)
-        if let delay = SentrySDKOverrides.Performance.extendAppLaunchDelay.floatValue {
+        if let delay = SentrySDKOverrides.AppStart.extendLaunchDelay.floatValue {
             let appStartSpan = SentrySDK.extendAppLaunch()
 
             let configSpan = appStartSpan?.startChild(operation: "app.init", description: "load configuration")
@@ -61,24 +61,24 @@ public struct SentrySDKWrapper {
             return $0
         }
         options.beforeSendSpan = { span in
-            guard !SentrySDKOverrides.Other.rejectAllSpans.boolValue else { return nil }
+            guard !SentrySDKOverrides.Spans.rejectAll.boolValue else { return nil }
             SentrySDKWrapper.spanCaptureHandler?(span)
             return span
         }
-        options.beforeCaptureScreenshot = { _ in !SentrySDKOverrides.Other.rejectScreenshots.boolValue }
-        options.beforeCaptureViewHierarchy = { _ in !SentrySDKOverrides.Other.rejectViewHierarchy.boolValue }
+        options.beforeCaptureScreenshot = { _ in !SentrySDKOverrides.Screenshot.rejectInBeforeCapture.boolValue }
+        options.beforeCaptureViewHierarchy = { _ in !SentrySDKOverrides.ViewHierarchy.rejectInBeforeCapture.boolValue }
         options.debug = !SentrySDKOverrides.Special.disableDebugMode.boolValue
 
 #if !os(macOS) && !os(watchOS) && !os(visionOS)
-        if #available(iOS 16.0, *), !SentrySDKOverrides.SessionReplay.disable.boolValue {
+        if #available(iOS 16.0, *), !SentrySDKOverrides.Replay.disable.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: SentrySDKOverrides.SessionReplay.sessionSampleRate.floatValue ?? 0,
-                onErrorSampleRate: SentrySDKOverrides.SessionReplay.onErrorSampleRate.floatValue ?? 1,
-                maskAllText: !SentrySDKOverrides.SessionReplay.disableMaskAllText.boolValue,
-                maskAllImages: !SentrySDKOverrides.SessionReplay.disableMaskAllImages.boolValue,
-                enableViewRendererV2: !SentrySDKOverrides.SessionReplay.disableViewRendererV2.boolValue,
+                sessionSampleRate: SentrySDKOverrides.Replay.sessionSampleRate.floatValue ?? 0,
+                onErrorSampleRate: SentrySDKOverrides.Replay.onErrorSampleRate.floatValue ?? 1,
+                maskAllText: !SentrySDKOverrides.Replay.disableMaskAllText.boolValue,
+                maskAllImages: !SentrySDKOverrides.Replay.disableMaskAllImages.boolValue,
+                enableViewRendererV2: !SentrySDKOverrides.Replay.disableViewRendererV2.boolValue,
                 // Disable the fast view rendering, because we noticed parts (like the tab bar) are not rendered correctly
-                enableFastViewRendering: SentrySDKOverrides.SessionReplay.enableFastViewRendering.boolValue
+                enableFastViewRendering: SentrySDKOverrides.Replay.enableFastViewRendering.boolValue
             )
             
             // Configure network detail capture for testing
@@ -104,34 +104,30 @@ public struct SentrySDKWrapper {
                 "access-control-allow-credentials"
             ]
             let defaultReplayQuality = options.sessionReplay.quality
-            options.sessionReplay.quality = SentryReplayOptions.SentryReplayQuality(rawValue: (SentrySDKOverrides.SessionReplay.quality.stringValue as? NSString)?.integerValue ?? defaultReplayQuality.rawValue) ?? defaultReplayQuality
+            options.sessionReplay.quality = SentryReplayOptions.SentryReplayQuality(rawValue: (SentrySDKOverrides.Replay.quality.stringValue as? NSString)?.integerValue ?? defaultReplayQuality.rawValue) ?? defaultReplayQuality
+
+            options.experimental.enableReplayNetworkDetailsCapturing =
+                !SentrySDKOverrides.Replay.disableNetworkDetailsCapturing.boolValue
         }
 
 #endif // !os(macOS) && !os(watchOS) && !os(visionOS)
 
 #if !os(tvOS) && !os(watchOS)
-        if #available(iOS 15.0, macOS 12.0, *), !SentrySDKOverrides.Other.disableMetricKit.boolValue {
-            options.enableMetricKit = true
-            options.enableMetricKitRawPayload = !SentrySDKOverrides.Other.disableMetricKitRawPayloads.boolValue
+        if #available(iOS 15.0, macOS 12.0, *) {
+            options.enableMetricKit = !SentrySDKOverrides.MetricKit.disable.boolValue
+            options.enableMetricKitRawPayload =
+                options.enableMetricKit && !SentrySDKOverrides.MetricKit.disableRawPayloads.boolValue
         }
 #endif // !os(tvOS) && !os(watchOS)
 
-        options.tracesSampleRate = 1
-        if let sampleRate = SentrySDKOverrides.Tracing.sampleRate.floatValue {
-            options.tracesSampleRate = NSNumber(value: sampleRate)
-        }
-        if let samplerValue = SentrySDKOverrides.Tracing.samplerValue.floatValue {
-            options.tracesSampler = { _ in
-                return NSNumber(value: samplerValue)
-            }
-        }
+        configurePerformanceTracing(options)
 
 #if !os(tvOS) && !os(watchOS) && !os(visionOS)
         configureProfiling(options)
 #endif // !os(tvOS) && !os(watchOS) && !os(visionOS)
 
-        options.enableAutoSessionTracking = !SentrySDKOverrides.Performance.disableSessionTracking.boolValue
-        if let sessionTrackingIntervalMillis = SentrySDKOverrides.Performance.sessionTrackingIntervalMillis.stringValue {
+        options.enableAutoSessionTracking = !SentrySDKOverrides.Session.disableTracking.boolValue
+        if let sessionTrackingIntervalMillis = SentrySDKOverrides.Session.trackingIntervalMillis.stringValue {
             options.sessionTrackingIntervalMillis = UInt((sessionTrackingIntervalMillis as NSString).integerValue)
         }
 
@@ -139,41 +135,42 @@ public struct SentrySDKWrapper {
         options.add(inAppInclude: "iOS_External")
 
         // the benchmark test starts and stops a custom transaction using a UIButton, and automatic user interaction tracing stops the transaction that begins with that button press after the idle timeout elapses, stopping the profiler (only one profiler runs regardless of the number of concurrent transactions)
-        options.enableUserInteractionTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disableUITracing.boolValue
+        options.enableUserInteractionTracing = !isBenchmarking && !SentrySDKOverrides.UIEventTracking.disableTracing.boolValue
 
-        options.enablePreWarmedAppStartTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disablePrewarmedAppStartTracing.boolValue
-        options.experimental.enableStandaloneAppStartTracing = SentrySDKOverrides.Performance.enableStandaloneAppStartTracing.boolValue
-        options.enableUIViewControllerTracing = !SentrySDKOverrides.Performance.disableUIVCTracing.boolValue
+        options.enablePreWarmedAppStartTracing = !isBenchmarking && !SentrySDKOverrides.AppStart.disablePrewarmedTracing.boolValue
+        options.experimental.enableStandaloneAppStartTracing = SentrySDKOverrides.AppStart.enableStandaloneTracing.boolValue
+        options.enableUIViewControllerTracing = !SentrySDKOverrides.UIViewControllerTracing.disable.boolValue
 
         // -- Screenshot Options --
-        options.attachScreenshot = !SentrySDKOverrides.Other.disableAttachScreenshot.boolValue
+        options.attachScreenshot = !SentrySDKOverrides.Screenshot.disableAttachment.boolValue
         options.screenshot.enableViewRendererV2 = !SentrySDKOverrides.Screenshot.disableViewRendererV2.boolValue
         // The fast view renderer is opt-in, therefore it is assumed to be disabled by default.
         options.screenshot.enableFastViewRendering = SentrySDKOverrides.Screenshot.enableFastViewRendering.boolValue
         options.screenshot.maskAllImages = !SentrySDKOverrides.Screenshot.disableMaskAllImages.boolValue
         options.screenshot.maskAllText = !SentrySDKOverrides.Screenshot.disableMaskAllText.boolValue
 
-        options.attachViewHierarchy = !SentrySDKOverrides.Other.disableAttachViewHierarchy.boolValue
+        options.attachViewHierarchy = !SentrySDKOverrides.ViewHierarchy.disableAttachment.boolValue
 #endif // !os(macOS) && !os(watchOS)
 
         // disable during benchmarks because we run CPU for 15 seconds at full throttle which can trigger ANRs
-        options.enableAppHangTracking = !isBenchmarking && !SentrySDKOverrides.Performance.disableANRTracking.boolValue
+        options.enableAppHangTracking = !isBenchmarking && !SentrySDKOverrides.AppHangs.disableTracking.boolValue
 
         // UI tests generate false OOMs
-        options.enableWatchdogTerminationTracking = !isUITest && !isBenchmarking && !SentrySDKOverrides.Performance.disableWatchdogTracking.boolValue
+        options.enableWatchdogTerminationTracking = !isUITest && !isBenchmarking && !SentrySDKOverrides.WatchdogTerminations.disableTracking.boolValue
 
-        options.enableAutoPerformanceTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disablePerformanceTracing.boolValue
+        options.enableAutoPerformanceTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disableAutoTracing.boolValue
 
-        options.enableNetworkTracking = !SentrySDKOverrides.Networking.disablePerformanceTracking.boolValue
-        options.enableCaptureFailedRequests = !SentrySDKOverrides.Networking.disableFailedRequestTracking.boolValue
-        options.enableNetworkBreadcrumbs = !SentrySDKOverrides.Networking.disableBreadcrumbs.boolValue
+        options.enableNetworkTracking = !SentrySDKOverrides.NetworkTracking.disablePerformanceTracking.boolValue
+        options.enableCaptureFailedRequests = !SentrySDKOverrides.NetworkTracking.disableFailedRequestTracking.boolValue
+        options.enableNetworkBreadcrumbs = !SentrySDKOverrides.NetworkTracking.disableBreadcrumbs.boolValue
 
-        options.enableFileIOTracing = !SentrySDKOverrides.Performance.disableFileIOTracing.boolValue
-        options.enableAutoBreadcrumbTracking = !SentrySDKOverrides.Other.disableBreadcrumbs.boolValue
-        options.enableCoreDataTracing = !SentrySDKOverrides.Performance.disableCoreDataTracing.boolValue
-        options.enableSwizzling = !SentrySDKOverrides.Other.disableSwizzling.boolValue
-        options.enableCrashHandler = !SentrySDKOverrides.Other.disableCrashHandling.boolValue
-        options.enablePersistingTracesWhenCrashing = true
+        options.enableFileIOTracing = !SentrySDKOverrides.FileIO.disableTracing.boolValue
+        options.enableAutoBreadcrumbTracking = !SentrySDKOverrides.Breadcrumbs.disableAutomatic.boolValue
+        options.enableCoreDataTracing = !SentrySDKOverrides.CoreData.disableTracing.boolValue
+        options.enableSwizzling = !SentrySDKOverrides.Swizzling.disable.boolValue
+        options.enableCrashHandler = !SentrySDKOverrides.Crash.disableHandler.boolValue
+        options.enablePersistingTracesWhenCrashing =
+            !SentrySDKOverrides.Crash.disablePersistingTracesWhenCrashing.boolValue
 
         options.onLastRunStatusDetermined = { status, crashEvent in
             let eventId = crashEvent?.eventId.sentryIdString ?? "nil"
@@ -183,9 +180,9 @@ public struct SentrySDKWrapper {
         options.failedRequestStatusCodes = [ HttpStatusCodeRange(min: 400, max: 599) ]
 
     #if targetEnvironment(simulator)
-        options.enableSpotlight = !SentrySDKOverrides.Other.disableSpotlight.boolValue
+        options.enableSpotlight = !SentrySDKOverrides.Spotlight.disable.boolValue
     #else
-        options.enableSpotlight = false
+        options.enableSpotlight = SentrySDKOverrides.Spotlight.enable.boolValue
     #endif // targetEnvironment(simulator)
 
         options.beforeBreadcrumb = { breadcrumb in
@@ -204,7 +201,7 @@ public struct SentrySDKWrapper {
 #endif // !os(macOS) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
         // Integration: Logs
-        options.enableLogs = true
+        options.enableLogs = !SentrySDKOverrides.Logs.disable.boolValue
 
         // Integration: Metrics
         options.enableMetrics = SentrySDKOverrides.Metrics.enable.boolValue
@@ -225,16 +222,35 @@ public struct SentrySDKWrapper {
         }
 
         // Experimental features
-        options.enableFileManagerSwizzling = !SentrySDKOverrides.Other.disableFileManagerSwizzling.boolValue
-        options.experimental.enableUnhandledCPPExceptionsV2 = true
-
+        options.enableFileManagerSwizzling = !SentrySDKOverrides.FileIO.disableFileManagerSwizzling.boolValue
+        options.experimental.enableUnhandledCPPExceptionsV2 =
+            !SentrySDKOverrides.Crash.disableUnhandledCPPExceptionsV2.boolValue
+        options.experimental.enableWatchdogTerminationsV2 =
+            !SentrySDKOverrides.WatchdogTerminations.disableV2.boolValue
 #if os(macOS) && !SENTRY_NO_UI_FRAMEWORK
-        options.enableUncaughtNSExceptionReporting = true
+        options.enableUncaughtNSExceptionReporting =
+            !SentrySDKOverrides.Crash.disableUncaughtNSExceptionReporting.boolValue
 #endif
     }
 
+    private func configurePerformanceTracing(_ options: Options) {
+        options.tracesSampleRate = 1
+        if let sampleRate = SentrySDKOverrides.Performance.sampleRate.floatValue {
+            options.tracesSampleRate = NSNumber(value: sampleRate)
+        }
+        if let samplerValue = SentrySDKOverrides.Performance.samplerValue.floatValue {
+            options.tracesSampler = { _ in
+                return NSNumber(value: samplerValue)
+            }
+        }
+        if SentrySDKOverrides.Performance.disableTracing.boolValue {
+            options.tracesSampleRate = 0
+            options.tracesSampler = nil
+        }
+    }
+
     func configureInitialScope(scope: Scope, options: Options) -> Scope {
-        if let environmentOverride = SentrySDKOverrides.Other.environment.stringValue {
+        if let environmentOverride = SentrySDKOverrides.Scope.environment.stringValue {
             scope.setEnvironment(environmentOverride)
         } else if isBenchmarking {
             scope.setEnvironment("benchmarking")
@@ -255,8 +271,8 @@ public struct SentrySDKWrapper {
         setTagsForConfiguredOverrides(scope: scope)
         injectGitInformation(scope: scope)
 
-        let user = User(userId: SentrySDKOverrides.Other.userID.stringValue ?? "1")
-        user.email = SentrySDKOverrides.Other.userEmail.stringValue ?? "tony@example.com"
+        let user = User(userId: SentrySDKOverrides.Scope.userID.stringValue ?? "1")
+        user.email = SentrySDKOverrides.Scope.userEmail.stringValue ?? "tony@example.com"
         user.username = username
         user.name = userFullName
         scope.setUser(user)
@@ -275,7 +291,7 @@ public struct SentrySDKWrapper {
     }
 
     var userFullName: String {
-        let name = SentrySDKOverrides.Other.userFullName.stringValue ?? NSFullUserName()
+        let name = SentrySDKOverrides.Scope.userFullName.stringValue ?? NSFullUserName()
         guard !name.isEmpty else {
             return "cocoa developer"
         }
@@ -283,7 +299,7 @@ public struct SentrySDKWrapper {
     }
 
     var username: String {
-        let username = SentrySDKOverrides.Other.username.stringValue ?? NSUserName()
+        let username = SentrySDKOverrides.Scope.username.stringValue ?? NSUserName()
         guard !username.isEmpty else {
             return (self.env["SIMULATOR_HOST_HOME"] as? NSString)?
                 .lastPathComponent ?? "cocoadev"
@@ -546,7 +562,7 @@ extension SentrySDKWrapper {
     
     /// Whether or not profiling benchmarks are being run; this requires disabling certain other features for proper functionality.
     var isBenchmarking: Bool { args.contains("--io.sentry.test.benchmarking") }
-    var isUITest: Bool { env[SentrySDKOverrides.Other.environment.rawValue] == "ui-tests" }
+    var isUITest: Bool { env[SentrySDKOverrides.Scope.environment.rawValue] == "ui-tests" }
 }
 
 // MARK: Profiling configuration

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -9,19 +9,38 @@ schemeTemplates:
         "--io.sentry.special.wipe-data": false
         "--io.sentry.special.disable-debug-mode": false
 
+        # events
+        "--io.sentry.events.reject-all": false
+        "--io.sentry.events.attach-all-threads": false
+
+        # performance
+        "--io.sentry.performance.disable-tracing": false
+        "--io.sentry.performance.disable-auto-tracing": false
+        "--io.sentry.performance.disable-time-to-full-display-tracing": false
+
+        # app start
+        "--io.sentry.app-start.disable-prewarmed-tracing": false
+        "--io.sentry.app-start.enable-standalone-tracing": false
+
+        # replay
+        "--io.sentry.replay.disable": false
+        "--io.sentry.replay.disable-view-renderer-v2": false
+        "--io.sentry.replay.enable-fast-view-rendering": false
+        "--io.sentry.replay.disable-mask-all-images": false
+        "--io.sentry.replay.disable-mask-all-text": false
+        "--io.sentry.replay.disable-network-details-capturing": false
+
         # screenshot
-        "--io.sentry.screenshot.disable": false
+        "--io.sentry.screenshot.disable-attachment": false
+        "--io.sentry.screenshot.reject-in-before-capture": false
         "--io.sentry.screenshot.disable-view-renderer-v2": false
-        "--io.sentry.screenshot.disable-fast-view-rendering": false
+        "--io.sentry.screenshot.enable-fast-view-rendering": false
         "--io.sentry.screenshot.disable-mask-all-images": false
         "--io.sentry.screenshot.disable-mask-all-text": false
 
-        # session replay
-        "--io.sentry.session-replay.disable": false
-        "--io.sentry.session-replay.disable-view-renderer-v2": false
-        "--io.sentry.session-replay.enable-fast-view-rendering": false
-        "--io.sentry.session-replay.disable-mask-all-images": false
-        "--io.sentry.session-replay.disable-mask-all-text": false
+        # view hierarchy
+        "--io.sentry.view-hierarchy.disable-attachment": false
+        "--io.sentry.view-hierarchy.reject-in-before-capture": false
 
         # user feedback
         "--io.sentry.feedback.use-custom-feedback-button": false
@@ -43,93 +62,112 @@ schemeTemplates:
         "--io.sentry.profiling.disable-app-start-profiling": false
         "--io.sentry.profiling.continuous-profiler-immediate-stop": false
 
-        # networking
-        "--io.sentry.networking.disable-breadcrumbs": false
-        "--io.sentry.networking.disable-tracking": false
-        "--io.sentry.networking.disable-failed-request-tracking": false
+        # network tracking
+        "--io.sentry.network.disable-breadcrumbs": false
+        "--io.sentry.network.disable-tracking": false
+        "--io.sentry.network.disable-failed-request-tracking": false
 
-        # performance
-        "--io.sentry.performance.disable-app-hang-tracking-v2": false
-        "--io.sentry.performance.disable-time-to-full-display-tracing": false
-        "--io.sentry.performance.disable-performance-v2": false
-        "--io.sentry.performance.disable-file-io-tracing": false
-        "--io.sentry.performance.disable-automatic-session-tracking": false
-        "--io.sentry.performance.disable-watchdog-tracking": false
-        "--io.sentry.performance.enable-standalone-app-start-tracing": false
-        "--io.sentry.tracing.disable-tracing": false
-        "--io.sentry.performance.disable-core-data-tracing": false
-        "--io.sentry.performance.disable-uiviewcontroller-tracing": false
-        "--io.sentry.performance.disable-anr-tracking": false
-        "--io.sentry.performance.disable-auto-performance-tracing": false
-        "--io.sentry.performance.disable-ui-tracing": false
+        # ui event tracking
+        "--io.sentry.ui-events.disable-tracing": false
 
-        # events
-        "--io.sentry.events.reject-all": false
+        # uiviewcontroller tracing
+        "--io.sentry.uiviewcontroller-tracing.disable": false
 
-        # other
-        "--io.sentry.other.base64-attachment-data": false
-        "--io.sentry.other.disable-attach-view-hierarchy": false
-        "--io.sentry.other.disable-attach-screenshot": false
-        "--io.sentry.other.disable-automatic-breadcrumbs": false
-        "--io.sentry.other.disable-crash-handler": false
-        "--io.sentry.other.disable-filemanager-swizzling": false
-        "--io.sentry.other.disable-http-transport": false
-        "--io.sentry.other.disable-metrickit-integration": false
-        "--io.sentry.other.disable-metrickit-raw-payloads": false
-        "--io.sentry.other.disable-spotlight": true
-        "--io.sentry.other.disable-swizzling": false
-        "--io.sentry.other.reject-all-spans": false
-        "--io.sentry.other.reject-screenshots-in-before-capture-screenshot": false
-        "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy": false
+        # file io
+        "--io.sentry.file-io.disable-tracing": false
+        "--io.sentry.file-io.disable-file-manager-swizzling": false
+
+        # core data
+        "--io.sentry.core-data.disable-tracing": false
+
+        # app hangs
+        "--io.sentry.app-hangs.disable-tracking": false
+
+        # watchdog terminations
+        "--io.sentry.watchdog-terminations.disable-tracking": false
+        "--io.sentry.watchdog-terminations.disable-v2": false
+
+        # breadcrumbs
+        "--io.sentry.breadcrumbs.disable-automatic": false
+
+        # crash
+        "--io.sentry.crash.disable-handler": false
+        "--io.sentry.crash.disable-persisting-traces": false
+        "--io.sentry.crash.disable-unhandled-cpp-exceptions-v2": false
+        "--io.sentry.crash.disable-uncaught-ns-exception-reporting": false
+
+        # metric kit
+        "--io.sentry.metric-kit.disable": false
+        "--io.sentry.metric-kit.disable-raw-payloads": false
 
         # metrics
         "--io.sentry.metrics.enable": true
 
+        # logs
+        "--io.sentry.logs.disable": false
+
+        # spotlight
+        "--io.sentry.spotlight.disable": true
+        "--io.sentry.spotlight.enable": false
+
+        # swizzling
+        "--io.sentry.swizzling.disable": false
+
+        # transport
+        "--io.sentry.transport.disable-http": false
+
+        # attachments
+        "--io.sentry.attachments.base64-data": false
+
+        # spans
+        "--io.sentry.spans.reject-all": false
+
       environmentVariables:
+        # special
+        - variable: "--io.sentry.special.dsn"
+          value:
+          isEnabled: false
+
         # events
-        - variable: "--io.sentry.events.sampleRate"
-          value:
-          isEnabled: false
-
-        # session replay
-        - variable: "--io.sentry.session-replay.on-error-sample-rate"
-          value:
-          isEnabled: false
-        - variable: "--io.sentry.session-replay.session-sample-rate"
-          value:
-          isEnabled: false
-        - variable: "--io.sentry.session-replay.quality"
-          value:
-          isEnabled: false
-
-        # tracing
-        - variable: "--io.sentry.tracing.tracesSampleRate"
-          value:
-          isEnabled: false
-        - variable: "--io.sentry.tracing.tracesSamplerValue"
-          value:
-          isEnabled: false
-
-        # profiling
-        - variable: "--io.sentry.profiling.profilesSampleRate"
-          value:
-          isEnabled: false
-        - variable: "--io.sentry.profiling.profilesSamplerValue"
-          value:
-          isEnabled: false
-        - variable: "--io.sentry.profiling.profile-session-sample-rate"
+        - variable: "--io.sentry.events.sample-rate"
           value:
           isEnabled: false
 
         # performance
-        - variable: "--io.sentry.performance.sessionTrackingIntervalMillis"
+        - variable: "--io.sentry.performance.traces-sample-rate"
           value:
           isEnabled: false
-        - variable: "--io.sentry.performance.extend-app-launch-delay"
+        - variable: "--io.sentry.performance.traces-sampler-value"
+          value:
+          isEnabled: false
+
+        # app start
+        - variable: "--io.sentry.app-start.extend-launch-delay"
           value: 3
           isEnabled: false
 
-        # scope/user
+        # session
+        - variable: "--io.sentry.session.tracking-interval-millis"
+          value:
+          isEnabled: false
+
+        # replay
+        - variable: "--io.sentry.replay.on-error-sample-rate"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.replay.session-sample-rate"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.replay.quality"
+          value:
+          isEnabled: false
+
+        # profiling
+        - variable: "--io.sentry.profiling.profile-session-sample-rate"
+          value:
+          isEnabled: false
+
+        # scope
         - variable: "--io.sentry.scope.user.username"
           value:
           isEnabled: false
@@ -143,10 +181,5 @@ schemeTemplates:
           value:
           isEnabled: false
         - variable: "--io.sentry.scope.sdk-environment"
-          value:
-          isEnabled: false
-
-        # other
-        - variable: "--io.sentry.special.dsn"
           value:
           isEnabled: false

--- a/Samples/iOS-Swift/App/Sources/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/App/Sources/Profiling/ProfilingViewController.swift
@@ -63,7 +63,7 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
     }
 
     @IBAction func tracesSampleRateEdited(_ sender: UITextField) {
-        var sampleRate = SentrySDKOverrides.Tracing.sampleRate
+        var sampleRate = SentrySDKOverrides.Performance.sampleRate
         sampleRate.floatValue = getSampleRateOverride(field: sender)
     }
 
@@ -79,7 +79,7 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
     @IBAction func defineTracesSampleRateToggled(_ sender: UISwitch) {
         tracesSampleRateField.isEnabled = sender.isOn
 
-        var sampleRate = SentrySDKOverrides.Tracing.sampleRate
+        var sampleRate = SentrySDKOverrides.Performance.sampleRate
         sampleRate.floatValue = getSampleRateOverride(field: tracesSampleRateField)
     }
 

--- a/Samples/iOS-Swift/UITests/Sources/BaseUITest.swift
+++ b/Samples/iOS-Swift/UITests/Sources/BaseUITest.swift
@@ -34,7 +34,7 @@ extension BaseUITest {
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
-        app.launchArguments.append(SentrySDKOverrides.Other.disableSpotlight.rawValue)
+        app.launchArguments.append(SentrySDKOverrides.Spotlight.disable.rawValue)
         return app
     }
     

--- a/Samples/iOS-Swift/UITests/Sources/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/UITests/Sources/ProfilingUITests.swift
@@ -84,9 +84,9 @@ extension ProfilingUITests {
     fileprivate func setAppLaunchParameters(_ lifecycle: SentryProfileOptions.SentryProfileLifecycle?, _ shouldProfileNextLaunch: Bool) {
         app.launchArguments.append(contentsOf: [
             // these help avoid other profiles that'd be taken automatically, that interfere with the checking we do for the assertions later in the tests
-            SentrySDKOverrides.Other.disableSwizzling.rawValue,
-            SentrySDKOverrides.Performance.disablePerformanceTracing.rawValue,
-            SentrySDKOverrides.Performance.disableUIVCTracing.rawValue,
+            SentrySDKOverrides.Swizzling.disable.rawValue,
+            SentrySDKOverrides.Performance.disableAutoTracing.rawValue,
+            SentrySDKOverrides.UIViewControllerTracing.disable.rawValue,
             SentrySDKOverrides.Performance.disableTimeToFullDisplayTracing.rawValue,
 
             // sets a marker function to run in a load command that the launch profile should detect

--- a/Samples/iOS-Swift/UITests/Sources/UserFeedbackUITests.swift
+++ b/Samples/iOS-Swift/UITests/Sources/UserFeedbackUITests.swift
@@ -23,7 +23,7 @@ class UserFeedbackUITests: BaseUITest {
             SentrySDKOverrides.Special.disableEverything.rawValue,
             
             // write base64-encoded data into the envelope file for attachments instead of raw bytes, specifically for images. this way the entire envelope contents can be more easily passed as a string through the text field in the app to this process for validation.
-            SentrySDKOverrides.Other.base64AttachmentData.rawValue
+            SentrySDKOverrides.Attachments.base64Data.rawValue
         ])
         continueAfterFailure = true
     }
@@ -91,8 +91,8 @@ extension UserFeedbackUITests {
         launchApp(args: [
             SentrySDKOverrides.Feedback.allDefaults.rawValue
         ], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: "ui test user",
-            SentrySDKOverrides.Other.userEmail.rawValue: "ui-testing@sentry.io"
+            SentrySDKOverrides.Scope.userFullName.rawValue: "ui test user",
+            SentrySDKOverrides.Scope.userEmail.rawValue: "ui-testing@sentry.io"
         ])
         
         widgetButton.tap()
@@ -104,8 +104,8 @@ extension UserFeedbackUITests {
         launchApp(args: [
             SentrySDKOverrides.Feedback.noUserInjection.rawValue
         ], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: "ui test user",
-            SentrySDKOverrides.Other.userEmail.rawValue: "ui-testing@sentry.io"
+            SentrySDKOverrides.Scope.userFullName.rawValue: "ui test user",
+            SentrySDKOverrides.Scope.userEmail.rawValue: "ui-testing@sentry.io"
         ])
         
         widgetButton.tap()
@@ -159,8 +159,8 @@ extension UserFeedbackUITests {
         let testContactEmail = "andrew.mcknight@sentry.io"
         
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: testName,
-            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
+            SentrySDKOverrides.Scope.userFullName.rawValue: testName,
+            SentrySDKOverrides.Scope.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -247,8 +247,8 @@ extension UserFeedbackUITests {
         let testContactEmail = "andrew.mcknight@sentry.io"
         
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: testName,
-            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
+            SentrySDKOverrides.Scope.userFullName.rawValue: testName,
+            SentrySDKOverrides.Scope.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -276,8 +276,8 @@ extension UserFeedbackUITests {
         let testContactEmail = "andrew.mcknight@sentry.io"
         
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: testName,
-            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
+            SentrySDKOverrides.Scope.userFullName.rawValue: testName,
+            SentrySDKOverrides.Scope.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -313,8 +313,8 @@ extension UserFeedbackUITests {
         let testContactEmail = "andrew.mcknight@sentry.io"
         
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: testName,
-            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
+            SentrySDKOverrides.Scope.userFullName.rawValue: testName,
+            SentrySDKOverrides.Scope.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -473,8 +473,8 @@ extension UserFeedbackUITests {
         let testContactEmail = "andrew.mcknight@sentry.io"
         
         launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
-            SentrySDKOverrides.Other.userFullName.rawValue: testName,
-            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
+            SentrySDKOverrides.Scope.userFullName.rawValue: testName,
+            SentrySDKOverrides.Scope.userEmail.rawValue: testContactEmail
         ])
         
         try retrieveAppUnderTestApplicationSupportDirectory()

--- a/Samples/iOS-Swift/UITests/Sources/ViewLifecycleUITests.swift
+++ b/Samples/iOS-Swift/UITests/Sources/ViewLifecycleUITests.swift
@@ -11,7 +11,7 @@ class ViewLifecycleUITests: BaseUITest {
         super.setUp()
         launchApp(args: [
             SentrySDKOverrides.Performance.disableTimeToFullDisplayTracing.rawValue,
-            SentrySDKOverrides.Performance.disableANRTracking.rawValue
+            SentrySDKOverrides.AppHangs.disableTracking.rawValue
         ])
     }
 

--- a/Samples/iOS-SwiftUI/UITests/Sources/LaunchUITests.swift
+++ b/Samples/iOS-SwiftUI/UITests/Sources/LaunchUITests.swift
@@ -63,7 +63,7 @@ class LaunchUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
         app.launchArguments.append(contentsOf: [
-            SentrySDKOverrides.Other.disableSpotlight.rawValue,
+            SentrySDKOverrides.Spotlight.disable.rawValue,
             SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue
         ])
         return app

--- a/Samples/iOS-SwiftUI/UITests/Sources/UIApplicationSwizzleTests.swift
+++ b/Samples/iOS-SwiftUI/UITests/Sources/UIApplicationSwizzleTests.swift
@@ -7,7 +7,7 @@ final class UIApplicationSwizzleTests: XCTestCase {
   func testSendEvent() {
     let app = XCUIApplication()
     app.launchArguments.append(contentsOf: [
-        SentrySDKOverrides.Other.disableSpotlight.rawValue
+        SentrySDKOverrides.Spotlight.disable.rawValue
     ])
     app.safelyLaunch()
     

--- a/Samples/macOS-Swift/UITests/Sources/MacOSSwiftUITests.swift
+++ b/Samples/macOS-Swift/UITests/Sources/MacOSSwiftUITests.swift
@@ -58,9 +58,9 @@ private extension MacOSSwiftUITests {
     ) throws {
         app.launchArguments.append(contentsOf: [
             // these help avoid other profiles that'd be taken automatically, that interfere with the checking we do for the assertions later in the tests
-            SentrySDKOverrides.Other.disableSwizzling.rawValue,
-            SentrySDKOverrides.Performance.disablePerformanceTracing.rawValue,
-            SentrySDKOverrides.Performance.disableUIVCTracing.rawValue,
+            SentrySDKOverrides.Swizzling.disable.rawValue,
+            SentrySDKOverrides.Performance.disableAutoTracing.rawValue,
+            SentrySDKOverrides.UIViewControllerTracing.disable.rawValue,
 
             // sets a marker function to run in a load command that the launch profile should detect
             SentrySDKOverrides.Profiling.slowLoadMethod.rawValue,

--- a/Sources/Swift/Tools/SentryEnvelopeItem.swift
+++ b/Sources/Swift/Tools/SentryEnvelopeItem.swift
@@ -95,7 +95,7 @@
             }
             
             #if DEBUG || SENTRY_TEST || SENTRY_TEST_CI
-            if ProcessInfo.processInfo.arguments.contains("--io.sentry.other.base64-attachment-data") {
+            if ProcessInfo.processInfo.arguments.contains("--io.sentry.attachments.base64-data") {
                 data = attachmentData.base64EncodedString().data(using: .utf8)
             } else {
                 data = attachmentData
@@ -114,7 +114,7 @@
                 }
                 
                 #if DEBUG || SENTRY_TEST || SENTRY_TEST_CI
-                if ProcessInfo.processInfo.arguments.contains("--io.sentry.other.base64-attachment-data") {
+                if ProcessInfo.processInfo.arguments.contains("--io.sentry.attachments.base64-data") {
                     let fileData = fileManager.contents(atPath: attachmentPath)
                     data = fileData?.base64EncodedString().data(using: .utf8)
                 } else {


### PR DESCRIPTION
Group sample SDK override keys by integration so flags live next to the feature area that consumes them, such as replay keys under io.sentry.replay.*.

This also routes previously hard-coded sample options through SentrySDKOverrides and updates the shared feature flag definitions plus sample references to use the reorganized key names.

#skip-changelog