### PR TITLE
chore(ci): use asdf instead of rbenv for Bitrise jobs

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -116,16 +116,17 @@ jobs:
         name: Cache Ruby
         with:
           path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('sentry-react-native/.ruby-version') }}
+            ~/.asdf/installs/ruby
+          key: ruby-asdf-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('sentry-react-native/.ruby-version') }}
 
       - name: Install Ruby (Bitrise)
         if: matrix.runner_provider == 'bitrise'
         working-directory: sentry-react-native
         run: |
-          brew upgrade ruby-build
-          rbenv install -s
+          asdf plugin add ruby || true
+          asdf plugin update ruby
+          asdf install ruby $(cat .ruby-version)
+          asdf global ruby $(cat .ruby-version)
 
       - name: Setup Ruby
         if: matrix.runner_provider != 'bitrise'

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -79,15 +79,16 @@ jobs:
         name: Cache Ruby
         with:
           path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
+            ~/.asdf/installs/ruby
+          key: ruby-asdf-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'
         run: |
-          brew upgrade ruby-build
-          rbenv install -s
+          asdf plugin add ruby || true
+          asdf plugin update ruby
+          asdf install ruby $(cat .ruby-version)
+          asdf global ruby $(cat .ruby-version)
           bundle install
 
       - name: Setup Ruby

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -87,15 +87,16 @@ jobs:
         name: Cache Ruby
         with:
           path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
+            ~/.asdf/installs/ruby
+          key: ruby-asdf-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'
         run: |
-          brew upgrade ruby-build
-          rbenv install -s
+          asdf plugin add ruby || true
+          asdf plugin update ruby
+          asdf install ruby $(cat .ruby-version)
+          asdf global ruby $(cat .ruby-version)
           bundle install
 
       - name: Setup Ruby


### PR DESCRIPTION
## Summary
- Switch Bitrise CI jobs from rbenv to asdf for Ruby version management
- Bitrise images ship with asdf pre-installed, removing the need for `brew upgrade ruby-build`
- Update cache paths from `~/.rbenv/` to `~/.asdf/installs/ruby` with new cache key prefix

## Affected workflows
- `unit-test-common.yml`
- `ui-tests-common.yml`
- `test-cross-platform.yml`

Non-Bitrise runners (Cirrus Labs) are unchanged — they still use `ruby/setup-ruby`.

#skip-changelog