### PR TITLE
Mark feedback form aliases and conformances unavailable in app extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix missing `_OBJC_CLASS_$_` symbols in x86_64 slice of SentryObjC dynamic framework (#8037)
+- Mark feedback form aliases and conformances unavailable in app extensions (#8040)
 
 ## 9.17.0
 

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -350,6 +350,7 @@ import Foundation
     #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
     /// A UIKit view controller that displays the Sentry user feedback form.
     /// - warning: This is an experimental feature and may still have bugs.
+    @available(iOSApplicationExtension, unavailable)
     public typealias FeedbackForm = SentryUserFeedbackFormController
 
     /// The API for capturing user feedback.

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -259,6 +259,7 @@ extension SentryUserFeedbackFormController {
 }
 
 // MARK: UIAdaptivePresentationControllerDelegate
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackFormController: UIAdaptivePresentationControllerDelegate {
     /// Notifies feedback lifecycle callbacks when the user dismisses the form interactively.
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
@@ -267,6 +268,7 @@ extension SentryUserFeedbackFormController: UIAdaptivePresentationControllerDele
 }
 
 // MARK: UITextFieldDelegate
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackFormController: UITextFieldDelegate {
     /// Handles the return key for feedback form text fields.
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -281,6 +283,7 @@ extension SentryUserFeedbackFormController: UITextFieldDelegate {
 }
 
 // MARK: UITextViewDelegate
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackFormController: UITextViewDelegate {
     /// Updates validation state when the feedback message changes.
     public func textViewDidChange(_ textView: UITextView) {

--- a/Sources/Swift/SentrySwiftUI/SentryUserFeedbackFormView.swift
+++ b/Sources/Swift/SentrySwiftUI/SentryUserFeedbackFormView.swift
@@ -52,6 +52,7 @@ public struct SentryUserFeedbackFormView: UIViewControllerRepresentable {
 public extension SentrySDK {
     /// A SwiftUI view that displays the Sentry user feedback form.
     /// - warning: This is an experimental feature and may still have bugs.
+    @available(iOSApplicationExtension, unavailable)
     typealias FeedbackFormView = SentryUserFeedbackFormView
 }
 #endif

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -54293,6 +54293,9 @@
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormController"
               }
             ],
+            "declAttributes": [
+              "Available"
+            ],
             "declKind": "TypeAlias",
             "kind": "TypeAlias",
             "mangledName": "$s6Sentry0A3SDKC12FeedbackForma",
@@ -54309,6 +54312,9 @@
                 "printedName": "Sentry.SentryUserFeedbackFormView",
                 "usr": "s:6Sentry0A20UserFeedbackFormViewV"
               }
+            ],
+            "declAttributes": [
+              "Available"
             ],
             "declKind": "TypeAlias",
             "isFromExtension": true,


### PR DESCRIPTION
Annotating the aliases and conformance extensions restores the ability to link Sentry from apps that also contain app extensions (same class of issue as #5648 and #5787).

## :scroll: Description

SentryUserFeedbackFormController and SentryUserFeedbackFormView are @available(iOSApplicationExtension, unavailable), but the public SentrySDK.FeedbackForm / SentrySDK.FeedbackFormView typealiases and the UIAdaptivePresentationControllerDelegate / UITextFieldDelegate / UITextViewDelegate conformance extensions added in 9.17.0 are not.

In the prebuilt xcframework's emitted .swiftinterface these unannotated declarations reference extension-unavailable types, so any client target compiled with -application-extension (app extension targets, which Xcode requires to be extension-safe) fails to build the Sentry module from its interface:

  Sentry.swiftmodule/...private.swiftinterface:441:42: error:
  'SentryUserFeedbackFormController' is unavailable in application
  extensions for iOS


## :bulb: Motivation and Context

Our project doesn't compile with version 9.17.0 because this version is not compatible with extensions.

## :green_heart: How did you test it?

Used this patched version to see previously failed build, succeed.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
