### PR TITLE
fix: reflect extended app start duration in vitals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 
 - Deprecate the managed User Feedback widget/FAB. It will be removed in v10. Present the feedback form from your own UI with `SentrySDK.feedback.show()`, `SentrySDK.FeedbackForm`, or `.sentryFeedback(isPresented:)` instead. (#8022)
 
+### Fixes
+
+- App start duration on the Vitals dashboard now reflects the extended app launch time when using `extendAppLaunch()` (#TBD)
+
 ## 9.16.1
 
 > [!NOTE]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### Fixes
 
-- App start duration on the Vitals dashboard now reflects the extended app launch time when using `extendAppLaunch()` (#TBD)
+- App start duration on the Vitals dashboard now reflects the extended app launch time when using `extendAppLaunch()` (#8028)
 
 ## 9.16.1
 

--- a/Sources/Sentry/SentryAppStartMeasurement.m
+++ b/Sources/Sentry/SentryAppStartMeasurement.m
@@ -1,9 +1,10 @@
-#import "SentryAppStartMeasurement.h"
+#import "SentryAppStartMeasurement+Private.h"
 
 #if SENTRY_UIKIT_AVAILABLE
 
 #    import "SentryDateUtils.h"
 #    import "SentryLogC.h"
+#    import "SentrySpanProtocol.h"
 
 @implementation SentryAppStartTypeToString
 + (NSString *)convert:(SentryAppStartType)type
@@ -31,6 +32,15 @@
     NSDate *_moduleInitializationTimestamp;
     NSDate *_sdkStartTimestamp;
     NSDate *_didFinishLaunchingTimestamp;
+}
+
+- (NSTimeInterval)effectiveDuration
+{
+    NSDate *extendedEnd = self.extendedAppStartSpan.timestamp;
+    if (extendedEnd != nil) {
+        return [extendedEnd timeIntervalSinceDate:_appStartTimestamp];
+    }
+    return _duration;
 }
 #    endif // SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -30,7 +30,7 @@
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 #if SENTRY_HAS_UIKIT
-#    import "SentryAppStartMeasurement.h"
+#    import "SentryAppStartMeasurement+Private.h"
 #    import "SentryAppStartMeasurementProvider.h"
 #    import "SentryBuildAppStartSpans.h"
 #endif // SENTRY_HAS_UIKIT
@@ -796,7 +796,9 @@ static const NSTimeInterval SENTRY_AUTO_TRANSACTION_DEADLINE = 30.0;
 
         if (vitalsType != nil && appContextType != nil) {
             BOOL isStandalone = [self isStandaloneAppStartTransaction];
-            NSNumber *durationMs = @(appStartMeasurement.duration * 1000);
+            NSTimeInterval duration = isStandalone ? appStartMeasurement.effectiveDuration
+                                                   : appStartMeasurement.duration;
+            NSNumber *durationMs = @(duration * 1000);
 
             NSString *appStartType = (!isStandalone && appStartMeasurement.isPreWarmed)
                 ? [NSString stringWithFormat:@"%@.prewarmed", appContextType]

--- a/Sources/Sentry/include/SentryAppStartMeasurement+Private.h
+++ b/Sources/Sentry/include/SentryAppStartMeasurement+Private.h
@@ -24,6 +24,23 @@ NS_ASSUME_NONNULL_BEGIN
                 sdkStartTimestamp:(NSDate *)sdkStartTimestamp
       didFinishLaunchingTimestamp:(NSDate *)didFinishLaunchingTimestamp;
 
+/**
+ * The extended app start span, set when the user calls @c extendAppLaunch().
+ * Its @c timestamp is the authoritative end time of the extended app start, regardless of how
+ * the span was finished (direct @c finish(), child span completion, or @c finishExtendedAppLaunch).
+ *
+ * Default is nil.
+ */
+@property (nonatomic, strong, nullable) id<SentrySpan> extendedAppStartSpan;
+
+/**
+ * Returns the effective app start duration in seconds.
+ *
+ * When @c extendedAppStartSpan is set and finished, the duration spans from
+ * @c appStartTimestamp to the span's end timestamp. Otherwise falls back to @c duration.
+ */
+@property (readonly, nonatomic, assign) NSTimeInterval effectiveDuration;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryTracerConfiguration.h
+++ b/Sources/Sentry/include/SentryTracerConfiguration.h
@@ -62,7 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Default is nil.
  */
 @property (nonatomic, strong, nullable) SentryAppStartMeasurement *appStartMeasurement;
-
 #endif // SENTRY_HAS_UIKIT
 
 + (SentryTracerConfiguration *)configurationWithBlock:

--- a/Sources/Sentry/include/SentryTracerConfiguration.h
+++ b/Sources/Sentry/include/SentryTracerConfiguration.h
@@ -62,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Default is nil.
  */
 @property (nonatomic, strong, nullable) SentryAppStartMeasurement *appStartMeasurement;
+
 #endif // SENTRY_HAS_UIKIT
 
 + (SentryTracerConfiguration *)configurationWithBlock:

--- a/Sources/Swift/Integrations/AppStartTracking/SentryExtendedAppLaunchManager.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryExtendedAppLaunchManager.swift
@@ -69,6 +69,7 @@ final class SentryExtendedAppLaunchManager {
         let shouldFinishTracer: Bool = lock.synchronized {
             self.tracer = newTracer
             self.extendedSpan = child
+            config.appStartMeasurement?.extendedAppStartSpan = child
             return config.appStartMeasurement != nil
         }
 
@@ -91,6 +92,7 @@ final class SentryExtendedAppLaunchManager {
         SentrySDKLog.debug("Setting app start measurement on extended launch tracer")
         let tracerToFinish: (any Span)? = lock.synchronized {
             tracerConfiguration?.appStartMeasurement = measurement
+            measurement.extendedAppStartSpan = extendedSpan
             SentryAppStartMeasurementProvider.markAsRead()
             return tracer
         }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
@@ -347,6 +347,110 @@ class SentryExtendedAppLaunchTests: XCTestCase {
         XCTAssertEqual(hub.capturedTransactionsWithScope.invocations.count, 1,
             "Transaction should be captured once measurement arrives")
     }
+    // MARK: - Effective App Start Duration
+
+    func testEffectiveDuration_withoutExtendedEnd_returnsMeasurementDuration() {
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+
+        XCTAssertEqual(measurement.effectiveDuration, 0.5, accuracy: 0.001)
+    }
+
+    func testEffectiveDuration_withFinishedSpan_returnsExtendedDuration() {
+        _ = setUpIntegrationHub()
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+
+        let dateProvider = SentryDependencyContainer.sharedInstance().dateProvider as! TestCurrentDateProvider
+        let hub = SentrySDKInternal.currentHub()
+        let tracer = hub.startTransaction(
+            with: TransactionContext(name: "test", operation: "test"),
+            bindToScope: false,
+            customSamplingContext: [:],
+            configuration: SentryTracerConfiguration()
+        )
+        let span = tracer.startChild(operation: "app.start", description: "Extended App Start")
+        measurement.extendedAppStartSpan = span
+
+        dateProvider.setDate(date: measurement.appStartTimestamp.addingTimeInterval(2.0))
+        span.finish()
+
+        XCTAssertEqual(measurement.effectiveDuration, 2.0, accuracy: 0.001)
+    }
+
+    func testEffectiveAppStartDuration_withFinishedExtendedSpan_returnsExtendedDuration() throws {
+        let hub = setUpIntegrationHub()
+        let manager = SentryExtendedAppLaunchManager()
+        let span = try XCTUnwrap(manager.extend())
+
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+        StandaloneTransactionStrategy(extendedAppLaunchManager: manager).report(measurement, traceId: SentryId())
+
+        let dateProvider = try XCTUnwrap(SentryDependencyContainer.sharedInstance().dateProvider as? TestCurrentDateProvider)
+        dateProvider.setDate(date: measurement.appStartTimestamp.addingTimeInterval(2.0))
+        span.finish()
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let extra = try XCTUnwrap(serialized["extra"] as? [String: Any])
+        let startValue = try XCTUnwrap(extra["app.vitals.start.value"] as? NSNumber)
+
+        XCTAssertEqual(startValue.doubleValue, 2_000, accuracy: 1)
+    }
+
+    func testEffectiveAppStartDuration_withChildSpan_reflectsChildFinishTime() throws {
+        let hub = setUpIntegrationHub()
+        let manager = SentryExtendedAppLaunchManager()
+        let span = try XCTUnwrap(manager.extend())
+
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+        StandaloneTransactionStrategy(extendedAppLaunchManager: manager).report(measurement, traceId: SentryId())
+
+        let dateProvider = try XCTUnwrap(SentryDependencyContainer.sharedInstance().dateProvider as? TestCurrentDateProvider)
+        let child = span.startChild(operation: "app.init", description: "fetch config")
+        dateProvider.setDate(date: measurement.appStartTimestamp.addingTimeInterval(1.5))
+        child.finish()
+        dateProvider.setDate(date: measurement.appStartTimestamp.addingTimeInterval(3.0))
+        span.finish()
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let extra = try XCTUnwrap(serialized["extra"] as? [String: Any])
+        let startValue = try XCTUnwrap(extra["app.vitals.start.value"] as? NSNumber)
+
+        XCTAssertEqual(startValue.doubleValue, 3_000, accuracy: 1)
+    }
+
+    func testEffectiveAppStartDuration_finishViaManager_reflectsExtendedDuration() throws {
+        let hub = setUpIntegrationHub()
+        let manager = SentryExtendedAppLaunchManager()
+        manager.extend()
+
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+        StandaloneTransactionStrategy(extendedAppLaunchManager: manager).report(measurement, traceId: SentryId())
+
+        let dateProvider = try XCTUnwrap(SentryDependencyContainer.sharedInstance().dateProvider as? TestCurrentDateProvider)
+        dateProvider.setDate(date: measurement.appStartTimestamp.addingTimeInterval(1.0))
+        manager.finish()
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let extra = try XCTUnwrap(serialized["extra"] as? [String: Any])
+        let startValue = try XCTUnwrap(extra["app.vitals.start.value"] as? NSNumber)
+        let coldValue = try XCTUnwrap(extra["app.vitals.start.cold.value"] as? NSNumber)
+
+        XCTAssertEqual(startValue.doubleValue, 1_000, accuracy: 1)
+        XCTAssertEqual(coldValue.doubleValue, 1_000, accuracy: 1)
+    }
+
+    func testEffectiveAppStartDuration_nonExtended_usesMeasurementDuration() throws {
+        let hub = setUpIntegrationHub()
+        let manager = SentryExtendedAppLaunchManager()
+
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+        StandaloneTransactionStrategy(extendedAppLaunchManager: manager).report(measurement, traceId: SentryId())
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let extra = try XCTUnwrap(serialized["extra"] as? [String: Any])
+        let startValue = try XCTUnwrap(extra["app.vitals.start.value"] as? NSNumber)
+
+        XCTAssertEqual(startValue.doubleValue, 0.5 * 1_000, accuracy: 1)
+    }
 }
 
 #endif // os(iOS) || os(tvOS)


### PR DESCRIPTION
## Summary

- App start duration reported to the Vitals dashboard (`app.vitals.start.value`, `app.vitals.start.cold.value`, `app.vitals.start.warm.value`) now reflects the actual extended duration when `extendAppLaunch()` is used, instead of the fixed measurement duration (process start → first frame).
- Adds `extendedAppStartSpan` and `effectiveDuration` to `SentryAppStartMeasurement`, keeping all app start duration logic co-located on the measurement itself.
- The manager sets the span reference on the measurement from both orderings (extend-first and measurement-first), so `effectiveDuration` works regardless of how the extended span finishes (direct `finish()`, child span completion, or `finishExtendedAppLaunch()`).

## Test plan

- [x] `testEffectiveDuration_withoutExtendedEnd_returnsMeasurementDuration` — no extended span falls back to original duration
- [x] `testEffectiveDuration_withFinishedSpan_returnsExtendedDuration` — unit test on measurement with a finished span
- [x] `testEffectiveAppStartDuration_withFinishedExtendedSpan_returnsExtendedDuration` — end-to-end via `span.finish()`
- [x] `testEffectiveAppStartDuration_withChildSpan_reflectsChildFinishTime` — extended span with child spans
- [x] `testEffectiveAppStartDuration_finishViaManager_reflectsExtendedDuration` — end-to-end via `finishExtendedAppLaunch()`
- [x] `testEffectiveAppStartDuration_nonExtended_usesMeasurementDuration` — non-extended standalone uses original duration
- [x] Existing `SentryTracerTests` standalone tests still pass
- [x] All 25 `SentryExtendedAppLaunchTests` pass