### PR TITLE
chore(ci): enable Dependabot for Swift package dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,19 @@ updates:
     labels:
       - "ready-to-merge"
       - "dependencies"
+
+  - package-ecosystem: "swift"
+    directory: "/test-server"
+    schedule:
+      interval: weekly
+    labels:
+      - "ready-to-merge"
+      - "dependencies"
+
+  - package-ecosystem: "swift"
+    directory: "/Samples/macOS-CLI"
+    schedule:
+      interval: weekly
+    labels:
+      - "ready-to-merge"
+      - "dependencies"


### PR DESCRIPTION
## Description

Enable Dependabot for the two Swift Package Manager directories that pull dependencies from git:

- `/test-server` — Vapor (`vapor/vapor.git`)
- `/Samples/macOS-CLI` — gRPC Swift (`grpc/grpc-swift.git`)

Both use the same weekly schedule and labels as the existing Bundler and GitHub Actions entries.

#skip-changelog

Fixes: #8055

## Test plan

- [ ] Verify Dependabot picks up the new entries and opens PRs for available updates