### PR TITLE
feat: Add extended app start APIs to ObjC wrapper SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   - `extendAppLaunch()` -> `extendAppStart()`
   - `finishExtendedAppLaunch()` -> `finishExtendedAppStart()`
   - Added `getExtendedAppStartSpan()` to get the extended app span
+- Add extended app start APIs to ObjC wrapper SDK (#8163)
 
 ## 9.18.0
 

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -361,7 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)reportFullyDisplayed;
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
+#if !SENTRY_NO_UI_FRAMEWORK && (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
 /**
  * Extends the app launch measurement beyond the default end point.
  *

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -362,6 +362,35 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)reportFullyDisplayed;
 
 /**
+ * Extends the app launch measurement beyond the default end point.
+ *
+ * Call this method after @c startWithOptions: but before the @c didFinishLaunching notification
+ * is posted so the SDK doesn't finish the app start transaction automatically.
+ *
+ * Use @c getExtendedAppStartSpan to retrieve the span and add child spans that break down the
+ * extended launch period. Call @c finish on that span (or call @c finishExtendedAppStart) when
+ * the app is fully launched.
+ *
+ * @note This only has an effect when Standalone App Start tracing is enabled.
+ */
++ (void)extendAppStart;
+
+/**
+ * Returns the extended app start span, or @c nil if @c extendAppStart was not called,
+ * the SDK is not started, or the app start transaction was already created.
+ */
++ (nullable SentryObjCSpan *)getExtendedAppStartSpan;
+
+/**
+ * Finishes a previously extended app launch and sends the app start transaction.
+ *
+ * This is equivalent to calling @c finish on the span returned by @c getExtendedAppStartSpan.
+ * If @c extendAppStart was not called, or the extended launch was already finished, this method
+ * does nothing.
+ */
++ (void)finishExtendedAppStart;
+
+/**
  * Pauses sending detected app hangs to Sentry.
  * @note This method doesn't close the detection of app hangs. Instead, the app hang detection
  * will ignore detected app hangs until you call @c resumeAppHangTracking.

--- a/Sources/SentryObjC/Public/SentryObjCSDK.h
+++ b/Sources/SentryObjC/Public/SentryObjCSDK.h
@@ -361,6 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)reportFullyDisplayed;
 
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 /**
  * Extends the app launch measurement beyond the default end point.
  *
@@ -389,6 +390,7 @@ NS_ASSUME_NONNULL_BEGIN
  * does nothing.
  */
 + (void)finishExtendedAppStart;
+#endif
 
 /**
  * Pauses sending detected app hangs to Sentry.

--- a/Sources/SentryObjCCompat/SentryObjCSDK.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDK.swift
@@ -229,6 +229,7 @@ import Foundation
         SentrySDK.reportFullyDisplayed()
     }
 
+    #if os(iOS) || os(tvOS) || os(visionOS)
     @objc public static func extendAppStart() {
         SentrySDK.extendAppStart()
     }
@@ -241,6 +242,7 @@ import Foundation
     @objc public static func finishExtendedAppStart() {
         SentrySDK.finishExtendedAppStart()
     }
+    #endif
 
     @objc public static func pauseAppHangTracking() {
         SentrySDK.pauseAppHangTracking()

--- a/Sources/SentryObjCCompat/SentryObjCSDK.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDK.swift
@@ -229,7 +229,7 @@ import Foundation
         SentrySDK.reportFullyDisplayed()
     }
 
-    #if os(iOS) || os(tvOS) || os(visionOS)
+    #if !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS) || os(visionOS))
     @objc public static func extendAppStart() {
         SentrySDK.extendAppStart()
     }

--- a/Sources/SentryObjCCompat/SentryObjCSDK.swift
+++ b/Sources/SentryObjCCompat/SentryObjCSDK.swift
@@ -229,6 +229,19 @@ import Foundation
         SentrySDK.reportFullyDisplayed()
     }
 
+    @objc public static func extendAppStart() {
+        SentrySDK.extendAppStart()
+    }
+
+    @objc public static func getExtendedAppStartSpan() -> SentryObjCSpan? {
+        guard let span = SentrySDK.getExtendedAppStartSpan() else { return nil }
+        return SentryObjCSpan(span)
+    }
+
+    @objc public static func finishExtendedAppStart() {
+        SentrySDK.finishExtendedAppStart()
+    }
+
     @objc public static func pauseAppHangTracking() {
         SentrySDK.pauseAppHangTracking()
     }

--- a/Tests/SentryObjCTests/SentryObjCSDKTests.m
+++ b/Tests/SentryObjCTests/SentryObjCSDKTests.m
@@ -601,6 +601,81 @@
     [SentryObjCSDK flush:0.1];
 }
 
+#pragma mark - Extended App Start
+
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
+- (void)testExtendAppStart_shouldNotCrash
+{
+    // -- Act & Assert (no crash) --
+    [SentryObjCSDK extendAppStart];
+}
+
+- (void)testGetExtendedAppStartSpan_withoutExtending_shouldReturnNil
+{
+    // -- Act --
+    SentryObjCSpan *span = [SentryObjCSDK getExtendedAppStartSpan];
+
+    // -- Assert --
+    XCTAssertNil(span);
+}
+
+- (void)testGetExtendedAppStartSpan_afterExtending_shouldReturnSpan
+{
+    // -- Arrange --
+    [SentryObjCSDK extendAppStart];
+
+    // -- Act --
+    SentryObjCSpan *span = [SentryObjCSDK getExtendedAppStartSpan];
+
+    // -- Assert --
+    XCTAssertNotNil(span);
+    XCTAssertFalse(span.isFinished);
+}
+
+- (void)testFinishExtendedAppStart_withoutExtending_shouldNotCrash
+{
+    // -- Act & Assert (no crash) --
+    [SentryObjCSDK finishExtendedAppStart];
+}
+
+- (void)testFinishExtendedAppStart_afterExtending_shouldFinishSpan
+{
+    // -- Arrange --
+    [SentryObjCSDK extendAppStart];
+    SentryObjCSpan *span = [SentryObjCSDK getExtendedAppStartSpan];
+    XCTAssertNotNil(span);
+
+    // -- Act --
+    [SentryObjCSDK finishExtendedAppStart];
+
+    // -- Assert --
+    XCTAssertTrue(span.isFinished);
+}
+
+- (void)testFinishExtendedAppStart_calledTwice_shouldNotCrash
+{
+    // -- Arrange --
+    [SentryObjCSDK extendAppStart];
+
+    // -- Act & Assert (no crash) --
+    [SentryObjCSDK finishExtendedAppStart];
+    [SentryObjCSDK finishExtendedAppStart];
+}
+
+- (void)testGetExtendedAppStartSpan_afterFinish_shouldReturnNil
+{
+    // -- Arrange --
+    [SentryObjCSDK extendAppStart];
+    [SentryObjCSDK finishExtendedAppStart];
+
+    // -- Act --
+    SentryObjCSpan *span = [SentryObjCSDK getExtendedAppStartSpan];
+
+    // -- Assert --
+    XCTAssertNil(span);
+}
+#endif
+
 #pragma mark - Platform-Conditional
 
 #if TARGET_OS_IOS || TARGET_OS_TV

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2259,6 +2259,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "extendAppStart",
+    "parent": "SentryObjCSDK",
+    "returnType": "void",
+    "instance": false
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "extra",
     "parent": "SentryObjCEvent",
     "returnType": "NSDictionary<NSString *,id> * _Nullable",
@@ -2333,6 +2340,13 @@
     "parent": "SentryObjCSpan",
     "returnType": "void",
     "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "finishExtendedAppStart",
+    "parent": "SentryObjCSDK",
+    "returnType": "void",
+    "instance": false
   },
   {
     "kind": "ObjCMethodDecl",
@@ -2487,6 +2501,13 @@
     "parent": "SentryObjCHub",
     "returnType": "SentryObjCClient * _Nullable",
     "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "getExtendedAppStartSpan",
+    "parent": "SentryObjCSDK",
+    "returnType": "SentryObjCSpan * _Nullable",
+    "instance": false
   },
   {
     "kind": "ObjCMethodDecl",

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -2245,6 +2245,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "extendAppStart",
+    "parent": "SentryObjCSDK",
+    "returnType": "void",
+    "instance": false
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "extra",
     "parent": "SentryObjCEvent",
     "returnType": "NSDictionary<NSString *,id> * _Nullable",
@@ -2319,6 +2326,13 @@
     "parent": "SentryObjCSpan",
     "returnType": "void",
     "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "finishExtendedAppStart",
+    "parent": "SentryObjCSDK",
+    "returnType": "void",
+    "instance": false
   },
   {
     "kind": "ObjCMethodDecl",
@@ -2473,6 +2487,13 @@
     "parent": "SentryObjCHub",
     "returnType": "SentryObjCClient * _Nullable",
     "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "getExtendedAppStartSpan",
+    "parent": "SentryObjCSDK",
+    "returnType": "SentryObjCSpan * _Nullable",
+    "instance": false
   },
   {
     "kind": "ObjCMethodDecl",


### PR DESCRIPTION
## Summary
- Expose `extendAppStart()`, `getExtendedAppStartSpan()`, and `finishExtendedAppStart()` in `SentryObjCSDK` so ObjC-only consumers can use the extended app start measurement
- Adds declarations in `SentryObjCSDK.h` and wrapper implementations in `SentryObjCSDK.swift`
- Regenerated `sdk_api_objc.json` / `sdk_api_objc_v10.json`

## Test plan
- [x] `make build-ios` passes
- [x] `make generate-public-api` includes the new methods
- [ ] Verify ObjC sample app can call the new APIs

Closes #8169