### PR TITLE
ref: add accessor for application key window

### DIFF
--- a/Sources/Swift/Helper/SentryApplication.swift
+++ b/Sources/Swift/Helper/SentryApplication.swift
@@ -7,36 +7,39 @@ import UIKit
 #endif
 
 @objc @_spi(Private) public protocol SentryApplication {
-    
+
     // This can only be accessed on the main thread
     var mainThread_isActive: Bool { get }
 
-    #if !os(macOS) && !os(watchOS) && !SENTRY_NO_UI_FRAMEWORK
-    
+#if !os(macOS) && !os(watchOS) && !SENTRY_NO_UI_FRAMEWORK
+
     /**
      * Returns the application state available at @c UIApplication.sharedApplication.applicationState
      * Must be called on the main thread.
      */
     var unsafeApplicationState: UIApplication.State { get }
 
-/**
- * All windows connected to scenes.
- */
+    /// Gets the current key window
+    func getKeyWindow() -> UIWindow?
+
+    /**
+     * All windows connected to scenes.
+     */
     func getWindows() -> [UIWindow]?
-    
+
 #if (os(iOS) || os(tvOS))
     func getActiveWindowSize() -> CGSize
 #endif // os(iOS) || os(tvOS)
-    
+
     var connectedScenes: Set<UIScene> { get }
 
     var delegate: UIApplicationDelegate? { get }
 
-/**
- * Use @c [SentryUIApplication relevantViewControllers] and convert the
- * result to a string array with the class name of each view controller.
- */
+    /**
+     * Use @c [SentryUIApplication relevantViewControllers] and convert the
+     * result to a string array with the class name of each view controller.
+     */
     func relevantViewControllersNames() -> [String]?
-    #endif // canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK
+#endif // canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK
 }
 // swiftlint:enable missing_docs

--- a/Sources/Swift/Helper/SentryApplicationExtensions.swift
+++ b/Sources/Swift/Helper/SentryApplicationExtensions.swift
@@ -11,7 +11,7 @@ import UIKit
 @objc @_spi(Private) extension UIApplication: SentryApplication {
 
     @objc public func getKeyWindow() -> UIWindow? {
-        getWindows()?.first(where: \.isKeyWindow)
+        internal_getKeyWindow()
     }
 
     @objc public func getWindows() -> [UIWindow]? {
@@ -38,6 +38,15 @@ import UIKit
 }
 
 extension SentryApplication {
+    public func internal_getKeyWindow() -> UIWindow? {
+        var keyWindow: UIWindow?
+        Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({ [weak self] in
+            guard let self else { return }
+            keyWindow = self.getWindows()?.first(where: \.isKeyWindow)
+        }, timeout: 0.01)
+        return keyWindow
+    }
+
     // This cannot be declared with @objc so until we delete more ObjC code it needs a separate
     // function than the objc visible one.
     public func internal_getWindows() -> [UIWindow]? {

--- a/Sources/Swift/Helper/SentryApplicationExtensions.swift
+++ b/Sources/Swift/Helper/SentryApplicationExtensions.swift
@@ -10,6 +10,10 @@ import UIKit
 
 @objc @_spi(Private) extension UIApplication: SentryApplication {
 
+    @objc public func getKeyWindow() -> UIWindow? {
+        getWindows()?.first(where: \.isKeyWindow)
+    }
+
     @objc public func getWindows() -> [UIWindow]? {
         internal_getWindows()
     }

--- a/Sources/Swift/Integrations/AppHangTracking/HangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/HangTracker.swift
@@ -18,9 +18,12 @@ protocol RunLoopObserver { }
 
 extension DefaultHangTracker: HangTracker { }
 extension CFRunLoopObserver: RunLoopObserver { }
+
+typealias SentryRunLoopDelayTrackerDependencies = DateProviderProvider & ApplicationProvider
 #else
 typealias HangTracker = DefaultHangTracker<CFRunLoopObserver>
 typealias RunLoopObserver = CFRunLoopObserver
+typealias SentryRunLoopDelayTrackerDependencies = SentryDependencyContainer
 #endif
 
 typealias CreateObserverFunc<T> = (_ allocator: CFAllocator?, _ activities: CFOptionFlags, _ repeats: Bool, _ order: CFIndex, _ block: ((T?, CFRunLoopActivity) -> Void)?) -> T?
@@ -50,23 +53,23 @@ typealias RemoveObserverFunc<T> = (_ rl: CFRunLoop?, _ observer: T?, _ mode: CFR
 // 2: We don't want to acquire any locks every iteration of the runloop. It's ok to acquire locks in general
 // (the code does not need to be async signal safe) but it's not ok to acquire them on every runloop iteration.
 // 3: As simple as possible, using limited lines of code.
-final class DefaultHangTracker<T: RunLoopObserver> {
+final class DefaultHangTracker<T: RunLoopObserver, Dependencies: SentryRunLoopDelayTrackerDependencies> {
 
     // Must be initialized on the main queue
     init(
-        dateProvider: SentryCurrentDateProvider,
+        dependencies: Dependencies,
         createObserver: @escaping CreateObserverFunc<T>,
         addObserver: @escaping AddObserverFunc<T>,
         removeObserver: @escaping RemoveObserverFunc<T>,
         queue: DispatchQueue = DispatchQueue(label: "io.sentry.runloop-observer-checker")
     ) {
-        self.dateProvider = dateProvider
+        self.dateProvider = dependencies.dateProvider
         self.createObserver = createObserver
         self.addObserver = addObserver
         self.removeObserver = removeObserver
         self.queue = queue
 #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && !os(visionOS) && !os(watchOS)
-        let window = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }
+        let window = dependencies.application()?.getKeyWindow()
         let maxFPS = Double(window?.screen.maximumFramesPerSecond ?? 60)
 #else
         let maxFPS: Double = 60.0
@@ -223,9 +226,9 @@ final class DefaultHangTracker<T: RunLoopObserver> {
 }
 
 extension DefaultHangTracker where T == CFRunLoopObserver {
-    convenience init(dateProvider: SentryCurrentDateProvider) {
+    convenience init(dependencies: Dependencies) {
         self.init(
-            dateProvider: dateProvider,
+            dependencies: dependencies,
             createObserver: CFRunLoopObserverCreateWithHandler,
             addObserver: CFRunLoopAddObserver,
             removeObserver: CFRunLoopRemoveObserver)

--- a/Sources/Swift/Integrations/AppHangTracking/HangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/HangTracker.swift
@@ -21,7 +21,7 @@ extension CFRunLoopObserver: RunLoopObserver { }
 
 typealias SentryRunLoopDelayTrackerDependencies = DateProviderProvider & ApplicationProvider
 #else
-typealias HangTracker = DefaultHangTracker<CFRunLoopObserver>
+typealias HangTracker = DefaultHangTracker<CFRunLoopObserver, SentryDependencyContainer>
 typealias RunLoopObserver = CFRunLoopObserver
 typealias SentryRunLoopDelayTrackerDependencies = SentryDependencyContainer
 #endif

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -165,7 +165,9 @@ extension SentryFileManager: SentryFileManagerProtocol { }
     var coreDataSwizzling = SentryCoreDataSwizzling()
     // This is a var so that it's initialized lazily on first access. It never should get set
     // to a different value.
-    lazy var hangTracker: HangTracker = DefaultHangTracker(dateProvider: Dependencies.dateProvider)
+    lazy var hangTracker: HangTracker = {
+        DefaultHangTracker(dependencies: self)
+    }()
 
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
     private var _extraContextProvider: SentryExtraContextProvider?

--- a/Tests/SentryTests/Integrations/AppHangTracking/HangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/HangTrackerTests.swift
@@ -2,8 +2,6 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
-struct TestRunLoopObserver: RunLoopObserver { }
-
 final class HangTrackerTests: XCTestCase {
     
     private var createdObservationBlock: ((TestRunLoopObserver?, CFRunLoopActivity) -> Void)?
@@ -36,8 +34,9 @@ final class HangTrackerTests: XCTestCase {
     }
   
   func testHangTrackerCallsRemoveObserverOnDealloc() {
+      let mockDependencies = MockDependencies()
       var sut: DefaultHangTracker? = DefaultHangTracker(
-        dateProvider: TestCurrentDateProvider(),
+        dependencies: mockDependencies,
         createObserver: createObserver,
         addObserver: addObserver,
         removeObserver: removeObserver,
@@ -49,10 +48,10 @@ final class HangTrackerTests: XCTestCase {
   }
     
     func testDoesNotCaptureHangsThatAreNotOngoing() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -68,7 +67,7 @@ final class HangTrackerTests: XCTestCase {
         queue.suspend()
         observationBlock?(testObserver, .afterWaiting)
         // 10s passed, this is a hang
-        dateProvider.setSystemUptime(10)
+        mockDependencies.mockDateProvider.setSystemUptime(10)
         observationBlock?(testObserver, .beforeWaiting)
         
         // Start the queue again
@@ -87,10 +86,10 @@ final class HangTrackerTests: XCTestCase {
     }
     
     func testHangTrackerWhenNotHanging() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -106,7 +105,7 @@ final class HangTrackerTests: XCTestCase {
         queue.suspend()
         observationBlock?(testObserver, .afterWaiting)
         // 10 ms passed
-        dateProvider.setSystemUptime(0.01)
+        mockDependencies.mockDateProvider.setSystemUptime(0.01)
         observationBlock?(testObserver, .beforeWaiting)
         
         // Start the queue again
@@ -119,10 +118,10 @@ final class HangTrackerTests: XCTestCase {
     }
     
     func testHangTrackerCallsLateRunLoop() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -139,8 +138,8 @@ final class HangTrackerTests: XCTestCase {
         XCTAssertTrue(calledAddObserver, "Expected add observer to be called")
         
         observationBlock?(testObserver, .afterWaiting)
-        dateProvider.setSystemUptime(10)
-                
+        mockDependencies.mockDateProvider.setSystemUptime(10)
+
         wait(for: [expectation])
         
         // Note: We are writing to these variables on a bg thread but reading them here
@@ -164,10 +163,10 @@ final class HangTrackerTests: XCTestCase {
     }
     
     func testRemovesObserverDuringRunloop() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -188,10 +187,10 @@ final class HangTrackerTests: XCTestCase {
     }
     
     func testHangTrackerDeallocates() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         var sut: DefaultHangTracker? = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -222,10 +221,10 @@ final class HangTrackerTests: XCTestCase {
     /// Verifies that after one hang completes (ongoing=true then ongoing=false),
     /// a second hang is properly detected. This catches state-reset bugs with consecutive hangs.
     func testConsecutiveHangsAreDetected() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -252,7 +251,7 @@ final class HangTrackerTests: XCTestCase {
         
         // First hang: start
         observationBlock?(testObserver, .afterWaiting)
-        dateProvider.setSystemUptime(10)
+        mockDependencies.mockDateProvider.setSystemUptime(10)
         wait(for: [hangCallback])
         
         lock.synchronized {
@@ -274,9 +273,9 @@ final class HangTrackerTests: XCTestCase {
         XCTAssertFalse(lastOngoing, "First hang should no longer be ongoing")
         
         // Second hang: start (simulating another runloop iteration that hangs)
-        dateProvider.setSystemUptime(20)
+        mockDependencies.mockDateProvider.setSystemUptime(20)
         observationBlock?(testObserver, .afterWaiting)
-        dateProvider.setSystemUptime(35) // 15 second hang
+        mockDependencies.mockDateProvider.setSystemUptime(35) // 15 second hang
 
         lock.synchronized {
             hangCallback = XCTestExpectation(description: "Second hang detected")
@@ -310,10 +309,10 @@ final class HangTrackerTests: XCTestCase {
     /// is still in the waitForHang loop, the class does not deallocate until the loop exits,
     /// and then the dispatch queue is freed up (not blocked).
     func testDeallocWhileInWaitForHangLoop() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         var sut: DefaultHangTracker? = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -359,10 +358,11 @@ final class HangTrackerTests: XCTestCase {
     }
 
     func testMultipleObserversAllReceiveHangCallback() {
-        let dateProvider = TestCurrentDateProvider()
-        dateProvider.setSystemUptime(0)
+        let mockDependencies = MockDependencies()
+        mockDependencies.mockDateProvider.setSystemUptime(0)
+        mockDependencies.mockDateProvider.setSystemUptime(0)
         let sut = DefaultHangTracker(
-            dateProvider: dateProvider,
+            dependencies: mockDependencies,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,
@@ -415,7 +415,7 @@ final class HangTrackerTests: XCTestCase {
 
         // Trigger a hang
         observationBlock?(testObserver, .afterWaiting)
-        dateProvider.setSystemUptime(10)
+        mockDependencies.mockDateProvider.setSystemUptime(10)
 
         wait(for: [expectation1, expectation2, expectation3])
 
@@ -452,3 +452,15 @@ final class HangTrackerTests: XCTestCase {
     }
 
 }
+
+private struct MockDependencies: SentryRunLoopDelayTrackerDependencies {
+    let mockDateProvider = TestCurrentDateProvider()
+
+    var dateProvider: any Sentry.SentryCurrentDateProvider {
+        mockDateProvider
+    }
+
+    func application() -> (any Sentry.SentryApplication)? { nil }
+}
+
+private struct TestRunLoopObserver: RunLoopObserver { }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
@@ -440,12 +440,16 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
     }
 }
 
-private class MockDependencies: ANRTrackerBuilder & HangTrackerProvider & ProcessInfoProvider & AppStateManagerProvider & WatchdogTerminationScopeObserverBuilder & WatchdogTerminationTrackerBuilder & ExtensionDetectorProvider {
-    
+private class MockDependencies: ANRTrackerBuilder & HangTrackerProvider & ProcessInfoProvider & AppStateManagerProvider & WatchdogTerminationScopeObserverBuilder & WatchdogTerminationTrackerBuilder & ExtensionDetectorProvider & DateProviderProvider & ApplicationProvider {
+
     func getANRTracker(_ interval: TimeInterval) -> Sentry.SentryANRTracker {
         SentryDependencyContainer.sharedInstance().getANRTracker(interval)
     }
-    
+
+    var dateProvider: SentryCurrentDateProvider { TestCurrentDateProvider() }
+
+    func application() -> SentryApplication? { nil }
+
     struct TestRunLoopObserver: RunLoopObserver { }
     
     private func createObserver(_ allocator: CFAllocator?, _ activities: CFOptionFlags, _ repeats: Bool, _ order: CFIndex, _ block: ((TestRunLoopObserver?, CFRunLoopActivity) -> Void)?) -> TestRunLoopObserver {
@@ -458,7 +462,7 @@ private class MockDependencies: ANRTrackerBuilder & HangTrackerProvider & Proces
     
     lazy var hangTracker: HangTracker = {
         DefaultHangTracker(
-            dateProvider: TestCurrentDateProvider(),
+            dependencies: self,
             createObserver: createObserver,
             addObserver: addObserver,
             removeObserver: removeObserver,

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -170,5 +170,36 @@ class SentryUIApplicationTests: XCTestCase {
     private class MockKeyUIWindow: UIWindow {
         override var isKeyWindow: Bool { true }
     }
+
+    private class ThreadTrackingKeyUIWindow: UIWindow {
+        var isKeyWindowAccessedOnMainThread: Bool?
+        override var isKeyWindow: Bool {
+            isKeyWindowAccessedOnMainThread = Thread.isMainThread
+            return true
+        }
+    }
+
+    // MARK: - Thread Safety
+
+    func testGetKeyWindow_fromBackgroundThread_shouldAccessIsKeyWindowOnMainThread() {
+        // -- Arrange --
+        let sut = TestSentryUIApplication()
+        let keyWindow = ThreadTrackingKeyUIWindow(windowScene: Self.mockWindowScene)
+        sut.windows = [keyWindow]
+
+        // -- Act --
+        let expectation = expectation(description: "background thread")
+        var result: UIWindow?
+        DispatchQueue.global().async {
+            result = sut.getKeyWindow()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // -- Assert --
+        XCTAssertIdentical(result, keyWindow)
+        XCTAssertEqual(keyWindow.isKeyWindowAccessedOnMainThread, true,
+            "isKeyWindow must be accessed on the main thread")
+    }
 }
 #endif

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -88,6 +88,58 @@ class SentryUIApplicationTests: XCTestCase {
         XCTAssertEqual(sut.getWindows()?.count, 0)
     }
 
+    // MARK: - getKeyWindow
+
+    func testGetKeyWindow_whenNoWindows_shouldReturnNil() {
+        // -- Arrange --
+        let sut = TestSentryUIApplication()
+
+        // -- Act --
+        let result = sut.getKeyWindow()
+
+        // -- Assert --
+        XCTAssertNil(result)
+    }
+
+    func testGetKeyWindow_whenNoKeyWindow_shouldReturnNil() {
+        // -- Arrange --
+        let sut = TestSentryUIApplication()
+        sut.windows = [makeWindow(), makeWindow()]
+
+        // -- Act --
+        let result = sut.getKeyWindow()
+
+        // -- Assert --
+        XCTAssertNil(result)
+    }
+
+    func testGetKeyWindow_whenKeyWindowExists_shouldReturnKeyWindow() {
+        // -- Arrange --
+        let sut = TestSentryUIApplication()
+        let keyWindow = MockKeyUIWindow(windowScene: Self.mockWindowScene)
+        sut.windows = [makeWindow(), keyWindow]
+
+        // -- Act --
+        let result = sut.getKeyWindow()
+
+        // -- Assert --
+        XCTAssertIdentical(result, keyWindow)
+    }
+
+    func testGetKeyWindow_whenMultipleKeyWindows_shouldReturnFirst() {
+        // -- Arrange --
+        let sut = TestSentryUIApplication()
+        let firstKeyWindow = MockKeyUIWindow(windowScene: Self.mockWindowScene)
+        let secondKeyWindow = MockKeyUIWindow(windowScene: Self.mockWindowScene)
+        sut.windows = [makeWindow(), firstKeyWindow, secondKeyWindow]
+
+        // -- Act --
+        let result = sut.getKeyWindow()
+
+        // -- Assert --
+        XCTAssertIdentical(result, firstKeyWindow)
+    }
+
     func testInternalRelevantViewControllers_whenWindowFilterProvided_shouldOnlyUseMatchingWindows() throws {
         // -- Arrange --
         let excludedViewController = UIViewController()
@@ -113,6 +165,10 @@ class SentryUIApplicationTests: XCTestCase {
 
     private class TestUISceneDelegate: NSObject, UIWindowSceneDelegate {
         var window: UIWindow?
+    }
+
+    private class MockKeyUIWindow: UIWindow {
+        override var isKeyWindow: Bool { true }
     }
 }
 #endif

--- a/Tests/SentryTests/TestSentryUIApplication.swift
+++ b/Tests/SentryTests/TestSentryUIApplication.swift
@@ -3,7 +3,7 @@
 
 final class TestSentryUIApplication: SentryApplication {
     func getKeyWindow() -> UIWindow? {
-        return getWindows()?.first(where: \.isKeyWindow)
+        return internal_getKeyWindow()
     }
 
     func getWindows() -> [UIWindow]? {

--- a/Tests/SentryTests/TestSentryUIApplication.swift
+++ b/Tests/SentryTests/TestSentryUIApplication.swift
@@ -2,6 +2,10 @@
 @_spi(Private) @testable import Sentry
 
 final class TestSentryUIApplication: SentryApplication {
+    func getKeyWindow() -> UIWindow? {
+        return getWindows()?.first(where: \.isKeyWindow)
+    }
+
     func getWindows() -> [UIWindow]? {
         if let windows {
             return windows


### PR DESCRIPTION
Extracted from https://github.com/getsentry/sentry-cocoa/pull/8179

- Adds helper to get key window of current application
- Necessary so we can inject the application here:

https://github.com/getsentry/sentry-cocoa/blob/ebe71898e3f9752d584781d572eb2798d5b123b0/Sources/Swift/HangTracker.swift#L68-L73

- ~Usage is out-of-scope for this pull request, because the `HangTracker.swift` will be heavily refactored in #8179~ Adds dependency injection into the HangTracker with mocking in tests

## Changes

- `getKeyWindow()` now wraps the entire operation (window collection + `isKeyWindow` filtering) in `dispatchSyncOnMainQueue` via a new `internal_getKeyWindow()` extension method, ensuring UIKit properties are always accessed on the main thread
- `TestSentryUIApplication.getKeyWindow()` updated to use `internal_getKeyWindow()` for consistent thread safety
- Added thread-safety test verifying `isKeyWindow` is accessed on the main thread even when `getKeyWindow()` is called from a background thread

#skip-changelog