### PR TITLE
fix: Support geo in SentryGeo initWithDictionary

### DIFF
--- a/Sources/Sentry/SentryGeo.m
+++ b/Sources/Sentry/SentryGeo.m
@@ -6,6 +6,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryGeo
 
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary
+{
+    if (self = [super init]) {
+        id city = dictionary[@"city"];
+        if ([city isKindOfClass:[NSString class]]) {
+            self.city = city;
+        }
+
+        id countryCode = dictionary[@"country_code"];
+        if ([countryCode isKindOfClass:[NSString class]]) {
+            self.countryCode = countryCode;
+        }
+
+        id region = dictionary[@"region"];
+        if ([region isKindOfClass:[NSString class]]) {
+            self.region = region;
+        }
+    }
+    return self;
+}
+
 - (id)copyWithZone:(nullable NSZone *)zone
 {
     SentryGeo *copy = [[[self class] allocWithZone:zone] init];

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -1,5 +1,5 @@
 #import "SentryUser.h"
-#import "SentryGeo.h"
+#import "SentryGeo+Private.h"
 #import "SentryInternalDefines.h"
 #import "SentrySanitizerUtils.h"
 
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
                 self.ipAddress = value;
             } else if ([key isEqualToString:@"data"] && isDictionary) {
                 self.data = value;
+            } else if ([key isEqualToString:@"geo"] && isDictionary) {
+                self.geo = [[SentryGeo alloc] initWithDictionary:value];
             } else {
                 unknown[key] = value;
             }

--- a/Sources/Sentry/include/SentryGeo+Private.h
+++ b/Sources/Sentry/include/SentryGeo+Private.h
@@ -1,0 +1,16 @@
+#if __has_include(<Sentry/SentryGeo.h>)
+#    import <Sentry/SentryGeo.h>
+#else
+#    import "SentryGeo.h"
+#endif
+
+@interface SentryGeo ()
+
+/**
+ * Initializes a SentryGeo from a dictionary.
+ * @param dictionary The dictionary containing geo data.
+ * @return The SentryGeo.
+ */
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+
+@end

--- a/Tests/SentryTests/Protocol/SentryGeoTests.swift
+++ b/Tests/SentryTests/Protocol/SentryGeoTests.swift
@@ -3,6 +3,63 @@ import XCTest
 
 class SentryGeoTests: XCTestCase {
     
+    func testInitWithDictionary_AllProperties() throws {
+        let dict: [String: Any] = [
+            "city": "San Francisco",
+            "country_code": "US",
+            "region": "California"
+        ]
+        let geo = try XCTUnwrap(Geo(dictionary: dict))
+
+        XCTAssertEqual(geo.city, "San Francisco")
+        XCTAssertEqual(geo.countryCode, "US")
+        XCTAssertEqual(geo.region, "California")
+    }
+
+    func testInitWithDictionary_PartialProperties() throws {
+        let geo = try XCTUnwrap(Geo(dictionary: ["city": "Berlin"]))
+
+        XCTAssertEqual(geo.city, "Berlin")
+        XCTAssertNil(geo.countryCode)
+        XCTAssertNil(geo.region)
+    }
+
+    func testInitWithDictionary_EmptyDict() throws {
+        let geo = try XCTUnwrap(Geo(dictionary: [:]))
+
+        XCTAssertNil(geo.city)
+        XCTAssertNil(geo.countryCode)
+        XCTAssertNil(geo.region)
+    }
+
+    func testInitWithDictionary_WrongTypes() throws {
+        let dict: [String: Any] = [
+            "city": 123,
+            "country_code": ["not", "a", "string"],
+            "region": true
+        ]
+        let geo = try XCTUnwrap(Geo(dictionary: dict))
+
+        XCTAssertNil(geo.city)
+        XCTAssertNil(geo.countryCode)
+        XCTAssertNil(geo.region)
+    }
+
+    func testInitWithDictionary_RoundTrip() throws {
+        let dict: [String: Any] = [
+            "city": "San Francisco",
+            "country_code": "US",
+            "region": "California"
+        ]
+        let geo = try XCTUnwrap(Geo(dictionary: dict))
+        let serialized = geo.serialize()
+
+        XCTAssertEqual(serialized["city"] as? String, "San Francisco")
+        XCTAssertEqual(serialized["country_code"] as? String, "US")
+        XCTAssertEqual(serialized["region"] as? String, "California")
+        XCTAssertEqual(serialized.count, 3)
+    }
+
     func testSerializationWithAllProperties() throws {
         let geo = try XCTUnwrap(TestData.geo.copy() as? Geo)
         let actual = geo.serialize()

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -12,16 +12,43 @@ class SentryUserTests: XCTestCase {
             "data": [
                 "fixture-key": "fixture-value"
             ],
+            "geo": [
+                "city": "San Francisco",
+                "country_code": "US",
+                "region": "California"
+            ],
             "foo": "bar" // Unknown
         ]
         let user = PrivateSentrySDKOnly.user(with: dict)
-        
+
         XCTAssertEqual(user.userId, "fixture-id")
         XCTAssertEqual(user.email, "fixture-email")
         XCTAssertEqual(user.username, "fixture-username")
         XCTAssertEqual(user.ipAddress, "fixture-ip_address")
         XCTAssertEqual(user.data?["fixture-key"] as? String, "fixture-value")
+        XCTAssertEqual(user.geo?.city, "San Francisco")
+        XCTAssertEqual(user.geo?.countryCode, "US")
+        XCTAssertEqual(user.geo?.region, "California")
         XCTAssertEqual(user.value(forKey: "unknown") as? NSDictionary, ["foo": "bar"])
+    }
+
+    func testInitWithDictionary_GeoRoundTrip() {
+        let dict: [AnyHashable: Any] = [
+            "id": "user-1",
+            "geo": [
+                "city": "San Francisco",
+                "country_code": "US",
+                "region": "California"
+            ]
+        ]
+        let user = PrivateSentrySDKOnly.user(with: dict)
+        let serialized = user.serialize()
+
+        let geo = serialized["geo"] as? [String: Any]
+        XCTAssertEqual(geo?["city"] as? String, "San Francisco")
+        XCTAssertEqual(geo?["country_code"] as? String, "US")
+        XCTAssertEqual(geo?["region"] as? String, "California")
+        XCTAssertNil(serialized["unknown"])
     }
     
     func testSerializationWithAllProperties() throws {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentryGeo+Private.h"
 
 #import "SentryLaunchProfiling+Tests.h"
 


### PR DESCRIPTION
## :scroll: Description

Add `initWithDictionary:` to `SentryGeo` (via a private header) and handle the `"geo"` key in `SentryUser.initWithDictionary:` so that geo data is properly deserialized into the `geo` property instead of landing in the `unknown` dictionary.

Previously, passing a dictionary with a `"geo"` key to `SentryUser.initWithDictionary:` would store it in `unknown`. During serialization, `unknown` keys are written on top of the serialized dict, overwriting the properly-set `self.geo` property — causing duplicated or incorrect geo data.

## :bulb: Motivation and Context

Hybrid SDKs (e.g. React Native) pass user dictionaries that include `"geo"`. Without this fix, they need to manually strip the `"geo"` key before calling `initWithDictionary:` and set it separately — a workaround that was identified in https://github.com/getsentry/sentry-react-native/pull/6261#discussion_r3380121938.

## :green_heart: How did you test it?

- Added test for `initWithDictionary:` with geo fields
- Added round-trip test (`dict → initWithDictionary → serialize`) to verify geo survives serialization without leaking into `unknown`
- All 14 `SentryUserTests` pass

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog