### PR TITLE
chore(ci): pin actions/cache to full commit SHA

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: sentry-react-native/packages/core/RNSentryCocoaTester
         run: sed -i '' "s/parallelizable = \"YES\"/parallelizable = \"NO\"/" RNSentryCocoaTester.xcodeproj/xcshareddata/xcschemes/RNSentryCocoaTester.xcscheme
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         name: Cache Ruby
         with:
           path: |

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         name: Cache Ruby
         with:
           path: |

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -83,7 +83,7 @@ jobs:
           device: ${{ inputs.device }}
           platform: ${{ inputs.platform }}
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         name: Cache Ruby
         with:
           path: |


### PR DESCRIPTION
## Description

Pin the remaining 3 `actions/cache@v5` references to their full commit SHA (`27d5ce7f107fe9357f9df03efb73ab90386fccae`) for supply-chain safety. All other external actions in the repo were already SHA-pinned.

#skip-changelog

## Changed files

- `.github/workflows/test-cross-platform.yml`
- `.github/workflows/ui-tests-common.yml`
- `.github/workflows/unit-test-common.yml`