### PR TITLE
fix: race in SentrySDKInternal.isEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix use-after-free crash in `SentrySDKInternal.isEnabled` (#8310)
 - Fix dropped `platform` item header in profile-chunk envelopes (#8269)
 - Fix crash report ID generation so reports created at certain timestamps are not ignored (#8216)
 - Fix C++ exception capture on newer OS versions by page-aligning `mprotect` calls in the `__cxa_throw` swapper (#8221)

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -114,6 +114,9 @@ static NSDate *_Nullable startTimestamp = nil;
     // must be side-effect free. Snapshot under currentHubLock so ARC retains the hub before close()
     // can nil the static and free it; an unsynchronized read races with close() (use-after-free,
     // see #8267).
+    // Using a local copy of the hub to minimize the scope of currentHubLock and, more importantly,
+    // to avoid calling getClient within the scope of currentHubLock. getClient reads the atomic
+    // internal client property, which should minimize the risk of potential future deadlocks.
     SentryHubInternal *localCurrentHub = nil;
     @synchronized(currentHubLock) {
         localCurrentHub = currentHub;

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -110,7 +110,16 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (BOOL)isEnabled
 {
-    return currentHub != nil && [currentHub getClient] != nil;
+    // Avoid the SentrySDKInternal.currentHub getter: it lazily creates an empty hub, and this check
+    // must be side-effect free. Snapshot under currentHubLock so ARC retains the hub before close()
+    // can nil the static and free it; an unsynchronized read races with close() (use-after-free,
+    // see #8267).
+    SentryHubInternal *localCurrentHub = nil;
+    @synchronized(currentHubLock) {
+        localCurrentHub = currentHub;
+    }
+
+    return localCurrentHub != nil && [localCurrentHub getClient] != nil;
 }
 
 + (BOOL)lastRunStatusCalled

--- a/Tests/SentryTests/SentrySDKThreadTests.swift
+++ b/Tests/SentryTests/SentrySDKThreadTests.swift
@@ -37,4 +37,42 @@ final class SentrySDKThreadTests: XCTestCase {
         throw XCTSkip("watchOS has limited concurrency; this stress test times out waiting for 100 blocks")
 #endif
     }
+
+    /// Regression test for #8267: `addBreadcrumb` calls `isEnabled`, which read the static current hub
+    /// while `close()`/`setCurrentHub:` nils it and drops the last strong reference, causing a
+    /// use-after-free (EXC_BAD_ACCESS).
+    /// You may have to run this test repeatedly to reliably reproduce the problem.
+    func testCallingIsEnabledWhileSettingHubNil_DoesNotCrash() throws {
+        let options = Options()
+
+        for _ in 0..<100 {
+
+            // Install a hub whose only strong reference is the static currentHub, so nil'ing it
+            // deallocates the hub - the exact condition that triggers the use-after-free.
+            SentrySDKInternal.setCurrentHub(SentryHubInternal(client: SentryClientInternal(options: options), andScope: nil))
+
+            let exp = expectation(description: "wait")
+            exp.expectedFulfillmentCount = 200
+
+            let queue = DispatchQueue(label: "com.sentry.test_is_enabled", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+
+            for _ in 0..<100 {
+                queue.async {
+                    SentrySDKInternal.addBreadcrumb(Breadcrumb(level: .info, category: "test"))
+                    exp.fulfill()
+                }
+
+                queue.async {
+                    SentrySDKInternal.setCurrentHub(nil)
+                    exp.fulfill()
+                }
+            }
+
+            queue.activate()
+
+            wait(for: [exp], timeout: 10.0)
+        }
+
+        SentrySDKInternal.setCurrentHub(nil)
+    }
 }


### PR DESCRIPTION
## :scroll: Description

`SentrySDKInternal.isEnabled` read the `currentHub` static without synchronization while `close()` niled it and dropped the last strong reference, causing a use-after-free (EXC_BAD_ACCESS). It now snapshots the hub into a local under `currentHubLock` (forcing an ARC retain) before messaging it.

## :bulb: Motivation and Context

Fixes #8267. Crash observed via SDK-CRASHES-COCOA-5 when a swizzled `URLSession` completion fires `addBreadcrumb:` on a background thread while the SDK is being closed.

## :green_heart: How did you test it?

Added a regression test (`testCallingIsEnabledWhileSettingHubNil_DoesNotCrash`) that races `addBreadcrumb`/`isEnabled` against `setCurrentHub(nil)`. Under Thread Sanitizer it reports a data race in `+[SentrySDKInternal isEnabled]` before the fix and passes after.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).