### PR TITLE
chore: Auto-request mobile team review on public API changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @philipphofmann @philprime @noahsmartin @itaybre @NinjaLikesCheez
+
+# Public API surface — auto-request a mobile SDK team review on API changes
+/sdk_api*.json @getsentry/team-mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @philipphofmann @philprime @noahsmartin @itaybre @NinjaLikesCheez
 
-# Public API surface — auto-request a mobile SDK team review on API changes
-/sdk_api*.json @getsentry/team-mobile
+# Public API surface — also request a mobile SDK team review on API changes
+/sdk_api*.json @philipphofmann @philprime @noahsmartin @itaybre @NinjaLikesCheez @getsentry/team-mobile


### PR DESCRIPTION
## :scroll: Description

Adds a CODEOWNERS rule for the committed `swift-api-digester` snapshots at the repo root (`sdk_api*.json`)

## :bulb: Motivation and Context

Public API changes in the mobile SDKs should be reviewed by another mobile SDK team member for cross-SDK consistency. 

## :green_heart: How did you test it?

Manually

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
