### PR TITLE
docs: mark kSentryDataCategoryUserFeedback as unused

### DIFF
--- a/Sources/Sentry/include/SentryDataCategory.h
+++ b/Sources/Sentry/include/SentryDataCategory.h
@@ -12,6 +12,7 @@ typedef NS_ENUM(NSUInteger, SentryDataCategory) {
     kSentryDataCategorySession = 3,
     kSentryDataCategoryTransaction = 4,
     kSentryDataCategoryAttachment = 5,
+    // Unused, but kept so the following raw values stay stable and need no extra mapping logic.
     kSentryDataCategoryUserFeedback = 6,
     kSentryDataCategoryProfile = 7,
     kSentryDataCategoryMetricBucket = 8,


### PR DESCRIPTION
Marks the legacy `kSentryDataCategoryUserFeedback` as unused in the internal `SentryDataCategory` enum, instead of removing it.

### Why document instead of remove

The original idea was to remove the case. But the enum's raw integer values, while never persisted or sent on the wire (the wire format uses the string names), are bridged across the ObjC/Swift boundary by their `rawValue` (e.g. the `envelopeDeletedCallback` and `isRateLimitActive(_:)`). Removing the case would force either renumbering the subsequent values or adding special-case mapping logic for the resulting gap. Keeping the case documented as unused avoids both — the remaining raw values stay stable and no extra mapping logic is needed.

### Notes

- Not public API (header lives in `include/`, absent from `sdk_api.json`).
- No string name mapping in `SentryDataCategoryMapper`; `sentryDataCategoryForString` never returns it.
- Remaining references are a defensive guard in `RateLimitParser` and a cast test.

This came up while tackling https://github.com/getsentry/sentry-cocoa/issues/8174.

#skip-changelog
