### PR TITLE
ref: gate @objc on SentrySDK behind #if !SDK_V10

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+- Remove Objective-C `@objc` attributes from SentrySDK (#8308)

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -354,7 +354,8 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 {
     __block NSString *__nullable replayId;
 
-    [SentrySDK configureScope:^(SentryScope *_Nonnull scope) { replayId = scope.replayId; }];
+    [SentrySDKInternal
+        configureScope:^(SentryScope *_Nonnull scope) { replayId = scope.replayId; }];
 
     return replayId;
 }

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -495,7 +495,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
     breadcrumb.data = breadcrumbData;
-    [SentrySDK addBreadcrumb:breadcrumb];
+    [SentrySDKInternal addBreadcrumb:breadcrumb];
 
     objc_setAssociatedObject(sessionTask, &SENTRY_NETWORK_REQUEST_TRACKER_BREADCRUMB,
         [NSNumber numberWithBool:YES], OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -2,31 +2,51 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+#if SDK_V10
 /// The main entry point for the Sentry SDK.
 /// We recommend using `start(configureOptions:)` to initialize Sentry.
-@objc public final class SentrySDK: NSObject {
+public enum SentrySDK {}
+#else
+/// The main entry point for the Sentry SDK.
+/// We recommend using `start(configureOptions:)` to initialize Sentry.
+@objc public final class SentrySDK: NSObject {}
+#endif
+
+extension SentrySDK {
 
     // MARK: - Public
 
     /// The current active transaction or span bound to the scope.
-    @objc public static var span: Span? {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var span: Span? {
         return SentrySDKInternal.span
     }
 
     /// Indicates whether the Sentry SDK is enabled.
-    @objc public static var isEnabled: Bool {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var isEnabled: Bool {
         return SentrySDKInternal.isEnabled
     }
 
     #if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
     /// API to control session replay
-    @objc public static var replay: SentryReplayApi {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var replay: SentryReplayApi {
         return SentrySDKInternal.replay
     }
     #endif
 
     /// API to access Sentry logs
-    @objc public static var logger: SentryLogger {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var logger: SentryLogger {
         if !SentrySDKInternal.isEnabled {
             SentrySDKLog.fatal("Logs called before SentrySDK.start() will not be sent to Sentry.")
         }
@@ -85,12 +105,15 @@ import Foundation
     /// set a valid DSN.
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
-    @objc public static func start(options: Options) {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func start(options: Options) {
         // We save the options before checking for Xcode preview because
         // we will use this options in the preview
         setStart(with: options)
         guard SentryDependencyContainer.sharedInstance().processInfoWrapper
-                    .environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else {
+            .environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else {
             // Using NSLog because SentryLog was not initialized yet.
             NSLog("[SENTRY] [WARNING] SentrySDK not started. Running from Xcode preview.")
             return
@@ -102,7 +125,10 @@ import Foundation
     /// set a valid DSN.
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
-    @objc public static func start(configureOptions: @escaping (Options) -> Void) {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func start(configureOptions: @escaping (Options) -> Void) {
         let options = Options()
         configureOptions(options)
         start(options: options)
@@ -113,7 +139,9 @@ import Foundation
     /// Captures a manually created event and sends it to Sentry.
     /// - parameter event: The event to send to Sentry.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureEvent:)
+    #endif
     @discardableResult public static func capture(event: Event) -> SentryId {
         return SentrySDKInternal.capture(event: event)
     }
@@ -123,7 +151,9 @@ import Foundation
     /// - parameter event: The event to send to Sentry.
     /// - parameter scope: The scope containing event metadata.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureEvent:withScope:)
+    #endif
     @discardableResult public static func capture(event: Event, scope: Scope) -> SentryId {
         return SentrySDKInternal.capture(event: event, scope: scope)
     }
@@ -133,7 +163,9 @@ import Foundation
     /// - parameter event: The event to send to Sentry.
     /// - parameter block: The block mutating the scope only for this call.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureEvent:withScopeBlock:)
+    #endif
     @discardableResult public static func capture(event: Event, block: @escaping (Scope) -> Void) -> SentryId {
         return SentrySDKInternal.capture(event: event, block: block)
     }
@@ -144,7 +176,9 @@ import Foundation
     ///   - event: The event to send to Sentry.
     ///   - attachAllThreads: Whether to attach all threads with full stack traces. Overrides `Options.attachAllThreads`.
     /// - Returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureEvent:attachAllThreads:)
+    #endif
     @discardableResult public static func capture(event: Event, attachAllThreads: Bool) -> SentryId {
         event.attachAllThreadsOverride = NSNumber(value: attachAllThreads)
         return SentrySDKInternal.capture(event: event)
@@ -156,7 +190,10 @@ import Foundation
     /// - parameter name: The transaction name.
     /// - parameter operation: Short code identifying the type of operation the span is measuring.
     /// - returns: The created transaction.
-    @objc @discardableResult public static func startTransaction(name: String, operation: String) -> Span {
+    #if !SDK_V10
+    @objc
+    #endif
+    @discardableResult public static func startTransaction(name: String, operation: String) -> Span {
         return SentrySDKInternal.startTransaction(name: name, operation: operation)
     }
 
@@ -165,14 +202,19 @@ import Foundation
     /// - parameter operation: Short code identifying the type of operation the span is measuring.
     /// - parameter bindToScope: Indicates whether the SDK should bind the new transaction to the scope.
     /// - returns: The created transaction.
-    @objc @discardableResult public static func startTransaction(name: String, operation: String, bindToScope: Bool) -> Span {
+    #if !SDK_V10
+    @objc
+    #endif
+    @discardableResult public static func startTransaction(name: String, operation: String, bindToScope: Bool) -> Span {
         return SentrySDKInternal.startTransaction(name: name, operation: operation, bindToScope: bindToScope)
     }
 
     /// Creates a transaction, binds it to the hub and returns the instance.
     /// - parameter transactionContext: The transaction context.
     /// - returns: The created transaction.
+    #if !SDK_V10
     @objc(startTransactionWithContext:)
+    #endif
     @discardableResult public static func startTransaction(transactionContext: TransactionContext) -> Span {
         return SentrySDKInternal.startTransaction(transactionContext: transactionContext)
     }
@@ -181,7 +223,9 @@ import Foundation
     /// - parameter transactionContext: The transaction context.
     /// - parameter bindToScope: Indicates whether the SDK should bind the new transaction to the scope.
     /// - returns: The created transaction.
+    #if !SDK_V10
     @objc(startTransactionWithContext:bindToScope:)
+    #endif
     @discardableResult public static func startTransaction(transactionContext: TransactionContext, bindToScope: Bool) -> Span {
         return SentrySDKInternal.startTransaction(transactionContext: transactionContext, bindToScope: bindToScope)
     }
@@ -191,7 +235,9 @@ import Foundation
     /// - parameter bindToScope: Indicates whether the SDK should bind the new transaction to the scope.
     /// - parameter customSamplingContext: Additional information about the sampling context.
     /// - returns: The created transaction.
+    #if !SDK_V10
     @objc(startTransactionWithContext:bindToScope:customSamplingContext:)
+    #endif
     @discardableResult public static func startTransaction(transactionContext: TransactionContext, bindToScope: Bool, customSamplingContext: [String: Any]) -> Span {
         return SentrySDKInternal.startTransaction(transactionContext: transactionContext, bindToScope: bindToScope, customSamplingContext: customSamplingContext)
     }
@@ -200,7 +246,9 @@ import Foundation
     /// - parameter transactionContext: The transaction context.
     /// - parameter customSamplingContext: Additional information about the sampling context.
     /// - returns: The created transaction.
+    #if !SDK_V10
     @objc(startTransactionWithContext:customSamplingContext:)
+    #endif
     @discardableResult public static func startTransaction(transactionContext: TransactionContext, customSamplingContext: [String: Any]) -> Span {
         return SentrySDKInternal.startTransaction(transactionContext: transactionContext, customSamplingContext: customSamplingContext)
     }
@@ -210,7 +258,9 @@ import Foundation
     /// Captures an error event and sends it to Sentry.
     /// - parameter error: The error to send to Sentry.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureError:)
+    #endif
     @discardableResult public static func capture(error: Error) -> SentryId {
         return SentrySDKInternal.capture(error: error)
     }
@@ -220,7 +270,9 @@ import Foundation
     /// - parameter error: The error to send to Sentry.
     /// - parameter scope: The scope containing event metadata.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureError:withScope:)
+    #endif
     @discardableResult public static func capture(error: Error, scope: Scope) -> SentryId {
         return SentrySDKInternal.capture(error: error, scope: scope)
     }
@@ -230,7 +282,9 @@ import Foundation
     /// - parameter error: The error to send to Sentry.
     /// - parameter block: The block mutating the scope only for this call.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureError:withScopeBlock:)
+    #endif
     @discardableResult public static func capture(error: Error, block: @escaping (Scope) -> Void) -> SentryId {
         return SentrySDKInternal.capture(error: error, block: block)
     }
@@ -241,7 +295,9 @@ import Foundation
     ///   - error: The error to send to Sentry.
     ///   - attachAllThreads: Whether to attach all threads with full stack traces. Overrides `Options.attachAllThreads`.
     /// - Returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureError:attachAllThreads:)
+    #endif
     @discardableResult public static func capture(error: Error, attachAllThreads: Bool) -> SentryId {
         let hub = SentrySDKInternal.currentHub()
         return hub.captureError(error as NSError, with: hub.scope, attachAllThreads: NSNumber(value: attachAllThreads))
@@ -252,7 +308,9 @@ import Foundation
     /// Captures an exception event and sends it to Sentry.
     /// - parameter exception: The exception to send to Sentry.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureException:)
+    #endif
     @discardableResult public static func capture(exception: NSException) -> SentryId {
         return SentrySDKInternal.capture(exception: exception)
     }
@@ -262,7 +320,9 @@ import Foundation
     /// - parameter exception: The exception to send to Sentry.
     /// - parameter scope: The scope containing event metadata.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureException:withScope:)
+    #endif
     @discardableResult public static func capture(exception: NSException, scope: Scope) -> SentryId {
         return SentrySDKInternal.capture(exception: exception, scope: scope)
     }
@@ -272,7 +332,9 @@ import Foundation
     /// - parameter exception: The exception to send to Sentry.
     /// - parameter block: The block mutating the scope only for this call.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureException:withScopeBlock:)
+    #endif
     @discardableResult public static func capture(exception: NSException, block: @escaping (Scope) -> Void) -> SentryId {
         return SentrySDKInternal.capture(exception: exception, block: block)
     }
@@ -283,7 +345,9 @@ import Foundation
     ///   - exception: The exception to send to Sentry.
     ///   - attachAllThreads: Whether to attach all threads with full stack traces. Overrides `Options.attachAllThreads`.
     /// - Returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureException:attachAllThreads:)
+    #endif
     @discardableResult public static func capture(exception: NSException, attachAllThreads: Bool) -> SentryId {
         let hub = SentrySDKInternal.currentHub()
         return hub.capture(exception, with: hub.scope, attachAllThreads: NSNumber(value: attachAllThreads))
@@ -294,7 +358,9 @@ import Foundation
     /// Captures a message event and sends it to Sentry.
     /// - parameter message: The message to send to Sentry.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureMessage:)
+    #endif
     @discardableResult public static func capture(message: String) -> SentryId {
         return SentrySDKInternal.capture(message: message)
     }
@@ -304,7 +370,9 @@ import Foundation
     /// - parameter message: The message to send to Sentry.
     /// - parameter scope: The scope containing event metadata.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureMessage:withScope:)
+    #endif
     @discardableResult public static func capture(message: String, scope: Scope) -> SentryId {
         return SentrySDKInternal.capture(message: message, scope: scope)
     }
@@ -314,7 +382,9 @@ import Foundation
     /// - parameter message: The message to send to Sentry.
     /// - parameter block: The block mutating the scope only for this call.
     /// - returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureMessage:withScopeBlock:)
+    #endif
     @discardableResult public static func capture(message: String, block: @escaping (Scope) -> Void) -> SentryId {
         return SentrySDKInternal.capture(message: message, block: block)
     }
@@ -325,7 +395,9 @@ import Foundation
     ///   - message: The message to send to Sentry.
     ///   - attachAllThreads: Whether to attach all threads with full stack traces. Overrides `Options.attachAllThreads`.
     /// - Returns: The `SentryId` of the event or `SentryId.empty` if the event is not sent.
+    #if !SDK_V10
     @objc(captureMessage:attachAllThreads:)
+    #endif
     @discardableResult public static func capture(message: String, attachAllThreads: Bool) -> SentryId {
         let hub = SentrySDKInternal.currentHub()
         return hub.captureMessage(message, with: hub.scope, attachAllThreads: NSNumber(value: attachAllThreads))
@@ -339,7 +411,9 @@ import Foundation
     /// `SentrySDK.feedback.show()`, `SentrySDK.FeedbackForm`, or SwiftUI's
     /// `sentryFeedback(isPresented:)`. See https://docs.sentry.io/platforms/apple/user-feedback/
     /// for more information.
+    #if !SDK_V10
     @objc(captureFeedback:)
+    #endif
     public static func capture(feedback: SentryFeedback) {
       SentrySDKInternal.captureSerializedFeedback(
         feedback.serialize(),
@@ -357,7 +431,10 @@ import Foundation
     ///
     /// Use this to programmatically show the feedback form or access feedback-related functionality.
     @available(iOSApplicationExtension, unavailable)
-    @objc public static let feedback = {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static let feedback = {
       return SentryFeedbackAPI()
     }()
     #endif
@@ -365,7 +442,9 @@ import Foundation
     /// Adds a `Breadcrumb` to the current `Scope` of the current `Hub`. If the total number of breadcrumbs
     /// exceeds the `SentryOptions.maxBreadcrumbs` the SDK removes the oldest breadcrumb.
     /// - parameter crumb: The `Breadcrumb` to add to the current `Scope` of the current `Hub`.
+    #if !SDK_V10
     @objc(addBreadcrumb:)
+    #endif
     public static func addBreadcrumb(_ crumb: Breadcrumb) {
         SentrySDKInternal.addBreadcrumb(crumb)
     }
@@ -373,7 +452,9 @@ import Foundation
     /// Use this method to modify the current `Scope` of the current `Hub`. The SDK uses the `Scope` to attach
     /// contextual data to events.
     /// - parameter callback: The callback for configuring the current `Scope` of the current `Hub`.
+    #if !SDK_V10
     @objc(configureScope:)
+    #endif
     public static func configureScope(_ callback: @escaping (Scope) -> Void) {
         SentrySDKInternal.configureScope(callback)
     }
@@ -397,7 +478,10 @@ import Foundation
     /// Before ``SentrySDK/start(configureOptions:)`` finishes initializing the crash reporter,
     /// this property returns ``SentryLastRunStatus/unknown``. After initialization it returns
     /// either ``SentryLastRunStatus/didCrash`` or ``SentryLastRunStatus/didNotCrash``.
-    @objc public static var lastRunStatus: SentryLastRunStatus {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var lastRunStatus: SentryLastRunStatus {
         return SentryLastRunStatus(rawValue: Int(SentrySDKInternal.lastRunStatus)) ?? .unknown
     }
 
@@ -405,7 +489,10 @@ import Foundation
     /// - note: The SDK init waits synchronously for up to 5 seconds to flush out events if the app crashes
     /// within 2 seconds after the SDK init.
     /// - returns: true if the SDK detected a start-up crash and false if not.
-    @objc public static var detectedStartUpCrash: Bool {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static var detectedStartUpCrash: Bool {
         return SentrySDKInternal.detectedStartUpCrash
     }
 
@@ -414,7 +501,10 @@ import Foundation
     /// Set `user` to the current `Scope` of the current `Hub`.
     /// - parameter user: The user to set to the current `Scope`.
     /// - note: You must start the SDK before calling this method, otherwise it doesn't set the user.
-    @objc public static func setUser(_ user: User?) {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func setUser(_ user: User?) {
         SentrySDKInternal.setUser(user)
     }
 
@@ -424,14 +514,20 @@ import Foundation
     /// new one. You can use this method in combination with `endSession` to manually track
     /// sessions. The SDK uses `SentrySession` to inform Sentry about release and project
     /// associated project health.
-    @objc public static func startSession() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func startSession() {
         SentrySDKInternal.startSession()
     }
 
     /// Ends the current `SentrySession`. You can use this method in combination with `startSession` to
     /// manually track `SentrySessions`. The SDK uses `SentrySession` to inform Sentry about release and
     /// project associated project health.
-    @objc public static func endSession() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func endSession() {
         SentrySDKInternal.endSession()
     }
 
@@ -440,7 +536,10 @@ import Foundation
     /// - note: The SDK can't report a crash when a debugger is attached. Your application needs to run
     /// without a debugger attached to capture the crash and send it to Sentry the next time you launch
     /// your application.
-    @objc public static func crash() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func crash() {
         SentrySDKInternal.crash()
     }
 
@@ -450,7 +549,10 @@ import Foundation
     ///
     /// - seealso:
     /// https://docs.sentry.io/platforms/cocoa/performance/instrumentation/automatic-instrumentation/#time-to-full-display
-    @objc public static func reportFullyDisplayed() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func reportFullyDisplayed() {
         SentrySDKInternal.reportFullyDisplayed()
     }
 
@@ -485,13 +587,19 @@ import Foundation
     /// ```
     ///
     /// - Note: This only has an effect when Standalone App Start tracing is enabled.
-    @objc public static func extendAppStart() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func extendAppStart() {
         SentryDependencyContainer.sharedInstance().extendedAppLaunchManager.extend()
     }
 
     /// Returns the extended app start span, or `nil` if ``extendAppStart()`` was not called,
     /// the SDK is not started, or the app start transaction was already created.
-    @objc public static func getExtendedAppStartSpan() -> (any Span)? {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func getExtendedAppStartSpan() -> (any Span)? {
         SentryDependencyContainer.sharedInstance().extendedAppLaunchManager.extendedAppStartSpan()
     }
 
@@ -500,7 +608,10 @@ import Foundation
     /// This is equivalent to calling `finish()` on the span returned by ``getExtendedAppStartSpan()``.
     /// If ``extendAppStart()`` was not called, or the extended launch was already
     /// finished, this method does nothing.
-    @objc public static func finishExtendedAppStart() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func finishExtendedAppStart() {
         SentryDependencyContainer.sharedInstance().extendedAppLaunchManager.finish()
     }
     #endif
@@ -511,12 +622,18 @@ import Foundation
     ///
     /// This method doesn't close the detection of app hangs. Instead, the app hang detection
     /// will ignore detected app hangs until you call `resumeAppHangTracking`.
-    @objc public static func pauseAppHangTracking() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func pauseAppHangTracking() {
         SentrySDKInternal.pauseAppHangTracking()
     }
 
     /// Resumes sending detected app hangs to Sentry.
-    @objc public static func resumeAppHangTracking() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func resumeAppHangTracking() {
         SentrySDKInternal.resumeAppHangTracking()
     }
 
@@ -525,14 +642,19 @@ import Foundation
     /// doesn't dispose the client or the hub.
     /// - parameter timeout: The time to wait for the SDK to complete the flush.
     /// - note: This might take slightly longer than the specified timeout if there are many batched logs to capture.
+    #if !SDK_V10
     @objc(flush:)
+    #endif
     public static func flush(timeout: TimeInterval) {
         SentrySDKInternal.flush(timeout: timeout)
     }
 
     /// Closes the SDK, uninstalls all the integrations, and calls `flush` with
     /// `SentryOptions.shutdownTimeInterval`.
-    @objc public static func close() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func close() {
         SentrySDKInternal.close()
     }
 
@@ -555,7 +677,10 @@ import Foundation
     /// not permitted to manually start profiling.
     /// - note: Profiling is automatically disabled if a thread sanitizer is attached.
     /// - seealso: https://docs.sentry.io/platforms/apple/guides/ios/profiling/#continuous-profiling
-    @objc public static func startProfiler() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func startProfiler() {
         SentrySDKInternal.startProfiler()
     }
 
@@ -569,19 +694,28 @@ import Foundation
     /// interval completes, the profiler will continue running until another call to stop is made.
     /// - note: Profiling is automatically disabled if a thread sanitizer is attached.
     /// - seealso: https://docs.sentry.io/platforms/apple/guides/ios/profiling/#continuous-profiling
-    @objc public static func stopProfiler() {
+    #if !SDK_V10
+    @objc
+    #endif
+    public static func stopProfiler() {
         SentrySDKInternal.stopProfiler()
     }
     #endif
 
     // MARK: Internal
 
+    #if !SDK_V10
+    @objc
+    #endif
     // swiftlint:disable:next missing_docs
-    @_spi(Private) @objc public static var startOption: Options? {
+    @_spi(Private) public static var startOption: Options? {
         SentryDependencyContainer.sharedInstance().startOptions
     }
+    #if !SDK_V10
+    @objc
+    #endif
     // swiftlint:disable:next missing_docs
-    @_spi(Private) @objc public static func setStart(with option: Options?) {
+    @_spi(Private) public static func setStart(with option: Options?) {
         SentryDependencyContainer.sharedInstance().startOptions = option
     }
 }

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationObjCTests.m
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationObjCTests.m
@@ -6,6 +6,8 @@
 #import <SentrySwift.h>
 #import <XCTest/XCTest.h>
 
+#if !SDK_V10
+
 @interface SentryFileIOTrackingIntegrationObjCTests : XCTestCase
 
 @end
@@ -228,3 +230,5 @@
 }
 
 @end
+
+#endif

--- a/Tests/SentryTests/SentrySDKThreadTests.swift
+++ b/Tests/SentryTests/SentrySDKThreadTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 
 final class SentrySDKThreadTests: XCTestCase {
+
     /// Stress-tests concurrent bindClient + capture. Skipped on watchOS: limited concurrency (few threads)
     /// means the 100 async blocks often don’t all run within the 10s timeout.
     func testRaceWhenBindingClient() throws {

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -39,58 +39,6 @@
     [SentrySDKInternal.currentHub bindClient:nil];
 }
 
-- (void)testSDKDefaultHub
-{
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *_Nonnull options) {
-        options.dsn = @"https://username:password@app.getsentry.com/12345";
-    }];
-    XCTAssertNotNil([SentrySDKInternal.currentHub getClient]);
-    [SentrySDKInternal.currentHub bindClient:nil];
-}
-
-- (void)testSDKBreadCrumbAdd
-{
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *_Nonnull options) {
-        options.dsn = @"https://username:password@app.getsentry.com/12345";
-    }];
-
-    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
-                                                             category:@"testCategory"];
-    crumb.type = @"testType";
-    crumb.origin = @"testOrigin";
-    crumb.message = @"testMessage";
-    crumb.data = @{ @"testDataKey" : @"testDataVaue" };
-
-    [SentrySDK addBreadcrumb:crumb];
-}
-
-- (void)testSDKCaptureEvent
-{
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *_Nonnull options) {
-        options.dsn = @"https://username:password@app.getsentry.com/12345";
-    }];
-
-    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelFatal];
-
-    event.timestamp = [NSDate date];
-    event.message = [[SentryMessage alloc] initWithFormatted:@"testy test"];
-
-    [SentrySDK captureEvent:event];
-}
-
-- (void)testSDKCaptureError
-{
-    [SentrySDK startWithConfigureOptions:^(SentryOptions *_Nonnull options) {
-        options.dsn = @"https://username:password@app.getsentry.com/12345";
-    }];
-
-    NSError *error =
-        [NSError errorWithDomain:@"testworld"
-                            code:200
-                        userInfo:@{ NSLocalizedDescriptionKey : @"test ran out of money" }];
-    [SentrySDK captureError:error];
-}
-
 - (void)testLevelOrder
 {
     XCTAssertGreaterThan(kSentryLevelFatal, kSentryLevelError);

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -55981,6 +55981,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC13addBreadcrumbyySo0aD0CFZ",
             "moduleName": "Sentry",
@@ -55988,7 +55989,7 @@
             "objc_name": "addBreadcrumb:",
             "printedName": "addBreadcrumb(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)addBreadcrumb:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)addBreadcrumb:"
           },
           {
             "children": [
@@ -56012,6 +56013,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5errorSo0A2IdCs5Error_p_tFZ",
             "moduleName": "Sentry",
@@ -56019,7 +56021,7 @@
             "objc_name": "captureError:",
             "printedName": "capture(error:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureError:"
           },
           {
             "children": [
@@ -56049,6 +56051,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5error16attachAllThreadsSo0A2IdCs5Error_p_SbtFZ",
             "moduleName": "Sentry",
@@ -56056,7 +56059,7 @@
             "objc_name": "captureError:attachAllThreads:",
             "printedName": "capture(error:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:attachAllThreads:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureError:attachAllThreads:"
           },
           {
             "children": [
@@ -56105,6 +56108,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5error5blockSo0A2IdCs5Error_p_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
@@ -56112,7 +56116,7 @@
             "objc_name": "captureError:withScopeBlock:",
             "printedName": "capture(error:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:withScopeBlock:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureError:withScopeBlock:"
           },
           {
             "children": [
@@ -56142,6 +56146,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5error5scopeSo0A2IdCs5Error_p_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
@@ -56149,7 +56154,7 @@
             "objc_name": "captureError:withScope:",
             "printedName": "capture(error:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:withScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureError:withScope:"
           },
           {
             "children": [
@@ -56173,6 +56178,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5eventSo0A2IdCSo0A5EventC_tFZ",
             "moduleName": "Sentry",
@@ -56180,7 +56186,7 @@
             "objc_name": "captureEvent:",
             "printedName": "capture(event:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureEvent:"
           },
           {
             "children": [
@@ -56210,6 +56216,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5event16attachAllThreadsSo0A2IdCSo0A5EventC_SbtFZ",
             "moduleName": "Sentry",
@@ -56217,7 +56224,7 @@
             "objc_name": "captureEvent:attachAllThreads:",
             "printedName": "capture(event:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:attachAllThreads:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureEvent:attachAllThreads:"
           },
           {
             "children": [
@@ -56266,6 +56273,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5event5blockSo0A2IdCSo0A5EventC_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
@@ -56273,7 +56281,7 @@
             "objc_name": "captureEvent:withScopeBlock:",
             "printedName": "capture(event:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScopeBlock:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScopeBlock:"
           },
           {
             "children": [
@@ -56303,6 +56311,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture5event5scopeSo0A2IdCSo0A5EventC_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
@@ -56310,7 +56319,7 @@
             "objc_name": "captureEvent:withScope:",
             "printedName": "capture(event:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScope:"
           },
           {
             "children": [
@@ -56334,6 +56343,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture9exceptionSo0A2IdCSo11NSExceptionC_tFZ",
             "moduleName": "Sentry",
@@ -56341,7 +56351,7 @@
             "objc_name": "captureException:",
             "printedName": "capture(exception:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureException:"
           },
           {
             "children": [
@@ -56371,6 +56381,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture9exception16attachAllThreadsSo0A2IdCSo11NSExceptionC_SbtFZ",
             "moduleName": "Sentry",
@@ -56378,7 +56389,7 @@
             "objc_name": "captureException:attachAllThreads:",
             "printedName": "capture(exception:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:attachAllThreads:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureException:attachAllThreads:"
           },
           {
             "children": [
@@ -56427,6 +56438,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture9exception5blockSo0A2IdCSo11NSExceptionC_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
@@ -56434,7 +56446,7 @@
             "objc_name": "captureException:withScopeBlock:",
             "printedName": "capture(exception:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:withScopeBlock:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureException:withScopeBlock:"
           },
           {
             "children": [
@@ -56464,6 +56476,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture9exception5scopeSo0A2IdCSo11NSExceptionC_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
@@ -56471,7 +56484,7 @@
             "objc_name": "captureException:withScope:",
             "printedName": "capture(exception:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:withScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureException:withScope:"
           },
           {
             "children": [
@@ -56493,6 +56506,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture8feedbackyAA0A8FeedbackC_tFZ",
             "moduleName": "Sentry",
@@ -56500,7 +56514,7 @@
             "objc_name": "captureFeedback:",
             "printedName": "capture(feedback:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureFeedback:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureFeedback:"
           },
           {
             "children": [
@@ -56524,6 +56538,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture7messageSo0A2IdCSS_tFZ",
             "moduleName": "Sentry",
@@ -56531,7 +56546,7 @@
             "objc_name": "captureMessage:",
             "printedName": "capture(message:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureMessage:"
           },
           {
             "children": [
@@ -56561,6 +56576,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture7message16attachAllThreadsSo0A2IdCSS_SbtFZ",
             "moduleName": "Sentry",
@@ -56568,7 +56584,7 @@
             "objc_name": "captureMessage:attachAllThreads:",
             "printedName": "capture(message:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:attachAllThreads:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureMessage:attachAllThreads:"
           },
           {
             "children": [
@@ -56617,6 +56633,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture7message5blockSo0A2IdCSS_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
@@ -56624,7 +56641,7 @@
             "objc_name": "captureMessage:withScopeBlock:",
             "printedName": "capture(message:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScopeBlock:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScopeBlock:"
           },
           {
             "children": [
@@ -56654,6 +56671,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7capture7message5scopeSo0A2IdCSS_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
@@ -56661,7 +56679,7 @@
             "objc_name": "captureMessage:withScope:",
             "printedName": "capture(message:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScope:"
           },
           {
             "children": [
@@ -56677,13 +56695,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC5closeyyFZ",
             "moduleName": "Sentry",
             "name": "close",
             "printedName": "close()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)close"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)close"
           },
           {
             "children": [
@@ -56724,6 +56743,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC14configureScopeyyySo0aD0CcFZ",
             "moduleName": "Sentry",
@@ -56731,7 +56751,7 @@
             "objc_name": "configureScope:",
             "printedName": "configureScope(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)configureScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)configureScope:"
           },
           {
             "children": [
@@ -56747,13 +56767,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC5crashyyFZ",
             "moduleName": "Sentry",
             "name": "crash",
             "printedName": "crash()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)crash"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)crash"
           },
           {
             "children": [
@@ -56769,13 +56790,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC10endSessionyyFZ",
             "moduleName": "Sentry",
             "name": "endSession",
             "printedName": "endSession()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)endSession"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)endSession"
           },
           {
             "children": [
@@ -56791,13 +56813,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC14extendAppStartyyFZ",
             "moduleName": "Sentry",
             "name": "extendAppStart",
             "printedName": "extendAppStart()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)extendAppStart"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)extendAppStart"
           },
           {
             "children": [
@@ -56813,13 +56836,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC22finishExtendedAppStartyyFZ",
             "moduleName": "Sentry",
             "name": "finishExtendedAppStart",
             "printedName": "finishExtendedAppStart()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)finishExtendedAppStart"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)finishExtendedAppStart"
           },
           {
             "children": [
@@ -56848,6 +56872,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC5flush7timeoutySd_tFZ",
             "moduleName": "Sentry",
@@ -56855,7 +56880,7 @@
             "objc_name": "flush:",
             "printedName": "flush(timeout:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)flush:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)flush:"
           },
           {
             "children": [
@@ -56880,13 +56905,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC23getExtendedAppStartSpanSo0aG0_pSgyFZ",
             "moduleName": "Sentry",
             "name": "getExtendedAppStartSpan",
             "printedName": "getExtendedAppStartSpan()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)getExtendedAppStartSpan"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)getExtendedAppStartSpan"
           },
           {
             "children": [
@@ -56902,13 +56928,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC20pauseAppHangTrackingyyFZ",
             "moduleName": "Sentry",
             "name": "pauseAppHangTracking",
             "printedName": "pauseAppHangTracking()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)pauseAppHangTracking"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)pauseAppHangTracking"
           },
           {
             "children": [
@@ -56924,13 +56951,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC20reportFullyDisplayedyyFZ",
             "moduleName": "Sentry",
             "name": "reportFullyDisplayed",
             "printedName": "reportFullyDisplayed()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)reportFullyDisplayed"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)reportFullyDisplayed"
           },
           {
             "children": [
@@ -56946,13 +56974,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC21resumeAppHangTrackingyyFZ",
             "moduleName": "Sentry",
             "name": "resumeAppHangTracking",
             "printedName": "resumeAppHangTracking()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)resumeAppHangTracking"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)resumeAppHangTracking"
           },
           {
             "children": [
@@ -56982,13 +57011,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC7setUseryySo0aD0CSgFZ",
             "moduleName": "Sentry",
             "name": "setUser",
             "printedName": "setUser(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)setUser:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)setUser:"
           },
           {
             "children": [
@@ -57029,6 +57059,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC5start16configureOptionsyyAA0E0Cc_tFZ",
             "moduleName": "Sentry",
@@ -57036,7 +57067,7 @@
             "objc_name": "startWithConfigureOptions:",
             "printedName": "start(configureOptions:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startWithConfigureOptions:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startWithConfigureOptions:"
           },
           {
             "children": [
@@ -57058,6 +57089,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC5start7optionsyAA7OptionsC_tFZ",
             "moduleName": "Sentry",
@@ -57065,7 +57097,7 @@
             "objc_name": "startWithOptions:",
             "printedName": "start(options:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startWithOptions:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startWithOptions:"
           },
           {
             "children": [
@@ -57081,13 +57113,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC13startProfileryyFZ",
             "moduleName": "Sentry",
             "name": "startProfiler",
             "printedName": "startProfiler()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startProfiler"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startProfiler"
           },
           {
             "children": [
@@ -57103,13 +57136,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC12startSessionyyFZ",
             "moduleName": "Sentry",
             "name": "startSession",
             "printedName": "startSession()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startSession"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startSession"
           },
           {
             "children": [
@@ -57139,6 +57173,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction4name9operationSo0A4Span_pSS_SStFZ",
             "moduleName": "Sentry",
@@ -57146,7 +57181,7 @@
             "objc_name": "startTransactionWithName:operation:",
             "printedName": "startTransaction(name:operation:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:"
           },
           {
             "children": [
@@ -57182,6 +57217,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction4name9operation11bindToScopeSo0A4Span_pSS_SSSbtFZ",
             "moduleName": "Sentry",
@@ -57189,7 +57225,7 @@
             "objc_name": "startTransactionWithName:operation:bindToScope:",
             "printedName": "startTransaction(name:operation:bindToScope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:bindToScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:bindToScope:"
           },
           {
             "children": [
@@ -57213,6 +57249,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContextSo0A4Span_pSo0adF0C_tFZ",
             "moduleName": "Sentry",
@@ -57220,7 +57257,7 @@
             "objc_name": "startTransactionWithContext:",
             "printedName": "startTransaction(transactionContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:"
           },
           {
             "children": [
@@ -57250,6 +57287,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext11bindToScopeSo0A4Span_pSo0adF0C_SbtFZ",
             "moduleName": "Sentry",
@@ -57257,7 +57295,7 @@
             "objc_name": "startTransactionWithContext:bindToScope:",
             "printedName": "startTransaction(transactionContext:bindToScope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:"
           },
           {
             "children": [
@@ -57306,6 +57344,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext11bindToScope014customSamplingF0So0A4Span_pSo0adF0C_SbSDySSypGtFZ",
             "moduleName": "Sentry",
@@ -57313,7 +57352,7 @@
             "objc_name": "startTransactionWithContext:bindToScope:customSamplingContext:",
             "printedName": "startTransaction(transactionContext:bindToScope:customSamplingContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:customSamplingContext:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:customSamplingContext:"
           },
           {
             "children": [
@@ -57356,6 +57395,7 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext014customSamplingF0So0A4Span_pSo0adF0C_SDySSypGtFZ",
             "moduleName": "Sentry",
@@ -57363,7 +57403,7 @@
             "objc_name": "startTransactionWithContext:customSamplingContext:",
             "printedName": "startTransaction(transactionContext:customSamplingContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:customSamplingContext:"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:customSamplingContext:"
           },
           {
             "children": [
@@ -57379,13 +57419,14 @@
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
             "mangledName": "$s6Sentry0A3SDKC12stopProfileryyFZ",
             "moduleName": "Sentry",
             "name": "stopProfiler",
             "printedName": "stopProfiler()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)stopProfiler"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)stopProfiler"
           },
           {
             "children": [
@@ -57400,6 +57441,7 @@
               "Available"
             ],
             "declKind": "TypeAlias",
+            "isFromExtension": true,
             "kind": "TypeAlias",
             "mangledName": "$s6Sentry0A3SDKC12FeedbackForma",
             "moduleName": "Sentry",
@@ -57445,13 +57487,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC14crashedLastRunSbvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)crashedLastRun"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)crashedLastRun"
               }
             ],
             "children": [
@@ -57469,13 +57512,14 @@
             ],
             "declKind": "Var",
             "deprecated": true,
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC14crashedLastRunSbvpZ",
             "moduleName": "Sentry",
             "name": "crashedLastRun",
             "printedName": "crashedLastRun",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)crashedLastRun"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)crashedLastRun"
           },
           {
             "accessors": [
@@ -57494,13 +57538,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC20detectedStartUpCrashSbvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)detectedStartUpCrash"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)detectedStartUpCrash"
               }
             ],
             "children": [
@@ -57516,13 +57561,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC20detectedStartUpCrashSbvpZ",
             "moduleName": "Sentry",
             "name": "detectedStartUpCrash",
             "printedName": "detectedStartUpCrash",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)detectedStartUpCrash"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)detectedStartUpCrash"
           },
           {
             "accessors": [
@@ -57542,13 +57588,14 @@
                 ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)feedback"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)feedback"
               }
             ],
             "children": [
@@ -57567,6 +57614,7 @@
             ],
             "declKind": "Var",
             "hasStorage": true,
+            "isFromExtension": true,
             "isLet": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvpZ",
@@ -57574,7 +57622,7 @@
             "name": "feedback",
             "printedName": "feedback",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)feedback"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)feedback"
           },
           {
             "accessors": [
@@ -57640,13 +57688,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC9isEnabledSbvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)isEnabled"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)isEnabled"
               }
             ],
             "children": [
@@ -57662,13 +57711,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC9isEnabledSbvpZ",
             "moduleName": "Sentry",
             "name": "isEnabled",
             "printedName": "isEnabled",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)isEnabled"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)isEnabled"
           },
           {
             "accessors": [
@@ -57687,13 +57737,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC13lastRunStatusAA0a4LastdE0OvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)lastRunStatus"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)lastRunStatus"
               }
             ],
             "children": [
@@ -57709,13 +57760,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC13lastRunStatusAA0a4LastdE0OvpZ",
             "moduleName": "Sentry",
             "name": "lastRunStatus",
             "printedName": "lastRunStatus",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)lastRunStatus"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)lastRunStatus"
           },
           {
             "accessors": [
@@ -57734,13 +57786,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC6loggerAA0A6LoggerCvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)logger"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)logger"
               }
             ],
             "children": [
@@ -57756,13 +57809,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC6loggerAA0A6LoggerCvpZ",
             "moduleName": "Sentry",
             "name": "logger",
             "printedName": "logger",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)logger"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)logger"
           },
           {
             "accessors": [
@@ -57781,6 +57835,7 @@
                 ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvgZ",
                 "moduleName": "Sentry",
@@ -57809,6 +57864,7 @@
                 ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvsZ",
                 "moduleName": "Sentry",
@@ -57832,6 +57888,7 @@
             ],
             "declKind": "Var",
             "hasStorage": true,
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvpZ",
             "moduleName": "Sentry",
@@ -57857,13 +57914,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC6replaySo0A9ReplayApiCvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)replay"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)replay"
               }
             ],
             "children": [
@@ -57879,13 +57937,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC6replaySo0A9ReplayApiCvpZ",
             "moduleName": "Sentry",
             "name": "replay",
             "printedName": "replay",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)replay"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)replay"
           },
           {
             "accessors": [
@@ -57912,13 +57971,14 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A3SDKC4spanSo0A4Span_pSgvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)span"
+                "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cm)span"
               }
             ],
             "children": [
@@ -57942,13 +58002,14 @@
               "ObjC"
             ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A3SDKC4spanSo0A4Span_pSgvpZ",
             "moduleName": "Sentry",
             "name": "span",
             "printedName": "span",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)span"
+            "usr": "c:@CM@Sentry@objc(cs)SentrySDK(cpy)span"
           }
         ],
         "conformances": [

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -55639,31 +55639,6 @@
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "SentrySDK",
-                "printedName": "Sentry.SentrySDK",
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK"
-              }
-            ],
-            "declAttributes": [
-              "Dynamic",
-              "ObjC",
-              "Override"
-            ],
-            "declKind": "Constructor",
-            "init_kind": "Designated",
-            "kind": "Constructor",
-            "mangledName": "$s6Sentry0A3SDKCACycfc",
-            "moduleName": "Sentry",
-            "name": "init",
-            "objc_name": "init",
-            "overriding": true,
-            "printedName": "init()",
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(im)init"
-          },
-          {
-            "children": [
-              {
-                "kind": "TypeNominal",
                 "name": "Breadcrumb",
                 "printedName": "Sentry.Breadcrumb",
                 "usr": "c:objc(cs)SentryBreadcrumb"
@@ -55674,20 +55649,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC13addBreadcrumbyySo0aD0CFZ",
+            "mangledName": "$s6Sentry0A3SDKO13addBreadcrumbyySo0aD0CFZ",
             "moduleName": "Sentry",
             "name": "addBreadcrumb",
-            "objc_name": "addBreadcrumb:",
             "printedName": "addBreadcrumb(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)addBreadcrumb:"
+            "usr": "s:6Sentry0A3SDKO13addBreadcrumbyySo0aD0CFZ"
           },
           {
             "children": [
@@ -55705,20 +55676,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5errorSo0A2IdCs5Error_p_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5errorSo0A2IdCs5Error_p_tFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureError:",
             "printedName": "capture(error:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:"
+            "usr": "s:6Sentry0A3SDKO7capture5errorSo0A2IdCs5Error_p_tFZ"
           },
           {
             "children": [
@@ -55742,20 +55711,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5error16attachAllThreadsSo0A2IdCs5Error_p_SbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5error16attachAllThreadsSo0A2IdCs5Error_p_SbtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureError:attachAllThreads:",
             "printedName": "capture(error:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:attachAllThreads:"
+            "usr": "s:6Sentry0A3SDKO7capture5error16attachAllThreadsSo0A2IdCs5Error_p_SbtFZ"
           },
           {
             "children": [
@@ -55798,20 +55765,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5error5blockSo0A2IdCs5Error_p_ySo0A5ScopeCctFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5error5blockSo0A2IdCs5Error_p_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureError:withScopeBlock:",
             "printedName": "capture(error:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:withScopeBlock:"
+            "usr": "s:6Sentry0A3SDKO7capture5error5blockSo0A2IdCs5Error_p_ySo0A5ScopeCctFZ"
           },
           {
             "children": [
@@ -55835,20 +55800,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5error5scopeSo0A2IdCs5Error_p_So0A5ScopeCtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5error5scopeSo0A2IdCs5Error_p_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureError:withScope:",
             "printedName": "capture(error:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureError:withScope:"
+            "usr": "s:6Sentry0A3SDKO7capture5error5scopeSo0A2IdCs5Error_p_So0A5ScopeCtFZ"
           },
           {
             "children": [
@@ -55866,20 +55829,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5eventSo0A2IdCSo0A5EventC_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5eventSo0A2IdCSo0A5EventC_tFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureEvent:",
             "printedName": "capture(event:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:"
+            "usr": "s:6Sentry0A3SDKO7capture5eventSo0A2IdCSo0A5EventC_tFZ"
           },
           {
             "children": [
@@ -55903,20 +55864,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5event16attachAllThreadsSo0A2IdCSo0A5EventC_SbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5event16attachAllThreadsSo0A2IdCSo0A5EventC_SbtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureEvent:attachAllThreads:",
             "printedName": "capture(event:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:attachAllThreads:"
+            "usr": "s:6Sentry0A3SDKO7capture5event16attachAllThreadsSo0A2IdCSo0A5EventC_SbtFZ"
           },
           {
             "children": [
@@ -55959,20 +55918,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5event5blockSo0A2IdCSo0A5EventC_ySo0A5ScopeCctFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5event5blockSo0A2IdCSo0A5EventC_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureEvent:withScopeBlock:",
             "printedName": "capture(event:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScopeBlock:"
+            "usr": "s:6Sentry0A3SDKO7capture5event5blockSo0A2IdCSo0A5EventC_ySo0A5ScopeCctFZ"
           },
           {
             "children": [
@@ -55996,20 +55953,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture5event5scopeSo0A2IdCSo0A5EventC_So0A5ScopeCtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture5event5scopeSo0A2IdCSo0A5EventC_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureEvent:withScope:",
             "printedName": "capture(event:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureEvent:withScope:"
+            "usr": "s:6Sentry0A3SDKO7capture5event5scopeSo0A2IdCSo0A5EventC_So0A5ScopeCtFZ"
           },
           {
             "children": [
@@ -56027,20 +55982,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture9exceptionSo0A2IdCSo11NSExceptionC_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture9exceptionSo0A2IdCSo11NSExceptionC_tFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureException:",
             "printedName": "capture(exception:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:"
+            "usr": "s:6Sentry0A3SDKO7capture9exceptionSo0A2IdCSo11NSExceptionC_tFZ"
           },
           {
             "children": [
@@ -56064,20 +56017,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture9exception16attachAllThreadsSo0A2IdCSo11NSExceptionC_SbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture9exception16attachAllThreadsSo0A2IdCSo11NSExceptionC_SbtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureException:attachAllThreads:",
             "printedName": "capture(exception:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:attachAllThreads:"
+            "usr": "s:6Sentry0A3SDKO7capture9exception16attachAllThreadsSo0A2IdCSo11NSExceptionC_SbtFZ"
           },
           {
             "children": [
@@ -56120,20 +56071,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture9exception5blockSo0A2IdCSo11NSExceptionC_ySo0A5ScopeCctFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture9exception5blockSo0A2IdCSo11NSExceptionC_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureException:withScopeBlock:",
             "printedName": "capture(exception:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:withScopeBlock:"
+            "usr": "s:6Sentry0A3SDKO7capture9exception5blockSo0A2IdCSo11NSExceptionC_ySo0A5ScopeCctFZ"
           },
           {
             "children": [
@@ -56157,20 +56106,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture9exception5scopeSo0A2IdCSo11NSExceptionC_So0A5ScopeCtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture9exception5scopeSo0A2IdCSo11NSExceptionC_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureException:withScope:",
             "printedName": "capture(exception:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureException:withScope:"
+            "usr": "s:6Sentry0A3SDKO7capture9exception5scopeSo0A2IdCSo11NSExceptionC_So0A5ScopeCtFZ"
           },
           {
             "children": [
@@ -56186,20 +56133,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture8feedbackyAA0A8FeedbackC_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture8feedbackyAA0A8FeedbackC_tFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureFeedback:",
             "printedName": "capture(feedback:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureFeedback:"
+            "usr": "s:6Sentry0A3SDKO7capture8feedbackyAA0A8FeedbackC_tFZ"
           },
           {
             "children": [
@@ -56217,20 +56160,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture7messageSo0A2IdCSS_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture7messageSo0A2IdCSS_tFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureMessage:",
             "printedName": "capture(message:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:"
+            "usr": "s:6Sentry0A3SDKO7capture7messageSo0A2IdCSS_tFZ"
           },
           {
             "children": [
@@ -56254,20 +56195,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture7message16attachAllThreadsSo0A2IdCSS_SbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture7message16attachAllThreadsSo0A2IdCSS_SbtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureMessage:attachAllThreads:",
             "printedName": "capture(message:attachAllThreads:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:attachAllThreads:"
+            "usr": "s:6Sentry0A3SDKO7capture7message16attachAllThreadsSo0A2IdCSS_SbtFZ"
           },
           {
             "children": [
@@ -56310,20 +56249,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture7message5blockSo0A2IdCSS_ySo0A5ScopeCctFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture7message5blockSo0A2IdCSS_ySo0A5ScopeCctFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureMessage:withScopeBlock:",
             "printedName": "capture(message:block:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScopeBlock:"
+            "usr": "s:6Sentry0A3SDKO7capture7message5blockSo0A2IdCSS_ySo0A5ScopeCctFZ"
           },
           {
             "children": [
@@ -56347,20 +56284,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7capture7message5scopeSo0A2IdCSS_So0A5ScopeCtFZ",
+            "mangledName": "$s6Sentry0A3SDKO7capture7message5scopeSo0A2IdCSS_So0A5ScopeCtFZ",
             "moduleName": "Sentry",
             "name": "capture",
-            "objc_name": "captureMessage:withScope:",
             "printedName": "capture(message:scope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)captureMessage:withScope:"
+            "usr": "s:6Sentry0A3SDKO7capture7message5scopeSo0A2IdCSS_So0A5ScopeCtFZ"
           },
           {
             "children": [
@@ -56370,19 +56305,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC5closeyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO5closeyyFZ",
             "moduleName": "Sentry",
             "name": "close",
             "printedName": "close()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)close"
+            "usr": "s:6Sentry0A3SDKO5closeyyFZ"
           },
           {
             "children": [
@@ -56417,20 +56349,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC14configureScopeyyySo0aD0CcFZ",
+            "mangledName": "$s6Sentry0A3SDKO14configureScopeyyySo0aD0CcFZ",
             "moduleName": "Sentry",
             "name": "configureScope",
-            "objc_name": "configureScope:",
             "printedName": "configureScope(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)configureScope:"
+            "usr": "s:6Sentry0A3SDKO14configureScopeyyySo0aD0CcFZ"
           },
           {
             "children": [
@@ -56440,19 +56368,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC5crashyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO5crashyyFZ",
             "moduleName": "Sentry",
             "name": "crash",
             "printedName": "crash()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)crash"
+            "usr": "s:6Sentry0A3SDKO5crashyyFZ"
           },
           {
             "children": [
@@ -56462,19 +56387,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC10endSessionyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO10endSessionyyFZ",
             "moduleName": "Sentry",
             "name": "endSession",
             "printedName": "endSession()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)endSession"
+            "usr": "s:6Sentry0A3SDKO10endSessionyyFZ"
           },
           {
             "children": [
@@ -56484,19 +56406,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC14extendAppStartyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO14extendAppStartyyFZ",
             "moduleName": "Sentry",
             "name": "extendAppStart",
             "printedName": "extendAppStart()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)extendAppStart"
+            "usr": "s:6Sentry0A3SDKO14extendAppStartyyFZ"
           },
           {
             "children": [
@@ -56506,19 +56425,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC22finishExtendedAppStartyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO22finishExtendedAppStartyyFZ",
             "moduleName": "Sentry",
             "name": "finishExtendedAppStart",
             "printedName": "finishExtendedAppStart()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)finishExtendedAppStart"
+            "usr": "s:6Sentry0A3SDKO22finishExtendedAppStartyyFZ"
           },
           {
             "children": [
@@ -56541,20 +56457,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC5flush7timeoutySd_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO5flush7timeoutySd_tFZ",
             "moduleName": "Sentry",
             "name": "flush",
-            "objc_name": "flush:",
             "printedName": "flush(timeout:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)flush:"
+            "usr": "s:6Sentry0A3SDKO5flush7timeoutySd_tFZ"
           },
           {
             "children": [
@@ -56573,19 +56485,16 @@
                 "usr": "s:Sq"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC23getExtendedAppStartSpanSo0aG0_pSgyFZ",
+            "mangledName": "$s6Sentry0A3SDKO23getExtendedAppStartSpanSo0aG0_pSgyFZ",
             "moduleName": "Sentry",
             "name": "getExtendedAppStartSpan",
             "printedName": "getExtendedAppStartSpan()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)getExtendedAppStartSpan"
+            "usr": "s:6Sentry0A3SDKO23getExtendedAppStartSpanSo0aG0_pSgyFZ"
           },
           {
             "children": [
@@ -56595,19 +56504,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC20pauseAppHangTrackingyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO20pauseAppHangTrackingyyFZ",
             "moduleName": "Sentry",
             "name": "pauseAppHangTracking",
             "printedName": "pauseAppHangTracking()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)pauseAppHangTracking"
+            "usr": "s:6Sentry0A3SDKO20pauseAppHangTrackingyyFZ"
           },
           {
             "children": [
@@ -56617,19 +56523,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC20reportFullyDisplayedyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO20reportFullyDisplayedyyFZ",
             "moduleName": "Sentry",
             "name": "reportFullyDisplayed",
             "printedName": "reportFullyDisplayed()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)reportFullyDisplayed"
+            "usr": "s:6Sentry0A3SDKO20reportFullyDisplayedyyFZ"
           },
           {
             "children": [
@@ -56639,19 +56542,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC21resumeAppHangTrackingyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO21resumeAppHangTrackingyyFZ",
             "moduleName": "Sentry",
             "name": "resumeAppHangTracking",
             "printedName": "resumeAppHangTracking()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)resumeAppHangTracking"
+            "usr": "s:6Sentry0A3SDKO21resumeAppHangTrackingyyFZ"
           },
           {
             "children": [
@@ -56675,19 +56575,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC7setUseryySo0aD0CSgFZ",
+            "mangledName": "$s6Sentry0A3SDKO7setUseryySo0aD0CSgFZ",
             "moduleName": "Sentry",
             "name": "setUser",
             "printedName": "setUser(_:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)setUser:"
+            "usr": "s:6Sentry0A3SDKO7setUseryySo0aD0CSgFZ"
           },
           {
             "children": [
@@ -56722,20 +56619,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC5start16configureOptionsyyAA0E0Cc_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO5start16configureOptionsyyAA0E0Cc_tFZ",
             "moduleName": "Sentry",
             "name": "start",
-            "objc_name": "startWithConfigureOptions:",
             "printedName": "start(configureOptions:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startWithConfigureOptions:"
+            "usr": "s:6Sentry0A3SDKO5start16configureOptionsyyAA0E0Cc_tFZ"
           },
           {
             "children": [
@@ -56751,20 +56644,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC5start7optionsyAA7OptionsC_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO5start7optionsyAA7OptionsC_tFZ",
             "moduleName": "Sentry",
             "name": "start",
-            "objc_name": "startWithOptions:",
             "printedName": "start(options:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startWithOptions:"
+            "usr": "s:6Sentry0A3SDKO5start7optionsyAA7OptionsC_tFZ"
           },
           {
             "children": [
@@ -56774,19 +56663,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC13startProfileryyFZ",
+            "mangledName": "$s6Sentry0A3SDKO13startProfileryyFZ",
             "moduleName": "Sentry",
             "name": "startProfiler",
             "printedName": "startProfiler()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startProfiler"
+            "usr": "s:6Sentry0A3SDKO13startProfileryyFZ"
           },
           {
             "children": [
@@ -56796,19 +56682,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC12startSessionyyFZ",
+            "mangledName": "$s6Sentry0A3SDKO12startSessionyyFZ",
             "moduleName": "Sentry",
             "name": "startSession",
             "printedName": "startSession()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startSession"
+            "usr": "s:6Sentry0A3SDKO12startSessionyyFZ"
           },
           {
             "children": [
@@ -56832,20 +56715,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction4name9operationSo0A4Span_pSS_SStFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction4name9operationSo0A4Span_pSS_SStFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithName:operation:",
             "printedName": "startTransaction(name:operation:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction4name9operationSo0A4Span_pSS_SStFZ"
           },
           {
             "children": [
@@ -56875,20 +56756,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction4name9operation11bindToScopeSo0A4Span_pSS_SSSbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction4name9operation11bindToScopeSo0A4Span_pSS_SSSbtFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithName:operation:bindToScope:",
             "printedName": "startTransaction(name:operation:bindToScope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithName:operation:bindToScope:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction4name9operation11bindToScopeSo0A4Span_pSS_SSSbtFZ"
           },
           {
             "children": [
@@ -56906,20 +56785,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContextSo0A4Span_pSo0adF0C_tFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction18transactionContextSo0A4Span_pSo0adF0C_tFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithContext:",
             "printedName": "startTransaction(transactionContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction18transactionContextSo0A4Span_pSo0adF0C_tFZ"
           },
           {
             "children": [
@@ -56943,20 +56820,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext11bindToScopeSo0A4Span_pSo0adF0C_SbtFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction18transactionContext11bindToScopeSo0A4Span_pSo0adF0C_SbtFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithContext:bindToScope:",
             "printedName": "startTransaction(transactionContext:bindToScope:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction18transactionContext11bindToScopeSo0A4Span_pSo0adF0C_SbtFZ"
           },
           {
             "children": [
@@ -56999,20 +56874,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext11bindToScope014customSamplingF0So0A4Span_pSo0adF0C_SbSDySSypGtFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction18transactionContext11bindToScope014customSamplingF0So0A4Span_pSo0adF0C_SbSDySSypGtFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithContext:bindToScope:customSamplingContext:",
             "printedName": "startTransaction(transactionContext:bindToScope:customSamplingContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:bindToScope:customSamplingContext:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction18transactionContext11bindToScope014customSamplingF0So0A4Span_pSo0adF0C_SbSDySSypGtFZ"
           },
           {
             "children": [
@@ -57049,20 +56922,18 @@
               }
             ],
             "declAttributes": [
-              "DiscardableResult",
-              "Final",
-              "ObjC"
+              "DiscardableResult"
             ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC16startTransaction18transactionContext014customSamplingF0So0A4Span_pSo0adF0C_SDySSypGtFZ",
+            "mangledName": "$s6Sentry0A3SDKO16startTransaction18transactionContext014customSamplingF0So0A4Span_pSo0adF0C_SDySSypGtFZ",
             "moduleName": "Sentry",
             "name": "startTransaction",
-            "objc_name": "startTransactionWithContext:customSamplingContext:",
             "printedName": "startTransaction(transactionContext:customSamplingContext:)",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)startTransactionWithContext:customSamplingContext:"
+            "usr": "s:6Sentry0A3SDKO16startTransaction18transactionContext014customSamplingF0So0A4Span_pSo0adF0C_SDySSypGtFZ"
           },
           {
             "children": [
@@ -57072,19 +56943,16 @@
                 "printedName": "()"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Func",
             "funcSelfKind": "NonMutating",
+            "isFromExtension": true,
             "kind": "Function",
-            "mangledName": "$s6Sentry0A3SDKC12stopProfileryyFZ",
+            "mangledName": "$s6Sentry0A3SDKO12stopProfileryyFZ",
             "moduleName": "Sentry",
             "name": "stopProfiler",
             "printedName": "stopProfiler()",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)stopProfiler"
+            "usr": "s:6Sentry0A3SDKO12stopProfileryyFZ"
           },
           {
             "children": [
@@ -57099,12 +56967,13 @@
               "Available"
             ],
             "declKind": "TypeAlias",
+            "isFromExtension": true,
             "kind": "TypeAlias",
-            "mangledName": "$s6Sentry0A3SDKC12FeedbackForma",
+            "mangledName": "$s6Sentry0A3SDKO12FeedbackForma",
             "moduleName": "Sentry",
             "name": "FeedbackForm",
             "printedName": "FeedbackForm",
-            "usr": "s:6Sentry0A3SDKC12FeedbackForma"
+            "usr": "s:6Sentry0A3SDKO12FeedbackForma"
           },
           {
             "children": [
@@ -57121,11 +56990,11 @@
             "declKind": "TypeAlias",
             "isFromExtension": true,
             "kind": "TypeAlias",
-            "mangledName": "$s6Sentry0A3SDKC16FeedbackFormViewa",
+            "mangledName": "$s6Sentry0A3SDKO16FeedbackFormViewa",
             "moduleName": "Sentry",
             "name": "FeedbackFormView",
             "printedName": "FeedbackFormView",
-            "usr": "s:6Sentry0A3SDKC16FeedbackFormViewa"
+            "usr": "s:6Sentry0A3SDKO16FeedbackFormViewa"
           },
           {
             "accessors": [
@@ -57139,18 +57008,15 @@
                     "usr": "s:Sb"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC20detectedStartUpCrashSbvgZ",
+                "mangledName": "$s6Sentry0A3SDKO20detectedStartUpCrashSbvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)detectedStartUpCrash"
+                "usr": "s:6Sentry0A3SDKO20detectedStartUpCrashSbvgZ"
               }
             ],
             "children": [
@@ -57161,18 +57027,15 @@
                 "usr": "s:Sb"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC20detectedStartUpCrashSbvpZ",
+            "mangledName": "$s6Sentry0A3SDKO20detectedStartUpCrashSbvpZ",
             "moduleName": "Sentry",
             "name": "detectedStartUpCrash",
             "printedName": "detectedStartUpCrash",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)detectedStartUpCrash"
+            "usr": "s:6Sentry0A3SDKO20detectedStartUpCrashSbvpZ"
           },
           {
             "accessors": [
@@ -57186,19 +57049,16 @@
                     "usr": "c:@M@Sentry@objc(cs)SentryFeedbackAPI"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvgZ",
+                "mangledName": "$s6Sentry0A3SDKO8feedbackAA0A11FeedbackAPICvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)feedback"
+                "usr": "s:6Sentry0A3SDKO8feedbackAA0A11FeedbackAPICvgZ"
               }
             ],
             "children": [
@@ -57211,20 +57071,19 @@
             ],
             "declAttributes": [
               "Available",
-              "Final",
-              "HasStorage",
-              "ObjC"
+              "HasStorage"
             ],
             "declKind": "Var",
             "hasStorage": true,
+            "isFromExtension": true,
             "isLet": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC8feedbackAA0A11FeedbackAPICvpZ",
+            "mangledName": "$s6Sentry0A3SDKO8feedbackAA0A11FeedbackAPICvpZ",
             "moduleName": "Sentry",
             "name": "feedback",
             "printedName": "feedback",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)feedback"
+            "usr": "s:6Sentry0A3SDKO8feedbackAA0A11FeedbackAPICvpZ"
           },
           {
             "accessors": [
@@ -57238,18 +57097,15 @@
                     "usr": "s:6Sentry0A11InternalApiV"
                   }
                 ],
-                "declAttributes": [
-                  "Final"
-                ],
                 "declKind": "Accessor",
                 "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC8internalAA0A11InternalApiVvgZ",
+                "mangledName": "$s6Sentry0A3SDKO8internalAA0A11InternalApiVvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "s:6Sentry0A3SDKC8internalAA0A11InternalApiVvgZ"
+                "usr": "s:6Sentry0A3SDKO8internalAA0A11InternalApiVvgZ"
               }
             ],
             "children": [
@@ -57260,18 +57116,15 @@
                 "usr": "s:6Sentry0A11InternalApiV"
               }
             ],
-            "declAttributes": [
-              "Final"
-            ],
             "declKind": "Var",
             "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC8internalAA0A11InternalApiVvpZ",
+            "mangledName": "$s6Sentry0A3SDKO8internalAA0A11InternalApiVvpZ",
             "moduleName": "Sentry",
             "name": "internal",
             "printedName": "internal",
             "static": true,
-            "usr": "s:6Sentry0A3SDKC8internalAA0A11InternalApiVvpZ"
+            "usr": "s:6Sentry0A3SDKO8internalAA0A11InternalApiVvpZ"
           },
           {
             "accessors": [
@@ -57285,18 +57138,15 @@
                     "usr": "s:Sb"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC9isEnabledSbvgZ",
+                "mangledName": "$s6Sentry0A3SDKO9isEnabledSbvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)isEnabled"
+                "usr": "s:6Sentry0A3SDKO9isEnabledSbvgZ"
               }
             ],
             "children": [
@@ -57307,18 +57157,15 @@
                 "usr": "s:Sb"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC9isEnabledSbvpZ",
+            "mangledName": "$s6Sentry0A3SDKO9isEnabledSbvpZ",
             "moduleName": "Sentry",
             "name": "isEnabled",
             "printedName": "isEnabled",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)isEnabled"
+            "usr": "s:6Sentry0A3SDKO9isEnabledSbvpZ"
           },
           {
             "accessors": [
@@ -57332,18 +57179,15 @@
                     "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC13lastRunStatusAA0a4LastdE0OvgZ",
+                "mangledName": "$s6Sentry0A3SDKO13lastRunStatusAA0a4LastdE0OvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)lastRunStatus"
+                "usr": "s:6Sentry0A3SDKO13lastRunStatusAA0a4LastdE0OvgZ"
               }
             ],
             "children": [
@@ -57354,18 +57198,15 @@
                 "usr": "c:@M@Sentry@E@SentryLastRunStatus"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC13lastRunStatusAA0a4LastdE0OvpZ",
+            "mangledName": "$s6Sentry0A3SDKO13lastRunStatusAA0a4LastdE0OvpZ",
             "moduleName": "Sentry",
             "name": "lastRunStatus",
             "printedName": "lastRunStatus",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)lastRunStatus"
+            "usr": "s:6Sentry0A3SDKO13lastRunStatusAA0a4LastdE0OvpZ"
           },
           {
             "accessors": [
@@ -57379,18 +57220,15 @@
                     "usr": "c:@M@Sentry@objc(cs)SentryLogger"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC6loggerAA0A6LoggerCvgZ",
+                "mangledName": "$s6Sentry0A3SDKO6loggerAA0A6LoggerCvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)logger"
+                "usr": "s:6Sentry0A3SDKO6loggerAA0A6LoggerCvgZ"
               }
             ],
             "children": [
@@ -57401,18 +57239,15 @@
                 "usr": "c:@M@Sentry@objc(cs)SentryLogger"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC6loggerAA0A6LoggerCvpZ",
+            "mangledName": "$s6Sentry0A3SDKO6loggerAA0A6LoggerCvpZ",
             "moduleName": "Sentry",
             "name": "logger",
             "printedName": "logger",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)logger"
+            "usr": "s:6Sentry0A3SDKO6loggerAA0A6LoggerCvpZ"
           },
           {
             "accessors": [
@@ -57426,18 +57261,16 @@
                     "usr": "s:6Sentry0A18MetricsApiProtocolP"
                   }
                 ],
-                "declAttributes": [
-                  "Final"
-                ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvgZ",
+                "mangledName": "$s6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "s:6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvgZ"
+                "usr": "s:6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvgZ"
               },
               {
                 "accessorKind": "set",
@@ -57454,18 +57287,16 @@
                     "printedName": "()"
                   }
                 ],
-                "declAttributes": [
-                  "Final"
-                ],
                 "declKind": "Accessor",
                 "implicit": true,
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvsZ",
+                "mangledName": "$s6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvsZ",
                 "moduleName": "Sentry",
                 "name": "Set",
                 "printedName": "Set()",
                 "static": true,
-                "usr": "s:6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvsZ"
+                "usr": "s:6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvsZ"
               }
             ],
             "children": [
@@ -57477,18 +57308,18 @@
               }
             ],
             "declAttributes": [
-              "Final",
               "HasStorage"
             ],
             "declKind": "Var",
             "hasStorage": true,
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvpZ",
+            "mangledName": "$s6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvpZ",
             "moduleName": "Sentry",
             "name": "metrics",
             "printedName": "metrics",
             "static": true,
-            "usr": "s:6Sentry0A3SDKC7metricsAA0A18MetricsApiProtocol_pvpZ"
+            "usr": "s:6Sentry0A3SDKO7metricsAA0A18MetricsApiProtocol_pvpZ"
           },
           {
             "accessors": [
@@ -57502,18 +57333,15 @@
                     "usr": "c:objc(cs)SentryReplayApi"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC6replaySo0A9ReplayApiCvgZ",
+                "mangledName": "$s6Sentry0A3SDKO6replaySo0A9ReplayApiCvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)replay"
+                "usr": "s:6Sentry0A3SDKO6replaySo0A9ReplayApiCvgZ"
               }
             ],
             "children": [
@@ -57524,18 +57352,15 @@
                 "usr": "c:objc(cs)SentryReplayApi"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC6replaySo0A9ReplayApiCvpZ",
+            "mangledName": "$s6Sentry0A3SDKO6replaySo0A9ReplayApiCvpZ",
             "moduleName": "Sentry",
             "name": "replay",
             "printedName": "replay",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)replay"
+            "usr": "s:6Sentry0A3SDKO6replaySo0A9ReplayApiCvpZ"
           },
           {
             "accessors": [
@@ -57557,18 +57382,15 @@
                     "usr": "s:Sq"
                   }
                 ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
                 "declKind": "Accessor",
+                "isFromExtension": true,
                 "kind": "Accessor",
-                "mangledName": "$s6Sentry0A3SDKC4spanSo0A4Span_pSgvgZ",
+                "mangledName": "$s6Sentry0A3SDKO4spanSo0A4Span_pSgvgZ",
                 "moduleName": "Sentry",
                 "name": "Get",
                 "printedName": "Get()",
                 "static": true,
-                "usr": "c:@M@Sentry@objc(cs)SentrySDK(cm)span"
+                "usr": "s:6Sentry0A3SDKO4spanSo0A4Span_pSgvgZ"
               }
             ],
             "children": [
@@ -57587,28 +57409,18 @@
                 "usr": "s:Sq"
               }
             ],
-            "declAttributes": [
-              "Final",
-              "ObjC"
-            ],
             "declKind": "Var",
+            "isFromExtension": true,
             "kind": "Var",
-            "mangledName": "$s6Sentry0A3SDKC4spanSo0A4Span_pSgvpZ",
+            "mangledName": "$s6Sentry0A3SDKO4spanSo0A4Span_pSgvpZ",
             "moduleName": "Sentry",
             "name": "span",
             "printedName": "span",
             "static": true,
-            "usr": "c:@M@Sentry@objc(cs)SentrySDK(cpy)span"
+            "usr": "s:6Sentry0A3SDKO4spanSo0A4Span_pSgvpZ"
           }
         ],
         "conformances": [
-          {
-            "kind": "Conformance",
-            "mangledName": "$ss7CVarArgP",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP"
-          },
           {
             "kind": "Conformance",
             "mangledName": "$ss8CopyableP",
@@ -57618,62 +57430,19 @@
           },
           {
             "kind": "Conformance",
-            "mangledName": "$ss28CustomDebugStringConvertibleP",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "mangledName": "$ss23CustomStringConvertibleP",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "mangledName": "$sSQ",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ"
-          },
-          {
-            "kind": "Conformance",
             "mangledName": "$ss9EscapableP",
             "name": "Escapable",
             "printedName": "Escapable",
             "usr": "s:s9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "mangledName": "$sSH",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
           }
         ],
-        "declAttributes": [
-          "Final",
-          "ObjC"
-        ],
-        "declKind": "Class",
-        "inheritsConvenienceInitializers": true,
+        "declKind": "Enum",
         "kind": "TypeDecl",
-        "mangledName": "$s6Sentry0A3SDKC",
+        "mangledName": "$s6Sentry0A3SDKO",
         "moduleName": "Sentry",
         "name": "SentrySDK",
         "printedName": "SentrySDK",
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "usr": "c:@M@Sentry@objc(cs)SentrySDK"
+        "usr": "s:6Sentry0A3SDKO"
       },
       {
         "children": [


### PR DESCRIPTION
## Description

Gates all `@objc` attributes in `SentrySDK.swift` behind `#if !SDK_V10` so they are excluded when building for SDK v10, where `SentrySDK` is an `enum` instead of a class.

Uses conditional attribute gating (`#if !SDK_V10` / `#endif` around just the `@objc` line) instead of duplicating entire method bodies in `#if` / `#else` blocks.

Also updates ObjC call sites in `PrivateSentrySDKOnly` and `SentryNetworkTracker` to use `SentrySDKInternal` directly.

Closes https://github.com/getsentry/sentry-cocoa/issues/8131

#skip-changelog