### PR TITLE
docs: replace CocoaPods deprecation warning with dropped notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ We also provide pre-built XCFrameworks on [our GitHub Releases page](https://git
 
 To see all available installation options and how to integrate Sentry into your project, please refer to our [documentation](https://docs.sentry.io/platforms/apple/install/).
 
-> [!WARNING]
-> CocoaPods support has been deprecated and will no longer receive updates after June 2026. Please migrate to SPM or XCFrameworks. See [CocoaPods read-only change](https://blog.cocoapods.org/CocoaPods-Support-Plans/).
+> [!NOTE]
+> CocoaPods support has been dropped. The last version available via CocoaPods is [9.19.1](https://github.com/getsentry/sentry-cocoa/releases/tag/9.19.1). Please migrate to SPM or XCFrameworks.
 
 > [!WARNING]
 > **The minimum macOS deployment target will be raised to macOS 12 (Monterey)** with the upcoming release that adopts Xcode 27. Xcode 27 no longer supports deployment targets below macOS 12. If your app must support macOS 11 or earlier, please stay on the last SDK version released before this change. See [#8113](https://github.com/getsentry/sentry-cocoa/issues/8113) for full details.


### PR DESCRIPTION
## Summary

- Replace the CocoaPods deprecation warning in README with a note that support has been dropped
- Links to the last CocoaPods-compatible release (9.19.1)

Resolves COCOA-1254
Closes https://github.com/getsentry/sentry-cocoa/issues/7384
Closes https://github.com/getsentry/sentry-cocoa/issues/7393

#skip-changelog