### PR TITLE
ci: add Xcode 27 SPM build workflow

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -14,6 +14,12 @@ inputs:
       a major.minor like '16.4' or '26.0', or an exact installed version.
     required: false
     default: "latest"
+  allow-prerelease:
+    description: >-
+      When 'true', include prerelease (beta/RC/GM) Xcode versions during
+      resolution. By default prerelease versions are filtered out.
+    required: false
+    default: "false"
 outputs:
   xcode-version:
     description: "The resolved (concrete) Xcode version, e.g. '16.4' or '26.0.1'."
@@ -38,5 +44,10 @@ runs:
       shell: bash
       env:
         XCODE_INPUT: ${{ inputs.version }}
+        ALLOW_PRERELEASE: ${{ inputs.allow-prerelease }}
       run: |
-        "${{ github.action_path }}/../../../scripts/ci-select-xcode.sh" "$XCODE_INPUT"
+        PRERELEASE_FLAG=""
+        if [[ "$ALLOW_PRERELEASE" == "true" ]]; then
+          PRERELEASE_FLAG="--allow-prerelease"
+        fi
+        "${{ github.action_path }}/../../../scripts/ci-select-xcode.sh" $PRERELEASE_FLAG "$XCODE_INPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,30 +318,26 @@ jobs:
         with:
           version: "26"
       - run: |
-          set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-            -workspace . \
-            -scheme SentrySPM \
-            -sdk watchos \
-            -destination 'generic/platform=watchOS' \
-            build | tee raw-build-output-spm-watchos.log | xcbeautify --preserve-unbeautified
-        shell: sh
+          ./scripts/sentry-xcodebuild.sh \
+            --workspace . \
+            --scheme SentrySPM \
+            --sdk watchos \
+            --destination 'generic/platform=watchOS' \
+            --command build
       - run: |
-          set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-            -workspace . \
-            -scheme SentrySPM \
-            -sdk iphoneos \
-            -destination 'generic/platform=iphoneos' \
-            build | tee raw-build-output-spm-iphoneos.log | xcbeautify --preserve-unbeautified
-        shell: sh
+          ./scripts/sentry-xcodebuild.sh \
+            --workspace . \
+            --scheme SentrySPM \
+            --sdk iphoneos \
+            --destination 'generic/platform=iphoneos' \
+            --command build
 
       - name: Upload SPM Build Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
           name: raw-build-output-spm
-          path: |
-            raw-build-output-spm-watchos.log
-            raw-build-output-spm-iphoneos.log
+          path: raw-build-output.log
 
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-xcode
         with:
           version: "27"
+          allow-prerelease: "true"
       - name: Build SPM (${{ matrix.platform }})
         run: |
           set -o pipefail && NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -48,19 +48,18 @@ jobs:
           allow-prerelease: "true"
       - name: Build SPM (${{ matrix.platform }})
         run: |
-          set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-            -workspace . \
-            -scheme SentrySPM \
-            -sdk ${{ matrix.sdk }} \
-            -destination '${{ matrix.destination }}' \
-            build 2>&1 | tee raw-build-output-spm-${{ matrix.sdk }}.log | xcbeautify --preserve-unbeautified
-        shell: sh
+          ./scripts/sentry-xcodebuild.sh \
+            --workspace . \
+            --scheme SentrySPM \
+            --sdk ${{ matrix.sdk }} \
+            --destination '${{ matrix.destination }}' \
+            --command build
       - name: Upload Build Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-build-output-spm-${{ matrix.sdk }}
-          path: raw-build-output-spm-${{ matrix.sdk }}.log
+          name: raw-build-output-${{ matrix.sdk }}
+          path: raw-build-output.log
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -1,0 +1,65 @@
+name: Xcode 27
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-spm:
+    name: Build SPM ${{ matrix.platform }}
+    runs-on:
+      - bitrise_pool_name:xcode-beta
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: iOS
+            sdk: iphoneos
+            destination: "generic/platform=iphoneos"
+          - platform: watchOS
+            sdk: watchos
+            destination: "generic/platform=watchOS"
+          - platform: macOS
+            sdk: macosx
+            destination: "generic/platform=macOS"
+          - platform: tvOS
+            sdk: appletvos
+            destination: "generic/platform=tvOS"
+          - platform: visionOS
+            sdk: xros
+            destination: "generic/platform=visionOS"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Setup Xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          version: "27"
+      - name: Build SPM (${{ matrix.platform }})
+        run: |
+          set -o pipefail && NSUnbufferedIO=YES xcodebuild \
+            -workspace . \
+            -scheme SentrySPM \
+            -sdk ${{ matrix.sdk }} \
+            -destination '${{ matrix.destination }}' \
+            build 2>&1 | tee raw-build-output-spm-${{ matrix.sdk }}.log | xcbeautify --preserve-unbeautified
+        shell: sh
+      - name: Upload Build Logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: raw-build-output-spm-${{ matrix.sdk }}
+          path: raw-build-output-spm-${{ matrix.sdk }}.log
+      - name: Run CI Diagnostics
+        uses: ./.github/actions/ci-diagnostics
+        if: ${{ failure() || cancelled() }}

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -3,12 +3,14 @@
 # Selects an Xcode version and exports the latest available simulator runtime
 # per platform so downstream steps (and the Makefile) don't have to pin them.
 #
-# Usage: ci-select-xcode.sh <version>
+# Usage: ci-select-xcode.sh [--allow-prerelease] <version>
 #   <version> may be:
 #     - "latest"                   newest installed Xcode
 #     - a major (e.g. "16", "26")  newest installed minor/patch in that major
 #     - a major.minor (e.g. "16.4", "26.0")  newest installed patch in that line
 #     - an exact installed version (e.g. "26.0.1")
+#
+#   --allow-prerelease  include beta/RC/GM builds when resolving the version
 #
 # Exports to GITHUB_ENV (only if not already set in the caller's env):
 #   XCODE_VERSION             resolved version string
@@ -28,21 +30,36 @@ set -euo pipefail
 # shellcheck source=./scripts/ci-utils.sh disable=SC1091
 source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
-if [[ $# -lt 1 || -z "${1:-}" ]]; then
-    log_error "Usage: $0 <version>  (e.g. 'latest', '16', '26', '16.4', '26.0.1')"
+ALLOW_PRERELEASE=false
+POSITIONAL_ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --allow-prerelease) ALLOW_PRERELEASE=true ;;
+        *) POSITIONAL_ARGS+=("$arg") ;;
+    esac
+done
+
+if [[ ${#POSITIONAL_ARGS[@]} -lt 1 || -z "${POSITIONAL_ARGS[0]:-}" ]]; then
+    log_error "Usage: $0 [--allow-prerelease] <version>  (e.g. 'latest', '16', '26', '16.4', '26.0.1')"
     exit 1
 fi
 
-XCODE_INPUT="$1"
+XCODE_INPUT="${POSITIONAL_ARGS[0]}"
 
 # `xcodes installed` prints one Xcode per line; the first whitespace-separated
 # token is the version (the `(Selected)` marker, build number, and path follow).
-# Filter beta / RC / GM builds so CI never silently selects a prerelease Xcode
-# (e.g. `Xcode_26.5_beta_2.app`) when resolving 'latest' or a major.
-INSTALLED=$(xcodes installed \
-    | grep -viE '(beta|release[ _-]?candidate|[^a-z](rc|gm)[^a-z])' \
-    | awk '{print $1}' \
-    | sort -V)
+if [[ "$ALLOW_PRERELEASE" == true ]]; then
+    INSTALLED=$(xcodes installed \
+        | awk '{print $1}' \
+        | sort -V)
+else
+    # Filter beta / RC / GM builds so CI never silently selects a prerelease
+    # Xcode (e.g. `Xcode_26.5_beta_2.app`) when resolving 'latest' or a major.
+    INSTALLED=$(xcodes installed \
+        | grep -viE '(beta|release[ _-]?candidate|[^a-z](rc|gm)[^a-z])' \
+        | awk '{print $1}' \
+        | sort -V)
+fi
 
 if [[ -z "$INSTALLED" ]]; then
     log_error "'xcodes installed' returned no Xcode versions."

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -24,6 +24,9 @@ TEST_SCHEME="Sentry"
 TEST_PLAN=""
 RESULT_BUNDLE_PATH="results.xcresult"
 ONLY_TESTING=""
+WORKSPACE="Sentry.xcworkspace"
+SDK=""
+RAW_DESTINATION=""
 
 usage() {
     cat <<EOF
@@ -44,11 +47,16 @@ OPTIONS:
     --only-testing <tests>           Comma-separated test selectors.
                                       Each selector must be Target/Class or Target/Class/testMethod.
     -R, --result-bundle <path>       Result bundle path (default: results.xcresult)
+    -w, --workspace <path>           Workspace path (default: Sentry.xcworkspace)
+    --sdk <sdk>                      SDK override (e.g. iphoneos, watchos)
+    --destination <dest>             Raw xcodebuild destination string (bypasses
+                                      --platform resolution)
 
 EXAMPLES:
     $(basename "$0") -p iOS -c test
     $(basename "$0") -p macOS -c build -C Release
     $(basename "$0") -p iOS -c test --only-testing SentryTests/SentrySDKTests
+    $(basename "$0") -w . -s SentrySPM --sdk iphoneos --destination 'generic/platform=iphoneos' -c build
 
 EOF
     exit 1
@@ -102,6 +110,18 @@ while [[ $# -gt 0 ]]; do
             RESULT_BUNDLE_PATH="$2"
             shift 2
             ;;
+        -w|--workspace)
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        --sdk)
+            SDK="$2"
+            shift 2
+            ;;
+        --destination)
+            RAW_DESTINATION="$2"
+            shift 2
+            ;;
         *)
             log_error "Unknown option: $1"
             usage
@@ -124,6 +144,10 @@ resolve_runtime_version() {
         echo "$os"
     fi
 }
+
+if [ -n "$RAW_DESTINATION" ]; then
+    DESTINATION="$RAW_DESTINATION"
+else
 
 case $PLATFORM in
 
@@ -161,8 +185,12 @@ case $PLATFORM in
     ;;
 esac
 
+fi # RAW_DESTINATION check
+
 if [ -n "$CONFIGURATION_OVERRIDE" ]; then
     CONFIGURATION="$CONFIGURATION_OVERRIDE"
+elif [ -n "$RAW_DESTINATION" ]; then
+    CONFIGURATION=""
 else
     case $REF_NAME in
     "main")
@@ -200,13 +228,18 @@ esac
 
 if [ $RUN_BUILD == true ]; then
     log_info "Running xcodebuild build"
-    
+
+    BUILD_ARGS=(
+        -workspace "$WORKSPACE"
+        -scheme "$TEST_SCHEME"
+    )
+    [[ -n "$SDK" ]] && BUILD_ARGS+=(-sdk "$SDK")
+    [[ -n "$CONFIGURATION" ]] && BUILD_ARGS+=(-configuration "$CONFIGURATION")
+    BUILD_ARGS+=(-destination "$DESTINATION")
+    [[ -n "$DERIVED_DATA_PATH" ]] && BUILD_ARGS+=(-derivedDataPath "$DERIVED_DATA_PATH")
+
     set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-        -workspace Sentry.xcworkspace \
-        -scheme "$TEST_SCHEME" \
-        -configuration "$CONFIGURATION" \
-        -destination "$DESTINATION" \
-        -derivedDataPath "$DERIVED_DATA_PATH" \
+        "${BUILD_ARGS[@]}" \
         build 2>&1 |
         tee raw-build-output.log |
         xcbeautify --preserve-unbeautified
@@ -236,7 +269,7 @@ if [ $RUN_BUILD_FOR_TESTING == true ]; then
     log_info "Running xcodebuild build-for-testing"
 
     set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-        -workspace Sentry.xcworkspace \
+        -workspace "$WORKSPACE" \
         -scheme "$TEST_SCHEME" \
         "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}" \
         "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}" \
@@ -257,7 +290,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
     fi
 
     set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-        -workspace Sentry.xcworkspace \
+        -workspace "$WORKSPACE" \
         -scheme "$TEST_SCHEME" \
         "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}" \
         "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}" \

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -268,13 +268,17 @@ if [ $RUN_BUILD_FOR_TESTING == true ]; then
     # When no test plan is provided, we skip the -testPlan argument so xcodebuild uses the default test plan
     log_info "Running xcodebuild build-for-testing"
 
+    BFT_ARGS=(
+        -workspace "$WORKSPACE"
+        -scheme "$TEST_SCHEME"
+        "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}"
+        "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}"
+    )
+    [[ -n "$CONFIGURATION" ]] && BFT_ARGS+=(-configuration "$CONFIGURATION")
+    BFT_ARGS+=(-destination "$DESTINATION")
+
     set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-        -workspace "$WORKSPACE" \
-        -scheme "$TEST_SCHEME" \
-        "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}" \
-        "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}" \
-        -configuration "$CONFIGURATION" \
-        -destination "$DESTINATION" \
+        "${BFT_ARGS[@]}" \
         build-for-testing 2>&1 |
         tee raw-build-for-testing-output.log |
         xcbeautify --preserve-unbeautified
@@ -289,14 +293,18 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
         rm -rf "$RESULT_BUNDLE_PATH"
     fi
 
+    TWB_ARGS=(
+        -workspace "$WORKSPACE"
+        -scheme "$TEST_SCHEME"
+        "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}"
+        "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}"
+    )
+    [[ -n "$CONFIGURATION" ]] && TWB_ARGS+=(-configuration "$CONFIGURATION")
+    TWB_ARGS+=(-destination "$DESTINATION")
+    TWB_ARGS+=(-resultBundlePath "$RESULT_BUNDLE_PATH")
+
     set -o pipefail && NSUnbufferedIO=YES xcodebuild \
-        -workspace "$WORKSPACE" \
-        -scheme "$TEST_SCHEME" \
-        "${TEST_PLAN_ARGS[@]+${TEST_PLAN_ARGS[@]}}" \
-        "${ONLY_TESTING_ARGS[@]+${ONLY_TESTING_ARGS[@]}}" \
-        -configuration "$CONFIGURATION" \
-        -destination "$DESTINATION" \
-        -resultBundlePath "$RESULT_BUNDLE_PATH" \
+        "${TWB_ARGS[@]}" \
         test-without-building 2>&1 |
         tee raw-test-output.log |
         xcbeautify --report junit


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow that builds the SDK from source (SPM) with Xcode 27
- Builds all 5 platforms: iOS, watchOS, macOS, tvOS, visionOS
- Separate workflow so failures can be ignored while Xcode 27 is in beta

#skip-changelog