### PR TITLE
fix: guard sentrycrashfu_makePath against invalid paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- Fixes crash in sentrycrashfu_makePath during crash handling when the path is NULL, empty, or memory allocation fails (#8014)
 - Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 
 ## 9.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 
-- Fixes crash in sentrycrashfu_makePath during crash handling when the path is NULL, empty, or memory allocation fails (#8014)
+- Fixes crash in sentrycrashfu_makePath during crash handling when the path is NULL, empty, or memory allocation fails (#8143)
 - Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 
 ## 9.18.0

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -411,8 +411,18 @@ sentrycrashfu_readLineFromFD(const int fd, char *const buffer, const int maxLeng
 bool
 sentrycrashfu_makePath(const char *absolutePath)
 {
+    if (absolutePath == NULL || *absolutePath == '\0') {
+        SENTRY_ASYNC_SAFE_LOG_ERROR("Could not create path: absolutePath is NULL or empty");
+        return false;
+    }
+
     bool isSuccessful = false;
     char *pathCopy = strdup(absolutePath);
+    if (pathCopy == NULL) {
+        SENTRY_ASYNC_SAFE_LOG_ERROR("Could not duplicate path %s", absolutePath);
+        return false;
+    }
+
     for (char *ptr = pathCopy + 1; *ptr != '\0'; ptr++) {
         if (*ptr == '/') {
             *ptr = '\0';

--- a/Tests/SentryTests/SentryCrash/SentryCrashFileUtils_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashFileUtils_Tests.m
@@ -622,6 +622,35 @@
     XCTAssertTrue(bytesRead == 0, @"");
 }
 
+- (void)testMakePath_NULL
+{
+    XCTAssertFalse(sentrycrashfu_makePath(NULL));
+}
+
+- (void)testMakePath_EmptyString
+{
+    XCTAssertFalse(sentrycrashfu_makePath(""));
+}
+
+- (void)testMakePath_ValidPath
+{
+    // -- Arrange --
+    NSString *dirPath = [[[self.tempPath stringByAppendingPathComponent:@"make-path"]
+        stringByAppendingPathComponent:@"nested"] stringByAppendingPathComponent:@"directory"];
+
+    // -- Act --
+    bool result = sentrycrashfu_makePath([dirPath UTF8String]);
+
+    // -- Assert --
+    XCTAssertTrue(result);
+
+    bool isDirectory;
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:dirPath
+                                                       isDirectory:&isDirectory],
+        "Failed to create directory");
+    XCTAssertTrue(isDirectory);
+}
+
 - (void)testDeleteContentsOfPath_canNotDeletePath_shouldNotDeleteTopLevelPath
 {
     // -- Arrange --


### PR DESCRIPTION
## :scroll: Description

Hardens `sentrycrashfu_makePath` so it can no longer dereference invalid memory while the SentryCrash handler is already processing an exception. The function now returns its existing `false` failure indicator for `NULL` or empty paths, and when `strdup` fails to allocate, instead of crashing.

Root cause in `Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c:412`:

```c
char *pathCopy = strdup(absolutePath);
for (char *ptr = pathCopy + 1; *ptr != '\0'; ptr++) { ... }
```

There was no guard for three cases that are all plausible when the process is already in a corrupted post-exception state:

1. `absolutePath == NULL` makes `strdup(NULL)` undefined behavior.
2. `strdup` returning `NULL` on allocation failure, after which `pathCopy + 1` dereferences `NULL`.
3. An empty `absolutePath`, where `pathCopy + 1` reads one byte past the 1-byte allocation.

The fix adds two early guards (NULL/empty input, and failed `strdup`) that return `false` and log via `SENTRY_ASYNC_SAFE_LOG_ERROR` consistent with the rest of the file. The existing async-signal-safe convention is preserved.

## :bulb: Motivation and Context

Per #8014, `sentrycrashfu_makePath` crashes with EXC_BAD_ACCESS while `sentrycrashcm_handleException` is already handling an unrelated app-level exception. This secondary crash in the SDK's own report-writing path masks the real crash. It is the third most frequent pattern in SDK-CRASHES-COCOA-5 and also covers SDK-CRASHES-COCOA-61J (~10.7K events), affecting SDK 8.36.0 through 9.9.0 across iOS 16.x to 26.x.

Callers (`sentrycrashfu_makePath` from `SentryCrashC.c` and `SentryCrashReportStore.c`) already ignore or branch on the `bool` result, so the crash handler skips writing the report path instead of aborting the whole handler.

Fixes #8014

## :green_heart: How did you test it?

Added three cases to `Tests/SentryTests/SentryCrash/SentryCrashFileUtils_Tests.m` matching the existing `FileBasedTestCase` conventions:

- `testMakePath_NULL` — `sentrycrashfu_makePath(NULL)` returns false without crashing.
- `testMakePath_EmptyString` — empty path returns false.
- `testMakePath_ValidPath` — a nested absolute path under the test temp dir is created and verified to exist (no regression on the happy path).

`clang-format` was run on both changed files (no further changes). The Xcode build and full test suite will be validated by CI.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
