### PR TITLE
fix: rename extended app start span operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` ([#8220](https://github.com/getsentry/sentry-cocoa/pull/8220))
+- Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` (#8220)
 
 ## 9.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` ([#TBD](https://github.com/getsentry/sentry-cocoa/pull/TBD))
+
 ## 9.19.0
 
 > [!WARNING]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` ([#TBD](https://github.com/getsentry/sentry-cocoa/pull/TBD))
+- Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` ([#8220](https://github.com/getsentry/sentry-cocoa/pull/8220))
 
 ## 9.19.0
 

--- a/Sources/Swift/Integrations/AppStartTracking/SentryExtendedAppLaunchManager.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryExtendedAppLaunchManager.swift
@@ -5,7 +5,7 @@
 final class SentryExtendedAppLaunchManager {
     
     enum Constants {
-        static let extendedOperation = "\(SentrySpanOperationAppStart).extended_app_start"
+        static let extendedOperation = "\(SentrySpanOperationAppStart).extended"
     }
 
     private let lock = NSLock()

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
@@ -54,7 +54,7 @@ class SentryExtendedAppLaunchTests: XCTestCase {
     // MARK: - Constants
 
     func testExtendedOperation_shouldBeExpectedValue() {
-        XCTAssertEqual(SentryExtendedAppLaunchManager.Constants.extendedOperation, "app.start.extended_app_start")
+        XCTAssertEqual(SentryExtendedAppLaunchManager.Constants.extendedOperation, "app.start.extended")
     }
 
     // MARK: - SentryExtendedAppLaunchManager
@@ -76,7 +76,7 @@ class SentryExtendedAppLaunchTests: XCTestCase {
         manager.extend()
         let span = try XCTUnwrap(manager.extendedAppStartSpan())
 
-        XCTAssertEqual(span.operation, "app.start.extended_app_start")
+        XCTAssertEqual(span.operation, "app.start.extended")
         XCTAssertEqual(span.spanDescription, "Extended App Start")
         XCTAssertFalse(span.isFinished)
     }
@@ -158,7 +158,7 @@ class SentryExtendedAppLaunchTests: XCTestCase {
         XCTAssertEqual(extendedSpans.count, 1)
 
         let extendedSpan = try XCTUnwrap(extendedSpans.first)
-        XCTAssertEqual(extendedSpan["op"] as? String, "app.start.extended_app_start")
+        XCTAssertEqual(extendedSpan["op"] as? String, "app.start.extended")
     }
 
     func testFinishExtendedAppLaunch_extendedSpanStartsAtExtendCallTime() throws {


### PR DESCRIPTION
## Description

Shortens the extended app start span operation from `app.start.extended_app_start` to `app.start.extended` for consistency and brevity.

## How to Test

- Existing unit tests updated to verify the new operation name
- `SentryExtendedAppLaunchTests` covers the constant value, span creation, and serialized output

## Checklist

- [x] Tests updated
- [x] Changelog updated

Closes #8222