### PR TITLE
fix: dispatch UIApplication.applicationState read to main thread on SDK start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 
 - Add SentryObjC User Feedback presentation APIs and a feedback form factory returning `UIViewController` instances. (#8027)
+### Fixes
+
+- Hop to the main thread when reading `UIApplication.applicationState` during `SentrySDK.start` so calling start from a background thread (or non-main actor) no longer emits a `-[UIApplication applicationState] must be used from main thread only` runtime warning (#PRPENDING)
 
 ## 9.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add SentryObjC User Feedback presentation APIs and a feedback form factory returning `UIViewController` instances. (#8027)
 ### Fixes
 
-- Hop to the main thread when reading `UIApplication.applicationState` during `SentrySDK.start` so calling start from a background thread (or non-main actor) no longer emits a `-[UIApplication applicationState] must be used from main thread only` runtime warning (#PRPENDING)
+- Hop to the main thread when reading `UIApplication.applicationState` during `SentrySDK.start` so calling start from a background thread (or non-main actor) no longer emits a `-[UIApplication applicationState] must be used from main thread only` runtime warning (#8047)
 
 ## 9.17.1
 

--- a/Sources/Swift/Helper/ThreadSafeApplication.swift
+++ b/Sources/Swift/Helper/ThreadSafeApplication.swift
@@ -19,7 +19,7 @@ import UIKit
                 // would otherwise emit a `-[UIApplication applicationState] must be used
                 // from main thread only` runtime warning (#6591). Hop to main to read
                 // the value safely. The 10ms timeout matches the pattern used elsewhere
-                // in this file (e.g. internal_getWindows) — if main is contended we fall
+                // (e.g. internal_getWindows) — if main is contended we fall
                 // back to the same default the null-application branch uses, and the
                 // notification observers below will correct the state on the next
                 // foreground/background transition.

--- a/Sources/Swift/Helper/ThreadSafeApplication.swift
+++ b/Sources/Swift/Helper/ThreadSafeApplication.swift
@@ -11,7 +11,24 @@ import UIKit
         // so it kept a default value of 0 which happens to be defined to be `active`.
         // Acquiring the lock is not necessary here since the instance has not been initialized yet.
         if let application = applicationProvider() {
-            _internalState = application.unsafeApplicationState
+            if Thread.isMainThread {
+                _internalState = application.unsafeApplicationState
+            } else {
+                // UIApplication.applicationState must be accessed from the main thread,
+                // so calling SentrySDK.start from a background thread or a non-main actor
+                // would otherwise emit a `-[UIApplication applicationState] must be used
+                // from main thread only` runtime warning (#6591). Hop to main to read
+                // the value safely. The 10ms timeout matches the pattern used elsewhere
+                // in this file (e.g. internal_getWindows) — if main is contended we fall
+                // back to the same default the null-application branch uses, and the
+                // notification observers below will correct the state on the next
+                // foreground/background transition.
+                var stateOnMain: UIApplication.State = .active
+                Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({
+                    stateOnMain = application.unsafeApplicationState
+                }, timeout: 0.01)
+                _internalState = stateOnMain
+            }
         } else {
             SentrySDKLog.warning("Application is null in SentryThreadsafeApplication")
             _internalState = .active

--- a/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
+++ b/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
@@ -25,5 +25,35 @@ final class SentryThreadsafeApplicationTests: XCTestCase {
         notificationCenterWrapper.post(Notification(name: UIApplication.didEnterBackgroundNotification))
         XCTAssertEqual(.background, sut.applicationState)
     }
+
+    // Regression for #6591: SentrySDK.start emitted a
+    // `-[UIApplication applicationState] must be used from main thread only`
+    // runtime warning when called from a background thread, because the
+    // SentryThreadsafeApplication initializer read unsafeApplicationState
+    // directly from the calling thread. The fix dispatches to main; verify
+    // that even when init runs off the main thread, the underlying property
+    // access lands on main.
+    func testInit_OffMainThread_ReadsApplicationStateOnMainThread() {
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let application = TestSentryUIApplication()
+        application.unsafeApplicationState = .background
+
+        let initialized = expectation(description: "ThreadsafeApplication initialized off main thread")
+        var sut: SentryThreadsafeApplication?
+        DispatchQueue.global(qos: .userInitiated).async {
+            XCTAssertFalse(Thread.isMainThread, "test driver must run init off main")
+            sut = SentryThreadsafeApplication(
+                applicationProvider: { application },
+                notificationCenter: notificationCenterWrapper
+            )
+            initialized.fulfill()
+        }
+        wait(for: [initialized], timeout: 1.0)
+
+        XCTAssertEqual(true, application.unsafeApplicationStateReadOnMainThread,
+                       "unsafeApplicationState must be read from the main thread")
+        XCTAssertEqual(.background, sut?.applicationState,
+                       "the value read on main must be propagated to _internalState")
+    }
 }
 #endif

--- a/Tests/SentryTests/TestSentryUIApplication.swift
+++ b/Tests/SentryTests/TestSentryUIApplication.swift
@@ -37,8 +37,12 @@ final class TestSentryUIApplication: SentryApplication {
     }
 
     private var _underlyingAppState: UIApplication.State = .active
+    private(set) var unsafeApplicationStateReadOnMainThread: Bool?
     var unsafeApplicationState: UIApplication.State {
-        get { _underlyingAppState }
+        get {
+            unsafeApplicationStateReadOnMainThread = Thread.isMainThread
+            return _underlyingAppState
+        }
         set { _underlyingAppState = newValue }
     }
 


### PR DESCRIPTION
## Summary

`SentryThreadsafeApplication.init` reads `UIApplication.applicationState` synchronously from the calling thread. When `SentrySDK.start` runs on a background thread or a non-main actor (a documented but discouraged pattern — see #6591), Xcode emits a runtime warning on every launch:

```
-[UIApplication applicationState] must be used from main thread only
```

The issue author's use case is a non-main-isolated error-reporting service that wraps `SentrySDK.start`. A maintainer agreed it's worth fixing.

## Root cause

[`ThreadSafeApplication.swift:13–14`](Sources/Swift/Helper/ThreadSafeApplication.swift#L13-L14):

```swift
if let application = applicationProvider() {
    _internalState = application.unsafeApplicationState
}
```

`unsafeApplicationState` is a direct read of `UIApplication.applicationState`, which UIKit gates on `Thread.isMainThread` and reports via the runtime issue checker.

## Fix

Hop to the main thread for that single property read using the existing `Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue(_:timeout:)` helper — the same pattern already used elsewhere in this file (`internal_getWindows`, `internal_getActiveWindowSize`, `internal_relevantViewControllersNames`) with the same 10 ms timeout. On timeout we fall back to the existing `.active` default that the null-application branch uses, and the notification observers registered immediately afterward correct the state on the next foreground/background transition. The behavior when `start` is called on the main thread is unchanged.

```diff
 if let application = applicationProvider() {
-    _internalState = application.unsafeApplicationState
+    if Thread.isMainThread {
+        _internalState = application.unsafeApplicationState
+    } else {
+        var stateOnMain: UIApplication.State = .active
+        Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({
+            stateOnMain = application.unsafeApplicationState
+        }, timeout: 0.01)
+        _internalState = stateOnMain
+    }
 } else {
     SentrySDKLog.warning("Application is null in SentryThreadsafeApplication")
     _internalState = .active
 }
```

## Test plan

- [x] Added `testInit_OffMainThread_ReadsApplicationStateOnMainThread` to `SentryThreadsafeApplicationTests`. The test dispatches init onto a background queue and asserts (via a new `unsafeApplicationStateReadOnMainThread` tracker on `TestSentryUIApplication`) that the underlying property access landed on the main thread, and that the value is correctly propagated to `_internalState`.
- [x] `xcodebuild build` on the `Sentry` scheme (iOS Simulator, iPhone 17 Pro, iOS 26.4.1) — **BUILD SUCCEEDED** with the production-code change in place.
- [ ] Local `xcodebuild test` couldn't run the new test in this PR's checkout — `SentryTestUtils/Sources/ClearTestState.swift:52` calls `SentryAppStartMeasurementProvider.reset()` which Swift can't resolve (confirmed pre-existing on `main` without my changes). This appears to be a separate test-infra build issue; deferring to CI for the actual run.

## Changelog

Added an entry under `## Unreleased` per the convention used in the in-flight #8041 PR. (PR number placeholder `#PRPENDING` will need updating once this PR is assigned a number — happy to amend.)

## Notes for reviewer

- `TestSentryUIApplication` already had a `calledOnMainThread` tracker for `windows`; the new `unsafeApplicationStateReadOnMainThread` tracker follows the same pattern.
- The 10 ms timeout is identical to the existing usages in this file. If reviewers prefer no timeout (the no-timeout `dispatchSyncOnMainQueue(block:)` overload also exists), happy to switch — the timeout guards against the pathological case where the caller holds a lock that main is waiting on.

Closes #6591