### PR TITLE
feat: Attach profiling chunks to App Hangs V3

### DIFF
--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHang.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHang.swift
@@ -10,6 +10,25 @@ struct SentryAppHang {
             let instructionAddress: String?
             let function: String?
             let module: String?
+            let package: String?
+            let imageAddress: String?
+            let inApp: Bool?
+
+            init(
+                instructionAddress: String?,
+                function: String?,
+                module: String?,
+                package: String? = nil,
+                imageAddress: String? = nil,
+                inApp: Bool? = nil
+            ) {
+                self.instructionAddress = instructionAddress
+                self.function = function
+                self.module = module
+                self.package = package
+                self.imageAddress = imageAddress
+                self.inApp = inApp
+            }
         }
 
         struct Sample {

--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHang.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHang.swift
@@ -5,6 +5,44 @@ struct SentryAppHang {
         case ended
     }
 
+    struct ProfilingData {
+        struct Frame {
+            let instructionAddress: String?
+            let function: String?
+            let module: String?
+        }
+
+        struct Sample {
+            let timestamp: TimeInterval
+            let stackIndex: Int
+            let threadId: UInt64
+        }
+
+        struct ThreadMetadata {
+            let name: String
+            let priority: Int
+        }
+
+        let frames: [Frame]
+        let stacks: [[Int]]
+        let samples: [Sample]
+        let threadMetadata: [String: ThreadMetadata]
+    }
+
     let duration: TimeInterval
     let state: State
+
+    let profilerId: SentryId?
+    let profilingData: ProfilingData?
+    let startSystemTime: UInt64
+    let endSystemTime: UInt64
+
+    init(duration: TimeInterval, state: State, profilerId: SentryId? = nil, profilingData: ProfilingData? = nil, startSystemTime: UInt64 = 0, endSystemTime: UInt64 = 0) {
+        self.duration = duration
+        self.state = state
+        self.profilerId = profilerId
+        self.profilingData = profilingData
+        self.startSystemTime = startSystemTime
+        self.endSystemTime = endSystemTime
+    }
 }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
@@ -10,9 +10,9 @@ protocol SentryAppHangTracker {
 }
 extension SentryDefaultAppHangTracker: SentryAppHangTracker { }
 
-typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider
+typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider
 #else
-typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider
+typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider
 typealias SentryAppHangTracker = SentryDefaultAppHangTracker<SentryDependencyContainer>
 #endif
 
@@ -25,10 +25,26 @@ typealias SentryAppHangTracker = SentryDefaultAppHangTracker<SentryDependencyCon
 final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDependencies> {
     // MARK: - Types
 
+    struct Options {
+        let sampleIntervalMs: Int
+
+        init(sampleIntervalMs: Int = 100) {
+            self.sampleIntervalMs = sampleIntervalMs
+        }
+    }
+
     private struct ObserverEntry {
         let threshold: TimeInterval
         let handler: SentryAppHangTrackerHandler
         var hasBeenNotified: Bool = false
+    }
+
+    private struct HangProfilingContext {
+        let profilerId: SentryId
+        let startSystemTime: UInt64
+        let accumulator: SampleAccumulator?
+        let isUsingContinuousProfiler: Bool
+        var sampleTimer: DispatchSourceTimer?
     }
 
     // MARK: - State
@@ -36,12 +52,24 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
     private let runLoopDelayTracker: SentryRunLoopDelayTracker
     private var runLoopDelayTrackerObserverToken: SentryRunLoopDelayTrackerObserverToken?
 
+    private let threadInspector: SentryThreadInspector
+    private let dateProvider: SentryCurrentDateProvider
+
     private let observers = SentryMutex<[UUID: ObserverEntry]>([:])
+    private var activeProfilingContext: HangProfilingContext?
+
+    // MARK: - Configuration
+
+    let profilingOptions: Options
 
     // MARK: - Implementation
 
-    init(dependencies: Dependencies) {
+    init(dependencies: Dependencies, profilingOptions: Options = Options()) {
         self.runLoopDelayTracker = dependencies.runLoopDelayTracker
+        self.threadInspector = dependencies.threadInspector
+        self.dateProvider = dependencies.dateProvider
+        self.profilingOptions = profilingOptions
+        SentrySDKLog.debug("AppHangTracker: Initialized (sampleIntervalMs=\(profilingOptions.sampleIntervalMs))")
     }
 
     /// Adds an observer for app hangs exceeding the given threshold.
@@ -91,25 +119,209 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
     }
 
     private func processDelay(delay: SentryRunLoopDelay) {
-        // Collect notifications under the lock but invoke handlers outside the critical section
-        // to avoid deadlocks if a handler calls addObserver/removeObserver.
         let notifications: [(SentryAppHangTrackerHandler, SentryAppHang)] = observers.withLock { entries in
             var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []
-            for (token, entry) in entries {
-                if delay.isOngoing {
+
+            if delay.isOngoing {
+                let anyNeedsStart = entries.contains { _, entry in
+                    delay.duration > entry.threshold && !entry.hasBeenNotified
+                }
+                let context: HangProfilingContext? = anyNeedsStart ? startProfilingIfNeeded() : nil
+                if anyNeedsStart {
+                    SentrySDKLog.debug("AppHangTracker: Profiling context: profilerId=\(context?.profilerId.sentryIdString ?? "nil"), isUsingContinuousProfiler=\(context?.isUsingContinuousProfiler.description ?? "nil")")
+                }
+
+                for (token, entry) in entries {
                     if delay.duration > entry.threshold && !entry.hasBeenNotified {
                         entries[token]?.hasBeenNotified = true
-                        result.append((entry.handler, .init(duration: delay.duration, state: .started)))
+                        SentrySDKLog.debug("AppHangTracker: Hang started (duration=\(delay.duration)s, threshold=\(entry.threshold)s)")
+                        result.append((entry.handler, .init(
+                            duration: delay.duration,
+                            state: .started,
+                            profilerId: context?.profilerId,
+                            profilingData: nil,
+                            startSystemTime: context?.startSystemTime ?? 0,
+                            endSystemTime: dateProvider.systemTime()
+                        )))
                     }
-                } else if entry.hasBeenNotified {
-                    entries[token]?.hasBeenNotified = false
-                    result.append((entry.handler, .init(duration: delay.duration, state: .ended)))
+                }
+            } else {
+                let anyNeedsEnd = entries.values.contains { $0.hasBeenNotified }
+                let endTime = dateProvider.systemTime()
+                let profilingResult = anyNeedsEnd ? stopProfilingIfNeeded() : (profilerId: nil as SentryId?, profilingData: nil as SentryAppHang.ProfilingData?, startSystemTime: UInt64(0))
+                if anyNeedsEnd {
+                    SentrySDKLog.debug("AppHangTracker: Hang ended (duration=\(delay.duration)s), profilerId=\(profilingResult.profilerId?.sentryIdString ?? "nil"), hasSamples=\(profilingResult.profilingData != nil), sampleCount=\(profilingResult.profilingData?.samples.count ?? 0)")
+                }
+
+                for (token, entry) in entries {
+                    if entry.hasBeenNotified {
+                        entries[token]?.hasBeenNotified = false
+                        result.append((entry.handler, .init(
+                            duration: delay.duration,
+                            state: .ended,
+                            profilerId: profilingResult.profilerId,
+                            profilingData: profilingResult.profilingData,
+                            startSystemTime: profilingResult.startSystemTime,
+                            endSystemTime: endTime
+                        )))
+                    }
                 }
             }
+
             return result
         }
         for (handler, hang) in notifications {
             handler(hang)
         }
+    }
+
+    private func startProfilingIfNeeded() -> HangProfilingContext? {
+        guard activeProfilingContext == nil else {
+            SentrySDKLog.debug("AppHangTracker: startProfilingIfNeeded — already active, reusing existing context")
+            return activeProfilingContext
+        }
+
+        let startTime = dateProvider.systemTime()
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+        if SentryContinuousProfiler.isCurrentlyProfiling,
+           let existingId = SentryContinuousProfiler.currentProfilerID {
+            SentrySDKLog.debug("AppHangTracker: Piggyback on continuous profiler (profilerId=\(existingId.sentryIdString))")
+            let context = HangProfilingContext(
+                profilerId: existingId,
+                startSystemTime: startTime,
+                accumulator: nil,
+                isUsingContinuousProfiler: true
+            )
+            activeProfilingContext = context
+            return context
+        }
+#endif
+
+        let accumulator = SampleAccumulator()
+        let profilerId = SentryId()
+        SentrySDKLog.debug("AppHangTracker: Starting custom sampling (profilerId=\(profilerId.sentryIdString), intervalMs=\(profilingOptions.sampleIntervalMs))")
+        var context = HangProfilingContext(
+            profilerId: profilerId,
+            startSystemTime: startTime,
+            accumulator: accumulator,
+            isUsingContinuousProfiler: false
+        )
+
+        let threads = threadInspector.getCurrentThreadsWithStackTrace()
+        accumulator.appendSample(from: threads, timestamp: dateProvider.date().timeIntervalSince1970)
+        SentrySDKLog.debug("AppHangTracker: Took initial sample, \(threads.count) threads")
+
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
+        let intervalMs = profilingOptions.sampleIntervalMs
+        timer.schedule(deadline: .now() + .milliseconds(intervalMs), repeating: .milliseconds(intervalMs))
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            let threads = self.threadInspector.getCurrentThreadsWithStackTrace()
+            accumulator.appendSample(from: threads, timestamp: self.dateProvider.date().timeIntervalSince1970)
+        }
+        timer.resume()
+        context.sampleTimer = timer
+
+        activeProfilingContext = context
+        return context
+    }
+
+    private func stopProfilingIfNeeded() -> (profilerId: SentryId?, profilingData: SentryAppHang.ProfilingData?, startSystemTime: UInt64) {
+        guard let context = activeProfilingContext else {
+            SentrySDKLog.debug("AppHangTracker: stopProfilingIfNeeded — no active context")
+            return (nil, nil, 0)
+        }
+        activeProfilingContext = nil
+
+        context.sampleTimer?.cancel()
+
+        if context.isUsingContinuousProfiler {
+            SentrySDKLog.debug("AppHangTracker: Stopped profiling (continuous profiler path, profilerId=\(context.profilerId.sentryIdString))")
+            return (context.profilerId, nil, context.startSystemTime)
+        }
+
+        let profilingData = context.accumulator?.toProfilingData()
+        SentrySDKLog.debug("AppHangTracker: Stopped profiling (custom sampling, profilerId=\(context.profilerId.sentryIdString), frames=\(profilingData?.frames.count ?? 0), stacks=\(profilingData?.stacks.count ?? 0), samples=\(profilingData?.samples.count ?? 0))")
+        return (context.profilerId, profilingData, context.startSystemTime)
+    }
+}
+
+// MARK: - SampleAccumulator
+
+final class SampleAccumulator {
+    private struct FrameKey: Hashable {
+        let instructionAddress: String?
+        let function: String?
+        let module: String?
+    }
+
+    private var frameIndex: [FrameKey: Int] = [:]
+    private var frames: [SentryAppHang.ProfilingData.Frame] = []
+    private var stackIndex: [[Int]: Int] = [:]
+    private var stacks: [[Int]] = []
+    private var samples: [SentryAppHang.ProfilingData.Sample] = []
+    private var threadMetadata: [String: SentryAppHang.ProfilingData.ThreadMetadata] = [:]
+
+    func appendSample(from threads: [SentryThread], timestamp: TimeInterval) {
+        for thread in threads {
+            let threadId = thread.threadId?.uint64Value ?? 0
+            let threadIdStr = "\(threadId)"
+
+            if threadMetadata[threadIdStr] == nil {
+                threadMetadata[threadIdStr] = .init(
+                    name: thread.name ?? "Thread \(threadId)",
+                    priority: 0
+                )
+            }
+
+            var frameIndices: [Int] = []
+            if let stacktrace = thread.stacktrace {
+                for frame in stacktrace.frames {
+                    let key = FrameKey(
+                        instructionAddress: frame.instructionAddress,
+                        function: frame.function,
+                        module: frame.module
+                    )
+                    let idx: Int
+                    if let existing = frameIndex[key] {
+                        idx = existing
+                    } else {
+                        idx = frames.count
+                        frameIndex[key] = idx
+                        frames.append(.init(
+                            instructionAddress: frame.instructionAddress,
+                            function: frame.function,
+                            module: frame.module
+                        ))
+                    }
+                    frameIndices.append(idx)
+                }
+            }
+
+            let stackIdx: Int
+            if let existing = stackIndex[frameIndices] {
+                stackIdx = existing
+            } else {
+                stackIdx = stacks.count
+                stackIndex[frameIndices] = stackIdx
+                stacks.append(frameIndices)
+            }
+
+            samples.append(.init(
+                timestamp: timestamp,
+                stackIndex: stackIdx,
+                threadId: threadId
+            ))
+        }
+    }
+
+    func toProfilingData() -> SentryAppHang.ProfilingData {
+        SentryAppHang.ProfilingData(
+            frames: frames,
+            stacks: stacks,
+            samples: samples,
+            threadMetadata: threadMetadata
+        )
     }
 }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
@@ -10,9 +10,9 @@ protocol SentryAppHangTracker {
 }
 extension SentryDefaultAppHangTracker: SentryAppHangTracker { }
 
-typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider
+typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider & DispatchFactoryProvider
 #else
-typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider
+typealias SentryAppHangTrackerDependencies = RunLoopDelayTrackerProvider & ThreadInspectorProvider & DateProviderProvider & DispatchFactoryProvider
 typealias SentryAppHangTracker = SentryDefaultAppHangTracker<SentryDependencyContainer>
 #endif
 
@@ -42,9 +42,8 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
     private struct HangProfilingContext {
         let profilerId: SentryId
         let startSystemTime: UInt64
-        let accumulator: SampleAccumulator?
         let isUsingContinuousProfiler: Bool
-        var sampleTimer: DispatchSourceTimer?
+        var sampleTimer: SentryDispatchSourceWrapper?
     }
 
     // MARK: - State
@@ -54,9 +53,11 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
 
     private let threadInspector: SentryThreadInspector
     private let dateProvider: SentryCurrentDateProvider
+    private let dispatchFactory: SentryDispatchFactory
 
     private let observers = SentryMutex<[UUID: ObserverEntry]>([:])
     private var activeProfilingContext: HangProfilingContext?
+    private var accumulator = SentryProfilingSampleAccumulator()
 
     // MARK: - Configuration
 
@@ -68,6 +69,7 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
         self.runLoopDelayTracker = dependencies.runLoopDelayTracker
         self.threadInspector = dependencies.threadInspector
         self.dateProvider = dependencies.dateProvider
+        self.dispatchFactory = dependencies.dispatchFactory
         self.profilingOptions = profilingOptions
         SentrySDKLog.debug("AppHangTracker: Initialized (sampleIntervalMs=\(profilingOptions.sampleIntervalMs))")
     }
@@ -118,66 +120,87 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
         runLoopDelayTrackerObserverToken = nil
     }
 
+    // MARK: - Delay Processing
+
     private func processDelay(delay: SentryRunLoopDelay) {
+        // Collect notifications under the lock but invoke handlers outside the critical section
+        // to avoid deadlocks if a handler calls addObserver/removeObserver.
         let notifications: [(SentryAppHangTrackerHandler, SentryAppHang)] = observers.withLock { entries in
-            var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []
-
             if delay.isOngoing {
-                let anyNeedsStart = entries.contains { _, entry in
-                    delay.duration > entry.threshold && !entry.hasBeenNotified
-                }
-                let context: HangProfilingContext? = anyNeedsStart ? startProfilingIfNeeded() : nil
-                if anyNeedsStart {
-                    SentrySDKLog.debug("AppHangTracker: Profiling context: profilerId=\(context?.profilerId.sentryIdString ?? "nil"), isUsingContinuousProfiler=\(context?.isUsingContinuousProfiler.description ?? "nil")")
-                }
-
-                for (token, entry) in entries {
-                    if delay.duration > entry.threshold && !entry.hasBeenNotified {
-                        entries[token]?.hasBeenNotified = true
-                        SentrySDKLog.debug("AppHangTracker: Hang started (duration=\(delay.duration)s, threshold=\(entry.threshold)s)")
-                        result.append((entry.handler, .init(
-                            duration: delay.duration,
-                            state: .started,
-                            profilerId: context?.profilerId,
-                            profilingData: nil,
-                            startSystemTime: context?.startSystemTime ?? 0,
-                            endSystemTime: dateProvider.systemTime()
-                        )))
-                    }
-                }
+                return processOngoingDelay(delay: delay, entries: &entries)
             } else {
-                let anyNeedsEnd = entries.values.contains { $0.hasBeenNotified }
-                let endTime = dateProvider.systemTime()
-                let profilingResult = anyNeedsEnd ? stopProfilingIfNeeded() : (profilerId: nil as SentryId?, profilingData: nil as SentryAppHang.ProfilingData?, startSystemTime: UInt64(0))
-                if anyNeedsEnd {
-                    SentrySDKLog.debug("AppHangTracker: Hang ended (duration=\(delay.duration)s), profilerId=\(profilingResult.profilerId?.sentryIdString ?? "nil"), hasSamples=\(profilingResult.profilingData != nil), sampleCount=\(profilingResult.profilingData?.samples.count ?? 0)")
-                }
-
-                for (token, entry) in entries {
-                    if entry.hasBeenNotified {
-                        entries[token]?.hasBeenNotified = false
-                        result.append((entry.handler, .init(
-                            duration: delay.duration,
-                            state: .ended,
-                            profilerId: profilingResult.profilerId,
-                            profilingData: profilingResult.profilingData,
-                            startSystemTime: profilingResult.startSystemTime,
-                            endSystemTime: endTime
-                        )))
-                    }
-                }
+                return processEndedDelay(delay: delay, entries: &entries)
             }
-
-            return result
         }
         for (handler, hang) in notifications {
             handler(hang)
         }
     }
 
+    private func processOngoingDelay(
+        delay: SentryRunLoopDelay,
+        entries: inout [UUID: ObserverEntry]
+    ) -> [(SentryAppHangTrackerHandler, SentryAppHang)] {
+        let anyNeedsStart = entries.contains { _, entry in
+            delay.duration > entry.threshold && !entry.hasBeenNotified
+        }
+        guard anyNeedsStart else { return [] }
+
+        let context = startProfilingIfNeeded()
+        var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []
+
+        for (token, entry) in entries {
+            if delay.duration > entry.threshold && !entry.hasBeenNotified {
+                entries[token]?.hasBeenNotified = true
+                SentrySDKLog.debug("AppHangTracker: Hang started (duration=\(delay.duration)s, threshold=\(entry.threshold)s)")
+                result.append((entry.handler, .init(
+                    duration: delay.duration,
+                    state: .started,
+                    profilerId: context?.profilerId,
+                    profilingData: nil,
+                    startSystemTime: context?.startSystemTime ?? 0,
+                    endSystemTime: dateProvider.systemTime()
+                )))
+            }
+        }
+
+        return result
+    }
+
+    private func processEndedDelay(
+        delay: SentryRunLoopDelay,
+        entries: inout [UUID: ObserverEntry]
+    ) -> [(SentryAppHangTrackerHandler, SentryAppHang)] {
+        let anyNeedsEnd = entries.values.contains { $0.hasBeenNotified }
+        guard anyNeedsEnd else { return [] }
+
+        let endTime = dateProvider.systemTime()
+        let profilingResult = stopProfilingIfNeeded()
+        SentrySDKLog.debug("AppHangTracker: Hang ended (duration=\(delay.duration)s), profilerId=\(profilingResult.profilerId?.sentryIdString ?? "nil"), sampleCount=\(profilingResult.profilingData?.samples.count ?? 0)")
+
+        var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []
+
+        for (token, entry) in entries {
+            if entry.hasBeenNotified {
+                entries[token]?.hasBeenNotified = false
+                result.append((entry.handler, .init(
+                    duration: delay.duration,
+                    state: .ended,
+                    profilerId: profilingResult.profilerId,
+                    profilingData: profilingResult.profilingData,
+                    startSystemTime: profilingResult.startSystemTime,
+                    endSystemTime: endTime
+                )))
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Profiling
+
     private func startProfilingIfNeeded() -> HangProfilingContext? {
         guard activeProfilingContext == nil else {
-            SentrySDKLog.debug("AppHangTracker: startProfilingIfNeeded — already active, reusing existing context")
             return activeProfilingContext
         }
 
@@ -186,11 +209,10 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         if SentryContinuousProfiler.isCurrentlyProfiling,
            let existingId = SentryContinuousProfiler.currentProfilerID {
-            SentrySDKLog.debug("AppHangTracker: Piggyback on continuous profiler (profilerId=\(existingId.sentryIdString))")
+            SentrySDKLog.debug("AppHangTracker: Using existing continuous profiler (profilerId=\(existingId.sentryIdString))")
             let context = HangProfilingContext(
                 profilerId: existingId,
                 startSystemTime: startTime,
-                accumulator: nil,
                 isUsingContinuousProfiler: true
             )
             activeProfilingContext = context
@@ -198,30 +220,27 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
         }
 #endif
 
-        let accumulator = SampleAccumulator()
+        accumulator = SentryProfilingSampleAccumulator()
         let profilerId = SentryId()
+        let intervalNs = profilingOptions.sampleIntervalMs * 1_000_000
+
         SentrySDKLog.debug("AppHangTracker: Starting custom sampling (profilerId=\(profilerId.sentryIdString), intervalMs=\(profilingOptions.sampleIntervalMs))")
+
         var context = HangProfilingContext(
             profilerId: profilerId,
             startSystemTime: startTime,
-            accumulator: accumulator,
             isUsingContinuousProfiler: false
         )
-
-        let threads = threadInspector.getCurrentThreadsWithStackTrace()
-        accumulator.appendSample(from: threads, timestamp: dateProvider.date().timeIntervalSince1970)
-        SentrySDKLog.debug("AppHangTracker: Took initial sample, \(threads.count) threads")
-
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .userInitiated))
-        let intervalMs = profilingOptions.sampleIntervalMs
-        timer.schedule(deadline: .now() + .milliseconds(intervalMs), repeating: .milliseconds(intervalMs))
-        timer.setEventHandler { [weak self] in
-            guard let self else { return }
-            let threads = self.threadInspector.getCurrentThreadsWithStackTrace()
-            accumulator.appendSample(from: threads, timestamp: self.dateProvider.date().timeIntervalSince1970)
-        }
-        timer.resume()
-        context.sampleTimer = timer
+        context.sampleTimer = SentryDispatchSourceWrapper(
+            interval: intervalNs,
+            leeway: intervalNs / 10,
+            queue: dispatchFactory.createHighPriorityQueue("io.sentry.app-hang-profiling"),
+            eventHandler: { [weak self] in
+                guard let self else { return }
+                let threads = self.threadInspector.getCurrentThreadsWithStackTrace()
+                self.accumulator.appendSample(from: threads, timestamp: self.dateProvider.date().timeIntervalSince1970)
+            }
+        )
 
         activeProfilingContext = context
         return context
@@ -229,99 +248,17 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
 
     private func stopProfilingIfNeeded() -> (profilerId: SentryId?, profilingData: SentryAppHang.ProfilingData?, startSystemTime: UInt64) {
         guard let context = activeProfilingContext else {
-            SentrySDKLog.debug("AppHangTracker: stopProfilingIfNeeded — no active context")
             return (nil, nil, 0)
         }
         activeProfilingContext = nil
-
         context.sampleTimer?.cancel()
 
         if context.isUsingContinuousProfiler {
-            SentrySDKLog.debug("AppHangTracker: Stopped profiling (continuous profiler path, profilerId=\(context.profilerId.sentryIdString))")
             return (context.profilerId, nil, context.startSystemTime)
         }
 
-        let profilingData = context.accumulator?.toProfilingData()
-        SentrySDKLog.debug("AppHangTracker: Stopped profiling (custom sampling, profilerId=\(context.profilerId.sentryIdString), frames=\(profilingData?.frames.count ?? 0), stacks=\(profilingData?.stacks.count ?? 0), samples=\(profilingData?.samples.count ?? 0))")
+        let profilingData = accumulator.toProfilingData()
+        SentrySDKLog.debug("AppHangTracker: Stopped profiling (profilerId=\(context.profilerId.sentryIdString), frames=\(profilingData.frames.count), stacks=\(profilingData.stacks.count), samples=\(profilingData.samples.count))")
         return (context.profilerId, profilingData, context.startSystemTime)
-    }
-}
-
-// MARK: - SampleAccumulator
-
-final class SampleAccumulator {
-    private struct FrameKey: Hashable {
-        let instructionAddress: String?
-        let function: String?
-        let module: String?
-    }
-
-    private var frameIndex: [FrameKey: Int] = [:]
-    private var frames: [SentryAppHang.ProfilingData.Frame] = []
-    private var stackIndex: [[Int]: Int] = [:]
-    private var stacks: [[Int]] = []
-    private var samples: [SentryAppHang.ProfilingData.Sample] = []
-    private var threadMetadata: [String: SentryAppHang.ProfilingData.ThreadMetadata] = [:]
-
-    func appendSample(from threads: [SentryThread], timestamp: TimeInterval) {
-        for thread in threads {
-            let threadId = thread.threadId?.uint64Value ?? 0
-            let threadIdStr = "\(threadId)"
-
-            if threadMetadata[threadIdStr] == nil {
-                threadMetadata[threadIdStr] = .init(
-                    name: thread.name ?? "Thread \(threadId)",
-                    priority: 0
-                )
-            }
-
-            var frameIndices: [Int] = []
-            if let stacktrace = thread.stacktrace {
-                for frame in stacktrace.frames {
-                    let key = FrameKey(
-                        instructionAddress: frame.instructionAddress,
-                        function: frame.function,
-                        module: frame.module
-                    )
-                    let idx: Int
-                    if let existing = frameIndex[key] {
-                        idx = existing
-                    } else {
-                        idx = frames.count
-                        frameIndex[key] = idx
-                        frames.append(.init(
-                            instructionAddress: frame.instructionAddress,
-                            function: frame.function,
-                            module: frame.module
-                        ))
-                    }
-                    frameIndices.append(idx)
-                }
-            }
-
-            let stackIdx: Int
-            if let existing = stackIndex[frameIndices] {
-                stackIdx = existing
-            } else {
-                stackIdx = stacks.count
-                stackIndex[frameIndices] = stackIdx
-                stacks.append(frameIndices)
-            }
-
-            samples.append(.init(
-                timestamp: timestamp,
-                stackIndex: stackIdx,
-                threadId: threadId
-            ))
-        }
-    }
-
-    func toProfilingData() -> SentryAppHang.ProfilingData {
-        SentryAppHang.ProfilingData(
-            frames: frames,
-            stacks: stacks,
-            samples: samples,
-            threadMetadata: threadMetadata
-        )
     }
 }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
@@ -141,12 +141,10 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
         delay: SentryRunLoopDelay,
         entries: inout [UUID: ObserverEntry]
     ) -> [(SentryAppHangTrackerHandler, SentryAppHang)] {
-        let anyNeedsStart = entries.contains { _, entry in
-            delay.duration > entry.threshold && !entry.hasBeenNotified
-        }
-        guard anyNeedsStart else { return [] }
-
+        // Start profiling on the first ongoing delay, before any threshold is crossed.
+        // If the delay resolves before a threshold, the data is discarded in processEndedDelay.
         let context = startProfilingIfNeeded()
+
         var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []
 
         for (token, entry) in entries {
@@ -172,10 +170,14 @@ final class SentryDefaultAppHangTracker<Dependencies: SentryAppHangTrackerDepend
         entries: inout [UUID: ObserverEntry]
     ) -> [(SentryAppHangTrackerHandler, SentryAppHang)] {
         let anyNeedsEnd = entries.values.contains { $0.hasBeenNotified }
-        guard anyNeedsEnd else { return [] }
 
+        // Always stop profiling — it may have started before any threshold was crossed.
+        // If no observer was notified, the profiling data is discarded.
         let endTime = dateProvider.systemTime()
         let profilingResult = stopProfilingIfNeeded()
+
+        guard anyNeedsEnd else { return [] }
+
         SentrySDKLog.debug("AppHangTracker: Hang ended (duration=\(delay.duration)s), profilerId=\(profilingResult.profilerId?.sentryIdString ?? "nil"), sampleCount=\(profilingResult.profilingData?.samples.count ?? 0)")
 
         var result: [(SentryAppHangTrackerHandler, SentryAppHang)] = []

--- a/Sources/Swift/Integrations/AppHangTracking/SentryHangTrackingV3Integration.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryHangTrackingV3Integration.swift
@@ -51,11 +51,41 @@ final class SentryHangTrackingV3Integration<Dependencies: SentryHangTrackingV3In
             event.threads = [thread]
             event.exceptions = [exception]
 
+            if let profilerId = hang.profilerId {
+                SentrySDKLog.debug("Attaching profile (profilerId=\(profilerId.sentryIdString), hasProfilingData=\(hang.profilingData != nil))")
+                Self.attachProfile(
+                    to: event,
+                    profilerId: profilerId,
+                    profilingData: hang.profilingData,
+                    hub: dependencies.hub
+                )
+            }
+
             SentrySDKLog.debug("Capturing hang event (eventId=\(event.eventId.sentryIdString))")
             client.capture(event: event)
         }
 
         super.init()
+    }
+
+    private static func attachProfile(
+        to event: Event,
+        profilerId: SentryId,
+        profilingData: SentryAppHang.ProfilingData?,
+        hub: Hub
+    ) {
+        var contexts = event.context ?? [:]
+        contexts["profile"] = ["profiler_id": profilerId.sentryIdString]
+        event.context = contexts
+
+        guard let profilingData else { return }
+
+        guard let envelope = buildProfileChunkEnvelope(profilerId: profilerId, profilingData: profilingData, hub: hub) else {
+            SentrySDKLog.debug("Failed to build profile chunk envelope")
+            return
+        }
+
+        hub.captureEnvelope(envelope)
     }
 
     func uninstall() {
@@ -64,5 +94,82 @@ final class SentryHangTrackingV3Integration<Dependencies: SentryHangTrackingV3In
 
     static var name: String {
         "SentryHangTrackingV3Integration"
+    }
+}
+
+private func buildProfileChunkEnvelope(
+    profilerId: SentryId,
+    profilingData: SentryAppHang.ProfilingData,
+    hub: Hub
+) -> SentryEnvelope? {
+    let chunkId = SentryId()
+    let profileDict = profilingData.toDictionary()
+
+    var payload: [String: Any] = [:]
+    payload["version"] = "2"
+    payload["chunk_id"] = chunkId.sentryIdString
+    payload["profiler_id"] = profilerId.sentryIdString
+    payload["platform"] = "cocoa"
+    payload["profile"] = profileDict["profile"]
+
+    let options = hub.options
+    payload["environment"] = options.environment
+    payload["release"] = options.releaseName
+
+    payload["client_sdk"] = [
+        "name": SentryMeta.sdkName,
+        "version": SentryMeta.versionString
+    ]
+
+    let debugImages = SentryDependencyContainer.sharedInstance().debugImageProvider.getDebugImagesFromCache()
+    if !debugImages.isEmpty {
+        payload["debug_meta"] = [
+            "images": debugImages.map { $0.serialize() }
+        ]
+    }
+
+    guard let jsonData = SentrySerializationSwift.data(withJSONObject: payload) else {
+        SentrySDKLog.debug("Failed to serialize profile chunk payload to JSON")
+        return nil
+    }
+
+    let item = SentryEnvelopeItem(type: SentryEnvelopeItemTypes.profileChunk, data: jsonData, addPlatform: true)
+    return SentryEnvelope(id: chunkId, singleItem: item)
+}
+
+extension SentryAppHang.ProfilingData {
+    func toDictionary() -> [String: Any] {
+        let serializedFrames: [[String: Any]] = frames.map { frame in
+            var dict: [String: Any] = [:]
+            if let addr = frame.instructionAddress { dict["instruction_addr"] = addr }
+            if let function = frame.function { dict["function"] = function }
+            if let module = frame.module { dict["module"] = module }
+            return dict
+        }
+
+        let serializedStacks: [[NSNumber]] = stacks.map { stack in
+            stack.map { NSNumber(value: $0) }
+        }
+
+        let serializedSamples: [[String: Any]] = samples.map { sample in
+            [
+                "timestamp": NSNumber(value: sample.timestamp),
+                "thread_id": "\(sample.threadId)",
+                "stack_id": NSNumber(value: sample.stackIndex)
+            ]
+        }
+
+        let serializedThreadMetadata: [String: [String: Any]] = threadMetadata.mapValues { meta in
+            ["name": meta.name, "priority": NSNumber(value: meta.priority)]
+        }
+
+        return [
+            "profile": [
+                "frames": serializedFrames,
+                "stacks": serializedStacks,
+                "samples": serializedSamples,
+                "thread_metadata": serializedThreadMetadata
+            ]
+        ]
     }
 }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryHangTrackingV3Integration.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryHangTrackingV3Integration.swift
@@ -144,6 +144,9 @@ extension SentryAppHang.ProfilingData {
             if let addr = frame.instructionAddress { dict["instruction_addr"] = addr }
             if let function = frame.function { dict["function"] = function }
             if let module = frame.module { dict["module"] = module }
+            if let package = frame.package { dict["package"] = package }
+            if let imageAddress = frame.imageAddress { dict["image_addr"] = imageAddress }
+            if let inApp = frame.inApp { dict["in_app"] = inApp }
             return dict
         }
 

--- a/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
@@ -1,4 +1,6 @@
+#if DEBUG
 import Darwin.POSIX.dlfcn
+#endif
 
 struct SentryProfilingSampleAccumulator {
     private struct FrameKey: Hashable {
@@ -64,7 +66,11 @@ struct SentryProfilingSampleAccumulator {
         guard let stacktrace else { return [] }
         var indices: [Int] = []
         for frame in stacktrace.frames {
+            #if DEBUG
             let function = frame.function ?? resolveSymbolName(for: frame.instructionAddress)
+            #else
+            let function = frame.function
+            #endif
             let key = FrameKey(
                 instructionAddress: frame.instructionAddress,
                 function: function,
@@ -91,6 +97,7 @@ struct SentryProfilingSampleAccumulator {
         return indices
     }
 
+    #if DEBUG
     private func resolveSymbolName(for instructionAddress: String?) -> String? {
         guard let addressStr = instructionAddress,
               addressStr.hasPrefix("0x"),
@@ -101,6 +108,7 @@ struct SentryProfilingSampleAccumulator {
               let sname = info.dli_sname else { return nil }
         return String(cString: sname)
     }
+    #endif
 
     private mutating func deduplicateStack(_ frameIndices: [Int]) -> Int {
         if let existing = stackIndex[frameIndices] {

--- a/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
@@ -3,6 +3,8 @@ struct SentryProfilingSampleAccumulator {
         let instructionAddress: String?
         let function: String?
         let module: String?
+        let package: String?
+        let imageAddress: String?
     }
 
     private var frameIndex: [FrameKey: Int] = [:]
@@ -19,43 +21,13 @@ struct SentryProfilingSampleAccumulator {
 
             if threadMetadata[threadIdStr] == nil {
                 threadMetadata[threadIdStr] = .init(
-                    name: thread.name ?? "Thread \(threadId)",
+                    name: resolveThreadName(thread, threadId: threadId),
                     priority: 0
                 )
             }
 
-            var frameIndices: [Int] = []
-            if let stacktrace = thread.stacktrace {
-                for frame in stacktrace.frames {
-                    let key = FrameKey(
-                        instructionAddress: frame.instructionAddress,
-                        function: frame.function,
-                        module: frame.module
-                    )
-                    let idx: Int
-                    if let existing = frameIndex[key] {
-                        idx = existing
-                    } else {
-                        idx = frames.count
-                        frameIndex[key] = idx
-                        frames.append(.init(
-                            instructionAddress: frame.instructionAddress,
-                            function: frame.function,
-                            module: frame.module
-                        ))
-                    }
-                    frameIndices.append(idx)
-                }
-            }
-
-            let stackIdx: Int
-            if let existing = stackIndex[frameIndices] {
-                stackIdx = existing
-            } else {
-                stackIdx = stacks.count
-                stackIndex[frameIndices] = stackIdx
-                stacks.append(frameIndices)
-            }
+            let frameIndices = deduplicateFrames(from: thread.stacktrace)
+            let stackIdx = deduplicateStack(frameIndices)
 
             samples.append(.init(
                 timestamp: timestamp,
@@ -72,5 +44,55 @@ struct SentryProfilingSampleAccumulator {
             samples: samples,
             threadMetadata: threadMetadata
         )
+    }
+
+    private func resolveThreadName(_ thread: SentryThread, threadId: UInt64) -> String {
+        if let threadName = thread.name, !threadName.isEmpty {
+            return threadName
+        }
+        if thread.isMain?.boolValue == true {
+            return "main"
+        }
+        return "Thread \(threadId)"
+    }
+
+    private mutating func deduplicateFrames(from stacktrace: SentryStacktrace?) -> [Int] {
+        guard let stacktrace else { return [] }
+        var indices: [Int] = []
+        for frame in stacktrace.frames {
+            let key = FrameKey(
+                instructionAddress: frame.instructionAddress,
+                function: frame.function,
+                module: frame.module,
+                package: frame.package,
+                imageAddress: frame.imageAddress
+            )
+            if let existing = frameIndex[key] {
+                indices.append(existing)
+            } else {
+                let idx = frames.count
+                frameIndex[key] = idx
+                frames.append(.init(
+                    instructionAddress: frame.instructionAddress,
+                    function: frame.function,
+                    module: frame.module,
+                    package: frame.package,
+                    imageAddress: frame.imageAddress,
+                    inApp: frame.inApp?.boolValue
+                ))
+                indices.append(idx)
+            }
+        }
+        return indices
+    }
+
+    private mutating func deduplicateStack(_ frameIndices: [Int]) -> Int {
+        if let existing = stackIndex[frameIndices] {
+            return existing
+        }
+        let idx = stacks.count
+        stackIndex[frameIndices] = idx
+        stacks.append(frameIndices)
+        return idx
     }
 }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
@@ -1,3 +1,5 @@
+import Darwin.POSIX.dlfcn
+
 struct SentryProfilingSampleAccumulator {
     private struct FrameKey: Hashable {
         let instructionAddress: String?
@@ -60,9 +62,10 @@ struct SentryProfilingSampleAccumulator {
         guard let stacktrace else { return [] }
         var indices: [Int] = []
         for frame in stacktrace.frames {
+            let function = frame.function ?? resolveSymbolName(for: frame.instructionAddress)
             let key = FrameKey(
                 instructionAddress: frame.instructionAddress,
-                function: frame.function,
+                function: function,
                 module: frame.module,
                 package: frame.package,
                 imageAddress: frame.imageAddress
@@ -74,7 +77,7 @@ struct SentryProfilingSampleAccumulator {
                 frameIndex[key] = idx
                 frames.append(.init(
                     instructionAddress: frame.instructionAddress,
-                    function: frame.function,
+                    function: function,
                     module: frame.module,
                     package: frame.package,
                     imageAddress: frame.imageAddress,
@@ -84,6 +87,17 @@ struct SentryProfilingSampleAccumulator {
             }
         }
         return indices
+    }
+
+    private func resolveSymbolName(for instructionAddress: String?) -> String? {
+        guard let addressStr = instructionAddress,
+              addressStr.hasPrefix("0x"),
+              let addr = UInt(addressStr.dropFirst(2), radix: 16),
+              addr != 0 else { return nil }
+        var info = Dl_info()
+        guard dladdr(UnsafeRawPointer(bitPattern: addr), &info) != 0,
+              let sname = info.dli_sname else { return nil }
+        return String(cString: sname)
     }
 
     private mutating func deduplicateStack(_ frameIndices: [Int]) -> Int {

--- a/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
@@ -1,0 +1,76 @@
+struct SentryProfilingSampleAccumulator {
+    private struct FrameKey: Hashable {
+        let instructionAddress: String?
+        let function: String?
+        let module: String?
+    }
+
+    private var frameIndex: [FrameKey: Int] = [:]
+    private var frames: [SentryAppHang.ProfilingData.Frame] = []
+    private var stackIndex: [[Int]: Int] = [:]
+    private var stacks: [[Int]] = []
+    private var samples: [SentryAppHang.ProfilingData.Sample] = []
+    private var threadMetadata: [String: SentryAppHang.ProfilingData.ThreadMetadata] = [:]
+
+    mutating func appendSample(from threads: [SentryThread], timestamp: TimeInterval) {
+        for thread in threads {
+            let threadId = thread.threadId?.uint64Value ?? 0
+            let threadIdStr = "\(threadId)"
+
+            if threadMetadata[threadIdStr] == nil {
+                threadMetadata[threadIdStr] = .init(
+                    name: thread.name ?? "Thread \(threadId)",
+                    priority: 0
+                )
+            }
+
+            var frameIndices: [Int] = []
+            if let stacktrace = thread.stacktrace {
+                for frame in stacktrace.frames {
+                    let key = FrameKey(
+                        instructionAddress: frame.instructionAddress,
+                        function: frame.function,
+                        module: frame.module
+                    )
+                    let idx: Int
+                    if let existing = frameIndex[key] {
+                        idx = existing
+                    } else {
+                        idx = frames.count
+                        frameIndex[key] = idx
+                        frames.append(.init(
+                            instructionAddress: frame.instructionAddress,
+                            function: frame.function,
+                            module: frame.module
+                        ))
+                    }
+                    frameIndices.append(idx)
+                }
+            }
+
+            let stackIdx: Int
+            if let existing = stackIndex[frameIndices] {
+                stackIdx = existing
+            } else {
+                stackIdx = stacks.count
+                stackIndex[frameIndices] = stackIdx
+                stacks.append(frameIndices)
+            }
+
+            samples.append(.init(
+                timestamp: timestamp,
+                stackIndex: stackIdx,
+                threadId: threadId
+            ))
+        }
+    }
+
+    func toProfilingData() -> SentryAppHang.ProfilingData {
+        SentryAppHang.ProfilingData(
+            frames: frames,
+            stacks: stacks,
+            samples: samples,
+            threadMetadata: threadMetadata
+        )
+    }
+}

--- a/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryProfilingSampleAccumulator.swift
@@ -29,7 +29,9 @@ struct SentryProfilingSampleAccumulator {
             }
 
             let frameIndices = deduplicateFrames(from: thread.stacktrace)
-            let stackIdx = deduplicateStack(frameIndices)
+            // SentryStacktrace orders frames caller-to-callee (root-first),
+            // but profile V2 format expects leaf-first (matching the continuous profiler).
+            let stackIdx = deduplicateStack(Array(frameIndices.reversed()))
 
             samples.append(.init(
                 timestamp: timestamp,

--- a/Sources/Swift/SentryAppHangsOptions.swift
+++ b/Sources/Swift/SentryAppHangsOptions.swift
@@ -16,4 +16,7 @@ public struct AppHangsOptions {
 
     /// Duration before classifying as an app hang and reporting an event
     public var threshold: TimeInterval = 2.0
+
+    /// Interval in milliseconds between profiling samples during a hang.
+    public var profilingSampleIntervalMs: Int = 100
 }

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -170,7 +170,12 @@ extension SentryFileManager: SentryFileManagerProtocol { }
         SentryDefaultRunLoopDelayTracker(dependencies: self)
     }()
     lazy var appHangTracker: SentryAppHangTracker = {
-        SentryDefaultAppHangTracker(dependencies: self)
+        let sdkOptions = SentrySDKInternal.currentHub().getClient()?.getOptions() as? Options
+        let hangOptions = sdkOptions?.experimental.appHangs
+        let profilingOptions = SentryDefaultAppHangTracker<SentryDependencyContainer>.Options(
+            sampleIntervalMs: hangOptions?.profilingSampleIntervalMs ?? 100
+        )
+        return SentryDefaultAppHangTracker(dependencies: self, profilingOptions: profilingOptions)
     }()
 
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryAppHangsOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryAppHangsOptionsTests.swift
@@ -24,4 +24,17 @@ final class SentryAppHangsOptionsTests: XCTestCase {
         options.threshold = 10.0
         XCTAssertEqual(options.threshold, 10.0)
     }
+
+    // MARK: - Profiling Options
+
+    func testProfilingSampleIntervalMs_default_shouldBe100() {
+        let options = AppHangsOptions()
+        XCTAssertEqual(options.profilingSampleIntervalMs, 100)
+    }
+
+    func testProfilingSampleIntervalMs_canBeSet() {
+        var options = AppHangsOptions()
+        options.profilingSampleIntervalMs = 50
+        XCTAssertEqual(options.profilingSampleIntervalMs, 50)
+    }
 }

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
@@ -572,7 +572,9 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
 
     func testHangEnded_withProfiling_shouldIncludeProfilingData() throws {
         let delayTracker = MockSentryRunLoopDelayTracker()
-        let deps = MockDependencies(runLoopDelayTracker: delayTracker)
+        let inspector = TestThreadInspector.instance
+        inspector.allThreads = [TestData.thread]
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker, threadInspector: inspector)
         let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
         let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
         let callbacks = Invocations<SentryAppHang>()
@@ -652,6 +654,75 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
         )
     }
 
+    func testHangEnded_withProfiling_framesShouldIncludePackageAndInApp() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let inspector = TestThreadInspector.instance
+        inspector.allThreads = [TestData.thread]
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker, threadInspector: inspector)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let startedExpectation = expectation(description: "Started")
+        let endedExpectation = expectation(description: "Ended")
+        let token = sut.addObserver(threshold: 0.25) { hang in
+            callbacks.record(hang)
+            switch hang.state {
+            case .started: startedExpectation.fulfill()
+            case .ended: endedExpectation.fulfill()
+            }
+        }
+        defer { sut.removeObserver(token: token) }
+
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        wait(for: [startedExpectation], timeout: 1)
+        delayTracker.simulateDelay(duration: 1.0, ongoing: false)
+        wait(for: [endedExpectation], timeout: 1)
+
+        let profilingData = try XCTUnwrap(callbacks.get(1)?.profilingData)
+        XCTAssertGreaterThan(profilingData.frames.count, 0)
+
+        let frame = profilingData.frames[0]
+        XCTAssertNotNil(frame.package, "Frame should include package from SentryFrame")
+        XCTAssertNotNil(frame.inApp, "Frame should include inApp from SentryFrame")
+        XCTAssertNotNil(frame.imageAddress, "Frame should include imageAddress from SentryFrame")
+    }
+
+    func testHangEnded_withProfiling_threadMetadataShouldUseMainForMainThread() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let inspector = TestThreadInspector.instance
+        let mainThread = SentryThread(threadId: NSNumber(value: 0))
+        mainThread.name = nil
+        mainThread.isMain = NSNumber(value: true)
+        mainThread.crashed = NSNumber(value: false)
+        mainThread.current = NSNumber(value: false)
+        mainThread.stacktrace = TestData.thread.stacktrace
+        inspector.allThreads = [mainThread]
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker, threadInspector: inspector)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let startedExpectation = expectation(description: "Started")
+        let endedExpectation = expectation(description: "Ended")
+        let token = sut.addObserver(threshold: 0.25) { hang in
+            callbacks.record(hang)
+            switch hang.state {
+            case .started: startedExpectation.fulfill()
+            case .ended: endedExpectation.fulfill()
+            }
+        }
+        defer { sut.removeObserver(token: token) }
+
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        wait(for: [startedExpectation], timeout: 1)
+        delayTracker.simulateDelay(duration: 1.0, ongoing: false)
+        wait(for: [endedExpectation], timeout: 1)
+
+        let profilingData = try XCTUnwrap(callbacks.get(1)?.profilingData)
+        let threadId = "\(mainThread.threadId?.uint64Value ?? 0)"
+        let metadata = try XCTUnwrap(profilingData.threadMetadata[threadId])
+        XCTAssertEqual(metadata.name, "main", "Main thread should be named 'main' even when SentryThread.name is nil")
+    }
+
     func testAddObserver_afterAllRemovedAndStopped_shouldStartFreshTracking() throws {
         // -- Arrange --
         let delayTracker = MockSentryRunLoopDelayTracker()
@@ -699,9 +770,14 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
 
 private struct MockDependencies: SentryAppHangTrackerDependencies {
     let runLoopDelayTracker: SentryRunLoopDelayTracker
-    var threadInspector: SentryThreadInspector { SentryThreadInspector(options: nil) }
+    let threadInspector: SentryThreadInspector
     var dateProvider: SentryCurrentDateProvider { TestCurrentDateProvider() }
     var dispatchFactory: SentryDispatchFactory { SentryDispatchFactory() }
+
+    init(runLoopDelayTracker: SentryRunLoopDelayTracker, threadInspector: SentryThreadInspector? = nil) {
+        self.runLoopDelayTracker = runLoopDelayTracker
+        self.threadInspector = threadInspector ?? SentryThreadInspector(options: nil)
+    }
 }
 
 private class MockSentryRunLoopDelayTracker: SentryRunLoopDelayTracker {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
@@ -723,6 +723,64 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
         XCTAssertEqual(metadata.name, "main", "Main thread should be named 'main' even when SentryThread.name is nil")
     }
 
+    func testProfiling_shouldStartBeforeThresholdIsCrossed() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let inspector = TestThreadInspector.instance
+        inspector.allThreads = [TestData.thread]
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker, threadInspector: inspector)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let startedExpectation = expectation(description: "Started")
+        let endedExpectation = expectation(description: "Ended")
+        let token = sut.addObserver(threshold: 2.0) { hang in
+            callbacks.record(hang)
+            switch hang.state {
+            case .started: startedExpectation.fulfill()
+            case .ended: endedExpectation.fulfill()
+            }
+        }
+        defer { sut.removeObserver(token: token) }
+
+        // Simulate delays below threshold — profiling should already be running
+        delayTracker.simulateDelay(duration: 0.1, ongoing: true)
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        delayTracker.simulateDelay(duration: 1.0, ongoing: true)
+
+        // Now cross the threshold
+        delayTracker.simulateDelay(duration: 2.5, ongoing: true)
+        wait(for: [startedExpectation], timeout: 1)
+
+        delayTracker.simulateDelay(duration: 3.0, ongoing: false)
+        wait(for: [endedExpectation], timeout: 1)
+
+        let endedHang = try XCTUnwrap(callbacks.get(1))
+        let profilingData = try XCTUnwrap(endedHang.profilingData)
+        XCTAssertGreaterThan(profilingData.samples.count, 0, "Should have samples from before the threshold was crossed")
+    }
+
+    func testProfiling_shouldDiscardDataWhenDelayEndsBelowThreshold() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let inspector = TestThreadInspector.instance
+        inspector.allThreads = [TestData.thread]
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker, threadInspector: inspector)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let token = sut.addObserver(threshold: 2.0) { hang in
+            callbacks.record(hang)
+        }
+        defer { sut.removeObserver(token: token) }
+
+        // Delay starts but resolves before threshold
+        delayTracker.simulateDelay(duration: 0.1, ongoing: true)
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        delayTracker.simulateDelay(duration: 1.0, ongoing: false)
+
+        // No observer should be notified — profiling data should be discarded
+        XCTAssertTrue(callbacks.isEmpty, "Observer should not be notified for sub-threshold delays")
+    }
+
     func testAddObserver_afterAllRemovedAndStopped_shouldStartFreshTracking() throws {
         // -- Arrange --
         let delayTracker = MockSentryRunLoopDelayTracker()

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
@@ -547,6 +547,111 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
         wait(for: [backgroundDone], timeout: 10)
     }
 
+    // MARK: - Profiling Tests
+
+    func testHangStarted_withProfiling_shouldIncludeProfilerId() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let expectation = expectation(description: "Observer notified")
+        let token = sut.addObserver(threshold: 0.25) { hang in
+            callbacks.record(hang)
+            expectation.fulfill()
+        }
+        defer { sut.removeObserver(token: token) }
+
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        wait(for: [expectation], timeout: 1)
+
+        let hang = try XCTUnwrap(callbacks.first)
+        XCTAssertEqual(hang.state, .started)
+        XCTAssertNotNil(hang.profilerId, "Started hang should include a profilerId when profiling is enabled")
+    }
+
+    func testHangEnded_withProfiling_shouldIncludeProfilingData() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+        let callbacks = Invocations<SentryAppHang>()
+        let startedExpectation = expectation(description: "Started")
+        let endedExpectation = expectation(description: "Ended")
+        let token = sut.addObserver(threshold: 0.25) { hang in
+            callbacks.record(hang)
+            switch hang.state {
+            case .started: startedExpectation.fulfill()
+            case .ended: endedExpectation.fulfill()
+            }
+        }
+        defer { sut.removeObserver(token: token) }
+
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        wait(for: [startedExpectation], timeout: 1)
+        delayTracker.simulateDelay(duration: 1.0, ongoing: false)
+        wait(for: [endedExpectation], timeout: 1)
+
+        let endedHang = try XCTUnwrap(callbacks.get(1))
+        XCTAssertEqual(endedHang.state, .ended)
+        XCTAssertNotNil(endedHang.profilerId)
+        XCTAssertNotNil(endedHang.profilingData, "Ended hang should include profiling data")
+        XCTAssertGreaterThan(endedHang.profilingData?.samples.count ?? 0, 0, "Should have at least one sample")
+    }
+
+    func testHangEnded_withTwoObservers_bothReceiveProfilingData() throws {
+        let delayTracker = MockSentryRunLoopDelayTracker()
+        let deps = MockDependencies(runLoopDelayTracker: delayTracker)
+        let options = SentryDefaultAppHangTracker<MockDependencies>.Options(sampleIntervalMs: 100)
+        let sut = SentryDefaultAppHangTracker(dependencies: deps, profilingOptions: options)
+
+        let callbacksA = Invocations<SentryAppHang>()
+        let callbacksB = Invocations<SentryAppHang>()
+        let startedA = expectation(description: "Observer A started")
+        let endedA = expectation(description: "Observer A ended")
+        let startedB = expectation(description: "Observer B started")
+        let endedB = expectation(description: "Observer B ended")
+
+        let tokenA = sut.addObserver(threshold: 0.25) { hang in
+            callbacksA.record(hang)
+            switch hang.state {
+            case .started: startedA.fulfill()
+            case .ended: endedA.fulfill()
+            }
+        }
+        let tokenB = sut.addObserver(threshold: 0.25) { hang in
+            callbacksB.record(hang)
+            switch hang.state {
+            case .started: startedB.fulfill()
+            case .ended: endedB.fulfill()
+            }
+        }
+        defer {
+            sut.removeObserver(token: tokenA)
+            sut.removeObserver(token: tokenB)
+        }
+
+        delayTracker.simulateDelay(duration: 0.5, ongoing: true)
+        wait(for: [startedA, startedB], timeout: 1)
+
+        delayTracker.simulateDelay(duration: 1.0, ongoing: false)
+        wait(for: [endedA, endedB], timeout: 1)
+
+        let endedHangA = try XCTUnwrap(callbacksA.get(1))
+        let endedHangB = try XCTUnwrap(callbacksB.get(1))
+
+        XCTAssertNotNil(endedHangA.profilerId, "Observer A should receive profilerId")
+        XCTAssertNotNil(endedHangB.profilerId, "Observer B should receive profilerId")
+        XCTAssertNotNil(endedHangA.profilingData, "Observer A should receive profiling data")
+        XCTAssertNotNil(endedHangB.profilingData, "Observer B should receive profiling data")
+
+        XCTAssertEqual(
+            endedHangA.profilerId?.sentryIdString,
+            endedHangB.profilerId?.sentryIdString,
+            "Both observers should share the same profilerId"
+        )
+    }
+
     func testAddObserver_afterAllRemovedAndStopped_shouldStartFreshTracking() throws {
         // -- Arrange --
         let delayTracker = MockSentryRunLoopDelayTracker()
@@ -594,6 +699,8 @@ final class SentryDefaultAppHangTrackerTests: XCTestCase {
 
 private struct MockDependencies: SentryAppHangTrackerDependencies {
     let runLoopDelayTracker: SentryRunLoopDelayTracker
+    var threadInspector: SentryThreadInspector { SentryThreadInspector(options: nil) }
+    var dateProvider: SentryCurrentDateProvider { TestCurrentDateProvider() }
 }
 
 private class MockSentryRunLoopDelayTracker: SentryRunLoopDelayTracker {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
@@ -701,6 +701,7 @@ private struct MockDependencies: SentryAppHangTrackerDependencies {
     let runLoopDelayTracker: SentryRunLoopDelayTracker
     var threadInspector: SentryThreadInspector { SentryThreadInspector(options: nil) }
     var dateProvider: SentryCurrentDateProvider { TestCurrentDateProvider() }
+    var dispatchFactory: SentryDispatchFactory { SentryDispatchFactory() }
 }
 
 private class MockSentryRunLoopDelayTracker: SentryRunLoopDelayTracker {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingV3IntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingV3IntegrationTests.swift
@@ -280,7 +280,8 @@ final class SentryHangTrackingV3IntegrationTests: XCTestCase {
     func testProfilingData_toDictionary_serializesFrames() throws {
         let data = SentryAppHang.ProfilingData(
             frames: [
-                .init(instructionAddress: "0x1", function: "foo", module: "Bar"),
+                .init(instructionAddress: "0x1", function: "foo", module: "Bar",
+                      package: "sentrytest", imageAddress: "0x100000", inApp: true),
                 .init(instructionAddress: nil, function: nil, module: nil)
             ],
             stacks: [[0, 1]],
@@ -296,6 +297,9 @@ final class SentryHangTrackingV3IntegrationTests: XCTestCase {
         XCTAssertEqual(frames[0]["instruction_addr"] as? String, "0x1")
         XCTAssertEqual(frames[0]["function"] as? String, "foo")
         XCTAssertEqual(frames[0]["module"] as? String, "Bar")
+        XCTAssertEqual(frames[0]["package"] as? String, "sentrytest")
+        XCTAssertEqual(frames[0]["image_addr"] as? String, "0x100000")
+        XCTAssertEqual(frames[0]["in_app"] as? Bool, true)
         XCTAssertTrue(frames[1].isEmpty)
     }
 

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingV3IntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingV3IntegrationTests.swift
@@ -23,7 +23,8 @@ final class SentryHangTrackingV3IntegrationTests: XCTestCase {
     private func makeSUT(
         enableV3: Bool = true,
         includeClient: Bool = true,
-        extensionIdentifier: String? = nil
+        extensionIdentifier: String? = nil,
+        hub: Hub? = nil
     ) -> SentryHangTrackingV3Integration<MockIntegrationDependencies>? {
         let options = Options()
         options.experimental.appHangs.enableV3 = enableV3
@@ -45,7 +46,7 @@ final class SentryHangTrackingV3IntegrationTests: XCTestCase {
         let deps = MockIntegrationDependencies(
             appHangTracker: mockTracker,
             client: includeClient ? testClient : nil,
-            hub: StubHub(),
+            hub: hub ?? StubHub(),
             extensionDetector: SentryExtensionDetector(infoPlistWrapper: infoPlistWrapper)
         )
         return SentryHangTrackingV3Integration(with: options, dependencies: deps)
@@ -153,6 +154,170 @@ final class SentryHangTrackingV3IntegrationTests: XCTestCase {
         XCTAssertTrue(testClient.captureEventInvocations.isEmpty)
     }
 
+    // MARK: - Profiling Context Tests
+
+    func testHangEnded_withProfilerId_setsProfileContextOnEvent() throws {
+        let stubHub = SpyHub()
+        let sut = makeSUT(hub: stubHub)
+        _ = sut
+
+        let profilerId = SentryId()
+        let hang = SentryAppHang(
+            duration: 2.0,
+            state: .ended,
+            profilerId: profilerId,
+            profilingData: nil,
+            startSystemTime: 1_000,
+            endSystemTime: 2_000
+        )
+        mockTracker.simulateHang(hang)
+
+        let event = try XCTUnwrap(testClient.captureEventInvocations.last)
+        let profileContext = try XCTUnwrap(event.context?["profile"] as? [String: Any])
+        XCTAssertEqual(profileContext["profiler_id"] as? String, profilerId.sentryIdString)
+    }
+
+    func testHangEnded_withoutProfilerId_doesNotSetProfileContext() throws {
+        let sut = makeSUT()
+        _ = sut
+
+        let hang = SentryAppHang(duration: 2.0, state: .ended)
+        mockTracker.simulateHang(hang)
+
+        let event = try XCTUnwrap(testClient.captureEventInvocations.last)
+        XCTAssertNil(event.context?["profile"])
+    }
+
+    func testHangEnded_withProfilingData_sendsProfileChunkEnvelope() throws {
+        let stubHub = SpyHub()
+        let sut = makeSUT(hub: stubHub)
+        _ = sut
+
+        let profilerId = SentryId()
+        let profilingData = SentryAppHang.ProfilingData(
+            frames: [
+                .init(instructionAddress: "0x1234", function: "main", module: "App")
+            ],
+            stacks: [[0]],
+            samples: [
+                .init(timestamp: 1_724_777_211.503, stackIndex: 0, threadId: 123)
+            ],
+            threadMetadata: ["123": .init(name: "main", priority: 31)]
+        )
+        let hang = SentryAppHang(
+            duration: 2.0,
+            state: .ended,
+            profilerId: profilerId,
+            profilingData: profilingData,
+            startSystemTime: 1_000,
+            endSystemTime: 2_000
+        )
+        mockTracker.simulateHang(hang)
+
+        XCTAssertEqual(stubHub.capturedEnvelopes.count, 1)
+        let envelope = try XCTUnwrap(stubHub.capturedEnvelopes.first)
+        XCTAssertEqual(envelope.items.count, 1)
+        XCTAssertEqual(envelope.items.first?.header.type, SentryEnvelopeItemTypes.profileChunk)
+    }
+
+    func testHangEnded_withProfilerIdButNoData_doesNotSendEnvelope() throws {
+        let stubHub = SpyHub()
+        let sut = makeSUT(hub: stubHub)
+        _ = sut
+
+        let hang = SentryAppHang(
+            duration: 2.0,
+            state: .ended,
+            profilerId: SentryId(),
+            profilingData: nil,
+            startSystemTime: 1_000,
+            endSystemTime: 2_000
+        )
+        mockTracker.simulateHang(hang)
+
+        XCTAssertTrue(stubHub.capturedEnvelopes.isEmpty)
+    }
+
+    func testProfileChunkEnvelope_containsExpectedPayload() throws {
+        let stubHub = SpyHub()
+        let sut = makeSUT(hub: stubHub)
+        _ = sut
+
+        let profilerId = SentryId()
+        let profilingData = SentryAppHang.ProfilingData(
+            frames: [
+                .init(instructionAddress: "0xABCD", function: "doWork", module: "MyApp")
+            ],
+            stacks: [[0]],
+            samples: [
+                .init(timestamp: 1_724_777_215.123, stackIndex: 0, threadId: 42)
+            ],
+            threadMetadata: ["42": .init(name: "main", priority: 31)]
+        )
+        let hang = SentryAppHang(
+            duration: 2.0,
+            state: .ended,
+            profilerId: profilerId,
+            profilingData: profilingData,
+            startSystemTime: 1_000,
+            endSystemTime: 2_000
+        )
+        mockTracker.simulateHang(hang)
+
+        let envelope = try XCTUnwrap(stubHub.capturedEnvelopes.first)
+        let itemData = try XCTUnwrap(envelope.items.first?.data)
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: itemData) as? [String: Any])
+
+        XCTAssertEqual(payload["version"] as? String, "2")
+        XCTAssertEqual(payload["profiler_id"] as? String, profilerId.sentryIdString)
+        XCTAssertEqual(payload["platform"] as? String, "cocoa")
+        XCTAssertNotNil(payload["chunk_id"])
+        XCTAssertNotNil(payload["profile"])
+    }
+
+    // MARK: - ProfilingData Serialization Tests
+
+    func testProfilingData_toDictionary_serializesFrames() throws {
+        let data = SentryAppHang.ProfilingData(
+            frames: [
+                .init(instructionAddress: "0x1", function: "foo", module: "Bar"),
+                .init(instructionAddress: nil, function: nil, module: nil)
+            ],
+            stacks: [[0, 1]],
+            samples: [.init(timestamp: 1_724_777_211.503, stackIndex: 0, threadId: 1)],
+            threadMetadata: [:]
+        )
+
+        let dict = data.toDictionary()
+        let profile = try XCTUnwrap(dict["profile"] as? [String: Any])
+        let frames = try XCTUnwrap(profile["frames"] as? [[String: Any]])
+
+        XCTAssertEqual(frames.count, 2)
+        XCTAssertEqual(frames[0]["instruction_addr"] as? String, "0x1")
+        XCTAssertEqual(frames[0]["function"] as? String, "foo")
+        XCTAssertEqual(frames[0]["module"] as? String, "Bar")
+        XCTAssertTrue(frames[1].isEmpty)
+    }
+
+    func testProfilingData_toDictionary_serializesSamples() throws {
+        let data = SentryAppHang.ProfilingData(
+            frames: [.init(instructionAddress: "0x1", function: "f", module: "M")],
+            stacks: [[0]],
+            samples: [.init(timestamp: 1_724_777_213.000, stackIndex: 0, threadId: 99)],
+            threadMetadata: [:]
+        )
+
+        let dict = data.toDictionary()
+        let profile = try XCTUnwrap(dict["profile"] as? [String: Any])
+        let samples = try XCTUnwrap(profile["samples"] as? [[String: Any]])
+
+        XCTAssertEqual(samples.count, 1)
+        XCTAssertEqual(samples[0]["thread_id"] as? String, "99")
+        XCTAssertEqual(samples[0]["stack_id"] as? NSNumber, NSNumber(value: 0))
+        let timestamp = try XCTUnwrap((samples[0]["timestamp"] as? NSNumber)?.doubleValue)
+        XCTAssertEqual(timestamp, 1_724_777_213.000, accuracy: 0.001)
+    }
+
     // MARK: - Name Tests
 
     func testName_shouldReturnCorrectName() {
@@ -189,6 +354,17 @@ private struct StubHub: Hub {
     func configureScope(_ callback: @escaping (Scope) -> Void) {}
     func storeEnvelope(_ envelope: SentryEnvelope) {}
     func captureEnvelope(_ envelope: SentryEnvelope) {}
+    func setTrace(_ traceId: SentryId, spanId: SpanId) {}
+    var options: Options { Options() }
+}
+
+private class SpyHub: Hub {
+    var capturedEnvelopes = [SentryEnvelope]()
+    func configureScope(_ callback: @escaping (Scope) -> Void) {}
+    func storeEnvelope(_ envelope: SentryEnvelope) {}
+    func captureEnvelope(_ envelope: SentryEnvelope) {
+        capturedEnvelopes.append(envelope)
+    }
     func setTrace(_ traceId: SentryId, spanId: SpanId) {}
     var options: Options { Options() }
 }


### PR DESCRIPTION
## :scroll: Description

Add stack trace sampling during app hangs to provide flamechart context in Sentry. When a hang is detected, the tracker collects thread stack traces at configurable intervals, deduplicates frames/stacks, and sends a `profile_chunk` envelope item in V2 format linked to the hang event via `contexts.profile.profiler_id`.

Frames include `instruction_addr`, `package`, `image_addr`, and `in_app` — matching what `SentryCrashStackEntryMapper` provides and giving the backend full context for symbolication and in-app filtering. Thread metadata captures real pthread names (e.g., "main", "com.apple.uikit.eventfetch-thread") and falls back to "main" for `isMain` threads when the pthread name is empty.

## :bulb: Motivation and Context

App hang events currently lack profiling context — users see that a hang occurred but can't inspect the flamechart to understand what code was running. This adds lightweight profiling (via `SentryProfilingSampleAccumulator`) that piggybacks on the existing V3 hang tracker, or falls back to the continuous profiler when available.

Reference: https://github.com/getsentry/sentry-cocoa/pull/8117

### Design Decisions

**Sampling via `DispatchSource` timer (not `sigprof`)**
The existing continuous profiler uses `sigprof`-based signal sampling via the C++ `SentryProfiler` infrastructure. We intentionally chose a `SentryDispatchSourceWrapper` timer with `SentryThreadInspector.getCurrentThreadsWithStackTrace()` instead because:
- Only one `sigprof` handler can exist per process — using it here would conflict with the continuous profiler when both are active.
- App hangs last seconds; the overhead difference between sigprof and thread-inspector sampling at 100ms intervals is negligible for this use case.
- Keeps the implementation in pure Swift, avoiding coupling to the C++ profiler lifecycle.

When the continuous profiler is already running, we piggyback on its profiler ID and skip custom sampling entirely.

**Own Swift serialization (not reusing C++ `sentry_continuousProfileChunkEnvelope`)**
The existing C++ serializer expects `SentryProfilerState` data (`SentryBacktrace` structs). Our accumulator produces Swift structs (`SentryAppHang.ProfilingData`). Bridging between the two would add more complexity than serializing the V2 JSON directly. Both produce the same wire format (`frames`, `stacks`, `samples`, `thread_metadata`), and the Swift path is covered by unit tests that validate the V2 shape field-by-field.

**Frame data matches `SentryCrashStackEntryMapper` output**
Our frames include `instruction_addr`, `package`, `image_addr`, and `in_app` — the same fields `SentryCrashStackEntryMapper.sentryCrashStackEntryToSentryFrame:` populates. The continuous profiler only sends `instruction_addr` in its frames; we send richer data because `SentryThreadInspector` already provides it. Function names and symbols are resolved server-side via symbolication using `image_addr` + `instruction_addr`.

**Thread name resolution**
Thread metadata uses the pthread name when available, falls back to "main" for `isMain` threads (matching the continuous profiler's `ThreadMetadataCache` behavior), and uses "Thread N" as a last resort. Priority is hardcoded to 0 because `SentryThread` doesn't expose thread priority — the continuous profiler gets it via C++ `pthread_getschedparam()` which isn't available through our Swift path.

## :green_heart: How did you test it?

- Unit tests for `SentryDefaultAppHangTracker` profiling (multi-observer, profiler lifecycle, frame completeness, thread metadata)
- Unit tests for `SentryHangTrackingV3Integration` (profile context, envelope building, serialization including new frame fields)
- Unit tests for `AppHangsOptions` (`profilingSampleIntervalMs`)
- Manual testing with Flinky app + Proxyman to verify envelope payloads include `package`, `image_addr`, `in_app` on frames and real thread names in metadata
- Verified event JSON via `sentry` CLI shows `contexts.profile.profiler_id` and server-side symbolication resolves function names

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
