### PR TITLE
chore: fix typos in SentryCrash comments

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
@@ -181,7 +181,7 @@ typedef struct SentryCrash_MonitorContext {
         bool isJailbroken;
         /**
          * @warning We must not send this information off device because Apple forbids that.
-         * We are allowed send the amount of time that has elapsed between events that occurred
+         * We are allowed to send the amount of time that has elapsed between events that occurred
          * within the app though. For more information see
          * https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.
          */

--- a/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
+++ b/Sources/SentryCrash/Recording/SentryCrashBinaryImageCache.c
@@ -239,7 +239,7 @@ sentrycrashbic_startCache(void)
     // This must be done on a background thread to not block app launch due to the extensive use of
     // locks in the image added callback. The main culprit is the calls to `dladdr`. The downside of
     // doing this async is if there is a crash very shortly after app launch we might not have
-    // recorded all the load addresses of images yet. We think this is an acceptible tradeoff to not
+    // recorded all the load addresses of images yet. We think this is an acceptable tradeoff to not
     // block app launch, since it's always possible to crash early in app launch before Sentry can
     // capture the crash.
 #if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1438,7 +1438,7 @@ writeRecrash(
 
 /** Prepare a report writer for use.
  *
- * @oaram writer The writer to prepare.
+ * @param writer The writer to prepare.
  *
  * @param context JSON writer contextual information.
  */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.h
@@ -57,7 +57,7 @@ typedef void (*cxa_throw_type)(void *, void *, void (*)(void *));
  * implementation to rebind dynamic symbols on iOS and macOS.
  *
  * The implementation is adapted from https://github.com/kstenerud/KSCrash and based on
- * https://github.com/facebook/fishhook.alignas We have a local copy of how the fishhook works in
+ * https://github.com/facebook/fishhook. We have a local copy of how the fishhook works in
  * develop-docs/Fishhook-Explanation.md.
  *
  * @param handler The new exception throw handler to install

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashID.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashID.h
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-/** Generate a new human readabale, null terminated, globally unique ID string.
+/** Generate a new human readable, null terminated, globally unique ID string.
  *
  * @param destinationBuffer37Bytes Buffer of at least 37 bytes to hold the ID.
  */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
@@ -347,7 +347,7 @@ int sentrycrashjson_beginElement(
     SentryCrashJSONEncodeContext *const context, const char *const name);
 
 /** Add JSON data manually.
- * This function just passes your data directly through, even if it's malforned.
+ * This function just passes your data directly through, even if it's malformed.
  *
  * @param context The encoding context.
  *
@@ -526,7 +526,7 @@ typedef struct SentryCrashJSONDecodeCallbacks {
  *
  * @param userData Any data you would like passed to the callbacks.
  *
- * @oaram errorOffset If not null, will contain the offset into the data
+ * @param errorOffset If not null, will contain the offset into the data
  *                    where the error (if any) occurred.
  *
  * @return SentryCrashJSON_OK if successful. An error code otherwise.

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
@@ -423,7 +423,7 @@ extractTaggedNSDate(const void *const object)
  * Note: The Objective-C runtime is free to change a class address,
  * so I can't just blindly store class pointers at application start
  * and then compare against them later. However, comparing strings is
- * slow, so I've reached a compromise. Since I'm omly using this at
+ * slow, so I've reached a compromise. Since I'm only using this at
  * crash time, I can assume that the Objective-C environment is frozen.
  * As such, I can keep a cache of discovered classes. If, however, this
  * library is used outside of a frozen environment, caching will be

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.h
@@ -266,7 +266,7 @@ uintptr_t sentrycrashobjc_taggedPointerPayload(const void *taggedObjectPtr);
 int sentrycrashobjc_getDescription(void *object, char *buffer, int bufferLength);
 
 /** Get the class type of an object.
- * There are a number of common class types that SentryCrashObjC understamds,
+ * There are a number of common class types that SentryCrashObjC understands,
  * listed in SentryCrashObjCClassType.
  *
  * @param object The object to query.

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.h
@@ -165,7 +165,7 @@ struct timeval sentrycrashsysctl_currentProcessStartTime(void);
  *
  * @param pid The process ID.
  *
- * @param procInfo Struct to hold the proces information.
+ * @param procInfo Struct to hold the process information.
  *
  * @return true if the operation was successful.
  */


### PR DESCRIPTION
Fix typos in SentryCrash comments and doc strings. Comment/string-only; no behavior change.

#skip-changelog

Closes #8211