### PR TITLE
fix: dropped platform item header in profile-chunk envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix dropped `platform` item header in profile-chunk envelopes (#8269)
 - Fix crash report ID generation so reports created at certain timestamps are not ignored (#8216)
 - Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8221)
 - Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` (#8220)

--- a/Sources/Sentry/SentryEnvelopeItemHeader.m
+++ b/Sources/Sentry/SentryEnvelopeItemHeader.m
@@ -60,7 +60,7 @@
     }
 
     if (self.platform) {
-        [target setValue:self.contentType forKey:@"platform"];
+        [target setValue:self.platform forKey:@"platform"];
     }
 
     if (self.itemCount) {

--- a/Tests/SentryTests/Protocol/SentryEnvelopeItemHeaderTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeItemHeaderTests.swift
@@ -40,12 +40,28 @@ class SentryEnvelopeItemHeaderTests: XCTestCase {
     
     func test_SentryEnvelopeItemHeaderSerialization_WithFilename() {
         let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, filenname: "SomeFileName", contentType: "text/html")
-        
+
         let data = header.serialize()
         XCTAssertEqual(data["type"] as? String, "SomeType")
         XCTAssertEqual(data["length"] as? Int, 10)
         XCTAssertEqual(data["filename"] as? String, "SomeFileName")
         XCTAssertEqual(data["content_type"] as? String, "text/html")
         XCTAssertEqual(data.count, 4)
+    }
+
+    // Regression test for the platform item header being dropped from profile-chunk
+    // envelopes: serialize used to write contentType (nil here) under the "platform"
+    // key, so setValue:nil removed it. Found while investigating
+    // https://github.com/getsentry/sentry-cocoa/issues/8174
+    func test_SentryEnvelopeItemHeaderSerialization_WithPlatform() {
+        let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10)
+        header.platform = "cocoa"
+
+        let data = header.serialize()
+        XCTAssertEqual(data["type"] as? String, "SomeType")
+        XCTAssertEqual(data["length"] as? Int, 10)
+        XCTAssertNil(data["content_type"])
+        XCTAssertEqual(data["platform"] as? String, "cocoa")
+        XCTAssertEqual(data.count, 3)
     }
 }


### PR DESCRIPTION
## 📜 Description

`SentryEnvelopeItemHeader.serialize` wrote `self.contentType` (always `nil` when `platform` is set) under the `platform` key, so `setValue:nil` dropped the header from every profile-chunk envelope.

Copy-paste error from the adjacent `content_type` block that slipped through review in [#5041](<https://github.com/getsentry/sentry-cocoa/issues/5041>); the new branch had no test coverage. The [Java SDK](<https://github.com/getsentry/sentry-java/blob/main/sentry/src/main/java/io/sentry/SentryEnvelopeItemHeader.java>) correctly writes the `platform` value.

## 💡 Motivation and Context

Nobody noticed because Relay falls back to the payload's platform field, so billing/categorization keep working — no rush for customers to update. Cocoa just takes the slow rate-limiting path. Relay plans to make the header mandatory.

Found while investigating getsentry/sentry-cocoa#8174.

## 💚 How did you test it?

Regression test asserting the serialized `platform` value; fails without the fix.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).