### PR TITLE
ci: add workflow to compare M4, M4 Pro, and M2 Pro machines

### DIFF
--- a/.github/workflows/compare-machines.yml
+++ b/.github/workflows/compare-machines.yml
@@ -1,0 +1,26 @@
+name: Compare Machines
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fast-unit-tests:
+    name: Fast Unit Tests (iOS 26) on ${{matrix.pool}}
+    uses: ./.github/workflows/unit-test-common.yml
+    secrets: inherit
+    with:
+      name: iOS 26 Sentry (${{matrix.pool}})
+      runs-on: ${{matrix.pool}}
+      timeout: 20
+      should_skip: false
+      xcode: "26"
+      platform: iOS
+      scheme: Sentry
+      runner_provider: bitrise
+    strategy:
+      matrix:
+        pool: ["tahoe", "tahoe-xl", "test-m4-pro"]


### PR DESCRIPTION
## Summary
- Adds a new `compare-machines.yml` workflow that runs iOS 26 unit tests across three Bitrise pools to compare machine performance:
  - `tahoe` (M4)
  - `tahoe-xl` (M2 Pro)
  - `test-m4-pro` (M4 Pro)

#skip-changelog