### PR TITLE
chore: fix typos in public API doc comments

### DIFF
--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -169,7 +169,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 /**
  * Configure session replay with different breadcrumb converter
- * and screeshot provider. Used by the Hybrid SDKs.
+ * and screenshot provider. Used by the Hybrid SDKs.
  * Passing nil will keep the previous value.
  */
 + (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter

--- a/Sources/Sentry/Public/SentryAttachment.h
+++ b/Sources/Sentry/Public/SentryAttachment.h
@@ -75,7 +75,7 @@ SENTRY_NO_INIT
 
 /**
  * Initializes an attachment with a path.
- * @discussion The specifid file is read lazily when the SDK captures an event or
+ * @discussion The specified file is read lazily when the SDK captures an event or
  * transaction not when the attachment is initialized.
  * @param path The path of the file whose contents you want to upload to Sentry.
  * @param filename The name of the attachment to display in Sentry.

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -139,7 +139,7 @@ typedef SentryBreadcrumb *_Nullable (^SentryBeforeBreadcrumbCallback)(
     SentryBreadcrumb *_Nonnull breadcrumb);
 
 /**
- * Block can be used to mutate event before its send.
+ * Block can be used to mutate event before it's sent.
  * To avoid sending the event altogether, return nil instead.
  */
 typedef SentryEvent *_Nullable (^SentryBeforeSendEventCallback)(SentryEvent *_Nonnull event);

--- a/Sources/Sentry/Public/SentryException.h
+++ b/Sources/Sentry/Public/SentryException.h
@@ -49,7 +49,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryStacktrace *_Nullable stacktrace;
 
 /**
- * Initialize an SentryException with value and type.
+ * Initialize a SentryException with value and type.
  * @param value Nullable string describing the exception
  * @param type Nullable string with the type of the exception
  * @return SentryException

--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -61,7 +61,7 @@ SENTRY_NO_INIT
 @property (nullable, nonatomic, strong) SentryMechanismContext *meta;
 
 /**
- * Initialize an SentryMechanism with a type
+ * Initialize a SentryMechanism with a type
  * @param type String
  * @return SentryMechanism
  */

--- a/Sources/Sentry/Public/SentryReplayApi.h
+++ b/Sources/Sentry/Public/SentryReplayApi.h
@@ -49,13 +49,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * By calling this function an overlay will appear covering the parts
  * of the app that will be masked for the session replay.
- * This will only work if the debbuger is attached and it will
+ * This will only work if the debugger is attached and it will
  * cause some slow frames.
  *
  * @note This method must be called from the main thread.
  *
  * @warning This is an experimental feature and may still have bugs.
- * Do not use this is production.
+ * Do not use this in production.
  */
 - (void)showMaskPreview;
 
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * By calling this function an overlay will appear covering the parts
  * of the app that will be masked for the session replay.
- * This will only work if the debbuger is attached and it will
+ * This will only work if the debugger is attached and it will
  * cause some slow frames.
  *
  * @param opacity The opacity of the overlay.
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note This method must be called from the main thread.
  *
  * @warning This is an experimental feature and may still have bugs.
- * Do not use this is production.
+ * Do not use this in production.
  */
 - (void)showMaskPreview:(CGFloat)opacity;
 
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note This method must be called from the main thread.
  *
  * @warning This is an experimental feature and may still have bugs.
- * Do not use this is production.
+ * Do not use this in production.
  */
 - (void)hideMaskPreview;
 

--- a/Sources/Sentry/Public/SentrySerializable.h
+++ b/Sources/Sentry/Public/SentrySerializable.h
@@ -13,8 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 /**
- * Serialize the contents of the object into an NSDictionary. Make to copy all properties of the
- * original object so modifications to it don't have an impact on the serialized NSDictionary.
+ * Serialize the contents of the object into an NSDictionary. Make sure to copy all properties of
+ * the original object so modifications to it don't have an impact on the serialized NSDictionary.
  */
 - (NSDictionary<NSString *, id> *)serialize;
 

--- a/Sources/Sentry/Public/SentrySpanContext.h
+++ b/Sources/Sentry/Public/SentrySpanContext.h
@@ -64,14 +64,14 @@ SENTRY_NO_INIT
 
 /**
  * Init a @c SentryContext with an operation code.
- * @note @c traceId and @c spanId with be randomly created; @c sampled by default is
+ * @note @c traceId and @c spanId will be randomly created; @c sampled by default is
  * @c kSentrySampleDecisionUndecided .
  */
 - (instancetype)initWithOperation:(NSString *)operation;
 
 /**
  * Init a @c SentryContext with an operation code and mark it as sampled or not.
- * TraceId and SpanId with be randomly created.
+ * TraceId and SpanId will be randomly created.
  * @param operation The operation this span is measuring.
  * @param sampled Determines whether the trace should be sampled.
  */

--- a/Sources/Sentry/Public/SentrySpanId.h
+++ b/Sources/Sentry/Public/SentrySpanId.h
@@ -21,7 +21,7 @@ NS_SWIFT_NAME(SpanId)
 
 /**
  * Creates a SentrySpanId from a 16 character string.
- * Returns a empty SentrySpanId with the input is invalid.
+ * Returns an empty SentrySpanId when the input is invalid.
  */
 - (instancetype)initWithValue:(NSString *)value;
 

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryRedactRegionType.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryRedactRegionType.swift
@@ -8,11 +8,11 @@ public enum SentryRedactRegionType: String, Codable, Equatable {
     case clipOut = "clip_out"
 
     /// Push a clip region to the drawing context.
-    /// This is used for views that clip to its bounds.
+    /// This is used for views that clip to their bounds.
     case clipBegin = "clip_begin"
 
     /// Pop the last Pushed region from the drawing context.
-    /// Used after prossing every child of a view that clip to its bounds.
+    /// Used after processing every child of a view that clips to its bounds.
     case clipEnd = "clip_end"
 
     /// These regions are redacted first, there is no way to avoid it.

--- a/Sources/Swift/Integrations/Screenshot/SentryScreenshotOptions.swift
+++ b/Sources/Swift/Integrations/Screenshot/SentryScreenshotOptions.swift
@@ -62,7 +62,7 @@ public final class SentryViewScreenshotOptions: NSObject, SentryRedactOptions {
     // MARK: - Masking
     
     /**
-     * Indicates whether the screenshot should redact all non-bundled image
+     * Indicates whether the screenshot should redact all non-bundled images
      * in the app by drawing a black rectangle over it.
      *
      * - Note: See ``SentryViewScreenshotOptions.init`` for the default value.
@@ -80,7 +80,7 @@ public final class SentryViewScreenshotOptions: NSObject, SentryRedactOptions {
     /**
      * A list of custom UIView subclasses that need
      * to be masked during the screenshot.
-     * By default Sentry already mask text and image elements from UIKit
+     * By default Sentry already masks text and image elements from UIKit
      * Every child of a view that is redacted will also be redacted.
      *
      * - Note: See ``SentryViewScreenshotOptions.init`` for the default value.

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -119,7 +119,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     public var sessionSampleRate: Float
 
     /**
-     * Indicates the percentage in which a 30 seconds replay will be send with error events.
+     * Indicates the percentage in which a 30 seconds replay will be sent with error events.
      * - Specifying 0 means never, 1.0 means always.
      *
      * - Note: The value needs to be >= 0.0 and \<= 1.0. When setting a value out of range the SDK sets it
@@ -137,7 +137,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     public var maskAllText: Bool
 
     /**
-     * Indicates whether session replay should redact all non-bundled image
+     * Indicates whether session replay should redact all non-bundled images
      * in the app by drawing a black rectangle over it.
      *
      * - Note: See ``SentryReplayOptions.DefaultValues.maskAllImages`` for the default value.
@@ -155,7 +155,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     /**
      * A list of custom UIView subclasses that need
      * to be masked during session replay.
-     * By default Sentry already mask text and image elements from UIKit
+     * By default Sentry already masks text and image elements from UIKit
      * Every child of a view that is redacted will also be redacted.
      *
      * - Note: See ``SentryReplayOptions.DefaultValues.maskedViewClasses`` for the default value.
@@ -290,7 +290,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * this method can be slow, especially when rendering complex views, therefore enabling this flag will switch to render the underlying `CALayer` instead.
      *
      * - Note: This flag can only be used together with `enableViewRendererV2` with up to 20% faster render times.
-     * - Warning: Rendering the view hiearchy using the `CALayer.render(in:)` method can lead to rendering issues, especially when using custom views.
+     * - Warning: Rendering the view hierarchy using the `CALayer.render(in:)` method can lead to rendering issues, especially when using custom views.
      *            For complete rendering, it is recommended to set this option to `false`. In case you prefer performance over completeness, you can
      *            set this option to `true`.
      * - Experiment: This is an experimental feature and is therefore disabled by default. In case you are noticing issues with the experimental
@@ -454,7 +454,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
 
     /**
      * Number of frames per second of the replay.
-     * The more the havier the process is.
+     * The more the heavier the process is.
      * The minimum is 1, if set to zero this will change to 1.
      *
      * - Note: See ``SentryReplayOptions.DefaultValues.frameRate`` for the default value.

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -29,8 +29,8 @@ public final class SentryFeedback: NSObject {
     var associatedEventId: SentryId?
 
     /// - parameters:
-    ///   - associatedEventId The ID for an event you'd like associated with the feedback.
-    ///   - attachments Attachment objects for any files to include with the feedback.
+    ///   - associatedEventId: The ID for an event you'd like associated with the feedback.
+    ///   - attachments: Attachment objects for any files to include with the feedback.
     @objc public init(message: String, name: String?, email: String?, source: SentryFeedbackSource = .widget, associatedEventId: SentryId? = nil, attachments: [Attachment]? = nil) {
         self.eventId = SentryId()
         self.name = name


### PR DESCRIPTION
#### Description

Fixes typos and grammar mistakes in public-facing API doc comments. Comment-only; no behavior change.

#skip-changelog

Closes #8190