### PR TITLE
chore: fix typos in Objective-C comments

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -94,7 +94,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     // We don't have access to didFinishLaunchingTimestamp on HybridSDKs,
     // the Cocoa SDK misses the didFinishLaunchNotification and
     // the didBecomeVisibleNotification. Therefore, we can't set the
-    // didFinishLaunchingTimestamp. This would only work for munualy initialized native SDKs.
+    // didFinishLaunchingTimestamp. This would only work for manually initialized native SDKs.
 
     return @{
         @"type" : type,

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -214,7 +214,7 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
  * only apply to a single launch. subsequent launches must be configured by subsequent calls to
  * @c SentrySDK.startWIithOptions ; if that is not called, either deliberately by SDK consumers or
  * due to a problem before it can run, then we won't reuse the config–in the worst case, the launch
- * profile itself is the root cause of such a cycle, so this mitigates that and other possibities
+ * profile itself is the root cause of such a cycle, so this mitigates that and other possibilities
  */
 void
 _sentry_cleanUpConfigFile(void)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -270,8 +270,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     event.exceptions = exceptions;
 
-    // Once the UI displays the mechanism data we can the userInfo from the event.context using only
-    // the root error's userInfo.
+    // Once the UI displays the mechanism data we can remove the userInfo from the event.context
+    // using only the root error's userInfo.
     [self setUserInfo:sentry_sanitize_dictionary(error.userInfo) withEvent:event];
 
     return event;
@@ -305,7 +305,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     SentryException *exception = [[SentryException alloc] initWithValue:exceptionValue
                                                                    type:error.domain];
 
-    // Sentry uses the error domain and code on the mechanism for gouping
+    // Sentry uses the error domain and code on the mechanism for grouping
     SentryMechanism *mechanism = [[SentryMechanism alloc] initWithType:@"NSError"];
     SentryMechanismContext *mechanismMeta = [[SentryMechanismContext alloc] init];
     mechanismMeta.error = [[SentryNSError alloc] initWithDomain:error.domain code:error.code];

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -151,7 +151,7 @@
         event.releaseName = self.userContext[@"release"];
 
         // We want to set the release and dist to the version from the crash report
-        // itself otherwise it can happend that we have two different version when
+        // itself otherwise it can happen that we have two different versions when
         // the app crashes right before an app update #218 #219
         if (nil == event.releaseName && appContext[@"app_identifier"] && appContext[@"app_version"]
             && appContext[@"app_build"]) {

--- a/Sources/Sentry/SentryDefaultThreadInspector.m
+++ b/Sources/Sentry/SentryDefaultThreadInspector.m
@@ -121,8 +121,8 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
  * This method retrieves thread information from the suspend method
  * while the other retrieves information from the machine context.
  * Having both approaches in the same method can lead to inconsistency between the number of
- * threads, and while there is suspended threads we can't call into obj-c, so the previous approach
- * wont work for retrieving stacktrace information for every thread.
+ * threads, and while there are suspended threads we can't call into obj-c, so the previous approach
+ * won't work for retrieving stacktrace information for every thread.
  */
 - (NSArray<SentryThread *> *)getCurrentThreadsWithStackTrace
 {
@@ -135,7 +135,7 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         thread_act_array_t suspendedThreads = NULL;
         mach_msg_type_number_t numSuspendedThreads = 0;
 
-        // SentryThreadInspector is crashing when there is too many threads.
+        // SentryThreadInspector is crashing when there are too many threads.
         // We add a limit of 70 threads because in test with up to 100 threads it seems fine.
         // We are giving it an extra safety margin.
         sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
@@ -143,7 +143,7 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         // DANGER: Do not try to allocate memory in the heap or call Objective-C code in this
         // section Doing so when the threads are suspended may lead to deadlocks or crashes.
 
-        // If no threads was suspended we don't need to do anything.
+        // If no threads were suspended we don't need to do anything.
         // This may happen if there is more than max amount of threads (70).
         if (numSuspendedThreads == 0) {
             return threads;

--- a/Sources/Sentry/SentryDevice.m
+++ b/Sources/Sentry/SentryDevice.m
@@ -184,7 +184,7 @@ NSString *
 sentry_getOSVersion(void)
 {
 #if TARGET_OS_WATCH
-    // This function is only used for profiling, and profiling don't run for watchOS
+    // This function is only used for profiling, and profiling doesn't run for watchOS
     return @"";
 #elif SENTRY_HAS_UIKIT
     return [UIDevice currentDevice].systemVersion;

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SentryEvent
 
 // This is a designated initializer so that it can be called by the Swift
-// sublcass that adds a `Decodable` conformance. It shares an implementation
+// subclass that adds a `Decodable` conformance. It shares an implementation
 // with `initWithLevel:`.
 - (instancetype)init
 {

--- a/Sources/Sentry/SentryFileIOTrackerHelper.m
+++ b/Sources/Sentry/SentryFileIOTrackerHelper.m
@@ -116,7 +116,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
                       method:(NSNumber * (^)(void))method
 {
 
-    // We dont track reads from a url that is not a file url
+    // We don't track reads from a url that is not a file url
     // because these reads are handled by NSURLSession and
     // SentryNetworkTracker will create spans in these cases.
     if (![url.scheme isEqualToString:NSURLFileScheme]) {
@@ -266,7 +266,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
                                               operation:(NSString *)operation
                                    processDirectoryPath:(NSString *)processDirectoryPath
 {
-    // Some iOS versions nest constructors calls. This counter help us avoid create more than one
+    // Some iOS versions nest constructors calls. This counter helps us avoid creating more than one
     // span for the same operation.
     NSNumber *count =
         [[NSThread currentThread].threadDictionary objectForKey:SENTRY_TRACKING_COUNTER_KEY];

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -122,7 +122,7 @@
 
     SentryEnvelope *envelopeToStore = [self addClientReportTo:envelope];
 
-    // With this we accept the a tradeoff. We might loose some envelopes when a hard crash happens,
+    // With this we accept a tradeoff. We might lose some envelopes when a hard crash happens,
     // because this being done on a background thread, but instead we don't block the calling
     // thread, which could be the main thread.
     __weak SentryHttpTransport *weakSelf = self;

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -778,7 +778,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    // If captured envelope cointains not handled errors, these are not going to crash the app and
+    // If captured envelope contains not handled errors, these are not going to crash the app and
     // we should create new session.
     [client captureEnvelope:[self updateSessionState:envelope startNewSession:YES]];
 }

--- a/Sources/Sentry/SentryNSFileManagerSwizzlingHelper.m
+++ b/Sources/Sentry/SentryNSFileManagerSwizzlingHelper.m
@@ -24,7 +24,7 @@ static BOOL swizzlingIsActive = FALSE;
 
     // Before iOS 18.0, macOS 15.0 and tvOS 18.0 the NSFileManager used NSData.writeToFile
     // internally, which was tracked using swizzling of NSData. This behaviour changed, therefore
-    // the file manager needs to swizzled for later versions.
+    // the file manager needs to be swizzled for later versions.
     //
     // Ref: https://github.com/swiftlang/swift-foundation/pull/410
     if (@available(iOS 18, macOS 15, tvOS 18, *)) {

--- a/Sources/Sentry/SentryNSURLSessionTaskSearch.m
+++ b/Sources/Sentry/SentryNSURLSessionTaskSearch.m
@@ -40,9 +40,9 @@ https://github.com/AFNetworking/AFNetworking/blob/4eaec5b586ddd897ebeda896e332a6
         [NSURLSessionConfiguration ephemeralSessionConfiguration];
     NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
 
-    // We dont use `localDataTask` as a task, we just need to know its class,
-    // thats why the URL parameter is a empty url that points nowhere.
-    // AFNetwork uses nil as parameter, but according to documentation this a nonnull parameter,
+    // We don't use `localDataTask` as a task, we just need to know its class,
+    // that's why the URL parameter is an empty url that points nowhere.
+    // AFNetwork uses nil as parameter, but according to documentation this is a nonnull parameter,
     // and when bridged to swift, the nil parameters causes an exception.
     NSURLSessionDataTask *localDataTask =
         [session dataTaskWithURL:SENTRY_UNWRAP_NULLABLE(NSURL, [NSURL URLWithString:@""])];

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -723,7 +723,7 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
     // Validate if the observer conforms because the API doesn't require
     // observers to conform anymore due to the protocol being written in Swift
     // but protocol forwarded in ObjC
-    // Additionaly, conformsToProtocol:@protocol(SentryScopeObserver) seems to fail
+    // Additionally, conformsToProtocol:@protocol(SentryScopeObserver) seems to fail
     // because the conformance is declared in a Category, so runtime checks fail.
     // So we use check for all SentryScopeObserver functions AND an assertion to get alerts on tests
     // As a compile check if any of these selectors cease to exist, this should fail to build.

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -165,7 +165,7 @@
 {
     // The purpose of TTID and TTFD is to measure how long
     // takes to the content of the screen to change.
-    // Thats why we need to wait for the next frame to be drawn.
+    // That's why we need to wait for the next frame to be drawn.
     if (_initialDisplayReported && self.initialDisplaySpan.isFinished == NO) {
         SENTRY_LOG_DEBUG(@"Finishing initial display span");
         self.initialDisplaySpan.timestamp = newFrameDate;

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -45,7 +45,7 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
         // Even though NSURLSessionTask doesn't have 'setCurrentRequest', some subclasses
         // do. For those subclasses we replace the currentRequest with a mutable one with
         // the additional trace header. Since NSURLSessionTask is a public class and can be
-        // override, we believe this is not considered a private api.
+        // overridden, we believe this is not considered a private api.
         SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
         if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {
             NSMutableURLRequest *newRequest = [sessionTask.currentRequest mutableCopy];

--- a/Sources/Sentry/include/SentryCrash.h
+++ b/Sources/Sentry/include/SentryCrash.h
@@ -103,8 +103,8 @@ SENTRY_NO_INIT
 
 // We removed searchQueueNames in 4.0.0 see:
 // https://github.com/getsentry/sentry-cocoa/commit/b728c74e898e6ed3b1cab0b1cf5b6c8892b29b70,
-// because we were deferencing a pointer to the dispatch queue, which could have been deallocated by
-// the time you deference it. Also see this comment in some WebKit code:
+// because we were dereferencing a pointer to the dispatch queue, which could have been deallocated
+// by the time you dereference it. Also see this comment in some WebKit code:
 // https://github.com/WebKit/WebKit/blob/09225dc168d445890bb0e2a5fa8bc19aef8556f2/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm#L119.
 
 /** If YES, introspect memory contents during a crash.

--- a/Sources/Sentry/include/SentryFileManagerHelper.h
+++ b/Sources/Sentry/include/SentryFileManagerHelper.h
@@ -53,7 +53,7 @@ SENTRY_NO_INIT
 - (void)deleteOldEnvelopesFromAllSentryPaths:(NSTimeInterval)now;
 
 /**
- * Only used for teting.
+ * Only used for testing.
  */
 - (void)deleteAllEnvelopes;
 

--- a/Sources/Sentry/include/SentryPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryPerformanceTracker.h
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Checks if given span is waiting to be finished.
  * @param spanId Id of the span to be checked.
- * @return A boolean value indicating whether the span still waiting to be finished.
+ * @return A boolean value indicating whether the span is still waiting to be finished.
  */
 - (BOOL)isSpanAlive:(SentrySpanId *)spanId;
 

--- a/Sources/Sentry/include/SentryScope+PrivateSwift.h
+++ b/Sources/Sentry/include/SentryScope+PrivateSwift.h
@@ -16,7 +16,7 @@ static NSString *const SENTRY_CONTEXT_APP_KEY = @"app";
     NS_SWIFT_NAME(setPropagationContext(traceId:spanId:));
 
 /**
- * Set global user -> thus will be sent with every event
+ * Set global user -> this will be sent with every event
  */
 @property (atomic, strong) SentryUser *_Nullable userObject;
 

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSDictionary *_Nullable)deserializeDictionaryFromJsonData:(NSData *)data;
 
 /**
- * Extract the level from data of an envelopte item containing an event. Default is the 'error'
+ * Extract the level from data of an envelope item containing an event. Default is the 'error'
  * level, see https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
  */
 + (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData;

--- a/Sources/Sentry/include/SentrySpanDataKey.h
+++ b/Sources/Sentry/include/SentrySpanDataKey.h
@@ -21,7 +21,7 @@
 // Objective-C.
 //
 // - Note: The following constants are defined as `extern` with an `.m` implementation file, as we
-// did face compliation errors in tests and sample apps not being able to import the constants, i.e.
+// did face compilation errors in tests and sample apps not being able to import the constants, i.e.
 // `Undefined symbol: _SentrySpanOperationUiLoad`. We might want to revisit this in the future.
 
 SENTRY_EXTERN NSString *const SentrySpanDataKeyFileSize;

--- a/Sources/Sentry/include/SentrySpanOperation.h
+++ b/Sources/Sentry/include/SentrySpanOperation.h
@@ -17,7 +17,7 @@
 // Objective-C.
 //
 // - Note: The following constants are defined as `extern` with an `.m` implementation file, as we
-// did face compliation errors in tests and sample apps not being able to import the constants, i.e.
+// did face compilation errors in tests and sample apps not being able to import the constants, i.e.
 // `Undefined symbol: _SentrySpanOperationUiLoad`. We might want to revisit this in the future.
 
 SENTRY_EXTERN NSString *const SentrySpanOperationAppLifecycle;

--- a/Sources/Sentry/include/SentryStacktraceBuilder.h
+++ b/Sources/Sentry/include/SentryStacktraceBuilder.h
@@ -30,7 +30,7 @@ SENTRY_NO_INIT
  * SentrySDK until frames from a different package are found. When including Sentry via the Swift
  * Package Manager the package is the same as the application that includes Sentry. In this case the
  * full stacktrace is returned without skipping frames.
- * This function is not async safe but is faster then the 'buildStacktraceForCurrentThread'
+ * This function is not async safe but is faster than the 'buildStacktraceForCurrentThread'
  * alternative.
  */
 - (nullable SentryStacktrace *)buildStacktraceForCurrentThreadAsyncUnsafe;
@@ -47,7 +47,7 @@ SENTRY_NO_INIT
 - (SentryStacktrace *)buildStackTraceFromStackEntries:(SentryCrashStackEntry *)entries
                                                amount:(unsigned int)amount;
 /**
- * Buils a stacktrace with the provided frames
+ * Builds a stacktrace with the provided frames
  */
 + (SentryStacktrace *)buildStacktraceFromFrames:(NSArray<SentryFrame *> *)frames;
 @end

--- a/Sources/Sentry/include/SentryTraceOrigin.h
+++ b/Sources/Sentry/include/SentryTraceOrigin.h
@@ -17,7 +17,7 @@
 // implemented as an `NSString` constant list.
 //
 // - Note: The following constants are defined as `extern` with an `.m` implementation file, as we
-// did face compliation errors in tests and sample apps not being able to import the constants, i.e.
+// did face compilation errors in tests and sample apps not being able to import the constants, i.e.
 // `Undefined symbol: _SentrySpanOperationUiLoad`. We might want to revisit this in the future.
 
 SENTRY_EXTERN NSString *const SentryTraceOriginAutoAppStart;

--- a/Sources/Sentry/include/SentryWeakMap.h
+++ b/Sources/Sentry/include/SentryWeakMap.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryWeakMap<KeyType, ObjectType> : NSObject
 
 /**
- * Returns a the value associated with a given key.
+ * Returns the value associated with a given key.
  *
  * - Parameter aKey: The key for which to return the corresponding value.
  * - Returns: The value associated with aKey, or nil if no value is associated with aKey.


### PR DESCRIPTION
Fixes typos in Objective-C comments and one log string across the SDK core.

#skip-changelog

Closes #8209