### PR TITLE
test: mark testStoppingProfilerTransmitsLastFullChunk as flaky

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -75,6 +75,7 @@
     {
       "parallelizable" : false,
       "skippedTests" : [
+        "SentryContinuousProfilerTests\/testStoppingProfilerTransmitsLastFullChunk()",
         "SentryProfilerTests\/testProfilerMutationDuringSlicing"
       ],
       "target" : {

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -34,6 +34,16 @@
         "identifier" : "63AA76641EB8CB2F00D153DE",
         "name" : "SentryTests"
       }
+    },
+    {
+      "selectedTests" : [
+        "SentryContinuousProfilerTests\/testStoppingProfilerTransmitsLastFullChunk()"
+      ],
+      "target" : {
+        "containerPath" : "container:Sentry.xcodeproj",
+        "identifier" : "8431EECF29B27B1100D8DC56",
+        "name" : "SentryProfilerTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
Move `SentryContinuousProfilerTests/testStoppingProfilerTransmitsLastFullChunk` into the flaky test plan.

The test intermittently fails on Catalyst CI with `XCTAssertEqual failed: ("Optional(2)") is not equal to ("Optional(3)")` — the number of transmitted chunks is timing-dependent.

- Skip in `Sentry_Base.xctestplan` under the `SentryProfilerTests` target
- Add to `Sentry_Flaky.xctestplan` under a new `SentryProfilerTests` target entry (existing entries were only for `SentryTests`)

Example failure: https://github.com/getsentry/sentry-cocoa/actions/runs/27811229773/job/82306420992?pr=8083

#skip-changelog

Closes #8120