### PR TITLE
test: Reproduce SubClassFinder crash with @available gesture types

### DIFF
--- a/Samples/iOS-SwiftUI/App/Sources/HorizontalDragGesture.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/HorizontalDragGesture.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func horizontalDragGesture(
+        onChanged: ((CGSize) -> Void)? = nil,
+        onEnded: ((CGSize) -> Void)? = nil
+    ) -> some View {
+        if #available(iOS 18.0, *) {
+            gesture(
+                HorizontalPanGesture()
+                    .onChanged { onChanged?($0) }
+                    .onEnded { onEnded?($0) }
+            )
+        } else {
+            gesture(
+                DragGesture()
+                    .onChanged { onChanged?($0.translation) }
+                    .onEnded { onEnded?($0.translation) }
+            )
+        }
+    }
+}
+
+@available(iOS 18.0, *)
+private struct HorizontalPanGesture: UIGestureRecognizerRepresentable {
+    var onChanged: ((CGSize) -> Void)?
+    var onEnded: ((CGSize) -> Void)?
+
+    func makeUIGestureRecognizer(context: Context) -> UIPanGestureRecognizer {
+        let gesture = UIPanGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handlePan(_:))
+        )
+        gesture.maximumNumberOfTouches = 1
+        gesture.cancelsTouchesInView = false
+        gesture.delegate = context.coordinator
+        return gesture
+    }
+
+    func updateUIGestureRecognizer(
+        _ recognizer: UIPanGestureRecognizer,
+        context: Context
+    ) {
+        context.coordinator.onChanged = onChanged
+        context.coordinator.onEnded = onEnded
+    }
+
+    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator {
+        Coordinator()
+    }
+
+    func onChanged(_ action: @escaping (CGSize) -> Void) -> Self {
+        var copy = self
+        copy.onChanged = action
+        return copy
+    }
+
+    func onEnded(_ action: @escaping (CGSize) -> Void) -> Self {
+        var copy = self
+        copy.onEnded = action
+        return copy
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onChanged: ((CGSize) -> Void)?
+        var onEnded: ((CGSize) -> Void)?
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+                return false
+            }
+            let velocity = panGesture.velocity(in: gestureRecognizer.view)
+            return abs(velocity.x) > abs(velocity.y)
+        }
+
+        @objc func handlePan(_ gestureRecognizer: UIPanGestureRecognizer) {
+            let translation = gestureRecognizer.translation(in: gestureRecognizer.view)
+            let size = CGSize(width: translation.x, height: translation.y)
+            switch gestureRecognizer.state {
+            case .changed:
+                onChanged?(size)
+            case .ended, .cancelled, .failed:
+                onEnded?(size)
+            default:
+                break
+            }
+        }
+    }
+}

--- a/Samples/iOS-SwiftUI/App/Sources/LoremIpsumView.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/LoremIpsumView.swift
@@ -7,10 +7,17 @@ struct LoremIpsumView: View {
     
     @StateObject var viewModel = LoremIpsumViewModel()
     
+    @State private var dragOffset: CGSize = .zero
+
     var body: some View {
         SentryTracedView("Lorem Ipsum") {
             Text(viewModel.text)
                 .padding(16)
+                .offset(x: dragOffset.width)
+                .horizontalDragGesture(
+                    onChanged: { dragOffset = $0 },
+                    onEnded: { _ in dragOffset = .zero }
+                )
         }
     }
 }

--- a/Samples/iOS-SwiftUI/UITests/Sources/LaunchUITests.swift
+++ b/Samples/iOS-SwiftUI/UITests/Sources/LaunchUITests.swift
@@ -59,6 +59,15 @@ class LaunchUITests: XCTestCase {
     XCTAssertNotEqual(sentryErrorId.sentryIdString, SentryId.empty.sentryIdString, "The id should not be empty, since empty is used to indicate the capture did not work.")
   }
 
+    func testAppLaunchWithAvailabilityGatedGesture() {
+        let app = newAppSession()
+        app.safelyLaunch()
+
+        let transactionName = app.staticTexts["TRANSACTION_NAME"]
+        XCTAssertTrue(transactionName.waitForExistence(timeout: 10),
+            "App should launch without crashing even with @available(iOS 18.0, *) gesture types in the binary")
+    }
+
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -3,6 +3,10 @@ import ObjectiveC
 @_spi(Private) import SentryTestUtils
 import XCTest
 
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
 #if os(iOS) || os(tvOS)
 class SentrySubClassFinderTests: XCTestCase {
     
@@ -119,4 +123,132 @@ class SecondViewController: UIViewController {}
 class ViewControllerNumberThree: UIViewController {}
 class VCAnyNaming: UIViewController {}
 class FakeViewController {}
+#endif
+
+// MARK: - Availability-gated gesture crash reproduction
+//
+// Mirrors a real crash: an app defines a gesture conforming to
+// UIGestureRecognizerRepresentable (iOS 18+) behind @available.
+// The nested Coordinator (NSObject subclass) is registered in the ObjC runtime.
+// When SubClassFinder calls NSClassFromString on it, Swift metadata resolution
+// triggers protocol conformance lookup for UIGestureRecognizerRepresentable.
+// On iOS versions where the protocol doesn't exist, this crashes.
+
+#if os(iOS)
+
+@available(iOS 26.0, *)
+private struct TestHorizontalPanGesture: UIGestureRecognizerRepresentable {
+    var onChanged: ((CGSize) -> Void)?
+    var onEnded: ((CGSize) -> Void)?
+
+    func makeUIGestureRecognizer(context: Context) -> UIPanGestureRecognizer {
+        let gesture = UIPanGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handlePan(_:))
+        )
+        gesture.maximumNumberOfTouches = 1
+        gesture.cancelsTouchesInView = false
+        gesture.delegate = context.coordinator
+        return gesture
+    }
+
+    func updateUIGestureRecognizer(
+        _ recognizer: UIPanGestureRecognizer,
+        context: Context
+    ) {
+        context.coordinator.onChanged = onChanged
+        context.coordinator.onEnded = onEnded
+    }
+
+    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator {
+        Coordinator()
+    }
+
+    func onChanged(_ action: @escaping (CGSize) -> Void) -> Self {
+        var copy = self
+        copy.onChanged = action
+        return copy
+    }
+
+    func onEnded(_ action: @escaping (CGSize) -> Void) -> Self {
+        var copy = self
+        copy.onEnded = action
+        return copy
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onChanged: ((CGSize) -> Void)?
+        var onEnded: ((CGSize) -> Void)?
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+                return false
+            }
+            let velocity = panGesture.velocity(in: gestureRecognizer.view)
+            return abs(velocity.x) > abs(velocity.y)
+        }
+
+        @objc func handlePan(_ gestureRecognizer: UIPanGestureRecognizer) {
+            let translation = gestureRecognizer.translation(in: gestureRecognizer.view)
+            let size = CGSize(width: translation.x, height: translation.y)
+            switch gestureRecognizer.state {
+            case .changed:
+                onChanged?(size)
+            case .ended, .cancelled, .failed:
+                onEnded?(size)
+            default:
+                break
+            }
+        }
+    }
+}
+
+@available(iOS 26.0, *)
+private struct TestGestureView: View {
+    var body: some View {
+        Text("Hello")
+            .gesture(
+                TestHorizontalPanGesture()
+                    .onChanged { _ in }
+                    .onEnded { _ in }
+            )
+    }
+}
+
+@available(iOS 26.0, *)
+@objc(TestHorizontalGestureVC)
+private class TestHorizontalGestureVC: UIHostingController<TestGestureView> {}
+
+extension SentrySubClassFinderTests {
+
+    func testActOnSubclassesOfViewController_WithAvailabilityGatedGestureClass() {
+        // Use real ObjC runtime class list — the test binary contains
+        // TestHorizontalPanGesture.Coordinator, an @available(iOS 26.0, *)
+        // NSObject subclass whose parent type conforms to
+        // UIGestureRecognizerRepresentable. NSClassFromString on the
+        // Coordinator triggers Swift metadata resolution that can crash
+        // on iOS versions where the protocol doesn't exist.
+        fixture.runtimeWrapper.classesNames = nil
+
+        let expect = expectation(description: "SubClassFinder callback")
+        expect.assertForOverFulfill = false
+
+        var foundClasses: [AnyClass] = []
+        let sut = fixture.getSut()
+        sut.actOnSubclassesOfViewController(inImage: fixture.imageName) { subClass in
+            XCTAssertTrue(Thread.isMainThread)
+            foundClasses.append(subClass)
+            expect.fulfill()
+        }
+
+        wait(for: [expect], timeout: 5)
+
+        XCTAssertTrue(foundClasses.contains(where: { $0 == FirstViewController.self }))
+
+        if #available(iOS 26.0, *) {
+            XCTAssertTrue(foundClasses.contains(where: { $0 == TestHorizontalGestureVC.self }))
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
Add prototype to reproduce a crash where NSClassFromString in SentrySubClassFinder.actOnSubclassesOfViewController triggers Swift metadata resolution for types with @available(iOS 18+) protocol conformances (UIGestureRecognizerRepresentable). On older iOS where the protocol doesn't exist, this causes EXC_BAD_ACCESS in swift_getSingletonMetadata.

Adds:
- HorizontalPanGesture view extension to iOS-SwiftUI sample app
- LoremIpsumView uses the gesture to mirror real-world usage
- UI test that launches the app to verify no crash on startup
- Unit test with @available(iOS 26+) gesture types in the real ObjC runtime class list to exercise the SubClassFinder code path

Note: crash only reproduces on real iOS 17.x devices, not on simulators (the simulator Swift runtime handles missing protocol metadata without crashing).

#skip-changelog

Ref #8152 