### PR TITLE
test: verify withLockIfAvailable returns nil when lock is held

### DIFF
--- a/Tests/SentryTests/Swift/Tools/SentryMutexTests.swift
+++ b/Tests/SentryTests/Swift/Tools/SentryMutexTests.swift
@@ -52,6 +52,18 @@ final class SentryMutexTests: XCTestCase {
         XCTAssertEqual(mutex.withLock { $0 }, "world")
     }
 
+    func testWithLockIfAvailable_whenLockIsHeld_shouldReturnNil() {
+        let mutex = SentryMutex("hello")
+
+        let outer = mutex.withLock { value -> String in
+            let inner = mutex.withLockIfAvailable { $0 }
+            XCTAssertNil(inner)
+            return value
+        }
+
+        XCTAssertEqual(outer, "hello")
+    }
+
     func testWithLockIfAvailable_whenBodyThrows_shouldPropagateError() {
         let mutex = SentryMutex(0)
 


### PR DESCRIPTION
Adds a test case that should have been part of #8214

Adds a test to validate that recursive locks are not available with `SentryMutex` but at least don't cause a deadlock

#skip-changelog