### PR TITLE
docs: Add installedIntegrationNames to internal API spec

### DIFF
--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -204,16 +204,16 @@ The factory block receives a closure that returns the original `IMP`. The caller
 
 ### `SentrySDK.internal.sdk` — `SentryInternalSdkApi`
 
-| Method                        | Replaced                                            |
-| ----------------------------- | --------------------------------------------------- |
-| `name: String`                | `PrivateSentrySDKOnly.getSdkName` / `.setSdkName:`  |
-| `versionString: String`       | `PrivateSentrySDKOnly.getSdkVersionString`          |
-| `setName(_:version:)`         | `PrivateSentrySDKOnly.setSdkName:andVersionString:` |
-| `addPackage(name:version:)`   | `PrivateSentrySDKOnly.addSdkPackage:version:`       |
-| `extraContext: [String: Any]` | `PrivateSentrySDKOnly.getExtraContext`              |
-| `installationID: String`      | `PrivateSentrySDKOnly.installationID`               |
-| `installedIntegrationNames: Set<String>` | `PrivateSentrySDKOnly.options.integrations` (see note) |
-| `trimmedInstalledIntegrationNames: [String]` | (none — see note) |
+| Method                                       | Replaced                                               |
+| -------------------------------------------- | ------------------------------------------------------ |
+| `name: String`                               | `PrivateSentrySDKOnly.getSdkName` / `.setSdkName:`     |
+| `versionString: String`                      | `PrivateSentrySDKOnly.getSdkVersionString`             |
+| `setName(_:version:)`                        | `PrivateSentrySDKOnly.setSdkName:andVersionString:`    |
+| `addPackage(name:version:)`                  | `PrivateSentrySDKOnly.addSdkPackage:version:`          |
+| `extraContext: [String: Any]`                | `PrivateSentrySDKOnly.getExtraContext`                 |
+| `installationID: String`                     | `PrivateSentrySDKOnly.installationID`                  |
+| `installedIntegrationNames: Set<String>`     | `PrivateSentrySDKOnly.options.integrations` (see note) |
+| `trimmedInstalledIntegrationNames: [String]` | (none — see note)                                      |
 
 `name` and `versionString` are read-write properties — the getter and setter replace both the get/set static methods.
 

--- a/develop-docs/SENTRY-INTERNAL-API.md
+++ b/develop-docs/SENTRY-INTERNAL-API.md
@@ -212,8 +212,14 @@ The factory block receives a closure that returns the original `IMP`. The caller
 | `addPackage(name:version:)`   | `PrivateSentrySDKOnly.addSdkPackage:version:`       |
 | `extraContext: [String: Any]` | `PrivateSentrySDKOnly.getExtraContext`              |
 | `installationID: String`      | `PrivateSentrySDKOnly.installationID`               |
+| `installedIntegrationNames: Set<String>` | `PrivateSentrySDKOnly.options.integrations` (see note) |
+| `trimmedInstalledIntegrationNames: [String]` | (none — see note) |
 
 `name` and `versionString` are read-write properties — the getter and setter replace both the get/set static methods.
+
+> **Note on `installedIntegrationNames`:** Flutter and other hybrid SDKs previously read `PrivateSentrySDKOnly.options.integrations` to append native integration names to event `sdk` payloads. `Options.integrations` was removed in v9 ([#6492](https://github.com/getsentry/sentry-cocoa/pull/6492)); it held configured integration class names, not the runtime installed set. `installedIntegrationNames` returns the class names currently registered on `SentryHub` (e.g. `SentryANRTrackingIntegration`). Returns an empty set before `SentrySDK.start()` or after `SentrySDK.close()`.
+>
+> **Note on `trimmedInstalledIntegrationNames`:** The event `sdk.integrations` field uses shortened names (e.g. `ANRTracking` instead of `SentryANRTrackingIntegration`). Hybrid SDKs that enrich Dart/JS events with native integrations should prefer this property — it delegates to `SentryHub.trimmedInstalledIntegrationNames` and matches what `SentrySdkInfo` serializes.
 
 ### `SentrySDK.internal.debug` — `SentryInternalDebugApi`
 
@@ -299,6 +305,21 @@ SentrySDK.internal.sdk.setName("sentry.cocoa.react-native", version: "6.0.0")
 SentrySDK.internal.appStart.hybridSDKMode = true
 let frames = SentrySDK.internal.performance.currentScreenFrames
 let success = SentrySDK.internal.replay.capture()
+let integrations = SentrySDK.internal.sdk.trimmedInstalledIntegrationNames
+```
+
+### Flutter (hybrid SDK — native integrations on events)
+
+```swift
+// Before (v8) — Options.integrations removed in v9
+import Sentry
+let nativeIntegrations = PrivateSentrySDKOnly.options.integrations ?? []
+// appended to event.sdk["integrations"]
+
+// After
+import Sentry
+let nativeIntegrations = SentrySDK.internal.sdk.trimmedInstalledIntegrationNames
+// same payload shape as event.sdk["integrations"]
 ```
 
 ### ObjC (hybrid SDK via SentryObjC wrapper)
@@ -322,6 +343,8 @@ id traceId = [[SentryIdClass alloc] initWithUUIDString:traceString];
 [SentryObjCSDK internal].appStart.hybridSDKMode = YES;
 SentryObjCScreenFrames *frames = [SentryObjCSDK internal].performance.currentScreenFrames;
 BOOL success = [[[SentryObjCSDK internal] replay] capture];
+NSArray<NSString *> *integrations =
+    [[[SentryObjCSDK internal] sdk] trimmedInstalledIntegrationNames];
 // Typed ID parameters — no NSClassFromString, no Sentry-Swift.h
 SentryObjCId *traceId = [[SentryObjCId alloc] initWithUUIDString:traceString];
 SentryObjCSpanId *spanId = [[SentryObjCSpanId alloc] initWithValue:spanString];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Expands `develop-docs/SENTRY-INTERNAL-API.md` with `installedIntegrationNames` and `trimmedInstalledIntegrationNames` on `SentrySDK.internal.sdk`.

This documents the planned hybrid SDK replacement for reading `PrivateSentrySDKOnly.options.integrations`, which was removed in v9 (#6492). Flutter and other hybrid SDKs need runtime access to native integration names when enriching Dart/JS event `sdk` payloads.

## Motivation and Context

Slack thread in #team-sdks-mobile: Flutter previously appended `PrivateSentrySDKOnly.options.integrations` to events, but that path is gone in v9. The spec now points hybrid SDKs at hub-backed properties instead:

- `installedIntegrationNames` — full class names (e.g. `SentryANRTrackingIntegration`)
- `trimmedInstalledIntegrationNames` — shortened names serialized in `sdk.integrations` (e.g. `ANRTracking`)

Placed under `SentrySDK.internal.sdk` because integrations are part of the SDK descriptor in event payloads, alongside `name`, `version`, and `packages`.

## How did you test it?

Documentation-only change.

## Checklist

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/G01PW6HRQNN/p1781549741152579?thread_ts=1781549741.152579&cid=G01PW6HRQNN)

<div><a href="https://cursor.com/agents/bc-5e2e825c-dab7-5a58-926e-ddab7a51e6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e2e825c-dab7-5a58-926e-ddab7a51e6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

