### PR TITLE
fix: isolate lazy TLS init in the signal monitor to managed runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 - Prevent feedback form on external displays (#8071)
+- Prevent lazy TLS-init in the signal crash handler for non-managed runtime builds.
 
 ## 9.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 - Prevent feedback form on external displays (#8071)
-- Prevent lazy TLS-init in the signal crash handler for non-managed runtime builds.
+- Prevent lazy TLS-init in the signal crash handler for non-managed runtime builds (#8148)
 
 ## 9.18.0
 

--- a/Sources/Sentry/include/SentryCrashC.h
+++ b/Sources/Sentry/include/SentryCrashC.h
@@ -54,7 +54,7 @@ void sentrycrash_uninstall(void);
 /** Tell SentryCrash to ignore the next occurrence of the given signal on the
  * calling thread. Used to prevent duplicate crash reports when the host runtime
  * is about to raise a signal (e.g. SIGABRT) that has already been captured as
- * a managed exception.
+ * a managed exception. No-op unless SENTRY_CRASH_MANAGED_RUNTIME is set.
  *
  * @param signum The signal number to ignore (e.g. SIGABRT).
  */

--- a/Sources/Sentry/include/SentryCrashMonitor_Signal.h
+++ b/Sources/Sentry/include/SentryCrashMonitor_Signal.h
@@ -43,7 +43,7 @@ void sentrycrashcm_setEnableSigtermReporting(bool enabled);
 
 /** Tell the signal monitor to ignore the next occurrence of the given signal
  * on the calling thread. Consumed by the next signal delivery, even if it
- * doesn't match.
+ * doesn't match. No-op unless SENTRY_CRASH_MANAGED_RUNTIME is set.
  */
 void sentrycrashcm_signal_ignore_next(int signum);
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -49,7 +49,9 @@
 
 static volatile bool g_isEnabled = false;
 static bool g_isSigtermReportingEnabled = false;
+#    ifdef SENTRY_CRASH_MANAGED_RUNTIME
 static _Thread_local int tl_ignoreSignum = 0;
+#    endif
 
 static SentryCrash_MonitorContext g_monitorContext;
 static SentryCrashStackCursor g_stackCursor;
@@ -100,11 +102,17 @@ restorePreviousSignalHandler(int sigNum)
 static void
 handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
 {
-    int ignoreSignum = tl_ignoreSignum;
+#    ifdef SENTRY_CRASH_MANAGED_RUNTIME
+    const int ignoreSignum = tl_ignoreSignum;
     tl_ignoreSignum = 0;
+#    endif
 
     SENTRY_ASYNC_SAFE_LOG_DEBUG("Trapped signal %d", sigNum);
-    if (g_isEnabled && sigNum != ignoreSignum) {
+    if (g_isEnabled
+#    ifdef SENTRY_CRASH_MANAGED_RUNTIME
+        && sigNum != ignoreSignum
+#    endif
+    ) {
         thread_act_array_t threads = NULL;
         mach_msg_type_number_t numThreads = 0;
         // Signal handlers preempt the crashing thread, so reentrancy can
@@ -133,7 +141,11 @@ handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
     }
 
     SENTRY_ASYNC_SAFE_LOG_DEBUG("Re-raising signal for regular handlers to catch.");
-    if (!g_isEnabled || sigNum == ignoreSignum) {
+    if (!g_isEnabled
+#    ifdef SENTRY_CRASH_MANAGED_RUNTIME
+        || sigNum == ignoreSignum
+#    endif
+    ) {
         // Avoid re-entering this handler on raise().
         restorePreviousSignalHandler(sigNum);
     }
@@ -326,8 +338,10 @@ sentrycrashcm_setEnableSigtermReporting(bool enabled)
 void
 sentrycrashcm_signal_ignore_next(int signum)
 {
-#if SENTRY_HAS_SIGNAL
+#if SENTRY_HAS_SIGNAL && defined(SENTRY_CRASH_MANAGED_RUNTIME)
     tl_ignoreSignum = signum;
+#else
+    (void)signum;
 #endif
 }
 


### PR DESCRIPTION
## :scroll: Description

Add a build-time guard for the thread-local state in the signal monitor representing the "current" ignored signal number. It is only needed in the context of managed runtimes, and normal SDK users should not have to pay for its lazy initialization, which is not safe in signal handlers.

This PR removes TLS usage and its definition (and thus initialization) from any build that doesn't involve managed runtime use of the `sentry-cocoa` SDK.

It doesn't fix the issue with managed runtime use; it only limits the blast radius.

## :bulb: Motivation and Context

Related to #8134 and isolates direct users of `sentry-cocoa` entirely from the reported effects.

## :green_heart: How did you test it?

Using the tests we already offer, this is not a behavioral change beyond removing the unnecessary initialization and access for users who do not run on .NET. Users targeting .NET have the same behavior as before.

I also verified that there are no lazy TLS access / `__tlv_bootstrap`-style paths by using

- `nm` to find the `_handleSignal` text symbol range
- `otool -rV` to inspect `__TEXT,__text` relocs 

and checking if any relocation in `handleSignal` contains `TLV`.

I did not automate this as a regression test, though. We can add it, though, with a bit of hard-coded testing setup (including `nm` and `otool` dependencies or equivalent). 

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
