### PR TITLE
chore(ci): add tvOS 17 unit test for bitrise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -408,6 +408,12 @@ jobs:
             xcode: "16"
             test-destination-os: "17.5"
             platform: "tvOS"
+          - name: tvOS 17 Sentry
+            runner_provider: bitrise
+            runs-on: sonoma
+            xcode: "16"
+            test-destination-os: "17.5"
+            platform: "tvOS"
 
           # tvOS 18
           - name: tvOS 18 Sentry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,7 +410,7 @@ jobs:
             platform: "tvOS"
           - name: tvOS 17 Sentry
             runner_provider: bitrise
-            runs-on: sonoma
+            runs-on: sequoia
             xcode: "16"
             test-destination-os: "17.5"
             platform: "tvOS"

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -76,21 +76,12 @@ jobs:
 
       - name: Install simulator runtime
         # Bitrise is missing tvOS 17.5 runtime, so we need to install it manually.
-        if: ${{ inputs.runner_provider == 'bitrise' && inputs.test-destination-os != '' && inputs.platform == 'tvOS' }}
+        if: ${{ inputs.runner_provider == 'bitrise' && inputs.test-destination-os == '17.5' && inputs.platform == 'tvOS' }}
         timeout-minutes: 5
         env:
-          OS_VERSION: ${{ inputs.test-destination-os }}
           PLATFORM: ${{ inputs.platform }}
-        run: |
-          if xcrun simctl list runtimes -j 2>/dev/null \
-              | jq -e --arg p "$PLATFORM" --arg v "$OS_VERSION" \
-                  '[.runtimes[] | select(.isAvailable == true) | select(.platform == $p) | select(.version == $v)] | length > 0' \
-                  > /dev/null 2>&1; then
-            echo "Runtime $PLATFORM $OS_VERSION is already installed"
-          else
-            echo "Installing $PLATFORM $OS_VERSION runtime..."
-            xcodebuild -downloadPlatform "$PLATFORM" -buildVersion "$OS_VERSION"
-          fi
+          OS_VERSION: ${{ inputs.test-destination-os }}
+        run: ./scripts/ci-install-simulator-runtime.sh --platform "$PLATFORM" --os-version "$OS_VERSION"
 
       - name: Resolve test destination
         id: resolve-test-destination

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install simulator runtime
         # Bitrise is missing tvOS 17.5 runtime, so we need to install it manually.
         if: ${{ inputs.runner_provider == 'bitrise' && inputs.test-destination-os != '' && inputs.platform == 'tvOS' }}
-        timeout-minutes: 30
+        timeout-minutes: 5
         env:
           OS_VERSION: ${{ inputs.test-destination-os }}
           PLATFORM: ${{ inputs.platform }}

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -74,6 +74,24 @@ jobs:
         with:
           version: ${{ inputs.xcode }}
 
+      - name: Install simulator runtime
+        # Bitrise is missing tvOS 17.5 runtime, so we need to install it manually.
+        if: ${{ inputs.runner_provider == 'bitrise' && inputs.test-destination-os != '' && inputs.platform == 'tvOS' }}
+        timeout-minutes: 30
+        env:
+          OS_VERSION: ${{ inputs.test-destination-os }}
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          if xcrun simctl list runtimes -j 2>/dev/null \
+              | jq -e --arg p "$PLATFORM" --arg v "$OS_VERSION" \
+                  '[.runtimes[] | select(.isAvailable == true) | select(.platform == $p) | select(.version == $v)] | length > 0' \
+                  > /dev/null 2>&1; then
+            echo "Runtime $PLATFORM $OS_VERSION is already installed"
+          else
+            echo "Installing $PLATFORM $OS_VERSION runtime..."
+            xcodebuild -downloadPlatform "$PLATFORM" -buildVersion "$OS_VERSION"
+          fi
+
       - name: Resolve test destination
         id: resolve-test-destination
         uses: ./.github/actions/resolve-test-destination

--- a/scripts/ci-install-simulator-runtime.sh
+++ b/scripts/ci-install-simulator-runtime.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+PLATFORM=""
+OS_VERSION=""
+
+usage() {
+    log_notice "Usage: $0"
+    log_notice "  --platform <value>      Platform name, e.g. iOS, tvOS (required)"
+    log_notice "  --os-version <value>    Runtime version, e.g. 17.5, 18.2 (required)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --platform)    PLATFORM="$2";    shift 2 ;;
+        --os-version)  OS_VERSION="$2";  shift 2 ;;
+        *)             usage ;;
+    esac
+done
+
+if [ -z "$PLATFORM" ]; then
+    log_error "Error: --platform is required"
+    usage
+fi
+
+if [ -z "$OS_VERSION" ]; then
+    log_error "Error: --os-version is required"
+    usage
+fi
+
+if xcrun simctl list runtimes -j 2>/dev/null \
+    | jq -e --arg p "$PLATFORM" --arg v "$OS_VERSION" \
+        '[.runtimes[] | select(.isAvailable == true) | select(.platform == $p) | select(.version == $v)] | length > 0' \
+        > /dev/null 2>&1; then
+    log_info "Runtime $PLATFORM $OS_VERSION is already installed"
+else
+    log_info "Installing $PLATFORM $OS_VERSION runtime..."
+    xcodebuild -downloadPlatform "$PLATFORM" -buildVersion "$OS_VERSION"
+fi


### PR DESCRIPTION
## :scroll: Description

Adds tvOS 17 to the unit tests.
Previously it was disabled, but I added a script to install tvOS 17 on the machines

## :bulb: Motivation and Context

More tests on Bitrise

## :green_heart: How did you test it?

CI

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).


Closes #8289