### PR TITLE
fix: silence retroactive conformance warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### Fixes
 
-- Silence retroactive conformance warning for `SentryLevel: CustomStringConvertible` (#8032)
+- Silence retroactive conformance warning for `SentryLevel: CustomStringConvertible` when building with SPM from source (#8032)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 
 ### Fixes
 
-- Silence retroactive conformance warning for `SentryLevel: CustomStringConvertible` (#PRNUM)
+- Silence retroactive conformance warning for `SentryLevel: CustomStringConvertible` (#8032)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   - Application Init: app.start -> app.start.application_init
   - Extended App Start: app.start -> app.start.extended_app_start
 
+### Fixes
+
+- Silence retroactive conformance warning for `SentryLevel: CustomStringConvertible` (#PRNUM)
+
 ### Deprecations
 
 - Deprecate the managed User Feedback widget/FAB. It will be removed in v10. Present the feedback form from your own UI with `SentrySDK.feedback.show()`, `SentrySDK.FeedbackForm`, or `.sentryFeedback(isPresented:)` instead. (#8022)

--- a/Sources/Swift/Core/Helper/Log/SentryLevel.swift
+++ b/Sources/Swift/Core/Helper/Log/SentryLevel.swift
@@ -3,7 +3,7 @@ import Foundation
 
 private let levelNames = ["none", "debug", "info", "warning", "error", "fatal"]
 
-extension SentryLevel: CustomStringConvertible {
+extension SentryLevel: @retroactive CustomStringConvertible {
     public var description: String {
         return levelNames[Int(self.rawValue)]
     }

--- a/Sources/Swift/Core/Helper/Log/SentryLevel.swift
+++ b/Sources/Swift/Core/Helper/Log/SentryLevel.swift
@@ -3,11 +3,17 @@ import Foundation
 
 private let levelNames = ["none", "debug", "info", "warning", "error", "fatal"]
 
-extension SentryLevel: @retroactive CustomStringConvertible {
+#if SWIFT_PACKAGE
+extension SentryLevel: @retroactive CustomStringConvertible {}
+#else
+extension SentryLevel: CustomStringConvertible {}
+#endif
+
+extension SentryLevel {
     public var description: String {
         return levelNames[Int(self.rawValue)]
     }
-    
+
     static func fromName(_ name: String?) -> SentryLevel {
         guard let name = name, let index = levelNames.firstIndex(of: name) else { return .error }
         return SentryLevel(rawValue: UInt(index)) ?? .error


### PR DESCRIPTION
## Description

Add `@retroactive` attribute to `SentryLevel: CustomStringConvertible` conformance to silence the Swift compiler warning about declaring a conformance of an imported type to an imported protocol. This only affects SPM builds from source, where `SentryLevel` is imported from a separate module. Non-SPM builds (CocoaPods, Carthage) are unaffected.

Saw the warning in: https://github.com/getsentry/sentry-cocoa/actions/runs/27231647882/job/80470365046?pr=8030

## How to Test

Build the project with SPM — the warning on `SentryLevel.swift:6` should be gone.