### PR TITLE
fix: preserve crash report ID high bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix crash report ID generation so reports created at certain timestamps are not ignored (#8216)
+
 ## 9.19.0
 
 > [!WARNING]

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 static int g_maxReportCount = 5;
@@ -180,21 +181,33 @@ pruneReports(void)
     }
 }
 
+static int64_t
+getBaseIDFromTime(const struct tm *reportTime)
+{
+    return (int64_t)reportTime->tm_sec + (int64_t)reportTime->tm_min * 61
+        + (int64_t)reportTime->tm_hour * 61 * 60 + (int64_t)reportTime->tm_yday * 61 * 60 * 24
+        + (int64_t)reportTime->tm_year * 61 * 60 * 24 * 366;
+}
+
+static void
+initializeIDsFromTime(const struct tm *reportTime)
+{
+    int64_t baseID = getBaseIDFromTime(reportTime);
+    baseID <<= 23;
+
+    g_nextUniqueIDHigh = baseID & ~(int64_t)0xffffffff;
+    uint32_t lowerBaseID = (uint32_t)(baseID & 0xffffffff);
+    g_nextUniqueIDLow = lowerBaseID;
+}
+
 static void
 initializeIDs(void)
 {
     time_t rawTime;
     time(&rawTime);
-    struct tm time;
-    gmtime_r(&rawTime, &time);
-    int64_t baseID = (int64_t)time.tm_sec + (int64_t)time.tm_min * 61
-        + (int64_t)time.tm_hour * 61 * 60 + (int64_t)time.tm_yday * 61 * 60 * 24
-        + (int64_t)time.tm_year * 61 * 60 * 24 * 366;
-    baseID <<= 23;
-
-    g_nextUniqueIDHigh = baseID & ~0xffffffff;
-    uint32_t lowerBaseID = (uint32_t)(baseID & 0xffffffff);
-    g_nextUniqueIDLow = lowerBaseID;
+    struct tm reportTime;
+    gmtime_r(&rawTime, &reportTime);
+    initializeIDsFromTime(&reportTime);
 }
 
 // Public API
@@ -232,6 +245,16 @@ sentrycrashcrs_getNextCrashReportPath(char *crashReportPathBuffer)
 {
     getCrashReportPathByID(getNextUniqueID(), crashReportPathBuffer);
 }
+
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+void
+sentrycrashcrs_initializeIDsWithTimeForTests(const struct tm *reportTime)
+{
+    pthread_mutex_lock(&g_mutex);
+    initializeIDsFromTime(reportTime);
+    pthread_mutex_unlock(&g_mutex);
+}
+#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
 int
 sentrycrashcrs_getReportCount(void)

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.h
@@ -123,6 +123,12 @@ void sentrycrashcrs_deleteReportWithID(int64_t reportID);
  */
 void sentrycrashcrs_setMaxReportCount(int maxReportCount);
 
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+struct tm;
+/** Initialize the report ID generator with UTC time fields for tests. */
+void sentrycrashcrs_initializeIDsWithTimeForTests(const struct tm *reportTime);
+#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+
 #ifdef __cplusplus
 }
 #endif

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define REPORT_PREFIX @"CrashReport-SentryCrashTest"
 
@@ -57,6 +58,37 @@ isReportStoreCanaryIntact(const GuardedSentryCrashCRSPathBuffer *buffer)
         }
     }
     return true;
+}
+
+static bool
+isLeapYear(int year)
+{
+    return ((year % 4) == 0 && (year % 100) != 0) || (year % 400) == 0;
+}
+
+static int
+zeroBasedDayOfYear(int year, int month, int day)
+{
+    static const int daysBeforeMonth[] = { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+    int dayOfYear = daysBeforeMonth[month - 1] + day - 1;
+    if (month > 2 && isLeapYear(year)) {
+        dayOfYear++;
+    }
+    return dayOfYear;
+}
+
+static struct tm
+makeUTCReportTime(int year, int month, int day, int hour, int minute, int second)
+{
+    return (struct tm) {
+        .tm_sec = second,
+        .tm_min = minute,
+        .tm_hour = hour,
+        .tm_mday = day,
+        .tm_mon = month - 1,
+        .tm_year = year - 1900,
+        .tm_yday = zeroBasedDayOfYear(year, month, day),
+    };
 }
 
 @interface SentryCrashReportStore_Tests : FileBasedTestCase
@@ -474,6 +506,24 @@ isReportStoreCanaryIntact(const GuardedSentryCrashCRSPathBuffer *buffer)
     XCTAssertEqualObjects([NSString stringWithUTF8String:attachmentsPath],
         [self.tempPath stringByAppendingPathComponent:
                 @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
+}
+
+- (void)testInitializeIDs_whenUTCDateProducesZeroLowBits_shouldKeepHighBits
+{
+    // -- Arrange --
+    [self prepareReportStoreWithPathEnd:
+            @"testInitializeIDs_whenUTCDateProducesZeroLowBits_shouldKeepHighBits"];
+    // 2026-06-23 22:01:27 UTC produces a shifted base ID with zero low 32 bits,
+    // but non-zero high bits.
+    struct tm reportTime = makeUTCReportTime(2026, 6, 23, 22, 1, 27);
+    sentrycrashcrs_initializeIDsWithTimeForTests(&reportTime);
+
+    // -- Act --
+    int64_t reportID = [self writeCrashReportWithStringContents:@"Testing"];
+
+    // -- Assert --
+    XCTAssertEqual(reportID, INT64_C(0x00792dee00000000));
+    [self expectHasReportCount:1];
 }
 
 - (void)test_initializeIDs


### PR DESCRIPTION
## :scroll: Description

This is a fun one. It essentially adds one cast to preserve the high bits in our report ID generation. This is required not only to avoid cycling IDs too frequently, but also to **avoid accidentally creating 0-IDs, which we then discard**. I pulled out the inner part that converts to ID from the `time_t` we get from `gmtime_r()` and added a regression test that shows the issue.

## :bulb: Motivation and Context

This problem appeared recently when [another PR highlighted flaky tests](https://github.com/getsentry/sentry-cocoa/actions/runs/28059901941/job/83071565579?pr=8170#step:12:119) in an unrelated part of the code. However, I also recently investigated that part of the code in the context of the `KSCrash` investigation and thus had somewhat of a clue what was happening there.

<img width="1008" height="405" alt="Screenshot 2026-06-24 at 14 54 47" src="https://github.com/user-attachments/assets/a0383ef1-934f-47e6-9b99-0795a29ba663" />

In particular, what popped into mind when looking at the logs was the fact that tests and retries all happened within the same second, which to me hinted at a connection to the report ID construction, which itself is based on a seconds counter, meaning **tests running within the same second will all use the same ID base**.

And it turned out I was right, but in a rather roundabout way. The three relevant parts in the code are here:

https://github.com/getsentry/sentry-cocoa/blob/34646fefc7fe26e9ed4fe543d53884d86639ddb9/Sources/SentryCrash/Recording/SentryCrashReportStore.c#L183-L198

https://github.com/getsentry/sentry-cocoa/blob/34646fefc7fe26e9ed4fe543d53884d86639ddb9/Sources/SentryCrash/Recording/SentryCrashReportStore.c#L153-L158

https://github.com/getsentry/sentry-cocoa/blob/34646fefc7fe26e9ed4fe543d53884d86639ddb9/Sources/SentryCrash/Recording/SentryCrashReportStore.c#L129-L133

The first creates a report ID based on the current time. The last two are iterations from `getReportIDs()` and `getReportCount()`. The latter two establish the first important fact: the SDK ignores reports with `ID == 0`. Regarding the first one, we have to look at the timestamp of the failing flaky tests: **2026-06-23 22:01:27**.

If we plug the timestamp into the formula, we get

```
baseID = 27
         + 1 * 61
         + 22 * 61 * 60
         + 173 * 61 * 60 * 24
         + 126 * 61 * 60 * 24 * 366
```
which produces `4066106368` or `0xf25bdc00`. After left-shifting by 23 bits, we get `0x00792dee00000000`. This means our entire lower 32 bits are 0.

Now we come to the bug: 
```C
     g_nextUniqueIDHigh = baseID & ~0xffffffff; 
```
The intention here is that it creates a negative masking for the lower bits, leaving us with the upper 32 bits (in their final 64-bit position). But the problem is that the mask `0xffffffff` is a 32-bit value in C, and inverting the bits yields `0x00000000`, which, in 64-bit, is also 0, i.e., a mask of `0x0000000000000000`, not the intended 64-bit mask `0xffffffff00000000`.

Since the lower 32 bits are 0 anyway, and we have now masked away the non-zero upper 32 bits, the resulting ID equals 0. Meaning our tests checking on counts will fail to count the first report generated. But also: any report generated in production during one such unlucky second will be ignored.

How often does this happen? Since we shift the seconds by 23 bits, we only have 9 bits left in our second-counter precision. Meaning, around every 512 seconds (ignoring the formula details), we cycle the IDs. Whenever the `baseID modulo 512 == 0` before shifting, the resulting ID equals zero. Of course, this also means we cycle the ID generation every 512 seconds, but I guess this is less of a problem since we generate crash reports here.

The fix is to cast `0xffffffff` to a 64-bit value, so that inverting the bits results in `0xffffffff00000000`, i.e., the expected mask. After my dive into this, I also looked upstream (in the old version, `develop` changed report generation considerably), and as you can expect, the bug was fixed. What is rather surprising and painful is that it [was fixed back in 2020](https://github.com/kstenerud/KSCrash/pull/365).

## :green_heart: How did you test it?

Added a unit test that fails with the old implementation and correctly handles the new one.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).


Closes #8217