### PR TITLE
fix: don't send logs and metrics when SDK is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- Don't send logs and metrics when the SDK is disabled (#8173)
 - Fixes crash caused by modifying breadcrumbs from multiple threads (#8114)
 - Prevent feedback form on external displays (#8071)
 - Keep the User Feedback screenshot trigger active after form dismissal. (#8048)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -924,7 +924,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (void)logDisabledMessage
 {
-    SENTRY_LOG_DEBUG(@"SDK disabled or no DSN set. Won't do anyting.");
+    SENTRY_LOG_DEBUG(@"SDK disabled or no DSN set. Won't do anything.");
 }
 
 - (SentryEvent *_Nullable)callEventProcessors:(SentryEvent *)event

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1145,6 +1145,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (void)_swiftCaptureLog:(NSObject *)log withScope:(SentryScope *)scope
 {
+    if ([self isDisabled]) {
+        [self logDisabledMessage];
+        return;
+    }
+
     if (self.options.enableLogs == NO) {
         SENTRY_LOG_DEBUG(@"Dropping log, because the option enableLogs is false.");
         return;

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -102,6 +102,10 @@ NS_ASSUME_NONNULL_BEGIN
 /// while `isDisabled` also returns YES for `options.enabled == false` or no DSN.
 @property (nonatomic, assign, readonly) BOOL isDisabled;
 
+/// Logs a debug message that data is dropped because the client is disabled. Exposed so Swift
+/// (e.g. metrics) logs the same message as event/envelope capture when dropping data.
+- (void)logDisabledMessage;
+
 /// Exposes the Telemetry Processor so Swift code can forward metrics directly without crossing the
 /// ObjC boundary. SentryMetric is a Swift struct and cannot be passed through ObjC methods, so
 /// we use a Swift extension on SentryClientInternal.

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -97,6 +97,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_swiftCaptureLog:(NSObject *)log withScope:(SentryScope *)scope;
 
+/// The gate `captureEvent`/`captureEnvelope` use to drop telemetry, exposed so Swift (e.g. metrics)
+/// can reuse it. Broader than the public `isEnabled` in `SentryClient.h`: `isEnabled` only reflects
+/// `close`, while `isDisabled` also returns YES for `options.enabled == false` or no DSN.
+@property (nonatomic, assign, readonly) BOOL isDisabled;
+
 /// Exposes the Telemetry Processor so Swift code can forward metrics directly without crossing the
 /// ObjC boundary. SentryMetric is a Swift struct and cannot be passed through ObjC methods, so
 /// we use a Swift extension on SentryClientInternal.

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -97,9 +97,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_swiftCaptureLog:(NSObject *)log withScope:(SentryScope *)scope;
 
-/// The gate `captureEvent`/`captureEnvelope` use to drop telemetry, exposed so Swift (e.g. metrics)
-/// can reuse it. Broader than the public `isEnabled` in `SentryClient.h`: `isEnabled` only reflects
-/// `close`, while `isDisabled` also returns YES for `options.enabled == false` or no DSN.
+/// Exposed so Swift (e.g. metrics) can reuse it to drop data when the client is disabled.
+/// Broader than the public `isEnabled` in `SentryClient.h`: `isEnabled` only reflects `close`,
+/// while `isDisabled` also returns YES for `options.enabled == false` or no DSN.
 @property (nonatomic, assign, readonly) BOOL isDisabled;
 
 /// Exposes the Telemetry Processor so Swift code can forward metrics directly without crossing the

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_swiftCaptureLog:(NSObject *)log withScope:(SentryScope *)scope;
 
 /// Exposed so Swift (e.g. metrics) can reuse it to drop data when the client is disabled.
-/// Broader than the public `isEnabled` in `SentryClient.h`: `isEnabled` only reflects `close`,
+/// Broader than `isEnabled` in `SentryClient.h`: `isEnabled` only reflects `close`,
 /// while `isDisabled` also returns YES for `options.enabled == false` or no DSN.
 @property (nonatomic, assign, readonly) BOOL isDisabled;
 

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -37,6 +37,22 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     // MARK: - Public API for Metrics
 
     func addMetric(_ metric: SentryMetric, scope: Scope) {
+        // We go directly to the client instead of through the hub because metrics only have a
+        // static API today and the hub doesn't implement any metrics methods. Ideally, metrics should also go
+        // through the hub to align with other telemetry types.
+        guard let client = SentrySDKInternal.currentHub().getClient() else {
+            SentrySDKLog.debug("MetricsIntegration: No client available, dropping metric")
+            return
+        }
+
+        // Bail out before scope enrichment and the beforeSendMetric callback so we don't run user
+        // code or do unnecessary work when the SDK is disabled. Mirrors the early return in
+        // SentryClient's log capture.
+        guard !client.isDisabled else {
+            client.logDisabledMessage()
+            return
+        }
+
         var mutableMetric = metric
         scope.addAttributesToItem(&mutableMetric, metadata: self.scopeMetaData)
 
@@ -47,13 +63,6 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
             mutableMetric = processedItem
         }
 
-        // We go directly to the client instead of through the hub because metrics only have a
-        // static API today and the hub doesn't implement any metrics methods. Ideally, metrics should also go
-        // through the hub to align with other telemetry types.
-        guard let client = SentrySDKInternal.currentHub().getClient() else {
-            SentrySDKLog.debug("MetricsIntegration: No client available, dropping metric")
-            return
-        }
         client.captureMetric(mutableMetric)
     }
 }
@@ -64,12 +73,8 @@ extension SentryClientInternal {
 
     /// Captures a metric by forwarding it to the telemetry processor's metrics buffer.
     /// This method stays entirely in Swift, avoiding the ObjC boundary since SentryMetric is a Swift struct.
+    /// Callers must check `isDisabled` before invoking; `SentryMetricsIntegration.addMetric` does this.
     func captureMetric(_ metric: SentryMetric) {
-        guard !self.isDisabled else {
-            self.logDisabledMessage()
-            return
-        }
-
         guard let processor = self.getTelemetryProcessor() as? SentryTelemetryProcessor else {
             SentrySDKLog.error("Cannot capture metric because the telemetry processor is not available. Discarding metric. This is unexpected and indicates a configuration issue.")
             return

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -65,7 +65,10 @@ extension SentryClientInternal {
     /// Captures a metric by forwarding it to the telemetry processor's metrics buffer.
     /// This method stays entirely in Swift, avoiding the ObjC boundary since SentryMetric is a Swift struct.
     func captureMetric(_ metric: SentryMetric) {
-        guard !self.isDisabled else { return }
+        guard !self.isDisabled else {
+            self.logDisabledMessage()
+            return
+        }
 
         guard let processor = self.getTelemetryProcessor() as? SentryTelemetryProcessor else {
             SentrySDKLog.error("Cannot capture metric because the telemetry processor is not available. Discarding metric. This is unexpected and indicates a configuration issue.")

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -73,8 +73,11 @@ extension SentryClientInternal {
 
     /// Captures a metric by forwarding it to the telemetry processor's metrics buffer.
     /// This method stays entirely in Swift, avoiding the ObjC boundary since SentryMetric is a Swift struct.
-    /// Callers must check `isDisabled` before invoking; `SentryMetricsIntegration.addMetric` does this.
+    /// `SentryMetricsIntegration.addMetric` already drops metrics (and logs) when the SDK is disabled;
+    /// this guard is a defensive safety net so a future caller can't bypass that gate.
     func captureMetric(_ metric: SentryMetric) {
+        guard !self.isDisabled else { return }
+
         guard let processor = self.getTelemetryProcessor() as? SentryTelemetryProcessor else {
             SentrySDKLog.error("Cannot capture metric because the telemetry processor is not available. Discarding metric. This is unexpected and indicates a configuration issue.")
             return

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -65,7 +65,7 @@ extension SentryClientInternal {
     /// Captures a metric by forwarding it to the telemetry processor's metrics buffer.
     /// This method stays entirely in Swift, avoiding the ObjC boundary since SentryMetric is a Swift struct.
     func captureMetric(_ metric: SentryMetric) {
-        guard self.isEnabled else { return }
+        guard !self.isDisabled else { return }
 
         guard let processor = self.getTelemetryProcessor() as? SentryTelemetryProcessor else {
             SentrySDKLog.error("Cannot capture metric because the telemetry processor is not available. Discarding metric. This is unexpected and indicates a configuration issue.")

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -76,7 +76,10 @@ extension SentryClientInternal {
     /// `SentryMetricsIntegration.addMetric` already drops metrics (and logs) when the SDK is disabled;
     /// this guard is a defensive safety net so a future caller can't bypass that gate.
     func captureMetric(_ metric: SentryMetric) {
-        guard !self.isDisabled else { return }
+        guard !self.isDisabled else {
+            self.logDisabledMessage()
+            return
+        }
 
         guard let processor = self.getTelemetryProcessor() as? SentryTelemetryProcessor else {
             SentrySDKLog.error("Cannot capture metric because the telemetry processor is not available. Discarding metric. This is unexpected and indicates a configuration issue.")

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -302,6 +302,36 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when no DSN is configured")
     }
 
+    func testAddMetric_whenClientDisabled_shouldNotCallBeforeSendMetric() throws {
+        // -- Arrange --
+        var beforeSendCalled = false
+        let client = try givenSdkWithHub { options in
+            options.enabled = false
+            options.beforeSendMetric = { metric in
+                beforeSendCalled = true
+                return metric
+            }
+        }
+        let integration = try getSut()
+
+        let scope = Scope()
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        integration.addMetric(metric, scope: scope)
+
+        // -- Assert --
+        XCTAssertFalse(beforeSendCalled, "beforeSendMetric should not be called when the SDK is disabled")
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when the SDK is disabled")
+    }
+
     func testAddMetric_whenClientDisabled_shouldLogDebugMessage() throws {
         // -- Arrange --
         let oldOutput = SentrySDKLog.getLogOutput()

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -302,6 +302,35 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when no DSN is configured")
     }
 
+    func testAddMetric_whenClientDisabled_shouldLogDebugMessage() throws {
+        // -- Arrange --
+        let oldOutput = SentrySDKLog.getLogOutput()
+        defer { SentrySDKLog.setOutput(oldOutput) }
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+        SentrySDKLog.configureLog(true, diagnosticLevel: .debug)
+
+        try givenSdkWithHub { $0.enabled = false }
+        let integration = try getSut()
+
+        let scope = Scope()
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        integration.addMetric(metric, scope: scope)
+
+        // -- Assert --
+        let logs = logOutput.loggedMessages.joined()
+        XCTAssertTrue(logs.contains("SDK disabled or no DSN set."), "Expected a debug log when dropping a metric, but got '\(logs)'")
+    }
+
     func testName_shouldReturnCorrectName() {
         // -- Act & Assert --
         XCTAssertEqual(SentryMetricsIntegration<SentryDependencyContainer>.name, "SentryMetricsIntegration")

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -361,6 +361,28 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertTrue(logs.contains("SDK disabled or no DSN set."), "Expected a debug log when dropping a metric, but got '\(logs)'")
     }
 
+    func testCaptureMetric_whenClientDisabled_shouldDropMetric() throws {
+        // Calls captureMetric directly, bypassing addMetric's gate, to verify the defensive
+        // guard inside captureMetric drops the metric when the SDK is disabled.
+        // -- Arrange --
+        let client = try givenSdkWithHub { $0.enabled = false }
+
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        client.captureMetric(metric)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when the SDK is disabled")
+    }
+
     func testName_shouldReturnCorrectName() {
         // -- Act & Assert --
         XCTAssertEqual(SentryMetricsIntegration<SentryDependencyContainer>.name, "SentryMetricsIntegration")

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -258,6 +258,50 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when client is disabled")
     }
 
+    func testAddMetric_whenSdkDisabledViaOptions_shouldDropMetric() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub { $0.enabled = false }
+        let integration = try getSut()
+
+        let scope = Scope()
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        integration.addMetric(metric, scope: scope)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when options.enabled is false")
+    }
+
+    func testAddMetric_whenNoDsn_shouldDropMetric() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub { $0.parsedDsn = nil }
+        let integration = try getSut()
+
+        let scope = Scope()
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        integration.addMetric(metric, scope: scope)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when no DSN is configured")
+    }
+
     func testName_shouldReturnCorrectName() {
         // -- Act & Assert --
         XCTAssertEqual(SentryMetricsIntegration<SentryDependencyContainer>.name, "SentryMetricsIntegration")

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -361,10 +361,16 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertTrue(logs.contains("SDK disabled or no DSN set."), "Expected a debug log when dropping a metric, but got '\(logs)'")
     }
 
-    func testCaptureMetric_whenClientDisabled_shouldDropMetric() throws {
+    func testCaptureMetric_whenClientDisabled_shouldDropMetricAndLogDebugMessage() throws {
         // Calls captureMetric directly, bypassing addMetric's gate, to verify the defensive
-        // guard inside captureMetric drops the metric when the SDK is disabled.
+        // guard inside captureMetric drops the metric and logs when the SDK is disabled.
         // -- Arrange --
+        let oldOutput = SentrySDKLog.getLogOutput()
+        defer { SentrySDKLog.setOutput(oldOutput) }
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+        SentrySDKLog.configureLog(true, diagnosticLevel: .debug)
+
         let client = try givenSdkWithHub { $0.enabled = false }
 
         let metric = SentryMetric(
@@ -381,6 +387,8 @@ class SentryMetricsIntegrationTests: XCTestCase {
 
         // -- Assert --
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0, "Metric should be dropped when the SDK is disabled")
+        let logs = logOutput.loggedMessages.joined()
+        XCTAssertTrue(logs.contains("SDK disabled or no DSN set."), "Expected a debug log when dropping a metric, but got '\(logs)'")
     }
 
     func testName_shouldReturnCorrectName() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2844,6 +2844,25 @@ final class SentryClientTests: XCTestCase {
         XCTAssertEqual(testProcessor.addLogInvocations.count, 0, "Log should be dropped when enableLogs is false")
     }
 
+    func testCaptureLog_whenClientDisabled_logDropped() {
+        // The full isDisabled logic is covered elsewhere; this just verifies _swiftCaptureLog
+        // consults it. We use the no-DSN case as a representative disabled state.
+        // -- Arrange --
+        let sut = fixture.getSutWithNoDsn()
+
+        let testProcessor = TestTelemetryProcessorForClient()
+        Dynamic(sut).telemetryProcessor = testProcessor
+
+        let log = SentryLog(level: .info, body: "This log should be dropped")
+        let scope = Scope()
+
+        // -- Act --
+        sut._swiftCaptureLog(log, with: scope)
+
+        // -- Assert --
+        XCTAssertEqual(testProcessor.addLogInvocations.count, 0, "Log should be dropped when the client is disabled")
+    }
+
 }
 
 private extension SentryClientTests {


### PR DESCRIPTION
## :scroll: Description

Gate logs and metrics on the client's `isDisabled` check, like `captureEvent`/`captureEnvelope`. Previously logs only checked `enableLogs` and metrics only checked `isEnabled`, so both were still sent when `options.enabled = false` or no DSN was set.

Two related notes:
- For metrics, the gate runs before `beforeSendMetric`, so the callback no longer fires when the SDK is disabled.
- Fixed a typo in the disabled-state debug log message (`anyting` → `anything`).

## :bulb: Motivation and Context

Fixes #8162

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the SentryObjC wrapper.
