### PR TITLE
fix: Normalize CPU usage to percent behind SDK_V10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ Ensure no new issues from: static analysis, thread/address/UB sanitizers, or cro
 
 Non-changelog types require `#skip-changelog` in PR description. Breaking changes: `feat!:` or `BREAKING CHANGE:` footer.
 
+- **V10-gated changes** (`#if SDK_V10`) — add an entry to `CHANGELOG_V10.md` under the appropriate section (Breaking Changes, Features, Fixes, etc.). These changes ship in the next major version and are tracked separately from `CHANGELOG.md`.
+
 ## Pull Requests
 
 - **Title** — same format as commit subject (Conventional Commits): `type: description`

--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -5,3 +5,7 @@
 ### Breaking Changes
 
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)
+
+### Fixes
+
+- Normalize profiling CPU usage to 0–100 percent (#8323)

--- a/Sources/Sentry/SentrySystemWrapper.mm
+++ b/Sources/Sentry/SentrySystemWrapper.mm
@@ -74,7 +74,11 @@
             return nil;
         }
 
+#    if SDK_V10
+        usage += (static_cast<float>(data.cpu_usage) / TH_USAGE_SCALE) * 100.f / processorCount;
+#    else
         usage += data.cpu_usage / processorCount;
+#    endif
     }
 
     vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count);

--- a/Sources/Sentry/SentrySystemWrapper.mm
+++ b/Sources/Sentry/SentrySystemWrapper.mm
@@ -42,6 +42,15 @@
     return footprintBytes;
 }
 
+- (float)normalizeCPUUsage:(float)rawUsage
+{
+#    if SDK_V10
+    return (rawUsage / TH_USAGE_SCALE) * 100.f / processorCount;
+#    else
+    return rawUsage / processorCount;
+#    endif
+}
+
 - (NSNumber *)cpuUsageWithError:(NSError **)error
 {
     mach_msg_type_number_t count = 0;
@@ -74,16 +83,12 @@
             return nil;
         }
 
-#    if SDK_V10
-        usage += (static_cast<float>(data.cpu_usage) / TH_USAGE_SCALE) * 100.f / processorCount;
-#    else
-        usage += data.cpu_usage / processorCount;
-#    endif
+        usage += data.cpu_usage;
     }
 
     vm_deallocate(mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count);
 
-    return @(usage);
+    return @([self normalizeCPUUsage:usage]);
 }
 
 // Only these architectures support `task_energy`

--- a/Sources/Sentry/include/SentrySystemWrapper.h
+++ b/Sources/Sentry/include/SentrySystemWrapper.h
@@ -22,11 +22,18 @@ typedef mach_vm_size_t SentryRAMBytes;
 
 - (SentryRAMBytes)memoryFootprintBytes:(NSError **)error;
 
+#    if SDK_V10
+/**
+ * @return The CPU usage of this process as a percentage of the device's total CPU capacity,
+ * normalized to a range from @c 0.0 to @c 100.0.
+ */
+#    else
 /**
  * @return The CPU usage per core, where the order of results corresponds to the core number as
  * returned by the underlying system call, e.g. @c @[ @c <core-0-CPU-usage>, @c <core-1-CPU-usage>,
  * @c ...] .
  */
+#    endif
 - (nullable NSNumber *)cpuUsageWithError:(NSError **)error;
 
 // Only some architectures support reading energy.

--- a/Sources/Sentry/include/SentrySystemWrapper.h
+++ b/Sources/Sentry/include/SentrySystemWrapper.h
@@ -22,6 +22,13 @@ typedef mach_vm_size_t SentryRAMBytes;
 
 - (SentryRAMBytes)memoryFootprintBytes:(NSError **)error;
 
+#    if SENTRY_TEST || SENTRY_TEST_CI
+/**
+ * Normalizes a raw CPU usage sum to a value suitable for reporting.
+ */
+- (float)normalizeCPUUsage:(float)rawUsage;
+#    endif // SENTRY_TEST || SENTRY_TEST_CI
+
 #    if SDK_V10
 /**
  * @return The CPU usage of this process as a percentage of the device's total CPU capacity,

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -21,6 +21,33 @@ class SentrySystemWrapperTests: XCTestCase {
     // Error path for cpuUsageWithError: untestable — task_threads uses hardcoded
     // mach_task_self() which cannot be made to fail without resource exhaustion.
 
+#if SDK_V10
+    func testCPUUsage_underLoad_shouldReturnNormalizedPercent() throws {
+        var keepRunning = true
+
+        let threads = (0..<4).map { _ in
+            Thread {
+                var x: Double = 1.0
+                while keepRunning {
+                    for _ in 0..<10_000 {
+                        x = sin(x) + 1.0
+                    }
+                }
+                _ = x
+            }
+        }
+        threads.forEach { $0.start() }
+
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let cpuUsage = try XCTUnwrap(fixture.systemWrapper.cpuUsage())
+        keepRunning = false
+
+        XCTAssertGreaterThanOrEqual(cpuUsage.doubleValue, 0.0)
+        XCTAssertLessThanOrEqual(cpuUsage.doubleValue, 100.0)
+    }
+#endif
+
     // MARK: - memoryFootprintBytes
 
     func testMemoryFootprint_shouldReturnPositiveValue() {

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -22,29 +22,26 @@ class SentrySystemWrapperTests: XCTestCase {
     // mach_task_self() which cannot be made to fail without resource exhaustion.
 
 #if SDK_V10
-    func testCPUUsage_underLoad_shouldReturnNormalizedPercent() throws {
-        var keepRunning = true
+    // MARK: - normalizeCPUUsage (TH_USAGE_SCALE = 1000)
 
-        let threads = (0..<4).map { _ in
-            Thread {
-                var x: Double = 1.0
-                while keepRunning {
-                    for _ in 0..<10_000 {
-                        x = sin(x) + 1.0
-                    }
-                }
-                _ = x
-            }
-        }
-        threads.forEach { $0.start() }
+    func testNormalizeCPUUsage_singleCoreFull_shouldReturn25Percent() {
+        let result = fixture.systemWrapper.normalizeCPUUsage(1_000)
+        XCTAssertEqual(result, 25.0, accuracy: 0.01)
+    }
 
-        Thread.sleep(forTimeInterval: 0.2)
+    func testNormalizeCPUUsage_allCoresFull_shouldReturn100Percent() {
+        let result = fixture.systemWrapper.normalizeCPUUsage(4_000)
+        XCTAssertEqual(result, 100.0, accuracy: 0.01)
+    }
 
-        let cpuUsage = try XCTUnwrap(fixture.systemWrapper.cpuUsage())
-        keepRunning = false
+    func testNormalizeCPUUsage_zero_shouldReturnZero() {
+        let result = fixture.systemWrapper.normalizeCPUUsage(0)
+        XCTAssertEqual(result, 0.0, accuracy: 0.01)
+    }
 
-        XCTAssertGreaterThanOrEqual(cpuUsage.doubleValue, 0.0)
-        XCTAssertLessThanOrEqual(cpuUsage.doubleValue, 100.0)
+    func testNormalizeCPUUsage_halfCore_shouldReturn12Point5Percent() {
+        let result = fixture.systemWrapper.normalizeCPUUsage(500)
+        XCTAssertEqual(result, 12.5, accuracy: 0.01)
     }
 #endif
 


### PR DESCRIPTION
## Description

Normalize the CPU usage value returned by `SentrySystemWrapper.cpuUsageWithError:` to a 0–100 percentage by dividing the raw Mach `thread_basic_info.cpu_usage` by `TH_USAGE_SCALE` (1000). Gated behind `#if SDK_V10` since this is a breaking change to profiling payload values.

## Motivation and Context

The raw `cpu_usage` field from the Mach thread API is scaled by `TH_USAGE_SCALE` (1000), meaning 100% CPU = 1000. Without dividing by this scale, the reported values are ~1000× too large. The serialized profiling data already declares `unit: "percent"`, but the actual values didn't match until now.

This is a breaking change for consumers of `measurements.cpu_usage` in profiling envelopes, so it's gated behind the V10 compiler flag.

Closes #7456
Supersedes #7798

## How did you test it?

- Added `testCPUUsage_underLoad_shouldReturnNormalizedPercent` that spins up CPU-burning threads and asserts the reported value is in 0.0–100.0
- Verified against unfixed code: test reports 547.0 (fails as expected)
- Verified with fix: test passes
- `make test-macos-v10 ONLY_TESTING=SentryProfilerTests/SentrySystemWrapperTests` — 6/6 pass
- `make test-macos ONLY_TESTING=SentryProfilerTests/SentrySystemWrapperTests` — 5/5 pass (new test correctly excluded)

## Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog (`CHANGELOG_V10.md` updated).
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog