### PR TITLE
docs: remove CocoaPods references from build docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ Non-changelog types require `#skip-changelog` in PR description. Breaking change
 
 ## CLI
 
-See `make help` and the Makefile for commands and documentation. Key targets: `make format`, `make analyze`, `make build-ios`, `make test-ios`, `make build-xcframework-dynamic`, `make pod-lint`.
+See `make help` and the Makefile for commands and documentation. Key targets: `make format`, `make analyze`, `make build-ios`, `make test-ios`, `make build-xcframework-dynamic`.
 
 ## Shell Scripts
 

--- a/develop-docs/ARCHITECTURE.md
+++ b/develop-docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Non public headers should be placed into `Sources/include`
 
 To make a header public follow these steps:
 
-- Move it into the folder [Public](/Sources/Sentry/Public). Both [CocoaPods](Sentry.podspec) and [Swift Package Manager](Package.swift) make all headers in this folder public.
+- Move it into the folder [Public](/Sources/Sentry/Public). [Swift Package Manager](Package.swift) makes all headers in this folder public.
 - Add it to the Umbrella Header [Sentry.h](/Sources/Sentry/Public/Sentry.h).
 - Set the target membership to public.
 

--- a/develop-docs/BUILD.md
+++ b/develop-docs/BUILD.md
@@ -23,7 +23,6 @@ This feature is experimental and is currently not compatible with SPM.
 
 ```bash
 make build-xcframework-dynamic  # Build Sentry-Dynamic XCFramework
-make pod-lint              # Validate CocoaPods specs
 ./scripts/bump-version.sh --version X.Y.Z # Bump version
 ```
 

--- a/develop-docs/INTEGRATIONS.md
+++ b/develop-docs/INTEGRATIONS.md
@@ -47,7 +47,6 @@ Each integration will be self-contained in `3rd-party-integration/INTEGRATION-NA
 - `Tests/` - Test for the integration
 - `README.md` - Integration-specific documentation
 - `Package.swift` - SPM package definition
-- `*.podspec` - CocoaPods specification
 
 **Example:**
 
@@ -56,13 +55,11 @@ Each integration will be self-contained in `3rd-party-integration/INTEGRATION-NA
   ├── SentryCocoaLumberjack/
   │   ├── Sources/
   │   ├── README.md
-  │   ├── Package.swift
-  │   └── SentryCocoaLumberjack.podspec
+  │   └── Package.swift
   └── SentrySwiftLog/
       ├── Sources/
       ├── README.md
-      ├── Package.swift
-      └── SentrySwiftLog.podspec
+      └── Package.swift
 ```
 
 Since SPM fails to resolve dependencies if the folder has the same name as one of the dependencies, we cannot use the library name as the folder name.


### PR DESCRIPTION
## Summary

The `scripts/pod-lib-lint.sh` and `make pod-lint` target were already removed in #8294. This PR cleans up the remaining documentation references:

- Remove `make pod-lint` from CLI key targets in `AGENTS.md`
- Remove `make pod-lint` from `develop-docs/BUILD.md`
- Remove CocoaPods reference from public header docs in `develop-docs/ARCHITECTURE.md`
- Remove podspec entries from integration structure docs in `develop-docs/INTEGRATIONS.md`
- Historical decision records in `DECISIONS.md` are left as-is (they document past reasoning)

Closes https://github.com/getsentry/sentry-cocoa/issues/7388

#skip-changelog