### PR TITLE
docs: warn about upcoming macOS 12 deprecation with Xcode 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+> [!WARNING]
+> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/discussions) for full details.
+
 ## 9.18.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 > [!WARNING]
-> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/discussions) for full details.
+> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
 
 ## 9.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 > [!WARNING]
-> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
+> **The minimum macOS deployment target will be raised to macOS 12 (Monterey)** with the upcoming release that adopts Xcode 27. Xcode 27 no longer supports deployment targets below macOS 12. If your app must support macOS 11 or earlier, please stay on the last SDK version released before this change. See [#8113](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
 
 ## 9.18.0
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To see all available installation options and how to integrate Sentry into your 
 > CocoaPods support has been deprecated and will no longer receive updates after June 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
 
 > [!WARNING]
-> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/discussions) for full details.
+> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
 
 # Initialization
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ To see all available installation options and how to integrate Sentry into your 
 > [!WARNING]
 > CocoaPods support has been deprecated and will no longer receive updates after June 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
 
+> [!WARNING]
+> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/discussions) for full details.
+
 # Initialization
 
 _Remember to call this as early in your application life cycle as possible_

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To see all available installation options and how to integrate Sentry into your 
 > CocoaPods support has been deprecated and will no longer receive updates after June 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
 
 > [!WARNING]
-> **macOS 12 support will be dropped** with the upcoming release that requires Xcode 27. Xcode 27 cannot produce valid builds targeting macOS 12 or earlier, so the new minimum supported macOS version will be **macOS 13 (Ventura)**. If your app must support macOS 12, please stay on the last SDK version released before this change. See the [announcement discussion](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
+> **The minimum macOS deployment target will be raised to macOS 12 (Monterey)** with the upcoming release that adopts Xcode 27. Xcode 27 no longer supports deployment targets below macOS 12. If your app must support macOS 11 or earlier, please stay on the last SDK version released before this change. See [#8113](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
 
 # Initialization
 


### PR DESCRIPTION
## What

Adds a `[!WARNING]` callout at the top of both `CHANGELOG.md` and `README.md` notifying users that the minimum macOS deployment target will be raised from macOS 10.14 to **macOS 12 (Monterey)** when the SDK adopts Xcode 27.

## Why

Xcode 27 bumps the range of supported minimum deployment targets to macOS 12 or later, requiring us to bump accordingly. Only ~0.5% of error events come from macOS 12; macOS 13+ covers >99%. Maintaining two Xcode versions in CI and shipping 2× pre-built XCFramework artifacts is disproportionate cost for that usage share.

## What was verified

- Both warnings render as GitHub-flavored Markdown `[!WARNING]` callout blocks.
- Both link to the tracking issue #8113.
- No other content was modified.

Refs: #8113

#skip-changelog