### PR TITLE
fix: align __cxa_throw mprotect ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8218)
+- Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8221)
 
 ## 9.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8218)
+
 ## 9.19.0
 
 > [!WARNING]

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
@@ -82,6 +82,22 @@ static size_t g_cxa_originals_capacity = 0;
 static size_t g_cxa_originals_count = 0;
 
 static bool
+getSystemPageSize(uintptr_t *pageSize)
+{
+    if (pageSize == NULL) {
+        return false;
+    }
+
+    const long systemPageSize = sysconf(_SC_PAGESIZE);
+    if (systemPageSize <= 0) {
+        return false;
+    }
+
+    *pageSize = (uintptr_t)systemPageSize;
+    return true;
+}
+
+static bool
 getMprotectPageAlignedRange(
     void *address, size_t size, void **pageAlignedAddress, size_t *pageAlignedSize)
 {
@@ -89,8 +105,8 @@ getMprotectPageAlignedRange(
         return false;
     }
 
-    const uintptr_t pageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
-    if (pageSize == 0) {
+    uintptr_t pageSize = 0;
+    if (!getSystemPageSize(&pageSize)) {
         return false;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
@@ -89,7 +89,7 @@ getMprotectPageAlignedRange(
         return false;
     }
 
-    const uintptr_t pageSize = (uintptr_t)getpagesize();
+    const uintptr_t pageSize = (uintptr_t)sysconf(_SC_PAGESIZE);
     if (pageSize == 0) {
         return false;
     }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
@@ -57,11 +57,13 @@
 #include <mach-o/dyld.h>
 #include <mach-o/nlist.h>
 #include <mach/mach.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include "SentryAsyncSafeLog.h"
 #include "SentryCrashMach-O.h"
@@ -78,6 +80,41 @@ static const char *const g_cxa_throw_name = "__cxa_throw";
 static SentryCrashImageToOriginalCxaThrowPair *g_cxa_originals = NULL;
 static size_t g_cxa_originals_capacity = 0;
 static size_t g_cxa_originals_count = 0;
+
+static bool
+getMprotectPageAlignedRange(
+    void *address, size_t size, void **pageAlignedAddress, size_t *pageAlignedSize)
+{
+    if (address == NULL || size == 0) {
+        return false;
+    }
+
+    const uintptr_t pageSize = (uintptr_t)getpagesize();
+    if (pageSize == 0) {
+        return false;
+    }
+
+    const uintptr_t start = (uintptr_t)address;
+    if (UINTPTR_MAX - start < size) {
+        return false;
+    }
+    const uintptr_t end = start + size;
+
+    const uintptr_t pageAlignedStart = start - (start % pageSize);
+    uintptr_t pageAlignedEnd = end;
+    const uintptr_t pageOffset = pageAlignedEnd % pageSize;
+    if (pageOffset != 0) {
+        const uintptr_t pageAdjustment = pageSize - pageOffset;
+        if (UINTPTR_MAX - pageAlignedEnd < pageAdjustment) {
+            return false;
+        }
+        pageAlignedEnd += pageAdjustment;
+    }
+
+    *pageAlignedAddress = (void *)pageAlignedStart;
+    *pageAlignedSize = (size_t)(pageAlignedEnd - pageAlignedStart);
+    return true;
+}
 
 static uintptr_t
 findOriginalCxaThrowFunction(uintptr_t image_dli_fbase_address)
@@ -199,10 +236,21 @@ perform_rebinding_with_section(const section_t *dataSection, intptr_t slide, nli
     // As the default protection for the SEG_DATA_CONST is read-only we set the default
     // oldProtection to VM_PROT_READ.
     vm_prot_t oldProtection = VM_PROT_READ;
+    void *mprotectAddress = NULL;
+    size_t mprotectSize = 0;
     if (isDataConst) {
         oldProtection = sentrycrash_macho_getSectionProtection(indirect_symbol_bindings);
-        if (mprotect(indirect_symbol_bindings, dataSection->size, PROT_READ | PROT_WRITE) != 0) {
-            SENTRY_ASYNC_SAFE_LOG_DEBUG(
+        // mprotect requires a page-aligned address. Older OS versions tolerated this unaligned
+        // Mach-O section start, but newer versions reject it with EINVAL. Align the full section
+        // range before changing protections.
+        if (!getMprotectPageAlignedRange(
+                indirect_symbol_bindings, dataSection->size, &mprotectAddress, &mprotectSize)) {
+            SENTRY_ASYNC_SAFE_LOG_ERROR("Failed to page-align mprotect range for section %s,%s",
+                dataSection->segname, dataSection->sectname);
+            return;
+        }
+        if (mprotect(mprotectAddress, mprotectSize, PROT_READ | PROT_WRITE) != 0) {
+            SENTRY_ASYNC_SAFE_LOG_ERROR(
                 "mprotect failed to set PROT_READ | PROT_WRITE for section %s,%s: %s",
                 dataSection->segname, dataSection->sectname, SENTRY_STRERROR_R(errno));
             return;
@@ -258,7 +306,7 @@ perform_rebinding_with_section(const section_t *dataSection, intptr_t slide, nli
         if (oldProtection & VM_PROT_EXECUTE) {
             protection |= PROT_EXEC;
         }
-        if (mprotect(indirect_symbol_bindings, dataSection->size, protection) != 0) {
+        if (mprotect(mprotectAddress, mprotectSize, protection) != 0) {
             SENTRY_ASYNC_SAFE_LOG_ERROR(
                 "mprotect failed to restore protection for section %s,%s: %s", dataSection->segname,
                 dataSection->sectname, SENTRY_STRERROR_R(errno));


### PR DESCRIPTION
## :scroll: Description

Page aligns Mach-O (down for start and up for end) section offsets before using them as address and size arguments with `mprotect()`.

Also checked against `KSCrash`

* `2.5.1` (latest stable) [still uses unaligned addresses](https://github.com/kstenerud/KSCrash/blob/62039fc55f3f673fefb3644099f646ae3c30fc5e/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c#L134-L186).
* `develop`: severely changed the swapper implementation altogether and [already uses page-aligned addresses](https://github.com/kstenerud/KSCrash/blob/2c09e26eba389ac9bd9763641cdabcd5722adb73/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c#L182-L218).

Ergo: no need to align with upstream. We replace it with `develop` anyway (no need to introduce surrounding changes to fix this).

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-cocoa/issues/8156

`mprotect()` has always required page-aligned addresses, but only in xOS/Xcode 27 does it return `EINVAL` for unaligned addresses.

## :green_heart: How did you test it?

* built with Xcode 27 beta and ran tests on iOS 27 simulator
* verified that unaligned addresses failed and that aligned addresses successfully added protection on iOS 27 simulator
* ran the iOS test suite against iOS 18.4 to counter-check

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
