### PR TITLE
docs(contributing): add AI use policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,10 @@ description, such as `Fixes #123`, `Closes #123`, or `Resolves #123`. The releas
 workflow only comments on issues GitHub recognizes as closed by the released PR; mentioning an issue
 without a closing keyword is not enough.
 
+## AI Use
+
+You are welcome to use whatever tools you prefer for making a contribution. However, any changes you propose have to be reviewed and tested by you, a human, first, before you submit a pull request with them for the Sentry team to review. If we feel like that didn't happen, we will close the PR outright. For example, we won't review visibly AI-generated PRs from an agent instructed to look for and "fix" open issues in the repo.
+
 ## Final Notes
 
 When contributing to the codebase, please make note of the following:


### PR DESCRIPTION
Adds an **AI Use** section to `CONTRIBUTING.md`, mirroring the policy already in place in [sentry-python](https://github.com/getsentry/sentry-python/blob/master/CONTRIBUTING.md#ai-use).

The section makes it explicit that contributors are responsible for reviewing and testing any AI-assisted changes themselves before submitting, and that visibly AI-generated PRs will be closed outright.

Agreed on in the June 22 retrospective after receiving low-quality AI-generated contributions.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC09MQRJGBU2%3A1782400354.755659%22)

Closes #8219