### PR TITLE
build: remove CocoaPods target from release automation

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,9 +3,9 @@ changelogPolicy: auto
 preReleaseCommand: bash ./scripts/bump.sh
 targets:
   - name: github
-  - name: cocoapods
-    id: sentry-cocoapod
-    specPath: Sentry.podspec
+  # The canonical name 'cocoapods:sentry-cocoa' is a historical artifact from when
+  # the SDK was distributed via CocoaPods. Changing it requires manual surgery in
+  # the sentry-release-registry repo, so we keep it as-is.
   - name: registry
     sdks:
       cocoapods:sentry-cocoa:


### PR DESCRIPTION
## Summary

- Remove the `cocoapods` craft target that publishes to CocoaPods trunk (`pod trunk push`)
- Keep the `registry` target with its `cocoapods:sentry-cocoa` canonical name — changing the canonical requires manual surgery in [sentry-release-registry](https://github.com/getsentry/sentry-release-registry), so we keep it as-is with a comment explaining why

Resolves COCOA-1250
Resolves https://github.com/getsentry/sentry-cocoa/issues/7389

#skip-changelog