### PR TITLE
chore(ci): update Xcode version for visionOS 2.5 Sentry job in nightly test workflow

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -72,7 +72,7 @@ jobs:
           - name: visionOS 2.5 Sentry
             runner_provider: bitrise
             runs-on: sequoia
-            xcode: "26"
+            xcode: "16"
             platform: "visionOS"
             timeout: 30
 


### PR DESCRIPTION
## :scroll: Description

Fixes visionOS 2.5 broken on bitrise

## :green_heart: How did you test it?

Triggered a manual job: https://github.com/getsentry/sentry-cocoa/actions/runs/27146074044/job/80124087040

#skip-changelog