### PR TITLE
chore(ci): remove continue-on-error for Bitrise runners

### DIFF
--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -51,7 +51,6 @@ jobs:
   # Intentionally skipped on release branches.
   build-xcframeworks:
     name: Build XCFrameworks on ${{matrix.runner_provider}}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
     needs: files-changed
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
     runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
@@ -77,7 +76,6 @@ jobs:
   # SPM tests for all 3rd-party integrations
   test-integrations-spm:
     name: SPM Tests | ${{matrix.integration_dir}} on ${{matrix.runner_provider}}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
     needs: [files-changed, build-xcframeworks]
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
     runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -36,7 +36,6 @@ jobs:
 
   test-react-native:
     name: React Native Installation on ${{matrix.runner_provider}}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_test_cross_platform_for_prs == 'true'
     needs: files-changed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,6 @@ jobs:
   # of a bug solely on a specific OS version is minimal.
   unit-tests-with-test-server:
     name: Unit with Test Server ${{matrix.name}} on ${{matrix.runner_provider}}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
     runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
     timeout-minutes: 20
     needs: build-test-server

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -61,7 +61,6 @@ jobs:
     if: ${{ !inputs.should_skip }}
     name: UI Tests Common
     runs-on: ${{ inputs.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', inputs.macos_version)) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', inputs.macos_version, github.run_id)) }}
-    continue-on-error: ${{ inputs.runner_provider == 'bitrise' }}
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -78,7 +78,6 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_critical_for_prs == 'true'
     needs: files-changed
     name: Run SwiftUI Crash Test on ${{matrix.runner_provider}}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
     runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
     strategy:
       matrix:

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -64,7 +64,6 @@ jobs:
   unit-tests:
     name: Unit ${{inputs.name}}
     runs-on: ${{ inputs.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', inputs.runs-on)) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', inputs.runs-on, github.run_id)) }}
-    continue-on-error: ${{ inputs.runner_provider == 'bitrise' }}
     timeout-minutes: ${{inputs.timeout}}
     if: ${{!inputs.should_skip}}
     steps:


### PR DESCRIPTION
## Summary
- Removed `continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}` from all workflow files
- Bitrise is now stable enough that its failures should block CI, same as Cirrus

## Changed workflows
- `test-cross-platform.yml` — `test-react-native` job
- `ui-tests-critical.yml` — `run-swiftui-crash-test` job
- `ui-tests-common.yml` — `common-ui-tests` job
- `unit-test-common.yml` — `unit-tests` job
- `test.yml` — `unit-tests-with-test-server` job
- `test-3rd-party-integrations.yml` — `build-xcframeworks` and `test-integrations-spm` jobs

#skip-changelog

Closes #8168