### PR TITLE
docs: design spec for SentrySDK.internal API

### DIFF
--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -78,6 +78,7 @@ Direct methods (no natural integration group):
 | `installationID: String`                     | `PrivateSentrySDKOnly.installationID`                          |
 | `options: Options`                           | `PrivateSentrySDKOnly.options`                                 |
 | `options(fromDictionary:) throws -> Options` | `PrivateSentrySDKOnly.optionsWithDictionary:didFailWithError:` |
+| `debugImages: [DebugMeta]`                   | `PrivateSentrySDKOnly.getDebugImages`                          |
 
 Sub-object accessors:
 
@@ -94,16 +95,20 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.replay` — `SentryInternalReplayApi`
 
-| Method                                               | Replaces                                         |
-| ---------------------------------------------------- | ------------------------------------------------ |
-| `configure(breadcrumbConverter:screenshotProvider:)` | `configureSessionReplayWith:screenshotProvider:` |
-| `capture()`                                          | `captureReplay`                                  |
-| `replayId: String?`                                  | `getReplayId`                                    |
-| `addIgnoreClasses(_:)`                               | `addReplayIgnoreClasses:`                        |
-| `addRedactClasses(_:)`                               | `addReplayRedactClasses:`                        |
-| `setIgnoreContainerClass(_:)`                        | `setIgnoreContainerClass:`                       |
-| `setRedactContainerClass(_:)`                        | `setRedactContainerClass:`                       |
-| `setTags(_:)`                                        | `setReplayTags:`                                 |
+| Method                                               | Replaces                                            |
+| ---------------------------------------------------- | --------------------------------------------------- |
+| `configure(breadcrumbConverter:screenshotProvider:)` | `configureSessionReplayWith:screenshotProvider:`    |
+| `capture() -> Bool`                                  | `captureReplay` + `getReplayIntegration` (see note) |
+| `replayId: String?`                                  | `getReplayId`                                       |
+| `addIgnoreClasses(_:)`                               | `addReplayIgnoreClasses:`                           |
+| `addRedactClasses(_:)`                               | `addReplayRedactClasses:`                           |
+| `setIgnoreContainerClass(_:)`                        | `setIgnoreContainerClass:`                          |
+| `setRedactContainerClass(_:)`                        | `setRedactContainerClass:`                          |
+| `setTags(_:)`                                        | `setReplayTags:`                                    |
+
+> **Note on `capture() -> Bool`:** React Native currently works around `captureReplay` being `void` by dynamically calling `getReplayIntegration` via `performSelector:` to access the integration's `captureReplay` which returns `BOOL`. The new API makes `capture()` return `Bool` directly, eliminating both the void limitation and the dynamic dispatch hack. `getReplayIntegration` is intentionally not exposed — callers should not need the integration object.
+
+> **Note on `debugImages`:** Flutter calls `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method is not declared in the current `PrivateSentrySDKOnly.h` header (it's available via `@_spi(Private)`) but is a real call site that needs a home. It lives directly on `.internal` rather than in a sub-object since it doesn't belong to any integration group.
 
 ### `SentrySDK.internal.profiling` — `SentryInternalProfilingApi`
 
@@ -388,7 +393,7 @@ import Sentry
 SentrySDK.internal.setSdkName("sentry.cocoa.react-native", version: "6.0.0")
 SentrySDK.internal.appStart.hybridSDKMode = true
 let frames = SentrySDK.internal.performance.currentScreenFrames
-SentrySDK.internal.replay.capture()
+let success = SentrySDK.internal.replay.capture()
 ```
 
 ### ObjC (hybrid SDK via SentryObjC wrapper)
@@ -400,13 +405,15 @@ SentrySDK.internal.replay.capture()
 PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = YES;
 SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
 [PrivateSentrySDKOnly captureReplay];
+// Workaround to get BOOL result:
+id integration = [PrivateSentrySDKOnly performSelector:@selector(getReplayIntegration)];
 
 // After
 #import <SentryObjC/SentryObjC.h>
 [[SentryObjCSDK internal] setSdkName:@"sentry.cocoa.react-native" version:@"6.0.0"];
 [SentryObjCSDK internal].appStart.hybridSDKMode = YES;
 SentryObjCScreenFrames *frames = [SentryObjCSDK internal].performance.currentScreenFrames;
-[[[SentryObjCSDK internal] replay] capture];
+BOOL success = [[[SentryObjCSDK internal] replay] capture];
 ```
 
 ## Public API Surface Impact

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -116,7 +116,7 @@ Sub-object accessors:
 | --------------- | -------------------------------- | ----------------------------------- |
 | `replay`        | `SentryInternalReplayApi`        | `SENTRY_TARGET_REPLAY_SUPPORTED`    |
 | `profiling`     | `SentryInternalProfilingApi`     | `SENTRY_TARGET_PROFILING_SUPPORTED` |
-| `appStart`      | `SentryInternalAppStartApi`      | `SENTRY_UIKIT_AVAILABLE`            |
+| `appStart`      | `SentryInternalAppStartApi`      | none                                |
 | `performance`   | `SentryInternalPerformanceApi`   | `SENTRY_UIKIT_AVAILABLE`            |
 | `screenshot`    | `SentryInternalScreenshotApi`    | `SENTRY_UIKIT_AVAILABLE`            |
 | `viewHierarchy` | `SentryInternalViewHierarchyApi` | `SENTRY_UIKIT_AVAILABLE`            |
@@ -284,6 +284,7 @@ public final class SentryInternalSwizzleApi {
     /// created by the factory block.
     ///
     /// The factory block receives a closure that returns the original `IMP`.
+    /// The caller must cast it to the correct function signature.
     /// Return a block whose signature matches the swizzled method
     /// (first two implicit parameters are `self` and `_cmd`).
     @discardableResult
@@ -303,7 +304,15 @@ public final class SentryInternalSwizzleApi {
             selector,
             in: cls,
             newImpFactory: { swizzleInfo in
-                factory { swizzleInfo!.getOriginalImplementation() }
+                factory {
+                    // SentrySwizzleOriginalIMP is void(*)(void), a type-erased
+                    // function pointer. Cast to IMP for the public API; the
+                    // caller casts again to the actual method signature.
+                    unsafeBitCast(
+                        swizzleInfo!.getOriginalImplementation(),
+                        to: IMP.self
+                    )
+                }
             },
             mode: swizzleMode,
             key: key
@@ -448,7 +457,7 @@ All methods on `PrivateSentrySDKOnly` receive deprecation annotations pointing t
 | `SentryInternalApi`              | `SentryObjCInternalApi.h`              | `SentryObjCInternalApi.swift`              | all        |
 | `SentryInternalReplayApi`        | `SentryObjCInternalReplayApi.h`        | `SentryObjCInternalReplayApi.swift`        | iOS, tvOS  |
 | `SentryInternalProfilingApi`     | `SentryObjCInternalProfilingApi.h`     | `SentryObjCInternalProfilingApi.swift`     | iOS, macOS |
-| `SentryInternalAppStartApi`      | `SentryObjCInternalAppStartApi.h`      | `SentryObjCInternalAppStartApi.swift`      | iOS, tvOS  |
+| `SentryInternalAppStartApi`      | `SentryObjCInternalAppStartApi.h`      | `SentryObjCInternalAppStartApi.swift`      | all        |
 | `SentryInternalPerformanceApi`   | `SentryObjCInternalPerformanceApi.h`   | `SentryObjCInternalPerformanceApi.swift`   | iOS, tvOS  |
 | `SentryInternalScreenshotApi`    | `SentryObjCInternalScreenshotApi.h`    | `SentryObjCInternalScreenshotApi.swift`    | iOS, tvOS  |
 | `SentryInternalViewHierarchyApi` | `SentryObjCInternalViewHierarchyApi.h` | `SentryObjCInternalViewHierarchyApi.swift` | iOS, tvOS  |

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -1,0 +1,429 @@
+# SentrySD c.internal — Structured Hybrid SDK API
+
+**Date:** 2026-06-08
+**Issue:** [#7881](https://github.com/getsentry/sentry-cocoa/issues/7881)
+**Contributors:** @philprime
+
+## Problem
+
+Hybrid SDKs (React Native, Flutter, .NET, Unity) consume `PrivateSentrySDKOnly`, a flat Objective-C class with 30+ static methods spanning unrelated subsystems. This causes three problems:
+
+1. **Build coupling.** Hybrid SDKs must add `${PODS_ROOT}/Sentry/Sources/Sentry/include` to their header search paths and `#import <Sentry/PrivateSentrySDKOnly.h>`. This blocks migration to SPM `binaryTarget` or pre-built `.xcframework` consumption, because those distribution channels don't expose private header search paths.
+
+2. **Flat namespace.** All methods live on one class with no grouping. `captureReplay`, `startProfilerForTrace:`, `currentScreenFrames`, `envelopeWithData:`, and `setSdkName:` all share the same scope, making the API hard to discover and reason about.
+
+3. **Naming is a workaround, not a contract.** The class name is intentionally ugly ("private...only") to discourage use, but there's no real access restriction. Any consumer can import it.
+
+## Design Goals
+
+1. **Structured, namespaced API.** Group methods by integration area with sub-objects: `SentrySDK.internal.replay`, `SentrySDK.internal.profiling`, etc.
+2. **Pure Swift.** The `SentrySDK.internal` API is Swift-only. No `@objc` annotations, no `NSObject` inheritance on the internal API types. Objective-C consumers use the ObjC wrapper SDK (`SentryObjCSDK.internal`).
+3. **Always available.** `SentrySDK.internal` is a static property that works before and after `SentrySDK.start()`. Sub-object methods that require a running SDK return nil or no-op, matching current `PrivateSentrySDKOnly` behavior.
+4. **Deprecate, don't remove.** `PrivateSentrySDKOnly` gets deprecation annotations but keeps its own implementation for at least one major version. It does not delegate to the new types (since they're pure Swift and it's ObjC).
+5. **Single PR.** All sub-objects and deprecations ship in one PR.
+
+## Non-Goals
+
+- Removing `PrivateSentrySDKOnly` (future major version).
+- Wrapping types already available in the public API (e.g., `SentrySDK.replay` for end users).
+- Changing the internal SDK architecture. The new types call the same internal code that `PrivateSentrySDKOnly` does today.
+
+## Architecture
+
+```
+Swift consumers:    SentrySDK.internal.replay.capture()
+                          |
+                    SentryInternalApi (pure Swift)
+                          |
+                    SentryInternalReplayApi, etc. (pure Swift)
+                          |
+                    SDK internals (SentryDependencyContainer, SentryHub, etc.)
+
+ObjC consumers:     [[SentryObjCSDK internal] replay].capture
+                          |
+                    SentryObjCInternalApi (@objc wrapper)
+                          |
+                    SentryObjCInternalReplayApi, etc. (@objc wrappers)
+                          |
+                    SDK internals (same path)
+
+Deprecated path:    [PrivateSentrySDKOnly captureReplay]
+                          |
+                    SDK internals (same path, independent impl)
+```
+
+All three paths converge on the same SDK internals. The new Swift types and the deprecated ObjC class are independent implementations that call the same underlying code.
+
+## API Grouping
+
+Methods are grouped by integration area, following the model established in PR [#8017](https://github.com/getsentry/sentry-cocoa/pull/8017).
+
+### `SentrySDK.internal` (root — `SentryInternalApi`)
+
+Direct methods (no natural integration group):
+
+| Method                                       | Replaces                                                       |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| `userWithDictionary(_:) -> User`             | `PrivateSentrySDKOnly.userWithDictionary:`                     |
+| `breadcrumbWithDictionary(_:) -> Breadcrumb` | `PrivateSentrySDKOnly.breadcrumbWithDictionary:`               |
+| `setTrace(_:spanId:)`                        | `PrivateSentrySDKOnly.setTrace:spanId:`                        |
+| `setLogOutput(_:)`                           | `PrivateSentrySDKOnly.setLogOutput:`                           |
+| `ignoreNextSignal(_:)`                       | `PrivateSentrySDKOnly.ignoreNextSignal:`                       |
+| `setSdkName(_:version:)`                     | `PrivateSentrySDKOnly.setSdkName:andVersionString:`            |
+| `setSdkName(_:)`                             | `PrivateSentrySDKOnly.setSdkName:`                             |
+| `sdkName: String`                            | `PrivateSentrySDKOnly.getSdkName`                              |
+| `sdkVersionString: String`                   | `PrivateSentrySDKOnly.getSdkVersionString`                     |
+| `addSdkPackage(name:version:)`               | `PrivateSentrySDKOnly.addSdkPackage:version:`                  |
+| `extraContext: [String: Any]`                | `PrivateSentrySDKOnly.getExtraContext`                         |
+| `installationID: String`                     | `PrivateSentrySDKOnly.installationID`                          |
+| `options: Options`                           | `PrivateSentrySDKOnly.options`                                 |
+| `options(fromDictionary:) throws -> Options` | `PrivateSentrySDKOnly.optionsWithDictionary:didFailWithError:` |
+
+Sub-object accessors:
+
+| Property        | Type                             | Platform guard                      |
+| --------------- | -------------------------------- | ----------------------------------- |
+| `replay`        | `SentryInternalReplayApi`        | `SENTRY_TARGET_REPLAY_SUPPORTED`    |
+| `profiling`     | `SentryInternalProfilingApi`     | `SENTRY_TARGET_PROFILING_SUPPORTED` |
+| `appStart`      | `SentryInternalAppStartApi`      | `SENTRY_UIKIT_AVAILABLE`            |
+| `performance`   | `SentryInternalPerformanceApi`   | `SENTRY_UIKIT_AVAILABLE`            |
+| `screenshot`    | `SentryInternalScreenshotApi`    | `SENTRY_UIKIT_AVAILABLE`            |
+| `viewHierarchy` | `SentryInternalViewHierarchyApi` | `SENTRY_UIKIT_AVAILABLE`            |
+| `envelope`      | `SentryInternalEnvelopeApi`      | none                                |
+| `screen`        | `SentryInternalScreenApi`        | `SENTRY_UIKIT_AVAILABLE`            |
+
+### `SentrySDK.internal.replay` — `SentryInternalReplayApi`
+
+| Method                                               | Replaces                                         |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| `configure(breadcrumbConverter:screenshotProvider:)` | `configureSessionReplayWith:screenshotProvider:` |
+| `capture()`                                          | `captureReplay`                                  |
+| `replayId: String?`                                  | `getReplayId`                                    |
+| `addIgnoreClasses(_:)`                               | `addReplayIgnoreClasses:`                        |
+| `addRedactClasses(_:)`                               | `addReplayRedactClasses:`                        |
+| `setIgnoreContainerClass(_:)`                        | `setIgnoreContainerClass:`                       |
+| `setRedactContainerClass(_:)`                        | `setRedactContainerClass:`                       |
+| `setTags(_:)`                                        | `setReplayTags:`                                 |
+
+### `SentrySDK.internal.profiling` — `SentryInternalProfilingApi`
+
+| Method                                        | Replaces                              |
+| --------------------------------------------- | ------------------------------------- |
+| `start(for traceId:) -> UInt64`               | `startProfilerForTrace:`              |
+| `collect(between:and:for:) -> [String: Any]?` | `collectProfileBetween:and:forTrace:` |
+| `discard(for traceId:)`                       | `discardProfilerForTrace:`            |
+
+### `SentrySDK.internal.appStart` — `SentryInternalAppStartApi`
+
+| Method                                                            | Replaces                           |
+| ----------------------------------------------------------------- | ---------------------------------- |
+| `hybridSDKMode: Bool`                                             | `appStartMeasurementHybridSDKMode` |
+| `measurement: SentryAppStartMeasurement?`                         | `appStartMeasurement`              |
+| `measurementWithSpans: [String: Any]?`                            | `appStartMeasurementWithSpans`     |
+| `onMeasurementAvailable: ((SentryAppStartMeasurement?) -> Void)?` | `onAppStartMeasurementAvailable`   |
+
+### `SentrySDK.internal.performance` — `SentryInternalPerformanceApi`
+
+| Method                                    | Replaces                                 |
+| ----------------------------------------- | ---------------------------------------- |
+| `framesTrackingHybridSDKMode: Bool`       | `framesTrackingMeasurementHybridSDKMode` |
+| `isFramesTrackingRunning: Bool`           | `isFramesTrackingRunning`                |
+| `currentScreenFrames: SentryScreenFrames` | `currentScreenFrames`                    |
+
+### `SentrySDK.internal.screenshot` — `SentryInternalScreenshotApi`
+
+| Method                 | Replaces             |
+| ---------------------- | -------------------- |
+| `capture() -> [Data]?` | `captureScreenshots` |
+
+### `SentrySDK.internal.viewHierarchy` — `SentryInternalViewHierarchyApi`
+
+| Method               | Replaces               |
+| -------------------- | ---------------------- |
+| `capture() -> Data?` | `captureViewHierarchy` |
+
+### `SentrySDK.internal.envelope` — `SentryInternalEnvelopeApi`
+
+| Method                                  | Replaces            |
+| --------------------------------------- | ------------------- |
+| `store(_:)`                             | `storeEnvelope:`    |
+| `capture(_:)`                           | `captureEnvelope:`  |
+| `deserialize(from:) -> SentryEnvelope?` | `envelopeWithData:` |
+
+### `SentrySDK.internal.screen` — `SentryInternalScreenApi`
+
+| Method           | Replaces            |
+| ---------------- | ------------------- |
+| `setCurrent(_:)` | `setCurrentScreen:` |
+
+## Swift Implementation Pattern
+
+Each sub-object is a plain Swift class (no `NSObject`, no `@objc`):
+
+```swift
+// Sources/Swift/HybridSDK/SentryInternalApi.swift
+
+/// APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
+///
+/// These methods are public for consumption by wrapper SDKs that bridge
+/// between native and managed runtimes. They may change, be renamed,
+/// or be removed in any minor release without prior deprecation.
+///
+/// App developers: prefer the standard `SentrySDK` API surface instead.
+public final class SentryInternalApi {
+    @_implementationOnly import _SentryPrivate
+
+    #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
+    public let replay = SentryInternalReplayApi()
+    #endif
+
+    public let envelope = SentryInternalEnvelopeApi()
+
+    // ... other sub-objects ...
+
+    public func setSdkName(_ name: String, version: String) {
+        SentryMeta.sdkName = name
+        SentryMeta.versionString = version
+    }
+
+    // ... direct methods ...
+}
+```
+
+```swift
+// Sources/Swift/HybridSDK/SentryInternalReplayApi.swift
+
+public final class SentryInternalReplayApi {
+    public func capture() {
+        // Same internal call as PrivateSentrySDKOnly.captureReplay
+        SentrySessionReplayIntegration.captureReplay()
+    }
+
+    public var replayId: String? {
+        SentrySessionReplayIntegration.getReplayId()
+    }
+
+    // ... other methods ...
+}
+```
+
+The `SentrySDK` extension:
+
+```swift
+// Sources/Swift/Helper/SentrySDK+Internal.swift
+
+extension SentrySDK {
+    /// APIs for hybrid SDKs (React Native, Flutter, .NET, Unity).
+    ///
+    /// These APIs may change in any minor release without deprecation.
+    /// App developers should use the standard `SentrySDK` API instead.
+    public static let `internal` = SentryInternalApi()
+}
+```
+
+## ObjC Wrapper Pattern
+
+Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
+
+**Header** (`Sources/SentryObjC/Public/SentryObjCInternalApi.h`):
+
+```objc
+#import <Foundation/Foundation.h>
+#import <SentryObjC/SentryObjCDefines.h>
+
+@class SentryObjCInternalReplayApi;
+@class SentryObjCInternalEnvelopeApi;
+// ... other forward declarations ...
+
+/// APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
+///
+/// These methods are public for consumption by wrapper SDKs that bridge
+/// between native and managed runtimes. They may change, be renamed,
+/// or be removed in any minor release without prior deprecation.
+///
+/// App developers: prefer the standard @c SentryObjCSDK API surface instead.
+@interface SentryObjCInternalApi : NSObject
+
+#if SENTRY_OBJC_REPLAY_SUPPORTED
+@property (nonatomic, readonly) SentryObjCInternalReplayApi *replay;
+#endif
+
+@property (nonatomic, readonly) SentryObjCInternalEnvelopeApi *envelope;
+
+// ... direct methods ...
+- (void)setSdkName:(NSString *)name version:(NSString *)version;
+- (NSString *)sdkName;
+- (NSString *)sdkVersionString;
+
+@end
+```
+
+**Wrapper** (`Sources/SentryObjCCompat/SentryObjCInternalApi.swift`):
+
+```swift
+@objc(SentryObjCInternalApi) public final class SentryObjCInternalApi: NSObject {
+    internal let wrapped = SentrySDK.`internal`
+
+    #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
+    @objc public var replay: SentryObjCInternalReplayApi {
+        SentryObjCInternalReplayApi(wrapped.replay)
+    }
+    #endif
+
+    @objc public var envelope: SentryObjCInternalEnvelopeApi {
+        SentryObjCInternalEnvelopeApi(wrapped.envelope)
+    }
+
+    @objc public func setSdkName(_ name: String, version: String) {
+        wrapped.setSdkName(name, version: version)
+    }
+
+    // ... other delegating methods ...
+}
+```
+
+**SentryObjCSDK extension** (`Sources/SentryObjCCompat/SentryObjCSDK+Internal.swift`):
+
+```swift
+extension SentryObjCSDK {
+    @objc public static let `internal` = SentryObjCInternalApi()
+}
+```
+
+Each sub-object follows the same header + wrapper pair pattern. See [SENTRY-OBJC.md](SENTRY-OBJC.md) for the full wrapper conventions.
+
+## Deprecation Strategy
+
+All methods on `PrivateSentrySDKOnly` receive deprecation annotations pointing to the new API:
+
+```objc
+// PrivateSentrySDKOnly.h
++ (void)captureReplay
+    __attribute__((deprecated("Use SentrySDK.internal.replay.capture() (Swift) "
+                              "or [[SentryObjCSDK internal].replay capture] (ObjC)")));
+```
+
+`PrivateSentrySDKOnly` retains its own implementation (does not delegate to the new Swift types). Both paths call the same SDK internals independently. Removal happens in the next major version.
+
+## Type Inventory
+
+| Swift type                       | ObjC header                            | ObjC wrapper                               | Platform   |
+| -------------------------------- | -------------------------------------- | ------------------------------------------ | ---------- |
+| `SentryInternalApi`              | `SentryObjCInternalApi.h`              | `SentryObjCInternalApi.swift`              | all        |
+| `SentryInternalReplayApi`        | `SentryObjCInternalReplayApi.h`        | `SentryObjCInternalReplayApi.swift`        | iOS, tvOS  |
+| `SentryInternalProfilingApi`     | `SentryObjCInternalProfilingApi.h`     | `SentryObjCInternalProfilingApi.swift`     | iOS, macOS |
+| `SentryInternalAppStartApi`      | `SentryObjCInternalAppStartApi.h`      | `SentryObjCInternalAppStartApi.swift`      | iOS, tvOS  |
+| `SentryInternalPerformanceApi`   | `SentryObjCInternalPerformanceApi.h`   | `SentryObjCInternalPerformanceApi.swift`   | iOS, tvOS  |
+| `SentryInternalScreenshotApi`    | `SentryObjCInternalScreenshotApi.h`    | `SentryObjCInternalScreenshotApi.swift`    | iOS, tvOS  |
+| `SentryInternalViewHierarchyApi` | `SentryObjCInternalViewHierarchyApi.h` | `SentryObjCInternalViewHierarchyApi.swift` | iOS, tvOS  |
+| `SentryInternalEnvelopeApi`      | `SentryObjCInternalEnvelopeApi.h`      | `SentryObjCInternalEnvelopeApi.swift`      | all        |
+| `SentryInternalScreenApi`        | `SentryObjCInternalScreenApi.h`        | `SentryObjCInternalScreenApi.swift`        | iOS, tvOS  |
+
+**Total:** 9 Swift types + 9 ObjC headers + 9 ObjC wrappers = 27 new files.
+
+## File Layout
+
+```
+Sources/
+├── Swift/
+│   └── HybridSDK/
+│       ├── SentryInternalApi.swift
+│       ├── SentryInternalReplayApi.swift
+│       ├── SentryInternalProfilingApi.swift
+│       ├── SentryInternalAppStartApi.swift
+│       ├── SentryInternalPerformanceApi.swift
+│       ├── SentryInternalScreenshotApi.swift
+│       ├── SentryInternalViewHierarchyApi.swift
+│       ├── SentryInternalEnvelopeApi.swift
+│       └── SentryInternalScreenApi.swift
+├── Swift/Helper/
+│   └── SentrySDK+Internal.swift              # extension adding .internal
+├── SentryObjC/Public/
+│   ├── SentryObjCInternalApi.h
+│   ├── SentryObjCInternalReplayApi.h
+│   ├── SentryObjCInternalProfilingApi.h
+│   ├── SentryObjCInternalAppStartApi.h
+│   ├── SentryObjCInternalPerformanceApi.h
+│   ├── SentryObjCInternalScreenshotApi.h
+│   ├── SentryObjCInternalViewHierarchyApi.h
+│   ├── SentryObjCInternalEnvelopeApi.h
+│   └── SentryObjCInternalScreenApi.h
+├── SentryObjCCompat/
+│   ├── SentryObjCInternalApi.swift
+│   ├── SentryObjCInternalReplayApi.swift
+│   ├── SentryObjCInternalProfilingApi.swift
+│   ├── SentryObjCInternalAppStartApi.swift
+│   ├── SentryObjCInternalPerformanceApi.swift
+│   ├── SentryObjCInternalScreenshotApi.swift
+│   ├── SentryObjCInternalViewHierarchyApi.swift
+│   ├── SentryObjCInternalEnvelopeApi.swift
+│   ├── SentryObjCInternalScreenApi.swift
+│   └── SentryObjCSDK+Internal.swift
+```
+
+## Documentation
+
+Every type and method carries a headerdoc/docstring with this preamble:
+
+> APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
+> These methods are public for consumption by wrapper SDKs that bridge between native and managed runtimes. They may change, be renamed, or be removed in any minor release without prior deprecation.
+> App developers: prefer the standard `SentrySDK` API surface instead.
+
+Individual methods carry per-method documentation explaining parameters and behavior, ported from the existing `PrivateSentrySDKOnly` headerdocs.
+
+## Call-Site Migration Examples
+
+### Swift (hybrid SDK)
+
+```swift
+// Before
+import Sentry
+PrivateSentrySDKOnly.setSdkName("sentry.cocoa.react-native", andVersionString: "6.0.0")
+PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
+let frames = PrivateSentrySDKOnly.currentScreenFrames
+PrivateSentrySDKOnly.captureReplay()
+
+// After
+import Sentry
+SentrySDK.internal.setSdkName("sentry.cocoa.react-native", version: "6.0.0")
+SentrySDK.internal.appStart.hybridSDKMode = true
+let frames = SentrySDK.internal.performance.currentScreenFrames
+SentrySDK.internal.replay.capture()
+```
+
+### ObjC (hybrid SDK via SentryObjC wrapper)
+
+```objc
+// Before
+#import <Sentry/PrivateSentrySDKOnly.h>
+[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.react-native" andVersionString:@"6.0.0"];
+PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = YES;
+SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
+[PrivateSentrySDKOnly captureReplay];
+
+// After
+#import <SentryObjC/SentryObjC.h>
+[[SentryObjCSDK internal] setSdkName:@"sentry.cocoa.react-native" version:@"6.0.0"];
+[SentryObjCSDK internal].appStart.hybridSDKMode = YES;
+SentryObjCScreenFrames *frames = [SentryObjCSDK internal].performance.currentScreenFrames;
+[[[SentryObjCSDK internal] replay] capture];
+```
+
+## Public API Surface Impact
+
+- `sdk_api.json` gains ~50 new public symbols (9 types + their methods/properties).
+- `sdk_api_objc.json` gains ~50 new symbols (9 ObjC types + methods).
+- `PrivateSentrySDKOnly` methods gain `deprecated` annotations (no removal, no ABI break).
+- `make generate-public-api` must be run and committed.
+
+## Testing
+
+- One ObjC integration test file per sub-object in `Tests/SentryObjCTests/` verifying the ObjC wrapper compiles and delegates correctly.
+- Swift unit tests in `Tests/SentryTests/HybridSDK/` for each `SentryInternal*Api` type, covering the same scenarios as existing `PrivateSentrySDKOnlyTests.swift`.
+- Verify `PrivateSentrySDKOnly` deprecation warnings compile cleanly (no errors, only warnings).
+
+## Open Questions
+
+1. **`SentryObjCSDK.internal` naming in ObjC.** `internal` is not a reserved word in ObjC, so no conflict. But should we verify no collision with Apple's runtime selectors?
+2. **Thread safety.** `PrivateSentrySDKOnly` methods are individually thread-safe via internal SDK locks. The new types delegate to the same internals, inheriting the same guarantees. Should we add `@Sendable` annotations to callback parameters?
+3. **`SentryInternalApi` as singleton vs. value.** Currently proposed as `static let` (singleton). If the SDK is closed and re-started, the sub-objects still point to the same instances. This matches current `PrivateSentrySDKOnly` behavior (static methods, no instance state) but worth confirming.

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -1,4 +1,4 @@
-# SentrySD c.internal — Structured Hybrid SDK API
+# SentrySDK.internal — Structured Hybrid SDK API
 
 **Date:** 2026-06-08
 **Issue:** [#7881](https://github.com/getsentry/sentry-cocoa/issues/7881)

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -108,6 +108,7 @@ Direct methods (no natural integration group):
 | `options: Options`                           | `PrivateSentrySDKOnly.options`                                 |
 | `options(fromDictionary:) throws -> Options` | `PrivateSentrySDKOnly.optionsWithDictionary:didFailWithError:` |
 | `debugImages: [DebugMeta]`                   | `PrivateSentrySDKOnly.getDebugImages`                          |
+| `debugImages(forAddresses:) -> [DebugMeta]`  | `SentryBinaryImageCache.imageByAddress:` (see note)            |
 
 Sub-object accessors:
 
@@ -139,6 +140,8 @@ Sub-object accessors:
 > **Note on `capture() -> Bool`:** React Native currently works around `captureReplay` being `void` by dynamically calling `getReplayIntegration` via `performSelector:` to access the integration's `captureReplay` which returns `BOOL`. The new API makes `capture()` return `Bool` directly, eliminating both the void limitation and the dynamic dispatch hack. `getReplayIntegration` is intentionally not exposed — callers should not need the integration object.
 
 > **Note on `debugImages`:** Flutter calls `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method is not declared in the current `PrivateSentrySDKOnly.h` header (it's available via `@_spi(Private)`) but is a real call site that needs a home. It lives directly on `.internal` rather than in a sub-object since it doesn't belong to any integration group.
+>
+> **Note on `debugImages(forAddresses:)`:** Godot currently bypasses the public API and accesses `SentryBinaryImageCache.imageByAddress(_:)` directly to look up debug images by raw `UInt64` addresses. The existing `SentryDebugImageProvider.getDebugImagesForImageAddressesFromCache(imageAddresses:)` only accepts hex `String` addresses, forcing C++/ObjC++ callers to do unnecessary string conversion. The new `debugImages(forAddresses:)` accepts `[UInt64]` directly, delegates to the binary image cache, and returns `[DebugMeta]` — eliminating the need to import internal types.
 
 ### `SentrySDK.internal.profiling` — `SentryInternalProfilingApi`
 

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -252,11 +252,14 @@ public final class SentryInternalApi {
 
 public final class SentryInternalReplayApi {
     public func capture() -> Bool {
-        SentrySessionReplayIntegration.captureReplay()
+        guard let integration = SentrySDK.currentHub().installedIntegration(
+            of: SentrySessionReplayIntegration.self
+        ) else { return false }
+        return integration.captureReplay()
     }
 
     public var replayId: String? {
-        SentrySessionReplayIntegration.getReplayId()
+        SentrySDK.currentHub().scope.replayId
     }
 
     // ... other methods ...

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -6,45 +6,44 @@
 
 ## Problem
 
-Hybrid SDKs (React Native, Flutter, .NET, Unity) consume `PrivateSentrySDKOnly`, a flat Objective-C class with 30+ static methods spanning unrelated subsystems. This causes three problems:
+Hybrid SDKs (React Native, Flutter, .NET, Unity) consumed `PrivateSentrySDKOnly`, a flat Objective-C class with 30+ static methods spanning unrelated subsystems. This caused three problems:
 
-1. **Build coupling.** Hybrid SDKs must add `${PODS_ROOT}/Sentry/Sources/Sentry/include` to their header search paths and `#import <Sentry/PrivateSentrySDKOnly.h>`. This blocks migration to SPM `binaryTarget` or pre-built `.xcframework` consumption, because those distribution channels don't expose private header search paths.
+1. **Build coupling.** Hybrid SDKs had to add `${PODS_ROOT}/Sentry/Sources/Sentry/include` to their header search paths and `#import <Sentry/PrivateSentrySDKOnly.h>`. This blocked migration to SPM `binaryTarget` or pre-built `.xcframework` consumption, because those distribution channels don't expose private header search paths.
 
-2. **Flat namespace.** All methods live on one class with no grouping. `captureReplay`, `startProfilerForTrace:`, `currentScreenFrames`, `envelopeWithData:`, and `setSdkName:` all share the same scope, making the API hard to discover and reason about.
+2. **Flat namespace.** All methods lived on one class with no grouping. `captureReplay`, `startProfilerForTrace:`, `currentScreenFrames`, `envelopeWithData:`, and `setSdkName:` all shared the same scope, making the API hard to discover and reason about.
 
-3. **Naming is a workaround, not a contract.** The class name is intentionally ugly ("private...only") to discourage use, but there's no real access restriction. Any consumer can import it.
+3. **Naming is a workaround, not a contract.** The class name was intentionally ugly ("private...only") to discourage use, but there was no real access restriction. Any consumer could import it.
 
 ## Design Goals
 
-1. **Structured, namespaced API.** Group methods by integration area with sub-objects: `SentrySDK.internal.replay`, `SentrySDK.internal.profiling`, etc.
-2. **Pure Swift with `@_spi(Private)`.** The `SentrySDK.internal` API is Swift-only. No `@objc` annotations, no `NSObject` inheritance on the internal API types. All types are marked `@_spi(Private)` to restrict visibility to consumers that explicitly opt in via `@_spi(Private) import Sentry`. Objective-C consumers use the ObjC wrapper SDK (`SentryObjCSDK.internal`).
-3. **Always available.** `SentrySDK.internal` is a lazy `var` property (protected by `NSRecursiveLock`) that works before and after `SentrySDK.start()`. It is reset on SDK close via `resetInternalApi()`. Sub-object methods that require a running SDK return nil or no-op, matching current `PrivateSentrySDKOnly` behavior.
-4. **Deprecate, don't remove.** `PrivateSentrySDKOnly` gets deprecation annotations but keeps its own implementation for at least one major version. It does not delegate to the new types (since they're pure Swift and it's ObjC).
-5. **Single PR.** All sub-objects and deprecations ship in one PR.
+1. **Structured, namespaced API.** Methods are grouped by integration area with sub-objects: `SentrySDK.internal.replay`, `SentrySDK.internal.profiling`, etc.
+2. **Pure Swift, public API.** The `SentrySDK.internal` API is Swift-only. No `@objc` annotations, no `NSObject` inheritance on the internal API types. All types are `public` — **not** gated behind `@_spi(Private)`. Hybrid SDK consumers and regular SDK users are treated as equal citizens; hybrid SDKs simply get additional functionality through `SentrySDK.internal`. Objective-C consumers use the ObjC wrapper SDK (`SentryObjCSDK.internal`).
+3. **Always available.** `SentrySDK.internal` is a lazy `var` property (protected by `NSRecursiveLock`) that works before and after `SentrySDK.start()`. It is reset on SDK close via `resetInternalApi()`. Sub-object methods that require a running SDK return nil or no-op, matching previous `PrivateSentrySDKOnly` behavior.
+4. **Deprecate, don't remove.** `PrivateSentrySDKOnly` received deprecation annotations but keeps its own implementation for at least one major version. It does not delegate to the new types (since they're pure Swift and it's ObjC).
 
 ## Non-Goals
 
-- Removing `PrivateSentrySDKOnly` (future major version).
+- Removing `PrivateSentrySDKOnly` (deferred to a future major version).
 - Wrapping types already available in the public API (e.g., `SentrySDK.replay` for end users).
-- Changing the internal SDK architecture. The new types call the same internal code that `PrivateSentrySDKOnly` does today.
+- Changing the internal SDK architecture. The new types call the same internal code that `PrivateSentrySDKOnly` did.
 
-## Eliminating Internal Header Imports
+## Eliminated Internal Header Imports
 
-Beyond replacing `PrivateSentrySDKOnly`, this API also eliminates the need for hybrid SDKs to import other internal headers:
+Beyond replacing `PrivateSentrySDKOnly`, this API also eliminated the need for hybrid SDKs to import other internal headers:
 
 ### `SentryOptionsInternal.h`
 
-Unity imports this solely for `+initWithDict:didFailWithError:`, which creates `SentryOptions` from a dictionary passed across the C#→ObjC bridge. This is already mapped to `.internal.options(fromDictionary:)` / `[[… internal] optionsFromDictionary:error:]`.
+Unity imported this solely for `+initWithDict:didFailWithError:`, which creates `SentryOptions` from a dictionary passed across the C#→ObjC bridge. This is now mapped to `.internal.options(fromDictionary:)` / `[[… internal] optionsFromDictionary:error:]`.
 
 ### `SentrySwizzle.h`
 
-React Native imports this for the `SentrySwizzleInstanceMethod` macro to swizzle `viewDidAppear:` on `RNSScreen` for frame tracking. The macro API is tightly coupled to the internal implementation (factory blocks, `SentrySwizzleInfo`, IMP casting).
+React Native imported this for the `SentrySwizzleInstanceMethod` macro to swizzle `viewDidAppear:` on `RNSScreen` for frame tracking. The macro API was tightly coupled to the internal implementation (factory blocks, `SentrySwizzleInfo`, IMP casting).
 
-With the new API, `SentrySDK.internal.swizzle.instanceMethod(_:in:mode:key:factory:)` / `[[[SentryObjCSDK internal] swizzle] swizzleInstanceMethod:inClass:newImpFactory:mode:key:]` wraps the same underlying `SentrySwizzle` mechanism behind a stable method call. Hybrid SDKs no longer need the header search path or macro definitions.
+The new API's `SentrySDK.internal.swizzle.instanceMethod(_:in:mode:key:factory:)` / `[[[SentryObjCSDK internal] swizzle] swizzleInstanceMethod:inClass:newImpFactory:mode:key:]` wraps the same underlying `SentrySwizzle` mechanism behind a stable method call. Hybrid SDKs no longer need the header search path or macro definitions.
 
 ### `Sentry-Swift.h`
 
-Unity imports this to access `SentryId` and `SentrySpanId` types, which are Swift classes only available to ObjC through the auto-generated bridging header. The Unity code even documents the workaround: _"This is a workaround to deal with SentryId living inside the Swift header."_ It uses `NSClassFromString()` to load these types dynamically.
+Unity imported this to access `SentryId` and `SentrySpanId` types, which are Swift classes only available to ObjC through the auto-generated bridging header. The Unity code even documented the workaround: _"This is a workaround to deal with SentryId living inside the Swift header."_ It used `NSClassFromString()` to load these types dynamically.
 
 With the new API, `SentryObjCInternalApi.setTrace:spanId:` accepts `SentryObjCId *` and `SentryObjCSpanId *` parameters — types that already exist in the `SentryObjC` public headers. Unity imports `<SentryObjC/SentryObjC.h>` instead, which provides both the internal API and the ID types.
 
@@ -62,9 +61,9 @@ No more `PrivateSentrySDKOnly.h`, `SentryOptionsInternal.h`, `Sentry-Swift.h`, o
 ```
 Swift consumers:    SentrySDK.internal.replay.capture()
                           |
-                    SentryInternalApi (@_spi(Private), pure Swift)
+                    SentryInternalApi (public, pure Swift)
                           |
-                    SentryInternalReplayApi, etc. (@_spi(Private), pure Swift)
+                    SentryInternalReplayApi, etc. (public, pure Swift)
                           |  (dependency injection via provider protocols)
                     SDK internals (SentryDependencyContainer, SentryHub, etc.)
 
@@ -85,13 +84,13 @@ All three paths converge on the same SDK internals. The new Swift types and the 
 
 ## API Grouping
 
-Methods are grouped by integration area, following the model established in PR [#8017](https://github.com/getsentry/sentry-cocoa/pull/8017).
+Methods are grouped by integration area, following the model established in PR [#8017](https://github.com/getsentry/sentry-cocoa/pull/8017). The "Replaced" column in the tables below shows which deprecated `PrivateSentrySDKOnly` method each new method supersedes.
 
 ### `SentrySDK.internal` (root — `SentryInternalApi`)
 
 Direct methods (no natural integration group):
 
-| Method                                       | Replaces                                                       |
+| Method                                       | Replaced                                                       |
 | -------------------------------------------- | -------------------------------------------------------------- |
 | `setTrace(_:spanId:)`                        | `PrivateSentrySDKOnly.setTrace:spanId:`                        |
 | `setLogOutput(_:)`                           | `PrivateSentrySDKOnly.setLogOutput:`                           |
@@ -119,7 +118,7 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.replay` — `SentryInternalReplayApi`
 
-| Method                                               | Replaces                                            |
+| Method                                               | Replaced                                            |
 | ---------------------------------------------------- | --------------------------------------------------- |
 | `configure(breadcrumbConverter:screenshotProvider:)` | `configureSessionReplayWith:screenshotProvider:`    |
 | `capture() -> Bool`                                  | `captureReplay` + `getReplayIntegration` (see note) |
@@ -130,11 +129,11 @@ Sub-object accessors:
 | `setRedactContainerClass(_:)`                        | `setRedactContainerClass:`                          |
 | `setTags(_:)`                                        | `setReplayTags:`                                    |
 
-> **Note on `capture() -> Bool`:** React Native currently works around `captureReplay` being `void` by dynamically calling `getReplayIntegration` via `performSelector:` to access the integration's `captureReplay` which returns `BOOL`. The new API makes `capture()` return `Bool` directly, eliminating both the void limitation and the dynamic dispatch hack. `getReplayIntegration` is intentionally not exposed — callers should not need the integration object.
+> **Note on `capture() -> Bool`:** React Native previously worked around `captureReplay` being `void` by dynamically calling `getReplayIntegration` via `performSelector:` to access the integration's `captureReplay` which returns `BOOL`. The new API returns `Bool` directly, eliminating both the void limitation and the dynamic dispatch hack. `getReplayIntegration` is intentionally not exposed — callers should not need the integration object.
 
 ### `SentrySDK.internal.profiling` — `SentryInternalProfilingApi`
 
-| Method                                        | Replaces                              |
+| Method                                        | Replaced                              |
 | --------------------------------------------- | ------------------------------------- |
 | `start(for traceId:) -> UInt64`               | `startProfilerForTrace:`              |
 | `collect(between:and:for:) -> [String: Any]?` | `collectProfileBetween:and:forTrace:` |
@@ -142,7 +141,7 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.appStart` — `SentryInternalAppStartApi`
 
-| Method                                                            | Replaces                           | Platform guard           |
+| Method                                                            | Replaced                           | Platform guard           |
 | ----------------------------------------------------------------- | ---------------------------------- | ------------------------ |
 | `hybridSDKMode: Bool`                                             | `appStartMeasurementHybridSDKMode` | none                     |
 | `measurementWithSpans: [String: Any]?`                            | `appStartMeasurementWithSpans`     | none                     |
@@ -151,7 +150,7 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.performance` — `SentryInternalPerformanceApi`
 
-| Method                                    | Replaces                                 |
+| Method                                    | Replaced                                 |
 | ----------------------------------------- | ---------------------------------------- |
 | `framesTrackingHybridSDKMode: Bool`       | `framesTrackingMeasurementHybridSDKMode` |
 | `isFramesTrackingRunning: Bool`           | `isFramesTrackingRunning`                |
@@ -159,19 +158,19 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.screenshot` — `SentryInternalScreenshotApi`
 
-| Method                 | Replaces             |
+| Method                 | Replaced             |
 | ---------------------- | -------------------- |
 | `capture() -> [Data]?` | `captureScreenshots` |
 
 ### `SentrySDK.internal.viewHierarchy` — `SentryInternalViewHierarchyApi`
 
-| Method               | Replaces               |
+| Method               | Replaced               |
 | -------------------- | ---------------------- |
 | `capture() -> Data?` | `captureViewHierarchy` |
 
 ### `SentrySDK.internal.envelope` — `SentryInternalEnvelopeApi`
 
-| Method                                  | Replaces            |
+| Method                                  | Replaced            |
 | --------------------------------------- | ------------------- |
 | `store(_:)`                             | `storeEnvelope:`    |
 | `capture(_:)`                           | `captureEnvelope:`  |
@@ -179,15 +178,15 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.screen` — `SentryInternalScreenApi`
 
-| Method           | Replaces            |
+| Method           | Replaced            |
 | ---------------- | ------------------- |
 | `setCurrent(_:)` | `setCurrentScreen:` |
 
 ### `SentrySDK.internal.swizzle` — `SentryInternalSwizzleApi`
 
-Replaces direct import of `SentrySwizzle.h` and its macro-based API (`SentrySwizzleInstanceMethod`, `SentrySWReturnType`, etc.).
+Replaced the direct import of `SentrySwizzle.h` and its macro-based API (`SentrySwizzleInstanceMethod`, `SentrySWReturnType`, etc.).
 
-| Method                                           | Replaces                            |
+| Method                                           | Replaced                            |
 | ------------------------------------------------ | ----------------------------------- |
 | `instanceMethod(_:in:mode:key:factory:) -> Bool` | `SentrySwizzleInstanceMethod` macro |
 
@@ -201,11 +200,11 @@ The factory block receives a closure that returns the original `IMP`. The caller
 | `.oncePerClass`                | Swizzle only once per class (recommended default)                  |
 | `.oncePerClassAndSuperclasses` | Swizzle only if neither this class nor any superclass was swizzled |
 
-> **Why not expose a simplified "before/after hook" API?** The factory-based API preserves full flexibility (custom argument handling, conditional forwarding, return value modification) at the cost of the caller doing IMP casting. A convenience wrapper could be added later if multiple hybrid SDKs converge on a simpler pattern.
+> **Why not a simplified "before/after hook" API?** The factory-based API preserves full flexibility (custom argument handling, conditional forwarding, return value modification) at the cost of the caller doing IMP casting. A convenience wrapper can be added later if multiple hybrid SDKs converge on a simpler pattern.
 
 ### `SentrySDK.internal.sdk` — `SentryInternalSdkApi`
 
-| Method                        | Replaces                                            |
+| Method                        | Replaced                                            |
 | ----------------------------- | --------------------------------------------------- |
 | `name: String`                | `PrivateSentrySDKOnly.getSdkName` / `.setSdkName:`  |
 | `versionString: String`       | `PrivateSentrySDKOnly.getSdkVersionString`          |
@@ -218,24 +217,24 @@ The factory block receives a closure that returns the original `IMP`. The caller
 
 ### `SentrySDK.internal.debug` — `SentryInternalDebugApi`
 
-| Method                                 | Replaces                                            |
+| Method                                 | Replaced                                            |
 | -------------------------------------- | --------------------------------------------------- |
 | `images: [DebugMeta]`                  | `PrivateSentrySDKOnly.getDebugImages`               |
 | `images(forAddresses:) -> [DebugMeta]` | `SentryBinaryImageCache.imageByAddress:` (see note) |
 
-> **Note on `images`:** Flutter calls `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method is not declared in the current `PrivateSentrySDKOnly.h` header (it's available via `@_spi(Private)`) but is a real call site that needs a home.
+> **Note on `images`:** Flutter previously called `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method was not declared in the `PrivateSentrySDKOnly.h` header (it was available as a Swift-only API) and needed a proper home.
 >
-> **Note on `images(forAddresses:)`:** Godot currently bypasses the public API and accesses `SentryBinaryImageCache.imageByAddress(_:)` directly to look up debug images by raw `UInt64` addresses. The existing `SentryDebugImageProvider.getDebugImagesForImageAddressesFromCache(imageAddresses:)` only accepts hex `String` addresses, forcing C++/ObjC++ callers to do unnecessary string conversion. The new `images(forAddresses:)` accepts `[UInt64]` directly, delegates to the binary image cache, and returns `[DebugMeta]` — eliminating the need to import internal types.
+> **Note on `images(forAddresses:)`:** Godot previously bypassed the public API and accessed `SentryBinaryImageCache.imageByAddress(_:)` directly to look up debug images by raw `UInt64` addresses. The existing `SentryDebugImageProvider.getDebugImagesForImageAddressesFromCache(imageAddresses:)` only accepted hex `String` addresses, forcing C++/ObjC++ callers to do unnecessary string conversion. `images(forAddresses:)` accepts `[UInt64]` directly, delegates to the binary image cache, and returns `[DebugMeta]` — eliminating the need to import internal types.
 
 ### `SentrySDK.internal.breadcrumbs` — `SentryInternalBreadcrumbApi`
 
-| Method                             | Replaces                                         |
+| Method                             | Replaced                                         |
 | ---------------------------------- | ------------------------------------------------ |
 | `fromDictionary(_:) -> Breadcrumb` | `PrivateSentrySDKOnly.breadcrumbWithDictionary:` |
 
 ### `SentrySDK.internal.user` — `SentryInternalUserApi`
 
-| Method                       | Replaces                                   |
+| Method                       | Replaced                                   |
 | ---------------------------- | ------------------------------------------ |
 | `fromDictionary(_:) -> User` | `PrivateSentrySDKOnly.userWithDictionary:` |
 
@@ -243,7 +242,7 @@ The factory block receives a closure that returns the original `IMP`. The caller
 
 **Swift types** (`Sources/Swift/HybridSDK/`):
 
-- All types are `@_spi(Private) public final class` — no `NSObject`, no `@objc`.
+- All types are `public final class` — no `NSObject`, no `@objc`, no `@_spi`.
 - Dependencies are injected via provider protocols (e.g., `HubProvider`, `DebugImageProvider`) backed by `SentryDependencyContainer`, making sub-objects testable in isolation.
 - `SentrySDK.internal` is a lazy `var` on `SentrySDK` protected by `NSRecursiveLock`, reset on SDK close via `resetInternalApi()`.
 
@@ -257,7 +256,7 @@ The factory block receives a closure that returns the original `IMP`. The caller
 
 ## Deprecation Strategy
 
-Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper) receive deprecation annotations — class-level and per-method — pointing to the new API path. Both retain their own implementations (they do not delegate to the new Swift types). All three paths call the same SDK internals independently. Removal happens in the next major version.
+Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper) received deprecation annotations — class-level and per-method — pointing to the new API path. Both retain their own implementations (they do not delegate to the new Swift types). All three paths call the same SDK internals independently. Removal is planned for the next major version.
 
 ## Type Inventory
 
@@ -278,7 +277,7 @@ Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper
 | `SentryInternalBreadcrumbApi`    | `SentryObjCInternalBreadcrumbApi.h`    | `SentryObjCInternalBreadcrumbApi.swift`    | all        |
 | `SentryInternalUserApi`          | `SentryObjCInternalUserApi.h`          | `SentryObjCInternalUserApi.swift`          | all        |
 
-**Total:** 14 Swift types + 14 ObjC headers + 14 ObjC wrappers = 42 new files.
+**Total:** 14 Swift types + 14 ObjC headers + 14 ObjC wrappers = 42 files.
 
 Swift types live in `Sources/Swift/HybridSDK/`, the entry point extension in `Sources/Swift/Helper/SentrySDK+Internal.swift`, ObjC headers in `Sources/SentryObjC/Public/`, and ObjC wrappers in `Sources/SentryObjCCompat/`.
 
@@ -329,20 +328,8 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 [[SentryObjCSDK internal] setTrace:traceId spanId:spanId];
 ```
 
-## Public API Surface Impact
-
-- `sdk_api.json` gains ~75 new public symbols (14 types + their methods/properties).
-- `sdk_api_objc.json` gains ~75 new symbols (14 ObjC types + methods + `SentryObjCSwizzleMode` enum).
-- `PrivateSentrySDKOnly` / `SentryObjCPrivateSDKOnly` gain `deprecated` annotations (no removal, no ABI break).
-- `make generate-public-api` must be run and committed.
-
 ## Testing
 
-- One ObjC integration test file per sub-object in `Tests/SentryObjCTests/` verifying the ObjC wrapper compiles and delegates correctly.
-- Swift unit tests in `Tests/SentryTests/HybridSDK/` for each `SentryInternal*Api` type, covering the same scenarios as existing `PrivateSentrySDKOnlyTests.swift`.
-- Verify `PrivateSentrySDKOnly` deprecation warnings compile cleanly (no errors, only warnings).
-
-## Open Questions
-
-1. **`SentryObjCSDK.internal` naming in ObjC.** `internal` is not a reserved word in ObjC, so no conflict. But should we verify no collision with Apple's runtime selectors?
-2. **Thread safety.** `PrivateSentrySDKOnly` methods are individually thread-safe via internal SDK locks. The new types delegate to the same internals, inheriting the same guarantees. Should we add `@Sendable` annotations to callback parameters?
+- One ObjC integration test file per sub-object in `Tests/SentryObjCTests/` verifies the ObjC wrapper compiles and delegates correctly.
+- Swift unit tests in `Tests/SentryTests/HybridSDK/` for each `SentryInternal*Api` type, covering the same scenarios as the existing `PrivateSentrySDKOnlyTests.swift`.
+- `PrivateSentrySDKOnly` deprecation warnings compile cleanly (no errors, only warnings).

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -36,6 +36,12 @@ Beyond replacing `PrivateSentrySDKOnly`, this API also eliminates the need for h
 
 Unity imports this solely for `+initWithDict:didFailWithError:`, which creates `SentryOptions` from a dictionary passed across the C#→ObjC bridge. This is already mapped to `.internal.options(fromDictionary:)` / `[[… internal] optionsFromDictionary:error:]`.
 
+### `SentrySwizzle.h`
+
+React Native imports this for the `SentrySwizzleInstanceMethod` macro to swizzle `viewDidAppear:` on `RNSScreen` for frame tracking. The macro API is tightly coupled to the internal implementation (factory blocks, `SentrySwizzleInfo`, IMP casting).
+
+With the new API, `SentrySDK.internal.swizzle.instanceMethod(_:in:mode:key:factory:)` / `[[[SentryObjCSDK internal] swizzle] swizzleInstanceMethod:inClass:newImpFactory:mode:key:]` wraps the same underlying `SentrySwizzle` mechanism behind a stable method call. Hybrid SDKs no longer need the header search path or macro definitions.
+
 ### `Sentry-Swift.h`
 
 Unity imports this to access `SentryId` and `SentrySpanId` types, which are Swift classes only available to ObjC through the auto-generated bridging header. The Unity code even documents the workaround: _"This is a workaround to deal with SentryId living inside the Swift header."_ It uses `NSClassFromString()` to load these types dynamically.
@@ -49,7 +55,7 @@ After migration, hybrid SDKs need only one import:
 - **Swift:** `import Sentry`
 - **ObjC:** `#import <SentryObjC/SentryObjC.h>`
 
-No more `PrivateSentrySDKOnly.h`, `SentryOptionsInternal.h`, or `Sentry-Swift.h`.
+No more `PrivateSentrySDKOnly.h`, `SentryOptionsInternal.h`, `Sentry-Swift.h`, or `SentrySwizzle.h`.
 
 ## Architecture
 
@@ -115,6 +121,7 @@ Sub-object accessors:
 | `viewHierarchy` | `SentryInternalViewHierarchyApi` | `SENTRY_UIKIT_AVAILABLE`            |
 | `envelope`      | `SentryInternalEnvelopeApi`      | none                                |
 | `screen`        | `SentryInternalScreenApi`        | `SENTRY_UIKIT_AVAILABLE`            |
+| `swizzle`       | `SentryInternalSwizzleApi`       | none                                |
 
 ### `SentrySDK.internal.replay` — `SentryInternalReplayApi`
 
@@ -184,6 +191,26 @@ Sub-object accessors:
 | ---------------- | ------------------- |
 | `setCurrent(_:)` | `setCurrentScreen:` |
 
+### `SentrySDK.internal.swizzle` — `SentryInternalSwizzleApi`
+
+Replaces direct import of `SentrySwizzle.h` and its macro-based API (`SentrySwizzleInstanceMethod`, `SentrySWReturnType`, etc.).
+
+| Method                                           | Replaces                            |
+| ------------------------------------------------ | ----------------------------------- |
+| `instanceMethod(_:in:mode:key:factory:) -> Bool` | `SentrySwizzleInstanceMethod` macro |
+
+The factory block receives a closure that returns the original `IMP`. The caller returns a new block (cast to `id`) that becomes the replacement implementation. This matches the underlying `SentrySwizzle` factory pattern but without requiring the header or macro definitions.
+
+**Mode enum** (`SentryInternalSwizzleApi.Mode`):
+
+| Case                           | Behavior                                                           |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `.always`                      | Swizzle every time, even if already swizzled                       |
+| `.oncePerClass`                | Swizzle only once per class (recommended default)                  |
+| `.oncePerClassAndSuperclasses` | Swizzle only if neither this class nor any superclass was swizzled |
+
+> **Why not expose a simplified "before/after hook" API?** The factory-based API preserves full flexibility (custom argument handling, conditional forwarding, return value modification) at the cost of the caller doing IMP casting. A convenience wrapper could be added later if multiple hybrid SDKs converge on a simpler pattern.
+
 ## Swift Implementation Pattern
 
 Each sub-object is a plain Swift class (no `NSObject`, no `@objc`):
@@ -207,6 +234,7 @@ public final class SentryInternalApi {
     #endif
 
     public let envelope = SentryInternalEnvelopeApi()
+    public let swizzle = SentryInternalSwizzleApi()
 
     // ... other sub-objects ...
 
@@ -232,6 +260,49 @@ public final class SentryInternalReplayApi {
     }
 
     // ... other methods ...
+}
+```
+
+```swift
+// Sources/Swift/HybridSDK/SentryInternalSwizzleApi.swift
+
+public final class SentryInternalSwizzleApi {
+
+    public enum Mode {
+        case always
+        case oncePerClass
+        case oncePerClassAndSuperclasses
+    }
+
+    /// Swizzles an instance method, replacing it with a new implementation
+    /// created by the factory block.
+    ///
+    /// The factory block receives a closure that returns the original `IMP`.
+    /// Return a block whose signature matches the swizzled method
+    /// (first two implicit parameters are `self` and `_cmd`).
+    @discardableResult
+    public func instanceMethod(
+        _ selector: Selector,
+        in cls: AnyClass,
+        mode: Mode = .oncePerClass,
+        key: UnsafeRawPointer,
+        factory: @escaping (_ getOriginalImplementation: @escaping () -> IMP) -> Any
+    ) -> Bool {
+        let swizzleMode: SentrySwizzleMode = switch mode {
+        case .always: .always
+        case .oncePerClass: .oncePerClass
+        case .oncePerClassAndSuperclasses: .oncePerClassAndSuperclasses
+        }
+        return SentrySwizzle.swizzleInstanceMethod(
+            selector,
+            in: cls,
+            newImpFactory: { swizzleInfo in
+                factory { swizzleInfo!.getOriginalImplementation() }
+            },
+            mode: swizzleMode,
+            key: key
+        )
+    }
 }
 ```
 
@@ -263,6 +334,7 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
 @class SentryObjCSpanId;
 @class SentryObjCInternalReplayApi;
 @class SentryObjCInternalEnvelopeApi;
+@class SentryObjCInternalSwizzleApi;
 // ... other forward declarations ...
 
 /// APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
@@ -279,6 +351,7 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
 #endif
 
 @property (nonatomic, readonly) SentryObjCInternalEnvelopeApi *envelope;
+@property (nonatomic, readonly) SentryObjCInternalSwizzleApi *swizzle;
 
 // ... direct methods ...
 - (void)setSdkName:(NSString *)name version:(NSString *)version;
@@ -321,6 +394,32 @@ extension SentryObjCSDK {
 }
 ```
 
+**Swizzle header** (`Sources/SentryObjC/Public/SentryObjCInternalSwizzleApi.h`):
+
+```objc
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, SentryObjCSwizzleMode) {
+    SentryObjCSwizzleModeAlways = 0,
+    SentryObjCSwizzleModeOncePerClass = 1,
+    SentryObjCSwizzleModeOncePerClassAndSuperclasses = 2
+};
+
+/// Stable swizzling API for hybrid SDKs.
+/// Replaces direct import of SentrySwizzle.h and its macro-based API.
+@interface SentryObjCInternalSwizzleApi : NSObject
+
+/// Swizzle an instance method. The factory block receives a block that
+/// returns the original IMP; return a new block matching the method signature.
+- (BOOL)swizzleInstanceMethod:(SEL _Nonnull)selector
+                      inClass:(Class _Nonnull)cls
+                newImpFactory:(id _Nonnull (^_Nonnull)(IMP _Nonnull (^_Nonnull)(void)))factoryBlock
+                         mode:(SentryObjCSwizzleMode)mode
+                          key:(const void *_Nonnull)key;
+
+@end
+```
+
 Each sub-object follows the same header + wrapper pair pattern. See [SENTRY-OBJC.md](SENTRY-OBJC.md) for the full wrapper conventions.
 
 ## Deprecation Strategy
@@ -349,8 +448,9 @@ All methods on `PrivateSentrySDKOnly` receive deprecation annotations pointing t
 | `SentryInternalViewHierarchyApi` | `SentryObjCInternalViewHierarchyApi.h` | `SentryObjCInternalViewHierarchyApi.swift` | iOS, tvOS  |
 | `SentryInternalEnvelopeApi`      | `SentryObjCInternalEnvelopeApi.h`      | `SentryObjCInternalEnvelopeApi.swift`      | all        |
 | `SentryInternalScreenApi`        | `SentryObjCInternalScreenApi.h`        | `SentryObjCInternalScreenApi.swift`        | iOS, tvOS  |
+| `SentryInternalSwizzleApi`       | `SentryObjCInternalSwizzleApi.h`       | `SentryObjCInternalSwizzleApi.swift`       | all        |
 
-**Total:** 9 Swift types + 9 ObjC headers + 9 ObjC wrappers = 27 new files.
+**Total:** 10 Swift types + 10 ObjC headers + 10 ObjC wrappers = 30 new files.
 
 ## File Layout
 
@@ -366,7 +466,8 @@ Sources/
 │       ├── SentryInternalScreenshotApi.swift
 │       ├── SentryInternalViewHierarchyApi.swift
 │       ├── SentryInternalEnvelopeApi.swift
-│       └── SentryInternalScreenApi.swift
+│       ├── SentryInternalScreenApi.swift
+│       └── SentryInternalSwizzleApi.swift
 ├── Swift/Helper/
 │   └── SentrySDK+Internal.swift              # extension adding .internal
 ├── SentryObjC/Public/
@@ -378,7 +479,8 @@ Sources/
 │   ├── SentryObjCInternalScreenshotApi.h
 │   ├── SentryObjCInternalViewHierarchyApi.h
 │   ├── SentryObjCInternalEnvelopeApi.h
-│   └── SentryObjCInternalScreenApi.h
+│   ├── SentryObjCInternalScreenApi.h
+│   └── SentryObjCInternalSwizzleApi.h
 ├── SentryObjCCompat/
 │   ├── SentryObjCInternalApi.swift
 │   ├── SentryObjCInternalReplayApi.swift
@@ -389,6 +491,7 @@ Sources/
 │   ├── SentryObjCInternalViewHierarchyApi.swift
 │   ├── SentryObjCInternalEnvelopeApi.swift
 │   ├── SentryObjCInternalScreenApi.swift
+│   ├── SentryObjCInternalSwizzleApi.swift
 │   └── SentryObjCSDK+Internal.swift
 ```
 
@@ -449,10 +552,57 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 [[SentryObjCSDK internal] setTrace:traceId spanId:spanId];
 ```
 
+### ObjC — Swizzle migration (React Native)
+
+```objc
+// Before — requires internal header search path
+#if __has_include(<Sentry/SentrySwizzle.h>)
+#    import <Sentry/SentrySwizzle.h>
+#else
+#    import "SentrySwizzle.h"
+#endif
+
++ (void)swizzleViewDidAppear
+{
+    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
+    if (rnsscreenclass == nil) { return; }
+
+    SEL selector = NSSelectorFromString(@"viewDidAppear:");
+    SentrySwizzleInstanceMethod(rnsscreenclass, selector, SentrySWReturnType(void),
+        SentrySWArguments(BOOL animated), SentrySWReplacement({
+            [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
+            SentrySWCallOriginal(animated);
+        }),
+        SentrySwizzleModeOncePerClass, (void *)selector);
+}
+
+// After — single import, no internal headers, no macros
+#import <SentryObjC/SentryObjC.h>
+
++ (void)swizzleViewDidAppear
+{
+    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
+    if (rnsscreenclass == nil) { return; }
+
+    SEL selector = NSSelectorFromString(@"viewDidAppear:");
+    [[[SentryObjCSDK internal] swizzle]
+        swizzleInstanceMethod:selector
+        inClass:rnsscreenclass
+        newImpFactory:^id(IMP (^getOriginal)(void)) {
+            return ^void(__unsafe_unretained id self, BOOL animated) {
+                [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
+                ((void (*)(id, SEL, BOOL))getOriginal())(self, selector, animated);
+            };
+        }
+        mode:SentryObjCSwizzleModeOncePerClass
+        key:(void *)selector];
+}
+```
+
 ## Public API Surface Impact
 
-- `sdk_api.json` gains ~50 new public symbols (9 types + their methods/properties).
-- `sdk_api_objc.json` gains ~50 new symbols (9 ObjC types + methods).
+- `sdk_api.json` gains ~55 new public symbols (10 types + their methods/properties).
+- `sdk_api_objc.json` gains ~55 new symbols (10 ObjC types + methods + `SentryObjCSwizzleMode` enum).
 - `PrivateSentrySDKOnly` methods gain `deprecated` annotations (no removal, no ABI break).
 - `make generate-public-api` must be run and committed.
 

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -17,8 +17,8 @@ Hybrid SDKs (React Native, Flutter, .NET, Unity) consume `PrivateSentrySDKOnly`,
 ## Design Goals
 
 1. **Structured, namespaced API.** Group methods by integration area with sub-objects: `SentrySDK.internal.replay`, `SentrySDK.internal.profiling`, etc.
-2. **Pure Swift.** The `SentrySDK.internal` API is Swift-only. No `@objc` annotations, no `NSObject` inheritance on the internal API types. Objective-C consumers use the ObjC wrapper SDK (`SentryObjCSDK.internal`).
-3. **Always available.** `SentrySDK.internal` is a static property that works before and after `SentrySDK.start()`. Sub-object methods that require a running SDK return nil or no-op, matching current `PrivateSentrySDKOnly` behavior.
+2. **Pure Swift with `@_spi(Private)`.** The `SentrySDK.internal` API is Swift-only. No `@objc` annotations, no `NSObject` inheritance on the internal API types. All types are marked `@_spi(Private)` to restrict visibility to consumers that explicitly opt in via `@_spi(Private) import Sentry`. Objective-C consumers use the ObjC wrapper SDK (`SentryObjCSDK.internal`).
+3. **Always available.** `SentrySDK.internal` is a lazy `var` property (protected by `NSRecursiveLock`) that works before and after `SentrySDK.start()`. It is reset on SDK close via `resetInternalApi()`. Sub-object methods that require a running SDK return nil or no-op, matching current `PrivateSentrySDKOnly` behavior.
 4. **Deprecate, don't remove.** `PrivateSentrySDKOnly` gets deprecation annotations but keeps its own implementation for at least one major version. It does not delegate to the new types (since they're pure Swift and it's ObjC).
 5. **Single PR.** All sub-objects and deprecations ship in one PR.
 
@@ -62,10 +62,10 @@ No more `PrivateSentrySDKOnly.h`, `SentryOptionsInternal.h`, `Sentry-Swift.h`, o
 ```
 Swift consumers:    SentrySDK.internal.replay.capture()
                           |
-                    SentryInternalApi (pure Swift)
+                    SentryInternalApi (@_spi(Private), pure Swift)
                           |
-                    SentryInternalReplayApi, etc. (pure Swift)
-                          |
+                    SentryInternalReplayApi, etc. (@_spi(Private), pure Swift)
+                          |  (dependency injection via provider protocols)
                     SDK internals (SentryDependencyContainer, SentryHub, etc.)
 
 ObjC consumers:     [[SentryObjCSDK internal] replay].capture
@@ -93,28 +93,17 @@ Direct methods (no natural integration group):
 
 | Method                                       | Replaces                                                       |
 | -------------------------------------------- | -------------------------------------------------------------- |
-| `userWithDictionary(_:) -> User`             | `PrivateSentrySDKOnly.userWithDictionary:`                     |
-| `breadcrumbWithDictionary(_:) -> Breadcrumb` | `PrivateSentrySDKOnly.breadcrumbWithDictionary:`               |
 | `setTrace(_:spanId:)`                        | `PrivateSentrySDKOnly.setTrace:spanId:`                        |
 | `setLogOutput(_:)`                           | `PrivateSentrySDKOnly.setLogOutput:`                           |
 | `ignoreNextSignal(_:)`                       | `PrivateSentrySDKOnly.ignoreNextSignal:`                       |
-| `setSdkName(_:version:)`                     | `PrivateSentrySDKOnly.setSdkName:andVersionString:`            |
-| `setSdkName(_:)`                             | `PrivateSentrySDKOnly.setSdkName:`                             |
-| `sdkName: String`                            | `PrivateSentrySDKOnly.getSdkName`                              |
-| `sdkVersionString: String`                   | `PrivateSentrySDKOnly.getSdkVersionString`                     |
-| `addSdkPackage(name:version:)`               | `PrivateSentrySDKOnly.addSdkPackage:version:`                  |
-| `extraContext: [String: Any]`                | `PrivateSentrySDKOnly.getExtraContext`                         |
-| `installationID: String`                     | `PrivateSentrySDKOnly.installationID`                          |
 | `options: Options`                           | `PrivateSentrySDKOnly.options`                                 |
 | `options(fromDictionary:) throws -> Options` | `PrivateSentrySDKOnly.optionsWithDictionary:didFailWithError:` |
-| `debugImages: [DebugMeta]`                   | `PrivateSentrySDKOnly.getDebugImages`                          |
-| `debugImages(forAddresses:) -> [DebugMeta]`  | `SentryBinaryImageCache.imageByAddress:` (see note)            |
 
 Sub-object accessors:
 
 | Property        | Type                             | Platform guard                      |
 | --------------- | -------------------------------- | ----------------------------------- |
-| `replay`        | `SentryInternalReplayApi`        | `SENTRY_TARGET_REPLAY_SUPPORTED`    |
+| `replay`        | `SentryInternalReplayApi`        | `SENTRY_UIKIT_AVAILABLE`            |
 | `profiling`     | `SentryInternalProfilingApi`     | `SENTRY_TARGET_PROFILING_SUPPORTED` |
 | `appStart`      | `SentryInternalAppStartApi`      | none                                |
 | `performance`   | `SentryInternalPerformanceApi`   | `SENTRY_UIKIT_AVAILABLE`            |
@@ -123,6 +112,10 @@ Sub-object accessors:
 | `envelope`      | `SentryInternalEnvelopeApi`      | none                                |
 | `screen`        | `SentryInternalScreenApi`        | `SENTRY_UIKIT_AVAILABLE`            |
 | `swizzle`       | `SentryInternalSwizzleApi`       | none                                |
+| `sdk`           | `SentryInternalSdkApi`           | none                                |
+| `debug`         | `SentryInternalDebugApi`         | none                                |
+| `breadcrumbs`   | `SentryInternalBreadcrumbApi`    | none                                |
+| `user`          | `SentryInternalUserApi`          | none                                |
 
 ### `SentrySDK.internal.replay` — `SentryInternalReplayApi`
 
@@ -139,10 +132,6 @@ Sub-object accessors:
 
 > **Note on `capture() -> Bool`:** React Native currently works around `captureReplay` being `void` by dynamically calling `getReplayIntegration` via `performSelector:` to access the integration's `captureReplay` which returns `BOOL`. The new API makes `capture()` return `Bool` directly, eliminating both the void limitation and the dynamic dispatch hack. `getReplayIntegration` is intentionally not exposed — callers should not need the integration object.
 
-> **Note on `debugImages`:** Flutter calls `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method is not declared in the current `PrivateSentrySDKOnly.h` header (it's available via `@_spi(Private)`) but is a real call site that needs a home. It lives directly on `.internal` rather than in a sub-object since it doesn't belong to any integration group.
->
-> **Note on `debugImages(forAddresses:)`:** Godot currently bypasses the public API and accesses `SentryBinaryImageCache.imageByAddress(_:)` directly to look up debug images by raw `UInt64` addresses. The existing `SentryDebugImageProvider.getDebugImagesForImageAddressesFromCache(imageAddresses:)` only accepts hex `String` addresses, forcing C++/ObjC++ callers to do unnecessary string conversion. The new `debugImages(forAddresses:)` accepts `[UInt64]` directly, delegates to the binary image cache, and returns `[DebugMeta]` — eliminating the need to import internal types.
-
 ### `SentrySDK.internal.profiling` — `SentryInternalProfilingApi`
 
 | Method                                        | Replaces                              |
@@ -153,12 +142,12 @@ Sub-object accessors:
 
 ### `SentrySDK.internal.appStart` — `SentryInternalAppStartApi`
 
-| Method                                                            | Replaces                           |
-| ----------------------------------------------------------------- | ---------------------------------- |
-| `hybridSDKMode: Bool`                                             | `appStartMeasurementHybridSDKMode` |
-| `measurement: SentryAppStartMeasurement?`                         | `appStartMeasurement`              |
-| `measurementWithSpans: [String: Any]?`                            | `appStartMeasurementWithSpans`     |
-| `onMeasurementAvailable: ((SentryAppStartMeasurement?) -> Void)?` | `onAppStartMeasurementAvailable`   |
+| Method                                                            | Replaces                           | Platform guard           |
+| ----------------------------------------------------------------- | ---------------------------------- | ------------------------ |
+| `hybridSDKMode: Bool`                                             | `appStartMeasurementHybridSDKMode` | none                     |
+| `measurementWithSpans: [String: Any]?`                            | `appStartMeasurementWithSpans`     | none                     |
+| `measurement: SentryAppStartMeasurement?`                         | `appStartMeasurement`              | `SENTRY_UIKIT_AVAILABLE` |
+| `onMeasurementAvailable: ((SentryAppStartMeasurement?) -> Void)?` | `onAppStartMeasurementAvailable`   | `SENTRY_UIKIT_AVAILABLE` |
 
 ### `SentrySDK.internal.performance` — `SentryInternalPerformanceApi`
 
@@ -214,55 +203,100 @@ The factory block receives a closure that returns the original `IMP`. The caller
 
 > **Why not expose a simplified "before/after hook" API?** The factory-based API preserves full flexibility (custom argument handling, conditional forwarding, return value modification) at the cost of the caller doing IMP casting. A convenience wrapper could be added later if multiple hybrid SDKs converge on a simpler pattern.
 
+### `SentrySDK.internal.sdk` — `SentryInternalSdkApi`
+
+| Method                        | Replaces                                            |
+| ----------------------------- | --------------------------------------------------- |
+| `name: String`                | `PrivateSentrySDKOnly.getSdkName` / `.setSdkName:`  |
+| `versionString: String`       | `PrivateSentrySDKOnly.getSdkVersionString`          |
+| `setName(_:version:)`         | `PrivateSentrySDKOnly.setSdkName:andVersionString:` |
+| `addPackage(name:version:)`   | `PrivateSentrySDKOnly.addSdkPackage:version:`       |
+| `extraContext: [String: Any]` | `PrivateSentrySDKOnly.getExtraContext`              |
+| `installationID: String`      | `PrivateSentrySDKOnly.installationID`               |
+
+`name` and `versionString` are read-write properties — the getter and setter replace both the get/set static methods.
+
+### `SentrySDK.internal.debug` — `SentryInternalDebugApi`
+
+| Method                                 | Replaces                                            |
+| -------------------------------------- | --------------------------------------------------- |
+| `images: [DebugMeta]`                  | `PrivateSentrySDKOnly.getDebugImages`               |
+| `images(forAddresses:) -> [DebugMeta]` | `SentryBinaryImageCache.imageByAddress:` (see note) |
+
+> **Note on `images`:** Flutter calls `PrivateSentrySDKOnly.getDebugImages()` to retrieve debug meta images for symbolication. This method is not declared in the current `PrivateSentrySDKOnly.h` header (it's available via `@_spi(Private)`) but is a real call site that needs a home.
+>
+> **Note on `images(forAddresses:)`:** Godot currently bypasses the public API and accesses `SentryBinaryImageCache.imageByAddress(_:)` directly to look up debug images by raw `UInt64` addresses. The existing `SentryDebugImageProvider.getDebugImagesForImageAddressesFromCache(imageAddresses:)` only accepts hex `String` addresses, forcing C++/ObjC++ callers to do unnecessary string conversion. The new `images(forAddresses:)` accepts `[UInt64]` directly, delegates to the binary image cache, and returns `[DebugMeta]` — eliminating the need to import internal types.
+
+### `SentrySDK.internal.breadcrumbs` — `SentryInternalBreadcrumbApi`
+
+| Method                             | Replaces                                         |
+| ---------------------------------- | ------------------------------------------------ |
+| `fromDictionary(_:) -> Breadcrumb` | `PrivateSentrySDKOnly.breadcrumbWithDictionary:` |
+
+### `SentrySDK.internal.user` — `SentryInternalUserApi`
+
+| Method                       | Replaces                                   |
+| ---------------------------- | ------------------------------------------ |
+| `fromDictionary(_:) -> User` | `PrivateSentrySDKOnly.userWithDictionary:` |
+
 ## Swift Implementation Pattern
 
-Each sub-object is a plain Swift class (no `NSObject`, no `@objc`):
+Each sub-object is a plain Swift class marked `@_spi(Private)` (no `NSObject`, no `@objc`). Dependencies are injected via provider protocols conforming to `SentryDependencyContainer`, making the sub-objects testable in isolation:
 
 ```swift
 // Sources/Swift/HybridSDK/SentryInternalApi.swift
 
-/// APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
-///
-/// These methods are public for consumption by wrapper SDKs that bridge
-/// between native and managed runtimes. They may change, be renamed,
-/// or be removed in any minor release without prior deprecation.
-///
-/// App developers: prefer the standard `SentrySDK` API surface instead.
 @_implementationOnly import _SentryPrivate
 
-public final class SentryInternalApi {
+@_spi(Private) public final class SentryInternalApi {
+
+    private let container: SentryDependencyContainer
 
     #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
-    public let replay = SentryInternalReplayApi()
+    public let replay: SentryInternalReplayApi
+    public let performance: SentryInternalPerformanceApi
+    public let screenshot: SentryInternalScreenshotApi
+    public let viewHierarchy: SentryInternalViewHierarchyApi
+    public let screen: SentryInternalScreenApi
     #endif
 
-    public let envelope = SentryInternalEnvelopeApi()
+    #if SENTRY_TARGET_PROFILING_SUPPORTED
+    public let profiling = SentryInternalProfilingApi()
+    #endif
+
+    public let appStart = SentryInternalAppStartApi()
+    public let envelope: SentryInternalEnvelopeApi
     public let swizzle = SentryInternalSwizzleApi()
+    public let sdk: SentryInternalSdkApi
+    public let debug: SentryInternalDebugApi
+    public let breadcrumbs = SentryInternalBreadcrumbApi()
+    public let user = SentryInternalUserApi()
 
-    // ... other sub-objects ...
-
-    public func setSdkName(_ name: String, version: String) {
-        SentryMeta.sdkName = name
-        SentryMeta.versionString = version
-    }
-
-    // ... direct methods ...
+    // ... direct methods (setTrace, setLogOutput, ignoreNextSignal, options) ...
 }
 ```
 
 ```swift
 // Sources/Swift/HybridSDK/SentryInternalReplayApi.swift
 
-public final class SentryInternalReplayApi {
+@_spi(Private) public final class SentryInternalReplayApi {
+
+    private let hubProvider: any HubProvider
+
+    internal init(provider: any HubProvider) {
+        self.hubProvider = provider
+    }
+
+    @discardableResult
     public func capture() -> Bool {
-        guard let integration = SentrySDK.currentHub().installedIntegration(
+        guard let integration = hubProvider.hub.installedIntegration(
             of: SentrySessionReplayIntegration.self
         ) else { return false }
         return integration.captureReplay()
     }
 
     public var replayId: String? {
-        SentrySDK.currentHub().scope.replayId
+        hubProvider.hub.scope.replayId
     }
 
     // ... other methods ...
@@ -272,7 +306,7 @@ public final class SentryInternalReplayApi {
 ```swift
 // Sources/Swift/HybridSDK/SentryInternalSwizzleApi.swift
 
-public final class SentryInternalSwizzleApi {
+@_spi(Private) public final class SentryInternalSwizzleApi {
 
     public enum Mode {
         case always
@@ -280,13 +314,6 @@ public final class SentryInternalSwizzleApi {
         case oncePerClassAndSuperclasses
     }
 
-    /// Swizzles an instance method, replacing it with a new implementation
-    /// created by the factory block.
-    ///
-    /// The factory block receives a closure that returns the original `IMP`.
-    /// The caller must cast it to the correct function signature.
-    /// Return a block whose signature matches the swizzled method
-    /// (first two implicit parameters are `self` and `_cmd`).
     @discardableResult
     public func instanceMethod(
         _ selector: Selector,
@@ -305,9 +332,6 @@ public final class SentryInternalSwizzleApi {
             in: cls,
             newImpFactory: { swizzleInfo in
                 factory {
-                    // SentrySwizzleOriginalIMP is void(*)(void), a type-erased
-                    // function pointer. Cast to IMP for the public API; the
-                    // caller casts again to the actual method signature.
                     unsafeBitCast(
                         swizzleInfo!.getOriginalImplementation(),
                         to: IMP.self
@@ -321,17 +345,18 @@ public final class SentryInternalSwizzleApi {
 }
 ```
 
-The `SentrySDK` extension:
+The `SentrySDK` extension uses a lazy singleton protected by a lock, allowing reset on SDK close:
 
 ```swift
 // Sources/Swift/Helper/SentrySDK+Internal.swift
 
 extension SentrySDK {
-    /// APIs for hybrid SDKs (React Native, Flutter, .NET, Unity).
-    ///
-    /// These APIs may change in any minor release without deprecation.
-    /// App developers should use the standard `SentrySDK` API instead.
-    public static let `internal` = SentryInternalApi()
+    @_spi(Private) public static var `internal`: SentryInternalApi {
+        // Lazy singleton protected by NSRecursiveLock.
+        // resetInternalApi() tears it down on SDK close.
+    }
+
+    static func resetInternalApi() { ... }
 }
 ```
 
@@ -347,32 +372,45 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
 
 @class SentryObjCId;
 @class SentryObjCSpanId;
+@class SentryObjCOptions;
 @class SentryObjCInternalReplayApi;
+@class SentryObjCInternalPerformanceApi;
+@class SentryObjCInternalScreenshotApi;
+@class SentryObjCInternalViewHierarchyApi;
+@class SentryObjCInternalScreenApi;
+@class SentryObjCInternalProfilingApi;
+@class SentryObjCInternalAppStartApi;
 @class SentryObjCInternalEnvelopeApi;
 @class SentryObjCInternalSwizzleApi;
-// ... other forward declarations ...
+@class SentryObjCInternalSdkApi;
+@class SentryObjCInternalDebugApi;
+@class SentryObjCInternalBreadcrumbApi;
+@class SentryObjCInternalUserApi;
 
-/// APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
-///
-/// These methods are public for consumption by wrapper SDKs that bridge
-/// between native and managed runtimes. They may change, be renamed,
-/// or be removed in any minor release without prior deprecation.
-///
-/// App developers: prefer the standard @c SentryObjCSDK API surface instead.
 @interface SentryObjCInternalApi : NSObject
 
 #if SENTRY_OBJC_REPLAY_SUPPORTED
 @property (nonatomic, readonly) SentryObjCInternalReplayApi *replay;
+@property (nonatomic, readonly) SentryObjCInternalPerformanceApi *performance;
+@property (nonatomic, readonly) SentryObjCInternalScreenshotApi *screenshot;
+@property (nonatomic, readonly) SentryObjCInternalViewHierarchyApi *viewHierarchy;
+@property (nonatomic, readonly) SentryObjCInternalScreenApi *screen;
 #endif
 
+@property (nonatomic, readonly) SentryObjCInternalAppStartApi *appStart;
 @property (nonatomic, readonly) SentryObjCInternalEnvelopeApi *envelope;
 @property (nonatomic, readonly) SentryObjCInternalSwizzleApi *swizzle;
+@property (nonatomic, readonly) SentryObjCInternalSdkApi *sdk;
+@property (nonatomic, readonly) SentryObjCInternalDebugApi *debug;
+@property (nonatomic, readonly) SentryObjCInternalBreadcrumbApi *breadcrumbs;
+@property (nonatomic, readonly) SentryObjCInternalUserApi *user;
 
-// ... direct methods ...
-- (void)setSdkName:(NSString *)name version:(NSString *)version;
-- (NSString *)sdkName;
-- (NSString *)sdkVersionString;
 - (void)setTrace:(SentryObjCId *)traceId spanId:(SentryObjCSpanId *)spanId;
+- (void)setLogOutput:(void (^)(NSString *))output;
+- (void)ignoreNextSignal:(int)signum;
+@property (nonatomic, readonly) SentryObjCOptions *options;
+- (nullable SentryObjCOptions *)optionsFromDictionary:(NSDictionary<NSString *, id> *)dictionary
+                                                error:(NSError **)error;
 
 @end
 ```
@@ -387,17 +425,24 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
     @objc public var replay: SentryObjCInternalReplayApi {
         SentryObjCInternalReplayApi(wrapped.replay)
     }
+    @objc public var performance: SentryObjCInternalPerformanceApi {
+        SentryObjCInternalPerformanceApi(wrapped.performance)
+    }
+    // ... screenshot, viewHierarchy, screen follow same pattern ...
     #endif
 
-    @objc public var envelope: SentryObjCInternalEnvelopeApi {
-        SentryObjCInternalEnvelopeApi(wrapped.envelope)
-    }
+    @objc public var appStart: SentryObjCInternalAppStartApi { ... }
+    @objc public var envelope: SentryObjCInternalEnvelopeApi { ... }
+    @objc public var swizzle: SentryObjCInternalSwizzleApi { ... }
+    @objc public var sdk: SentryObjCInternalSdkApi { ... }
+    @objc public var debug: SentryObjCInternalDebugApi { ... }
+    @objc public var breadcrumbs: SentryObjCInternalBreadcrumbApi { ... }
+    @objc public var user: SentryObjCInternalUserApi { ... }
 
-    @objc public func setSdkName(_ name: String, version: String) {
-        wrapped.setSdkName(name, version: version)
-    }
-
-    // ... other delegating methods ...
+    @objc public func setTrace(_ traceId: SentryObjCId, spanId: SentryObjCSpanId) { ... }
+    @objc public func setLogOutput(_ output: @escaping (String) -> Void) { ... }
+    @objc public func ignoreNextSignal(_ signum: Int32) { ... }
+    // ...
 }
 ```
 
@@ -439,13 +484,16 @@ Each sub-object follows the same header + wrapper pair pattern. See [SENTRY-OBJC
 
 ## Deprecation Strategy
 
-All methods on `PrivateSentrySDKOnly` receive deprecation annotations pointing to the new API:
+Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper) receive deprecation annotations. The entire `SentryObjCPrivateSDKOnly` class is deprecated, and each method has an individual annotation pointing to the new API path:
 
 ```objc
-// PrivateSentrySDKOnly.h
-+ (void)captureReplay
-    __attribute__((deprecated("Use SentrySDK.internal.replay.capture() (Swift) "
-                              "or [[SentryObjCSDK internal].replay capture] (ObjC)")));
+// SentryObjCPrivateSDKOnly.h — class-level deprecation
+DEPRECATED_MSG_ATTRIBUTE("Use SentryObjCSDK.internal instead")
+@interface SentryObjCPrivateSDKOnly : NSObject
+
+// Per-method deprecation (e.g. for sdk name)
++ (void)setSdkName:(NSString *)name andVersionString:(NSString *)version
+    DEPRECATED_MSG_ATTRIBUTE("Use SentryObjCSDK.internal.sdk.setName:version:");
 ```
 
 `PrivateSentrySDKOnly` retains its own implementation (does not delegate to the new Swift types). Both paths call the same SDK internals independently. Removal happens in the next major version.
@@ -464,8 +512,12 @@ All methods on `PrivateSentrySDKOnly` receive deprecation annotations pointing t
 | `SentryInternalEnvelopeApi`      | `SentryObjCInternalEnvelopeApi.h`      | `SentryObjCInternalEnvelopeApi.swift`      | all        |
 | `SentryInternalScreenApi`        | `SentryObjCInternalScreenApi.h`        | `SentryObjCInternalScreenApi.swift`        | iOS, tvOS  |
 | `SentryInternalSwizzleApi`       | `SentryObjCInternalSwizzleApi.h`       | `SentryObjCInternalSwizzleApi.swift`       | all        |
+| `SentryInternalSdkApi`           | `SentryObjCInternalSdkApi.h`           | `SentryObjCInternalSdkApi.swift`           | all        |
+| `SentryInternalDebugApi`         | `SentryObjCInternalDebugApi.h`         | `SentryObjCInternalDebugApi.swift`         | all        |
+| `SentryInternalBreadcrumbApi`    | `SentryObjCInternalBreadcrumbApi.h`    | `SentryObjCInternalBreadcrumbApi.swift`    | all        |
+| `SentryInternalUserApi`          | `SentryObjCInternalUserApi.h`          | `SentryObjCInternalUserApi.swift`          | all        |
 
-**Total:** 10 Swift types + 10 ObjC headers + 10 ObjC wrappers = 30 new files.
+**Total:** 14 Swift types + 14 ObjC headers + 14 ObjC wrappers = 42 new files.
 
 ## File Layout
 
@@ -482,7 +534,11 @@ Sources/
 │       ├── SentryInternalViewHierarchyApi.swift
 │       ├── SentryInternalEnvelopeApi.swift
 │       ├── SentryInternalScreenApi.swift
-│       └── SentryInternalSwizzleApi.swift
+│       ├── SentryInternalSwizzleApi.swift
+│       ├── SentryInternalSdkApi.swift
+│       ├── SentryInternalDebugApi.swift
+│       ├── SentryInternalBreadcrumbApi.swift
+│       └── SentryInternalUserApi.swift
 ├── Swift/Helper/
 │   └── SentrySDK+Internal.swift              # extension adding .internal
 ├── SentryObjC/Public/
@@ -495,7 +551,11 @@ Sources/
 │   ├── SentryObjCInternalViewHierarchyApi.h
 │   ├── SentryObjCInternalEnvelopeApi.h
 │   ├── SentryObjCInternalScreenApi.h
-│   └── SentryObjCInternalSwizzleApi.h
+│   ├── SentryObjCInternalSwizzleApi.h
+│   ├── SentryObjCInternalSdkApi.h
+│   ├── SentryObjCInternalDebugApi.h
+│   ├── SentryObjCInternalBreadcrumbApi.h
+│   └── SentryObjCInternalUserApi.h
 ├── SentryObjCCompat/
 │   ├── SentryObjCInternalApi.swift
 │   ├── SentryObjCInternalReplayApi.swift
@@ -507,6 +567,10 @@ Sources/
 │   ├── SentryObjCInternalEnvelopeApi.swift
 │   ├── SentryObjCInternalScreenApi.swift
 │   ├── SentryObjCInternalSwizzleApi.swift
+│   ├── SentryObjCInternalSdkApi.swift
+│   ├── SentryObjCInternalDebugApi.swift
+│   ├── SentryObjCInternalBreadcrumbApi.swift
+│   ├── SentryObjCInternalUserApi.swift
 │   └── SentryObjCSDK+Internal.swift
 ```
 
@@ -534,7 +598,7 @@ PrivateSentrySDKOnly.captureReplay()
 
 // After
 import Sentry
-SentrySDK.internal.setSdkName("sentry.cocoa.react-native", version: "6.0.0")
+SentrySDK.internal.sdk.setName("sentry.cocoa.react-native", version: "6.0.0")
 SentrySDK.internal.appStart.hybridSDKMode = true
 let frames = SentrySDK.internal.performance.currentScreenFrames
 let success = SentrySDK.internal.replay.capture()
@@ -557,7 +621,7 @@ id traceId = [[SentryIdClass alloc] initWithUUIDString:traceString];
 
 // After — single import, no internal headers
 #import <SentryObjC/SentryObjC.h>
-[[SentryObjCSDK internal] setSdkName:@"sentry.cocoa.react-native" version:@"6.0.0"];
+[[[SentryObjCSDK internal] sdk] setName:@"sentry.cocoa.react-native" version:@"6.0.0"];
 [SentryObjCSDK internal].appStart.hybridSDKMode = YES;
 SentryObjCScreenFrames *frames = [SentryObjCSDK internal].performance.currentScreenFrames;
 BOOL success = [[[SentryObjCSDK internal] replay] capture];
@@ -616,9 +680,9 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 
 ## Public API Surface Impact
 
-- `sdk_api.json` gains ~55 new public symbols (10 types + their methods/properties).
-- `sdk_api_objc.json` gains ~55 new symbols (10 ObjC types + methods + `SentryObjCSwizzleMode` enum).
-- `PrivateSentrySDKOnly` methods gain `deprecated` annotations (no removal, no ABI break).
+- `sdk_api.json` gains ~75 new public symbols (14 types + their methods/properties).
+- `sdk_api_objc.json` gains ~75 new symbols (14 ObjC types + methods + `SentryObjCSwizzleMode` enum).
+- `PrivateSentrySDKOnly` / `SentryObjCPrivateSDKOnly` gain `deprecated` annotations (no removal, no ABI break).
 - `make generate-public-api` must be run and committed.
 
 ## Testing
@@ -631,4 +695,4 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 
 1. **`SentryObjCSDK.internal` naming in ObjC.** `internal` is not a reserved word in ObjC, so no conflict. But should we verify no collision with Apple's runtime selectors?
 2. **Thread safety.** `PrivateSentrySDKOnly` methods are individually thread-safe via internal SDK locks. The new types delegate to the same internals, inheriting the same guarantees. Should we add `@Sendable` annotations to callback parameters?
-3. **`SentryInternalApi` as singleton vs. value.** Currently proposed as `static let` (singleton). If the SDK is closed and re-started, the sub-objects still point to the same instances. This matches current `PrivateSentrySDKOnly` behavior (static methods, no instance state) but worth confirming.
+3. ~~**`SentryInternalApi` as singleton vs. value.**~~ **Resolved:** implemented as a lazy `var` protected by `NSRecursiveLock`, with `resetInternalApi()` called on SDK close. This allows sub-objects to be recreated with fresh dependencies when the SDK restarts.

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -239,264 +239,25 @@ The factory block receives a closure that returns the original `IMP`. The caller
 | ---------------------------- | ------------------------------------------ |
 | `fromDictionary(_:) -> User` | `PrivateSentrySDKOnly.userWithDictionary:` |
 
-## Swift Implementation Pattern
+## Implementation Conventions
 
-Each sub-object is a plain Swift class marked `@_spi(Private)` (no `NSObject`, no `@objc`). Dependencies are injected via provider protocols conforming to `SentryDependencyContainer`, making the sub-objects testable in isolation:
+**Swift types** (`Sources/Swift/HybridSDK/`):
 
-```swift
-// Sources/Swift/HybridSDK/SentryInternalApi.swift
+- All types are `@_spi(Private) public final class` — no `NSObject`, no `@objc`.
+- Dependencies are injected via provider protocols (e.g., `HubProvider`, `DebugImageProvider`) backed by `SentryDependencyContainer`, making sub-objects testable in isolation.
+- `SentrySDK.internal` is a lazy `var` on `SentrySDK` protected by `NSRecursiveLock`, reset on SDK close via `resetInternalApi()`.
 
-@_implementationOnly import _SentryPrivate
+**ObjC wrappers** (`Sources/SentryObjC/Public/` headers + `Sources/SentryObjCCompat/` wrappers):
 
-@_spi(Private) public final class SentryInternalApi {
-
-    private let container: SentryDependencyContainer
-
-    #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
-    public let replay: SentryInternalReplayApi
-    public let performance: SentryInternalPerformanceApi
-    public let screenshot: SentryInternalScreenshotApi
-    public let viewHierarchy: SentryInternalViewHierarchyApi
-    public let screen: SentryInternalScreenApi
-    #endif
-
-    #if SENTRY_TARGET_PROFILING_SUPPORTED
-    public let profiling = SentryInternalProfilingApi()
-    #endif
-
-    public let appStart = SentryInternalAppStartApi()
-    public let envelope: SentryInternalEnvelopeApi
-    public let swizzle = SentryInternalSwizzleApi()
-    public let sdk: SentryInternalSdkApi
-    public let debug: SentryInternalDebugApi
-    public let breadcrumbs = SentryInternalBreadcrumbApi()
-    public let user = SentryInternalUserApi()
-
-    // ... direct methods (setTrace, setLogOutput, ignoreNextSignal, options) ...
-}
-```
-
-```swift
-// Sources/Swift/HybridSDK/SentryInternalReplayApi.swift
-
-@_spi(Private) public final class SentryInternalReplayApi {
-
-    private let hubProvider: any HubProvider
-
-    internal init(provider: any HubProvider) {
-        self.hubProvider = provider
-    }
-
-    @discardableResult
-    public func capture() -> Bool {
-        guard let integration = hubProvider.hub.installedIntegration(
-            of: SentrySessionReplayIntegration.self
-        ) else { return false }
-        return integration.captureReplay()
-    }
-
-    public var replayId: String? {
-        hubProvider.hub.scope.replayId
-    }
-
-    // ... other methods ...
-}
-```
-
-```swift
-// Sources/Swift/HybridSDK/SentryInternalSwizzleApi.swift
-
-@_spi(Private) public final class SentryInternalSwizzleApi {
-
-    public enum Mode {
-        case always
-        case oncePerClass
-        case oncePerClassAndSuperclasses
-    }
-
-    @discardableResult
-    public func instanceMethod(
-        _ selector: Selector,
-        in cls: AnyClass,
-        mode: Mode = .oncePerClass,
-        key: UnsafeRawPointer,
-        factory: @escaping (_ getOriginalImplementation: @escaping () -> IMP) -> Any
-    ) -> Bool {
-        let swizzleMode: SentrySwizzleMode = switch mode {
-        case .always: .always
-        case .oncePerClass: .oncePerClass
-        case .oncePerClassAndSuperclasses: .oncePerClassAndSuperclasses
-        }
-        return SentrySwizzle.swizzleInstanceMethod(
-            selector,
-            in: cls,
-            newImpFactory: { swizzleInfo in
-                factory {
-                    unsafeBitCast(
-                        swizzleInfo!.getOriginalImplementation(),
-                        to: IMP.self
-                    )
-                }
-            },
-            mode: swizzleMode,
-            key: key
-        )
-    }
-}
-```
-
-The `SentrySDK` extension uses a lazy singleton protected by a lock, allowing reset on SDK close:
-
-```swift
-// Sources/Swift/Helper/SentrySDK+Internal.swift
-
-extension SentrySDK {
-    @_spi(Private) public static var `internal`: SentryInternalApi {
-        // Lazy singleton protected by NSRecursiveLock.
-        // resetInternalApi() tears it down on SDK close.
-    }
-
-    static func resetInternalApi() { ... }
-}
-```
-
-## ObjC Wrapper Pattern
-
-Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
-
-**Header** (`Sources/SentryObjC/Public/SentryObjCInternalApi.h`):
-
-```objc
-#import <Foundation/Foundation.h>
-#import <SentryObjC/SentryObjCDefines.h>
-
-@class SentryObjCId;
-@class SentryObjCSpanId;
-@class SentryObjCOptions;
-@class SentryObjCInternalReplayApi;
-@class SentryObjCInternalPerformanceApi;
-@class SentryObjCInternalScreenshotApi;
-@class SentryObjCInternalViewHierarchyApi;
-@class SentryObjCInternalScreenApi;
-@class SentryObjCInternalProfilingApi;
-@class SentryObjCInternalAppStartApi;
-@class SentryObjCInternalEnvelopeApi;
-@class SentryObjCInternalSwizzleApi;
-@class SentryObjCInternalSdkApi;
-@class SentryObjCInternalDebugApi;
-@class SentryObjCInternalBreadcrumbApi;
-@class SentryObjCInternalUserApi;
-
-@interface SentryObjCInternalApi : NSObject
-
-#if SENTRY_OBJC_REPLAY_SUPPORTED
-@property (nonatomic, readonly) SentryObjCInternalReplayApi *replay;
-@property (nonatomic, readonly) SentryObjCInternalPerformanceApi *performance;
-@property (nonatomic, readonly) SentryObjCInternalScreenshotApi *screenshot;
-@property (nonatomic, readonly) SentryObjCInternalViewHierarchyApi *viewHierarchy;
-@property (nonatomic, readonly) SentryObjCInternalScreenApi *screen;
-#endif
-
-@property (nonatomic, readonly) SentryObjCInternalAppStartApi *appStart;
-@property (nonatomic, readonly) SentryObjCInternalEnvelopeApi *envelope;
-@property (nonatomic, readonly) SentryObjCInternalSwizzleApi *swizzle;
-@property (nonatomic, readonly) SentryObjCInternalSdkApi *sdk;
-@property (nonatomic, readonly) SentryObjCInternalDebugApi *debug;
-@property (nonatomic, readonly) SentryObjCInternalBreadcrumbApi *breadcrumbs;
-@property (nonatomic, readonly) SentryObjCInternalUserApi *user;
-
-- (void)setTrace:(SentryObjCId *)traceId spanId:(SentryObjCSpanId *)spanId;
-- (void)setLogOutput:(void (^)(NSString *))output;
-- (void)ignoreNextSignal:(int)signum;
-@property (nonatomic, readonly) SentryObjCOptions *options;
-- (nullable SentryObjCOptions *)optionsFromDictionary:(NSDictionary<NSString *, id> *)dictionary
-                                                error:(NSError **)error;
-
-@end
-```
-
-**Wrapper** (`Sources/SentryObjCCompat/SentryObjCInternalApi.swift`):
-
-```swift
-@objc(SentryObjCInternalApi) public final class SentryObjCInternalApi: NSObject {
-    internal let wrapped = SentrySDK.`internal`
-
-    #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
-    @objc public var replay: SentryObjCInternalReplayApi {
-        SentryObjCInternalReplayApi(wrapped.replay)
-    }
-    @objc public var performance: SentryObjCInternalPerformanceApi {
-        SentryObjCInternalPerformanceApi(wrapped.performance)
-    }
-    // ... screenshot, viewHierarchy, screen follow same pattern ...
-    #endif
-
-    @objc public var appStart: SentryObjCInternalAppStartApi { ... }
-    @objc public var envelope: SentryObjCInternalEnvelopeApi { ... }
-    @objc public var swizzle: SentryObjCInternalSwizzleApi { ... }
-    @objc public var sdk: SentryObjCInternalSdkApi { ... }
-    @objc public var debug: SentryObjCInternalDebugApi { ... }
-    @objc public var breadcrumbs: SentryObjCInternalBreadcrumbApi { ... }
-    @objc public var user: SentryObjCInternalUserApi { ... }
-
-    @objc public func setTrace(_ traceId: SentryObjCId, spanId: SentryObjCSpanId) { ... }
-    @objc public func setLogOutput(_ output: @escaping (String) -> Void) { ... }
-    @objc public func ignoreNextSignal(_ signum: Int32) { ... }
-    // ...
-}
-```
-
-**SentryObjCSDK extension** (`Sources/SentryObjCCompat/SentryObjCSDK+Internal.swift`):
-
-```swift
-extension SentryObjCSDK {
-    @objc public static let `internal` = SentryObjCInternalApi()
-}
-```
-
-**Swizzle header** (`Sources/SentryObjC/Public/SentryObjCInternalSwizzleApi.h`):
-
-```objc
-#import <Foundation/Foundation.h>
-
-typedef NS_ENUM(NSUInteger, SentryObjCSwizzleMode) {
-    SentryObjCSwizzleModeAlways = 0,
-    SentryObjCSwizzleModeOncePerClass = 1,
-    SentryObjCSwizzleModeOncePerClassAndSuperclasses = 2
-};
-
-/// Stable swizzling API for hybrid SDKs.
-/// Replaces direct import of SentrySwizzle.h and its macro-based API.
-@interface SentryObjCInternalSwizzleApi : NSObject
-
-/// Swizzle an instance method. The factory block receives a block that
-/// returns the original IMP; return a new block matching the method signature.
-- (BOOL)swizzleInstanceMethod:(SEL _Nonnull)selector
-                      inClass:(Class _Nonnull)cls
-                newImpFactory:(id _Nonnull (^_Nonnull)(IMP _Nonnull (^_Nonnull)(void)))factoryBlock
-                         mode:(SentryObjCSwizzleMode)mode
-                          key:(const void *_Nonnull)key;
-
-@end
-```
-
-Each sub-object follows the same header + wrapper pair pattern. See [SENTRY-OBJC.md](SENTRY-OBJC.md) for the full wrapper conventions.
+- Follow the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md): pure ObjC header in `SentryObjC`, Swift `@objc` wrapper in `SentryObjCCompat`.
+- Each wrapper holds a reference to the corresponding Swift type and delegates all calls.
+- `SentryObjCSDK.internal` is a `static let` on the ObjC SDK class.
+- UIKit-dependent sub-objects are guarded by `SENTRY_OBJC_REPLAY_SUPPORTED` in headers and `canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))` in Swift.
+- The swizzle wrapper introduces `SentryObjCSwizzleMode` (`NS_ENUM`) mapping to `SentryInternalSwizzleApi.Mode`.
 
 ## Deprecation Strategy
 
-Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper) receive deprecation annotations. The entire `SentryObjCPrivateSDKOnly` class is deprecated, and each method has an individual annotation pointing to the new API path:
-
-```objc
-// SentryObjCPrivateSDKOnly.h — class-level deprecation
-DEPRECATED_MSG_ATTRIBUTE("Use SentryObjCSDK.internal instead")
-@interface SentryObjCPrivateSDKOnly : NSObject
-
-// Per-method deprecation (e.g. for sdk name)
-+ (void)setSdkName:(NSString *)name andVersionString:(NSString *)version
-    DEPRECATED_MSG_ATTRIBUTE("Use SentryObjCSDK.internal.sdk.setName:version:");
-```
-
-`PrivateSentrySDKOnly` retains its own implementation (does not delegate to the new Swift types). Both paths call the same SDK internals independently. Removal happens in the next major version.
+Both `PrivateSentrySDKOnly` (Swift) and `SentryObjCPrivateSDKOnly` (ObjC wrapper) receive deprecation annotations — class-level and per-method — pointing to the new API path. Both retain their own implementations (they do not delegate to the new Swift types). All three paths call the same SDK internals independently. Removal happens in the next major version.
 
 ## Type Inventory
 
@@ -519,70 +280,7 @@ DEPRECATED_MSG_ATTRIBUTE("Use SentryObjCSDK.internal instead")
 
 **Total:** 14 Swift types + 14 ObjC headers + 14 ObjC wrappers = 42 new files.
 
-## File Layout
-
-```
-Sources/
-├── Swift/
-│   └── HybridSDK/
-│       ├── SentryInternalApi.swift
-│       ├── SentryInternalReplayApi.swift
-│       ├── SentryInternalProfilingApi.swift
-│       ├── SentryInternalAppStartApi.swift
-│       ├── SentryInternalPerformanceApi.swift
-│       ├── SentryInternalScreenshotApi.swift
-│       ├── SentryInternalViewHierarchyApi.swift
-│       ├── SentryInternalEnvelopeApi.swift
-│       ├── SentryInternalScreenApi.swift
-│       ├── SentryInternalSwizzleApi.swift
-│       ├── SentryInternalSdkApi.swift
-│       ├── SentryInternalDebugApi.swift
-│       ├── SentryInternalBreadcrumbApi.swift
-│       └── SentryInternalUserApi.swift
-├── Swift/Helper/
-│   └── SentrySDK+Internal.swift              # extension adding .internal
-├── SentryObjC/Public/
-│   ├── SentryObjCInternalApi.h
-│   ├── SentryObjCInternalReplayApi.h
-│   ├── SentryObjCInternalProfilingApi.h
-│   ├── SentryObjCInternalAppStartApi.h
-│   ├── SentryObjCInternalPerformanceApi.h
-│   ├── SentryObjCInternalScreenshotApi.h
-│   ├── SentryObjCInternalViewHierarchyApi.h
-│   ├── SentryObjCInternalEnvelopeApi.h
-│   ├── SentryObjCInternalScreenApi.h
-│   ├── SentryObjCInternalSwizzleApi.h
-│   ├── SentryObjCInternalSdkApi.h
-│   ├── SentryObjCInternalDebugApi.h
-│   ├── SentryObjCInternalBreadcrumbApi.h
-│   └── SentryObjCInternalUserApi.h
-├── SentryObjCCompat/
-│   ├── SentryObjCInternalApi.swift
-│   ├── SentryObjCInternalReplayApi.swift
-│   ├── SentryObjCInternalProfilingApi.swift
-│   ├── SentryObjCInternalAppStartApi.swift
-│   ├── SentryObjCInternalPerformanceApi.swift
-│   ├── SentryObjCInternalScreenshotApi.swift
-│   ├── SentryObjCInternalViewHierarchyApi.swift
-│   ├── SentryObjCInternalEnvelopeApi.swift
-│   ├── SentryObjCInternalScreenApi.swift
-│   ├── SentryObjCInternalSwizzleApi.swift
-│   ├── SentryObjCInternalSdkApi.swift
-│   ├── SentryObjCInternalDebugApi.swift
-│   ├── SentryObjCInternalBreadcrumbApi.swift
-│   ├── SentryObjCInternalUserApi.swift
-│   └── SentryObjCSDK+Internal.swift
-```
-
-## Documentation
-
-Every type and method carries a headerdoc/docstring with this preamble:
-
-> APIs intended for Sentry hybrid SDKs (React Native, Flutter, .NET, Unity).
-> These methods are public for consumption by wrapper SDKs that bridge between native and managed runtimes. They may change, be renamed, or be removed in any minor release without prior deprecation.
-> App developers: prefer the standard `SentrySDK` API surface instead.
-
-Individual methods carry per-method documentation explaining parameters and behavior, ported from the existing `PrivateSentrySDKOnly` headerdocs.
+Swift types live in `Sources/Swift/HybridSDK/`, the entry point extension in `Sources/Swift/Helper/SentrySDK+Internal.swift`, ObjC headers in `Sources/SentryObjC/Public/`, and ObjC wrappers in `Sources/SentryObjCCompat/`.
 
 ## Call-Site Migration Examples
 
@@ -631,53 +329,6 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 [[SentryObjCSDK internal] setTrace:traceId spanId:spanId];
 ```
 
-### ObjC — Swizzle migration (React Native)
-
-```objc
-// Before — requires internal header search path
-#if __has_include(<Sentry/SentrySwizzle.h>)
-#    import <Sentry/SentrySwizzle.h>
-#else
-#    import "SentrySwizzle.h"
-#endif
-
-+ (void)swizzleViewDidAppear
-{
-    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
-    if (rnsscreenclass == nil) { return; }
-
-    SEL selector = NSSelectorFromString(@"viewDidAppear:");
-    SentrySwizzleInstanceMethod(rnsscreenclass, selector, SentrySWReturnType(void),
-        SentrySWArguments(BOOL animated), SentrySWReplacement({
-            [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
-            SentrySWCallOriginal(animated);
-        }),
-        SentrySwizzleModeOncePerClass, (void *)selector);
-}
-
-// After — single import, no internal headers, no macros
-#import <SentryObjC/SentryObjC.h>
-
-+ (void)swizzleViewDidAppear
-{
-    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
-    if (rnsscreenclass == nil) { return; }
-
-    SEL selector = NSSelectorFromString(@"viewDidAppear:");
-    [[[SentryObjCSDK internal] swizzle]
-        swizzleInstanceMethod:selector
-        inClass:rnsscreenclass
-        newImpFactory:^id(IMP (^getOriginal)(void)) {
-            return ^void(__unsafe_unretained id self, BOOL animated) {
-                [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
-                ((void (*)(id, SEL, BOOL))getOriginal())(self, selector, animated);
-            };
-        }
-        mode:SentryObjCSwizzleModeOncePerClass
-        key:(void *)selector];
-}
-```
-
 ## Public API Surface Impact
 
 - `sdk_api.json` gains ~75 new public symbols (14 types + their methods/properties).
@@ -695,4 +346,3 @@ SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
 
 1. **`SentryObjCSDK.internal` naming in ObjC.** `internal` is not a reserved word in ObjC, so no conflict. But should we verify no collision with Apple's runtime selectors?
 2. **Thread safety.** `PrivateSentrySDKOnly` methods are individually thread-safe via internal SDK locks. The new types delegate to the same internals, inheriting the same guarantees. Should we add `@Sendable` annotations to callback parameters?
-3. ~~**`SentryInternalApi` as singleton vs. value.**~~ **Resolved:** implemented as a lazy `var` protected by `NSRecursiveLock`, with `resetInternalApi()` called on SDK close. This allows sub-objects to be recreated with fresh dependencies when the SDK restarts.

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -198,8 +198,9 @@ Each sub-object is a plain Swift class (no `NSObject`, no `@objc`):
 /// or be removed in any minor release without prior deprecation.
 ///
 /// App developers: prefer the standard `SentrySDK` API surface instead.
+@_implementationOnly import _SentryPrivate
+
 public final class SentryInternalApi {
-    @_implementationOnly import _SentryPrivate
 
     #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
     public let replay = SentryInternalReplayApi()
@@ -222,8 +223,7 @@ public final class SentryInternalApi {
 // Sources/Swift/HybridSDK/SentryInternalReplayApi.swift
 
 public final class SentryInternalReplayApi {
-    public func capture() {
-        // Same internal call as PrivateSentrySDKOnly.captureReplay
+    public func capture() -> Bool {
         SentrySessionReplayIntegration.captureReplay()
     }
 

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -28,6 +28,29 @@ Hybrid SDKs (React Native, Flutter, .NET, Unity) consume `PrivateSentrySDKOnly`,
 - Wrapping types already available in the public API (e.g., `SentrySDK.replay` for end users).
 - Changing the internal SDK architecture. The new types call the same internal code that `PrivateSentrySDKOnly` does today.
 
+## Eliminating Internal Header Imports
+
+Beyond replacing `PrivateSentrySDKOnly`, this API also eliminates the need for hybrid SDKs to import other internal headers:
+
+### `SentryOptionsInternal.h`
+
+Unity imports this solely for `+initWithDict:didFailWithError:`, which creates `SentryOptions` from a dictionary passed across the C#→ObjC bridge. This is already mapped to `.internal.options(fromDictionary:)` / `[[… internal] optionsFromDictionary:error:]`.
+
+### `Sentry-Swift.h`
+
+Unity imports this to access `SentryId` and `SentrySpanId` types, which are Swift classes only available to ObjC through the auto-generated bridging header. The Unity code even documents the workaround: _"This is a workaround to deal with SentryId living inside the Swift header."_ It uses `NSClassFromString()` to load these types dynamically.
+
+With the new API, `SentryObjCInternalApi.setTrace:spanId:` accepts `SentryObjCId *` and `SentryObjCSpanId *` parameters — types that already exist in the `SentryObjC` public headers. Unity imports `<SentryObjC/SentryObjC.h>` instead, which provides both the internal API and the ID types.
+
+### Result
+
+After migration, hybrid SDKs need only one import:
+
+- **Swift:** `import Sentry`
+- **ObjC:** `#import <SentryObjC/SentryObjC.h>`
+
+No more `PrivateSentrySDKOnly.h`, `SentryOptionsInternal.h`, or `Sentry-Swift.h`.
+
 ## Architecture
 
 ```
@@ -236,6 +259,8 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
 #import <Foundation/Foundation.h>
 #import <SentryObjC/SentryObjCDefines.h>
 
+@class SentryObjCId;
+@class SentryObjCSpanId;
 @class SentryObjCInternalReplayApi;
 @class SentryObjCInternalEnvelopeApi;
 // ... other forward declarations ...
@@ -259,6 +284,7 @@ Following the two-target architecture from [SENTRY-OBJC.md](SENTRY-OBJC.md):
 - (void)setSdkName:(NSString *)name version:(NSString *)version;
 - (NSString *)sdkName;
 - (NSString *)sdkVersionString;
+- (void)setTrace:(SentryObjCId *)traceId spanId:(SentryObjCSpanId *)spanId;
 
 @end
 ```
@@ -401,19 +427,26 @@ let success = SentrySDK.internal.replay.capture()
 ```objc
 // Before
 #import <Sentry/PrivateSentrySDKOnly.h>
+#import <Sentry/SentryOptionsInternal.h>  // Unity only
+#import <Sentry/Sentry-Swift.h>           // Unity only (workaround for SentryId)
 [PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.react-native" andVersionString:@"6.0.0"];
 PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = YES;
 SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
 [PrivateSentrySDKOnly captureReplay];
-// Workaround to get BOOL result:
-id integration = [PrivateSentrySDKOnly performSelector:@selector(getReplayIntegration)];
+// Unity workaround for SentryId living in Swift header:
+Class SentryIdClass = NSClassFromString(@"SentryId");
+id traceId = [[SentryIdClass alloc] initWithUUIDString:traceString];
 
-// After
+// After — single import, no internal headers
 #import <SentryObjC/SentryObjC.h>
 [[SentryObjCSDK internal] setSdkName:@"sentry.cocoa.react-native" version:@"6.0.0"];
 [SentryObjCSDK internal].appStart.hybridSDKMode = YES;
 SentryObjCScreenFrames *frames = [SentryObjCSDK internal].performance.currentScreenFrames;
 BOOL success = [[[SentryObjCSDK internal] replay] capture];
+// Typed ID parameters — no NSClassFromString, no Sentry-Swift.h
+SentryObjCId *traceId = [[SentryObjCId alloc] initWithUUIDString:traceString];
+SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];
+[[SentryObjCSDK internal] setTrace:traceId spanId:spanId];
 ```
 
 ## Public API Surface Impact


### PR DESCRIPTION
Design spec for replacing `PrivateSentrySDKOnly` with a structured, namespaced API: `SentrySDK.internal` (pure Swift, `@_spi(Private)`) and `SentryObjCSDK.internal` (ObjC wrapper).

The full spec lives in [`develop-docs/SENTRY-INTERNAL-API.md`](https://github.com/getsentry/sentry-cocoa/blob/docs/sentry-internal-api-spec/develop-docs/SENTRY-INTERNAL-API.md) — covering problem statement, design goals, API grouping (14 sub-objects), type inventory, implementation conventions, migration examples, and deprecation strategy.

Refs getsentry/sentry-cocoa#7881

#skip-changelog

<details>

<summary>Full API migration map & cross-SDK usage analysis</summary>

### `SentrySDK.internal` (root)

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+setSdkName:andVersionString:` | `.internal.sdk.setName(_:version:)` | `[[[… internal] sdk] setName:version:]` |
| `+setSdkName:` | `.internal.sdk.name =` | `[[[… internal] sdk] setName:]` |
| `+getSdkName` | `.internal.sdk.name` | `[[[… internal] sdk] name]` |
| `+getSdkVersionString` | `.internal.sdk.versionString` | `[[[… internal] sdk] versionString]` |
| `+addSdkPackage:version:` | `.internal.sdk.addPackage(name:version:)` | `[[[… internal] sdk] addPackageName:version:]` |
| `+getExtraContext` | `.internal.sdk.extraContext` | `[[[… internal] sdk] extraContext]` |
| `.installationID` | `.internal.sdk.installationID` | `[[[… internal] sdk] installationID]` |
| `.options` | `.internal.options` | `[[… internal] options]` |
| `+optionsWithDictionary:didFailWithError:` | `.internal.options(fromDictionary:) throws` | `[[… internal] optionsFromDictionary:error:]` |
| `+userWithDictionary:` | `.internal.user.fromDictionary(_:)` | `[[[… internal] user] fromDictionary:]` |
| `+breadcrumbWithDictionary:` | `.internal.breadcrumbs.fromDictionary(_:)` | `[[[… internal] breadcrumbs] fromDictionary:]` |
| `+setTrace:spanId:` | `.internal.setTrace(_:spanId:)` | `[[… internal] setTrace:(SentryObjCId *)spanId:(SentryObjCSpanId *)]` |
| `+setLogOutput:` | `.internal.setLogOutput(_:)` | `[[… internal] setLogOutput:]` |
| `+ignoreNextSignal:` | `.internal.ignoreNextSignal(_:)` | `[[… internal] ignoreNextSignal:]` |
| `+getDebugImages` (via `@_spi`) | `.internal.debug.images` | `[[[… internal] debug] images]` |

### `SentrySDK.internal.replay`

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+configureSessionReplayWith:screenshotProvider:` | `.internal.replay.configure(breadcrumbConverter:screenshotProvider:)` | `[[[… internal] replay] configureBreadcrumbConverter:screenshotProvider:]` |
| `+captureReplay` (void) + `getReplayIntegration` (dynamic hack) | `.internal.replay.capture() -> Bool` | `[[[… internal] replay] capture]` (returns `BOOL`) |
| `+getReplayId` | `.internal.replay.replayId` | `[[[… internal] replay] replayId]` |
| `+addReplayIgnoreClasses:` | `.internal.replay.addIgnoreClasses(_:)` | `[[[… internal] replay] addIgnoreClasses:]` |
| `+addReplayRedactClasses:` | `.internal.replay.addRedactClasses(_:)` | `[[[… internal] replay] addRedactClasses:]` |
| `+setIgnoreContainerClass:` | `.internal.replay.setIgnoreContainerClass(_:)` | `[[[… internal] replay] setIgnoreContainerClass:]` |
| `+setRedactContainerClass:` | `.internal.replay.setRedactContainerClass(_:)` | `[[[… internal] replay] setRedactContainerClass:]` |
| `+setReplayTags:` | `.internal.replay.setTags(_:)` | `[[[… internal] replay] setTags:]` |

### `SentrySDK.internal.profiling`

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+startProfilerForTrace:` | `.internal.profiling.start(for:)` | `[[[… internal] profiling] startForTrace:]` |
| `+collectProfileBetween:and:forTrace:` | `.internal.profiling.collect(between:and:for:)` | `[[[… internal] profiling] collectBetween:and:forTrace:]` |
| `+discardProfilerForTrace:` | `.internal.profiling.discard(for:)` | `[[[… internal] profiling] discardForTrace:]` |

### `SentrySDK.internal.appStart`

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `.appStartMeasurementHybridSDKMode` | `.internal.appStart.hybridSDKMode` | `[[[… internal] appStart] hybridSDKMode]` |
| `.appStartMeasurement` | `.internal.appStart.measurement` | `[[[… internal] appStart] measurement]` |
| `+appStartMeasurementWithSpans` | `.internal.appStart.measurementWithSpans` | `[[[… internal] appStart] measurementWithSpans]` |
| `.onAppStartMeasurementAvailable` | `.internal.appStart.onMeasurementAvailable` | `[[[… internal] appStart] onMeasurementAvailable]` |

### `SentrySDK.internal.performance`

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `.framesTrackingMeasurementHybridSDKMode` | `.internal.performance.framesTrackingHybridSDKMode` | `[[[… internal] performance] framesTrackingHybridSDKMode]` |
| `.isFramesTrackingRunning` | `.internal.performance.isFramesTrackingRunning` | `[[[… internal] performance] isFramesTrackingRunning]` |
| `.currentScreenFrames` | `.internal.performance.currentScreenFrames` | `[[[… internal] performance] currentScreenFrames]` |

### `SentrySDK.internal.screenshot`

| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+captureScreenshots` | `.internal.screenshot.capture()` | `[[[… internal] screenshot] capture]` |

### `SentrySDK.internal.viewHierarchy`

| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+captureViewHierarchy` | `.internal.viewHierarchy.capture()` | `[[[… internal] viewHierarchy] capture]` |

### `SentrySDK.internal.envelope`

<!-- linear:table-colwidths:266,266,266 -->
| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+storeEnvelope:` | `.internal.envelope.store(_:)` | `[[[… internal] envelope] store:]` |
| `+captureEnvelope:` | `.internal.envelope.capture(_:)` | `[[[… internal] envelope] capture:]` |
| `+envelopeWithData:` | `.internal.envelope.deserialize(from:)` | `[[[… internal] envelope] deserializeFrom:]` |

### `SentrySDK.internal.screen`

| Old (`PrivateSentrySDKOnly`) | New (Swift) | New (ObjC via `SentryObjCSDK`) |
| -- | -- | -- |
| `+setCurrentScreen:` | `.internal.screen.setCurrent(_:)` | `[[[… internal] screen] setCurrent:]` |

### Cross-SDK Usage Analysis

Verified against actual call sites in all five hybrid SDKs:

<!-- linear:table-colwidths:200,200,200,200 -->
| SDK | `PrivateSentrySDKOnly` call sites | Methods used | Migration path |
| -- | -- | -- | -- |
| **React Native** | ~80 | all 22+ APIs | `SentryObjCSDK.internal.*` (ObjC/ObjC++) |
| **Flutter/Dart** | ~25 (Swift) + FFI bindings | 20 APIs + `getDebugImages` | `SentrySDK.internal.*` (Swift) + FFI regen |
| **.NET (MAUI)** | 5 (via C# bindings / Objective Sharpie) | `setSdkName:`, `setTrace:spanId:`, `startProfilerForTrace:`, `collectProfileBetween:and:forTrace:`, `ignoreNextSignal:` | Regenerate C# bindings against new API |
| **Unity** | 6 (3 iOS + 3 macOS, all via `performSelector:`) | `setSdkName:`, `installationID`, `setTrace:spanId:` | `SentryObjCSDK.internal.*` — also eliminates `SentryOptionsInternal.h` and `Sentry-Swift.h` imports |
| **Unreal** | 2 (already on `SentryObjC*` wrappers) | `setSdkName:`, `captureEnvelope:` | `SentryObjCSDK.internal.*` (minimal) |

</details>
