### PR TITLE
fix(ci): prevent duplicate issue creation for unreferenced PRs

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-pr.yml
+++ b/.github/workflows/create-issue-for-unreferenced-pr.yml
@@ -86,11 +86,11 @@ jobs:
               state: 'all',
               sort: 'created',
               direction: 'desc',
-              per_page: 30,
+              per_page: 100,
             });
 
             const existingIssue = existingIssuesResponse.data.find(issue =>
-              !issue.pull_request && (issue.title === prTitle || (issue.body && issue.body.includes(prUrl)))
+              !issue.pull_request && issue.body && issue.body.includes(prUrl)
             );
 
             if (existingIssue) {

--- a/.github/workflows/create-issue-for-unreferenced-pr.yml
+++ b/.github/workflows/create-issue-for-unreferenced-pr.yml
@@ -77,13 +77,23 @@ jobs:
             }
 
             // Check if there's already an issue created by this automation for this PR
-            // Search for issues that mention this PR and were created by github-actions bot
-            const existingIssuesResponse = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open author:app/github-actions "${prUrl}" in:title in:body`,
+            // Uses the Issues list API (strongly consistent) instead of the Search API
+            // (eventually consistent) to avoid race conditions when multiple runs overlap.
+            const existingIssuesResponse = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              creator: 'github-actions[bot]',
+              state: 'all',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 30,
             });
 
-            if (existingIssuesResponse.data.total_count > 0) {
-              const existingIssue = existingIssuesResponse.data.items[0];
+            const existingIssue = existingIssuesResponse.data.find(issue =>
+              !issue.pull_request && (issue.title === prTitle || (issue.body && issue.body.includes(prUrl)))
+            );
+
+            if (existingIssue) {
               console.log(`An issue (#${existingIssue.number}) already exists for PR #${prNumber}, skipping creation.`);
               return;
             }


### PR DESCRIPTION
Replace the GitHub Search API with the Issues list API for the duplicate-issue
check in the "create issue for unreferenced PR" workflow.

The Search API (`github.rest.search.issuesAndPullRequests`) is eventually
consistent with an indexing delay. When multiple workflow runs overlap
(e.g. `ready_for_review` + `synchronize` firing within seconds), both runs
query the search index before either issue is indexed, and both create an
issue — exactly what happened on PR #8139, which got issues #8140 and #8141.

The Issues list API (`github.rest.issues.listForRepo`) should be strongly consistent,
so a concurrent run will see the issue immediately after it's created.

#skip-changelog