### PR TITLE
fix: snapshot currentHub under currentHubLock in span, startProfiler, stopProfiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix use-after-free race in `span`, `startProfiler`, and `stopProfiler` by snapshotting `currentHub` under `currentHubLock` before dereferencing. (#8318)
+
 ## 9.20.0
 
 > [!IMPORTANT]

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -105,7 +105,13 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (nullable id<SentrySpan>)span
 {
-    return currentHub.scope.span;
+    // Snapshot under currentHubLock so ARC retains the hub before close() can nil the static
+    // and free it; an unsynchronized read races with close() (use-after-free, see #8316).
+    SentryHubInternal *localCurrentHub = nil;
+    @synchronized(currentHubLock) {
+        localCurrentHub = currentHub;
+    }
+    return localCurrentHub.scope.span;
 }
 
 + (BOOL)isEnabled
@@ -628,7 +634,11 @@ static NSDate *_Nullable startTimestamp = nil;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 + (void)startProfiler
 {
-    SentryOptions *options = currentHub.client.options;
+    SentryHubInternal *localCurrentHub = nil;
+    @synchronized(currentHubLock) {
+        localCurrentHub = currentHub;
+    }
+    SentryOptions *options = localCurrentHub.client.options;
     if (options == nil) {
         SENTRY_LOG_WARN(@"Cannot start profiling when options are nil.");
         return;
@@ -685,7 +695,11 @@ static NSDate *_Nullable startTimestamp = nil;
         return;
     }
 
-    SentryOptions *options = currentHub.client.options;
+    SentryHubInternal *localCurrentHub = nil;
+    @synchronized(currentHubLock) {
+        localCurrentHub = currentHub;
+    }
+    SentryOptions *options = localCurrentHub.client.options;
     if (options == nil) {
         SENTRY_LOG_WARN(@"Cannot stop profiling when options are nil.");
         return;


### PR DESCRIPTION
## What

Fixes the thread-safety gap described in #8316.

`close()` nils the static `currentHub` while releasing the last ARC retain. Three methods read the bare global without holding `currentHubLock`, so a concurrent `close()` call races and may dereference a freed object (use-after-free / SIGSEGV):

| Method | Unsafe access |
|--------|--------------|
| `+span` | `currentHub.scope.span` |
| `+startProfiler` | `currentHub.client.options` |
| `+stopProfiler` | `currentHub.client.options` |

## How

Applied the same lock-snapshot pattern already established in `isEnabled` (#8310):

```objc
SentryHubInternal *localCurrentHub = nil;
@synchronized(currentHubLock) {
    localCurrentHub = currentHub;
}
// use localCurrentHub safely
```

The lock scope is kept narrow (snapshot only) to avoid calling into hub/client code while holding the lock, consistent with the rationale documented in `isEnabled`.

## Testing

Existing thread-safety tests cover `isEnabled` + `close()` races. The same pattern is applied here — no new test surface is needed beyond confirming no regression.

Fixes #8316