### PR TITLE
test: add `SIG_IGN` e2e crash test case

### DIFF
--- a/TestSamples/CrashE2E/App/Sources/CrashE2ECrashTriggers.swift
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2ECrashTriggers.swift
@@ -14,6 +14,8 @@ enum CrashE2ECrashTriggers {
             Thread.sleep(forTimeInterval: 0.5)
             CrashE2ETriggerDynamicBinaryImageCrash()
             abortBecauseScenarioReturned(scenario)
+        case .ignoredSignal:
+            triggerIgnoredSignal()
         case .managedRuntimeClosedSignal:
             SentrySDK.close()
             SentrySDK.crash()
@@ -22,6 +24,15 @@ enum CrashE2ECrashTriggers {
             CrashE2ERuntime.closeAndRestartSDK()
             SentrySDK.crash()
             abortBecauseScenarioReturned(scenario)
+        case .nsException, .cppExceptionV1, .cppExceptionV2, .swiftAsyncCPPExceptionV2Off,
+             .swiftAsyncCPPExceptionV2On, .unityCxaThrow, .objcObject, .idle, .drain,
+             .managedRuntimePreSDKSignal:
+            triggerExceptionScenario(scenario)
+        }
+    }
+
+    private static func triggerExceptionScenario(_ scenario: CrashE2EScenario) -> Never {
+        switch scenario {
         case .nsException:
             NSException(
                 name: NSExceptionName("CrashE2ENSException"),
@@ -45,7 +56,17 @@ enum CrashE2ECrashTriggers {
             abortBecauseScenarioReturned(scenario)
         case .idle, .drain, .managedRuntimePreSDKSignal:
             abortBecauseScenarioReturned(scenario)
+        case .signal, .binaryImages, .ignoredSignal, .managedRuntimeSignalChain,
+             .managedRuntimeClosedSignal, .managedRuntimeReinitSignal:
+            abortBecauseScenarioReturned(scenario)
         }
+    }
+
+    private static func triggerIgnoredSignal() -> Never {
+        NSLog("CrashE2E - raising pre-SDK ignored SIGPIPE")
+        raise(SIGPIPE)
+        NSLog("CrashE2E - ignored SIGPIPE did not terminate the process")
+        exit(0)
     }
 
     private static func triggerSwiftAsyncCPPException(_ scenario: CrashE2EScenario) -> Never {

--- a/TestSamples/CrashE2E/App/Sources/CrashE2ERuntime.swift
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2ERuntime.swift
@@ -12,6 +12,7 @@ enum CrashE2EScenario: String {
     case unityCxaThrow = "unity-cxa-throw"
     case objcObject = "objc-object"
     case binaryImages = "binary-images"
+    case ignoredSignal = "ignored-signal"
     case managedRuntimeSignalChain = "managed-runtime-signal-chain"
     case managedRuntimePreSDKSignal = "managed-runtime-pre-sdk-signal"
     case managedRuntimeClosedSignal = "managed-runtime-closed-signal"
@@ -68,6 +69,7 @@ enum CrashE2ERuntime {
     static func startSDK() {
         NSLog("CrashE2E - starting SDK with scenario: \(configuration.scenario.rawValue)")
         triggerPreSDKSignalIfNeeded()
+        installIgnoredSignalHandlerIfNeeded()
         installFakeManagedRuntimeHandlerIfNeeded()
         loadBinaryImageBeforeSDKIfNeeded()
         startConfiguredSDK()
@@ -85,7 +87,7 @@ enum CrashE2ERuntime {
         case .managedRuntimePreSDKSignal:
             abortBecausePreSDKScenarioReturned()
         case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
+             .binaryImages, .ignoredSignal, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
              .managedRuntimeReinitSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             NSLog("CrashE2E - will trigger scenario: \(configuration.scenario.rawValue)")
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
@@ -105,7 +107,7 @@ enum CrashE2ERuntime {
         case .managedRuntimePreSDKSignal:
             abortBecausePreSDKScenarioReturned()
         case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
+             .binaryImages, .ignoredSignal, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
              .managedRuntimeReinitSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             NSLog("CrashE2E - will trigger scenario synchronously: \(configuration.scenario.rawValue)")
             Thread.sleep(forTimeInterval: 0.5)
@@ -161,13 +163,19 @@ enum CrashE2ERuntime {
         abortBecausePreSDKScenarioReturned()
     }
 
+    private static func installIgnoredSignalHandlerIfNeeded() {
+        guard configuration.scenario == .ignoredSignal else { return }
+        NSLog("CrashE2E - installing SIG_IGN for SIGPIPE before SentrySDK.start")
+        signal(SIGPIPE, SIG_IGN)
+    }
+
     private static func installFakeManagedRuntimeHandlerIfNeeded() {
         switch configuration.scenario {
         case .managedRuntimeSignalChain, .managedRuntimeClosedSignal, .managedRuntimeReinitSignal:
             installFakeManagedRuntimeHandler()
         case .idle, .drain, .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow,
-             .objcObject, .binaryImages, .managedRuntimePreSDKSignal, .swiftAsyncCPPExceptionV2Off,
-             .swiftAsyncCPPExceptionV2On:
+             .objcObject, .binaryImages, .ignoredSignal, .managedRuntimePreSDKSignal,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             return
         }
     }

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
@@ -40,6 +40,7 @@ enum Scenario: String, CaseIterable {
     case unityCxaThrow = "unity-cxa-throw"
     case objcObject = "objc-object"
     case binaryImages = "binary-images"
+    case ignoredSignal = "ignored-signal"
     case managedRuntimeSignalChain = "managed-runtime-signal-chain"
     case managedRuntimePreSDKSignal = "managed-runtime-pre-sdk-signal"
     case managedRuntimeClosedSignal = "managed-runtime-closed-signal"
@@ -61,6 +62,7 @@ enum Scenario: String, CaseIterable {
         // expected to fail this scenario; use --keep-going to continue the default run.
         .objcObject,
         .binaryImages,
+        .ignoredSignal,
         .managedRuntimeSignalChain,
         .managedRuntimePreSDKSignal,
         .managedRuntimeClosedSignal,
@@ -75,14 +77,26 @@ enum Scenario: String, CaseIterable {
              .managedRuntimeReinitSignal:
             return true
         case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+             .binaryImages, .ignoredSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             return false
+        }
+    }
+
+    var expectsCrashTermination: Bool {
+        switch self {
+        case .ignoredSignal:
+            return false
+        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
+             .binaryImages, .managedRuntimeSignalChain, .managedRuntimePreSDKSignal,
+             .managedRuntimeClosedSignal, .managedRuntimeReinitSignal,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+            return true
         }
     }
 
     var expectsEvent: Bool {
         switch self {
-        case .managedRuntimePreSDKSignal, .managedRuntimeClosedSignal:
+        case .managedRuntimePreSDKSignal, .managedRuntimeClosedSignal, .ignoredSignal:
             return false
         case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
              .binaryImages, .managedRuntimeSignalChain, .managedRuntimeReinitSignal,

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
@@ -58,6 +58,8 @@ enum EventAssertions {
              .managedRuntimeClosedSignal, .managedRuntimeReinitSignal, .nsException:
             try assertCrashedThread(threadValues, expectedThreadID: exceptionThreadID,
                                     platform: platform, scenario: scenario)
+        case .ignoredSignal:
+            return
         }
     }
 
@@ -123,6 +125,9 @@ enum EventAssertions {
 
         case .objcObject:
             try assertObjCObjectThrow(firstException, mechanism: mechanism, platform: platform)
+
+        case .ignoredSignal:
+            return
         }
     }
 

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/MacOSPlatformRunner.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/MacOSPlatformRunner.swift
@@ -100,10 +100,17 @@ final class MacOSPlatformRunner {
         if result.timedOut {
             try fail("macOS app did not terminate for scenario: \(scenario.rawValue) (\(result.summary))")
         }
-        if result.succeeded {
-            try fail("macOS app exited successfully for crash scenario: \(scenario.rawValue)")
+        if scenario.expectsCrashTermination {
+            if result.succeeded {
+                try fail("macOS app exited successfully for crash scenario: \(scenario.rawValue)")
+            }
+            log("macOS crash process exited with \(result.summary).")
+        } else {
+            if !result.succeeded {
+                try fail("macOS app failed for non-crash scenario: \(scenario.rawValue) (\(result.summary))")
+            }
+            log("macOS non-crash process exited with \(result.summary).")
         }
-        log("macOS crash process exited with \(result.summary).")
     }
 
     private func runDrainLaunch(_ scenario: Scenario, executable: URL, cacheDir: URL,


### PR DESCRIPTION
## :scroll: Description

Adds an e2e crash test case for the `SIG_IGN` behavior introduced here: #1489 (via #1472). 

## :bulb: Motivation and Context

This feature was added to `SentryCrash` rather early and by a customer. So, it's likely something we should continue to support, is a sensible upstream candidate (does not exist in any version of `KSCrash`), and, as such, also requires e2e coverage.

## :green_heart: How did you test it?

This is the e2e test verifying the behavior introduced in #1489.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
