### PR TITLE
fix: unsynchronized debug-mode access in binary image cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8221)
 - Fix client report discarded-event counts for categories reported in quantities greater than one (e.g. spans): each drop now adds the full dropped quantity instead of incrementing by one (#8230)
 - Rename extended app start span operation from `app.start.extended_app_start` to `app.start.extended` (#8220)
+- Fix unsynchronized debug-mode access in the binary image cache (#8309)
 
 ## 9.19.0
 

--- a/Sources/Swift/Core/Helper/SentryBinaryImageCache.swift
+++ b/Sources/Swift/Core/Helper/SentryBinaryImageCache.swift
@@ -96,8 +96,8 @@ import Foundation
             size: size
         )
         
-        lock.synchronized {
-            guard let cache = self.cache else { return }
+        let shouldValidateDuplicatedSDK = lock.synchronized { () -> Bool in
+            guard let cache = self.cache else { return false }
             
             // Binary search insertion to maintain sorted order by address
             var left = 0
@@ -114,9 +114,10 @@ import Foundation
             }
             
             self.cache?.insert(newImage, at: left)
+            return self.isDebug
         }
         
-        if isDebug {
+        if shouldValidateDuplicatedSDK {
             // This validation adds some overhead with each class present in the image, so we only
             // run this when debug is enabled. A non main queue is used to avoid affecting the UI.
             LoadValidator.checkForDuplicatedSDK(imageName: nameString,

--- a/Sources/Swift/Tools/LoadValidator.swift
+++ b/Sources/Swift/Tools/LoadValidator.swift
@@ -8,6 +8,9 @@ import MachO
 @_spi(Private) public final class LoadValidator: NSObject {
     // Any class should be fine, ObjC classes are better
     static let targetClassName = NSStringFromClass(SentryDependencyContainerSwiftHelper.self)
+#if SENTRY_TEST || SENTRY_TEST_CI
+    static var checkForDuplicatedSDKCallback: ((String, UInt64, UInt64) -> Void)?
+#endif
     
     // This function is used to check for duplicated SDKs in the binary.
     // Since `SentryBinaryImageInfo` is not public and only available through the Hybrid SDK, we use the expanded parameters.
@@ -17,6 +20,9 @@ import MachO
                                                            imageSize: NSNumber,
                                                            objcRuntimeWrapper: SentryObjCRuntimeWrapper,
                                                            dispatchQueueWrapper: SentryDispatchQueueWrapper) {
+#if SENTRY_TEST || SENTRY_TEST_CI
+        checkForDuplicatedSDKCallback?(imageName, imageAddress.uint64Value, imageSize.uint64Value)
+#endif
         internalCheckForDuplicatedSDK(imageName, imageAddress.uint64Value, imageSize.uint64Value,
                                       objcRuntimeWrapper: objcRuntimeWrapper,
                                       dispatchQueueWrapper: dispatchQueueWrapper)

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -20,6 +20,7 @@ class SentryBinaryImageCacheTests: XCTestCase {
     }
 
     override func tearDown() {
+        LoadValidator.checkForDuplicatedSDKCallback = nil
         sut.stop()
         sentrycrashbic_useDefaultCacheState()
         SentryDependencyContainer.reset()
@@ -45,6 +46,36 @@ class SentryBinaryImageCacheTests: XCTestCase {
         let cache = try XCTUnwrap(sut.cache)
         XCTAssertEqual(1, cache.count)
         XCTAssertEqual("Expected Name at 100", sut.imageByAddress(100)?.name)
+    }
+
+    func testBinaryImageAdded_WhenDebugEnabled_shouldValidateDuplicatedSDK() throws {
+        sut.stop()
+        sut.start(true)
+        let validationInvocations = Invocations<(imageName: String, imageAddress: UInt64, imageSize: UInt64)>()
+        LoadValidator.checkForDuplicatedSDKCallback = { imageName, imageAddress, imageSize in
+            validationInvocations.record((imageName, imageAddress, imageSize))
+        }
+
+        let binaryImage = createCrashBinaryImage(100, name: "/usr/lib/system.dylib")
+        addBinaryImageToSut(binaryImage)
+
+        XCTAssertEqual(1, validationInvocations.count)
+        let invocation = try XCTUnwrap(validationInvocations.first)
+        XCTAssertEqual("/usr/lib/system.dylib", invocation.imageName)
+        XCTAssertEqual(binaryImage.address, invocation.imageAddress)
+        XCTAssertEqual(binaryImage.size, invocation.imageSize)
+    }
+
+    func testBinaryImageAdded_WhenDebugDisabled_shouldNotValidateDuplicatedSDK() {
+        let validationInvocations = Invocations<Void>()
+        LoadValidator.checkForDuplicatedSDKCallback = { _, _, _ in
+            validationInvocations.record(())
+        }
+
+        addBinaryImageToSut(createCrashBinaryImage(100, name: "/usr/lib/system.dylib"))
+
+        XCTAssertEqual(0, validationInvocations.count)
+        XCTAssertEqual(1, sut.cache?.count)
     }
 
     func testStop_WhenAlreadyStopped_shouldNotUnregisterExternalCallbacks() {


### PR DESCRIPTION
## :scroll: Description

This is a follow-up to #8226. While that PR was discontinued because it became more complex than anticipated, it resolved an issue that we can trivially fix even with the `NSRecursiveLock`-based implementation: access to `isDebug` in the `binaryImageAdded` callback should be synchronized within the lock scope, and the gate for  `LoadValidator.checkForDuplicatedSDK` should only check against a local variable returned from the lock scope.

## :bulb: Motivation and Context

This is definitely a variable that can be accessed by multiple threads and, as such, requires synchronization.

## :green_heart: How did you test it?

Ran our test suite. Proving that a synchronization is correct with tests is moot, but I think the change is small enough to be obvious. Thread sanitizer tests for life-cycle functions could be useful for such fixes, but I think introducing those is much bigger than this particular fix justifies.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
