### PR TITLE
fix(breadcrumb): Defensive copy on scope insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 
-- Defensive copy on scope insertion (#8114)
+- Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 
 ## 9.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 > [!WARNING]
 > **The minimum macOS deployment target will be raised to macOS 12 (Monterey)** with the upcoming release that adopts Xcode 27. Xcode 27 no longer supports deployment targets below macOS 12. If your app must support macOS 11 or earlier, please stay on the last SDK version released before this change. See [#8113](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.
 
+## Unreleased
+
+### Fixes
+
+- Defensive copy on scope insertion (#8114)
+
 ## 9.18.0
 
 ### Features

--- a/Sources/Sentry/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/SentryBreadcrumb+Private.h
@@ -14,6 +14,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The SentryBreadcrumb.
  */
 - (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
+
+/**
+ * Returns a snapshot copy with its own strong references to all property values.
+ * The copy is independent of the original: deallocating either one does not
+ * affect the other's ivars.
+ */
+- (SentryBreadcrumb *_Nonnull)snapshotCopy;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -202,6 +202,21 @@ sentry_deepCopyValue(id value)
     return [self initWithLevel:kSentryLevelInfo category:@"default"];
 }
 
+- (SentryBreadcrumb *)snapshotCopy
+{
+    SentryBreadcrumb *snapshot = [[SentryBreadcrumb alloc] init];
+    @synchronized(self) {
+        snapshot->_level = _level;
+        snapshot->_category = _category;
+        snapshot->_timestamp = _timestamp;
+        snapshot->_type = _type;
+        snapshot->_message = _message;
+        snapshot->_origin = _origin;
+        snapshot->_data = _data;
+    }
+    return snapshot;
+}
+
 #pragma mark - Serialization
 
 - (NSDictionary<NSString *, id> *)serialize

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -1,5 +1,6 @@
 #import "NSMutableDictionary+Sentry.h"
 #import "SentryAttachment+Private.h"
+#import "SentryBreadcrumb+Private.h"
 #import "SentryBreadcrumb.h"
 #import "SentryDefines.h"
 #import "SentryEvent+Private.h"
@@ -115,12 +116,17 @@ NS_ASSUME_NONNULL_BEGIN
         // O(n) because it needs to reshift the whole array. So when the breadcrumbs array was full
         // every add operation was O(n).
 
-        _breadcrumbArray[_currentBreadcrumbIndex] = crumb;
+        // Defensive copy: the scope owns an independent snapshot so that (1) callers
+        // mutating the breadcrumb after add don't affect stored data, and (2) when
+        // the ring buffer evicts an old entry its dealloc cannot race with another
+        // thread reading the same object's properties (see #8013).
+        SentryBreadcrumb *snapshot = [crumb snapshotCopy];
+        _breadcrumbArray[_currentBreadcrumbIndex] = snapshot;
 
         _currentBreadcrumbIndex = (_currentBreadcrumbIndex + 1) % _maxBreadcrumbs;
 
         // Serializing is expensive. Only do it once.
-        NSDictionary<NSString *, id> *serializedBreadcrumb = [crumb serialize];
+        NSDictionary<NSString *, id> *serializedBreadcrumb = [snapshot serialize];
         for (id<SentryScopeObserver> observer in [self observerSnapshot]) {
             [observer addSerializedBreadcrumb:serializedBreadcrumb];
         }

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -291,4 +291,52 @@ class SentryBreadcrumbTests: XCTestCase {
             _ = breadcrumb.serialize()
         }
     }
+
+    // MARK: - Snapshot Copy
+
+    func testSnapshotCopy_copiesAllProperties() {
+        let original = Breadcrumb(level: .error, category: "navigation")
+        original.timestamp = Date(timeIntervalSince1970: 42)
+        original.type = "http"
+        original.message = "clicked button"
+        original.origin = "flutter"
+        original.data = ["url": "https://example.com", "nested": ["a": 1]]
+
+        let snapshot = original.snapshotCopy()
+
+        XCTAssertEqual(snapshot.level, .error)
+        XCTAssertEqual(snapshot.category, "navigation")
+        XCTAssertEqual(snapshot.timestamp, Date(timeIntervalSince1970: 42))
+        XCTAssertEqual(snapshot.type, "http")
+        XCTAssertEqual(snapshot.message, "clicked button")
+        XCTAssertEqual(snapshot.origin, "flutter")
+        XCTAssertEqual(snapshot.data?["url"] as? String, "https://example.com")
+        let nested = snapshot.data?["nested"] as? [String: Any]
+        XCTAssertEqual(nested?["a"] as? Int, 1)
+    }
+
+    func testSnapshotCopy_isIndependentOfOriginal() {
+        let original = Breadcrumb(level: .info, category: "ui")
+        original.message = "before"
+        original.data = ["key": "before"]
+
+        let snapshot = original.snapshotCopy()
+
+        original.level = .error
+        original.category = "changed"
+        original.message = "after"
+        original.data = ["key": "after"]
+
+        XCTAssertEqual(snapshot.level, .info)
+        XCTAssertEqual(snapshot.category, "ui")
+        XCTAssertEqual(snapshot.message, "before")
+        XCTAssertEqual(snapshot.data?["key"] as? String, "before")
+    }
+
+    func testSnapshotCopy_isDifferentInstance() {
+        let original = Breadcrumb(level: .info, category: "test")
+        let snapshot = original.snapshotCopy()
+
+        XCTAssertFalse(original === snapshot)
+    }
 }

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -495,6 +495,73 @@ class SentryScopeSwiftTests: XCTestCase {
         })
     }
 
+    func testAddBreadcrumb_storesDefensiveCopy() {
+        let scope = Scope(maxBreadcrumbs: 5)
+        let crumb = Breadcrumb(level: .info, category: "ui")
+        crumb.message = "before"
+        crumb.data = ["key": "before"]
+
+        scope.addBreadcrumb(crumb)
+
+        crumb.message = "after"
+        crumb.data = ["key": "after"]
+
+        let stored = scope.breadcrumbs().first
+        XCTAssertNotNil(stored)
+        XCTAssertFalse(stored === crumb,
+            "Scope should store a copy, not the original object")
+        XCTAssertEqual(stored?.message, "before",
+            "Stored breadcrumb should not reflect mutations to the original")
+        XCTAssertEqual(stored?.data?["key"] as? String, "before",
+            "Stored breadcrumb data should not reflect mutations to the original")
+    }
+
+    func testAddBreadcrumb_evictionDoesNotCrash_whenReadConcurrently() {
+        // Regression test for https://github.com/getsentry/sentry-cocoa/issues/8013
+        // The ring buffer evicts old breadcrumbs when full. Without a defensive copy,
+        // the evicted breadcrumb's dealloc can race with a concurrent reader calling
+        // serialize on the same object, causing EXC_BAD_ACCESS.
+        let maxCrumbs = 5
+        let scope = Scope(maxBreadcrumbs: maxCrumbs)
+
+        let queue = DispatchQueue(label: "test.breadcrumb.race", attributes: .concurrent)
+        let expectation = expectation(description: "concurrent breadcrumb race")
+        expectation.expectedFulfillmentCount = 3
+
+        // Writer: continuously add breadcrumbs, forcing evictions
+        queue.async {
+            for i in 0..<2_000 {
+                let crumb = Breadcrumb(level: .info, category: "cat-\(i)")
+                crumb.message = "message-\(i)"
+                crumb.data = ["iteration": i, "padding": String(repeating: "x", count: 100)]
+                scope.addBreadcrumb(crumb)
+            }
+            expectation.fulfill()
+        }
+
+        // Reader 1: continuously read and serialize breadcrumbs
+        queue.async {
+            for _ in 0..<2_000 {
+                let crumbs = scope.breadcrumbs()
+                for crumb in crumbs {
+                    _ = crumb.serialize()
+                }
+            }
+            expectation.fulfill()
+        }
+
+        // Reader 2: continuously apply scope to events
+        queue.async {
+            for _ in 0..<1_000 {
+                let event = Event()
+                scope.applyTo(event: event, maxBreadcrumbs: UInt(maxCrumbs))
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 30)
+    }
+
     func testScopeObserver_passesDistinctCopyToObservers() {
         // Verify that observers receive a different object (copy) than the internal
         // mutable collection, preventing race conditions when observers dispatch async work.


### PR DESCRIPTION
Store a snapshot copy of the breadcrumb in the scope's ring buffer instead of the caller's original object.

This prevents a use-after-free crash (`EXC_BAD_ACCESS`) that occurs when the ring buffer evicts an old breadcrumb and its `dealloc`/`.cxx_destruct` races with another thread reading its properties. The crash is the second most frequent pattern in [SDK-CRASHES-COCOA-5](https://sentry.sentry.io/issues/4688158870/) (26 of 100 sampled events).

The fix adds a `snapshotCopy` method to `SentryBreadcrumb` that captures all properties under `@synchronized(self)` into a new independent instance. `SentryScope.addBreadcrumb:` now stores and serializes from this snapshot instead of the caller's object. This also prevents callers from mutating a breadcrumb after passing it to the scope and affecting stored data.

### Testing

The key regression test (`testAddBreadcrumb_storesDefensiveCopy`) was verified RED without the fix — it produced 3 assertion failures confirming the scope stored the caller's original object and mutations were visible through the scope. With the fix applied, all tests pass.

Additional tests cover `snapshotCopy` property copying, instance independence, and a concurrent stress test that exercises ring buffer eviction with simultaneous readers and serializers.

### Alternative considered

We explored migrating `SentryBreadcrumb` to a Swift class wrapping a value-type struct, which would eliminate the entire class of reference-sharing issues by using copy-on-write semantics. However, `SentryBreadcrumb` is a public API type referenced across many ObjC consumers (`SentryScope`, `SentryHub`, `SentryEvent`, `SentryDefines.h` callback typedefs, etc.), making this a larger refactor than appropriate for a targeted bugfix. We'll tackle the struct-based approach as part of the v10 Swift migration.

Fixes #8013