### PR TITLE
test: add Sentry+KSCrash to CrashE2E

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,24 +2,20 @@ excluded:
   - Pods
   - DerivedData
   - "**/SourcePackages/**"
-  - Utils/**/.build
-  - Samples/**/.build
   - "**/build/**"
   - DependencyManagerTests
   - Sources/SentryCrash
   - vendor
-  - test-server/.build/
   - Tests/Perf
   - SentryTestUtils/Dynamic/**
   - .build/**
+  - "**/.build/**"
   - .git/**
   - XCFrameworkBuildPath/**
   - 3rd-party-integrations/**/Packages/sentry-cocoa
-  - 3rd-party-integrations/**/.build
   # Exclude auto-generated files from sample app builds
   - "**/Build/Intermediates.noindex/iOS-Swift.build/**/DerivedSources/**"
   - "**/Build/Intermediates.noindex/iOS-SwiftClip.build/**/DerivedSources/**"
-  - "TestSamples/**"
 
 only_rules:
   - class_delegate_protocol

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ excluded:
   # Exclude auto-generated files from sample app builds
   - "**/Build/Intermediates.noindex/iOS-Swift.build/**/DerivedSources/**"
   - "**/Build/Intermediates.noindex/iOS-SwiftClip.build/**/DerivedSources/**"
+  - "TestSamples/**"
 
 only_rules:
   - class_delegate_protocol

--- a/TestSamples/CrashE2E/CrashE2E.yml
+++ b/TestSamples/CrashE2E/CrashE2E.yml
@@ -37,6 +37,32 @@ targets:
       Debug: App/Configurations/CrashE2E-iOS.xcconfig
       Release: App/Configurations/CrashE2E-iOS.xcconfig
 
+  CrashE2E-iOS-KSCrash:
+    type: application
+    platform: iOS
+    deploymentTarget: "16.0"
+    dependencies:
+      - target: "Sentry/Sentry+KSCrash"
+      - target: CrashE2EDynamicImageBefore-iOS
+        embed: true
+        link: false
+      - target: CrashE2EDynamicImageAfter-iOS
+        embed: true
+        link: false
+    sources:
+      - path: App/Sources
+        type: group
+        group: App
+        excludes:
+          - "**/.gitkeep"
+    configFiles:
+      Debug: App/Configurations/CrashE2E-iOS.xcconfig
+      Release: App/Configurations/CrashE2E-iOS.xcconfig
+    settings:
+      base:
+        PRODUCT_NAME: CrashE2E-iOS-KSCrash
+        PRODUCT_BUNDLE_IDENTIFIER: io.sentry.tests.CrashE2E.KSCrash.iOS
+
   CrashE2E-macOS:
     type: tool
     platform: macOS
@@ -58,6 +84,31 @@ targets:
       Release: App/Configurations/CrashE2E-macOS.xcconfig
     settings:
       base:
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CRASH_E2E_MACOS_CLI"
+
+  CrashE2E-macOS-KSCrash:
+    type: tool
+    platform: macOS
+    deploymentTarget: "11.0"
+    dependencies:
+      - target: "Sentry/Sentry+KSCrash"
+      - target: CrashE2EDynamicImageBefore-macOS
+        link: false
+      - target: CrashE2EDynamicImageAfter-macOS
+        link: false
+    sources:
+      - path: App/Sources
+        type: group
+        group: App
+        excludes:
+          - "**/.gitkeep"
+    configFiles:
+      Debug: App/Configurations/CrashE2E-macOS.xcconfig
+      Release: App/Configurations/CrashE2E-macOS.xcconfig
+    settings:
+      base:
+        PRODUCT_NAME: CrashE2E-macOS-KSCrash
+        PRODUCT_BUNDLE_IDENTIFIER: io.sentry.tests.CrashE2E.KSCrash.macOS
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CRASH_E2E_MACOS_CLI"
 
   CrashE2EDynamicImageBefore-iOS:
@@ -118,10 +169,30 @@ schemes:
     archive:
       config: Release
 
+  CrashE2E-iOS-KSCrash:
+    build:
+      buildImplicitDependencies: false
+      targets:
+        CrashE2E-iOS-KSCrash: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+
   CrashE2E-macOS:
     build:
       targets:
         CrashE2E-macOS: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+
+  CrashE2E-macOS-KSCrash:
+    build:
+      buildImplicitDependencies: false
+      targets:
+        CrashE2E-macOS-KSCrash: all
     run:
       config: Debug
     archive:

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
@@ -32,6 +32,53 @@ enum Platform: String {
     case macos
 }
 
+enum Reporter: String, CaseIterable {
+    case sentryCrash = "SentryCrash"
+    case ksCrash = "KSCrash"
+
+    init?(caseInsensitive value: String) {
+        guard let reporter = Self.allCases.first(where: { $0.rawValue.caseInsensitiveCompare(value) == .orderedSame }) else {
+            return nil
+        }
+        self = reporter
+    }
+
+    var iOSScheme: String {
+        switch self {
+        case .sentryCrash:
+            return "CrashE2E-iOS"
+        case .ksCrash:
+            return "CrashE2E-iOS-KSCrash"
+        }
+    }
+
+    var macOSScheme: String {
+        switch self {
+        case .sentryCrash:
+            return "CrashE2E-macOS"
+        case .ksCrash:
+            return "CrashE2E-macOS-KSCrash"
+        }
+    }
+
+    var iOSBundleID: String {
+        switch self {
+        case .sentryCrash:
+            return "io.sentry.tests.CrashE2E.iOS"
+        case .ksCrash:
+            return "io.sentry.tests.CrashE2E.KSCrash.iOS"
+        }
+    }
+
+    var iOSAppName: String {
+        "\(iOSScheme).app"
+    }
+
+    var macOSExecutableName: String {
+        macOSScheme
+    }
+}
+
 enum Scenario: String, CaseIterable {
     case signal
     case nsException = "ns-exception"
@@ -109,6 +156,7 @@ enum Scenario: String, CaseIterable {
 struct Config {
     let directories: Directories
     var platform: Platform = .all
+    var reporter: Reporter = .sentryCrash
     var scenarios: [Scenario] = Scenario.defaultScenarios
     var iosDestination: String?
     var iosDeviceID: String?
@@ -145,6 +193,7 @@ func usage(defaults: Config) -> String {
     return """
     Usage: run-crash-e2e.sh [options]
       --platform <all|ios|macos>          Platforms to run (default: all)
+      --reporter <SentryCrash|KSCrash>    Crash reporter to test (default: SentryCrash)
       --scenarios <space/comma list>      Scenarios to run (default: "\(defaultScenarios)")
                                           Known scenarios: \(knownScenarios)
       --ios-destination <destination>     xcodebuild iOS destination (default: auto-selected simulator id)

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/ConfigArgumentParser.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/ConfigArgumentParser.swift
@@ -2,6 +2,7 @@ import Foundation
 
 private enum ValueOption: String {
     case platform = "--platform"
+    case reporter = "--reporter"
     case scenarios = "--scenarios"
     case iosDestination = "--ios-destination"
     case iosDeviceID = "--ios-device-id"
@@ -58,6 +59,8 @@ struct ConfigArgumentParser {
         switch option {
         case .platform:
             try parsePlatform()
+        case .reporter:
+            try parseReporter()
         case .scenarios:
             try parseScenarios()
         case .iosDestination:
@@ -95,6 +98,15 @@ struct ConfigArgumentParser {
             throw CrashE2EFailure(message: "Invalid --platform: \(value)")
         }
         config.platform = platform
+        index += 2
+    }
+
+    private mutating func parseReporter() throws {
+        let value = try valueAfterCurrentArgument()
+        guard let reporter = Reporter(caseInsensitive: value) else {
+            throw CrashE2EFailure(message: "Invalid --reporter: \(value)")
+        }
+        config.reporter = reporter
         index += 2
     }
 

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/CrashE2ERunner.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/CrashE2ERunner.swift
@@ -80,10 +80,10 @@ final class CrashE2ERunner {
     }
 
     private func buildIOSApp(derivedDataPath: URL, label: String, extraBuildSettings: [String]) throws {
-        log("Building CrashE2E-iOS (\(label)).")
+        log("Building \(config.reporter.iOSScheme) (\(label)).")
         try xcodebuild([
             "-project", config.directories.crashE2EDir.appendingPathComponent("CrashE2E.xcodeproj").path,
-            "-scheme", "CrashE2E-iOS",
+            "-scheme", config.reporter.iOSScheme,
             "-configuration", "Debug",
             "-destination", iOSRunner.xcodebuildDestination,
             "-derivedDataPath", derivedDataPath.path,
@@ -92,10 +92,10 @@ final class CrashE2ERunner {
     }
 
     private func buildMacOSApp(derivedDataPath: URL, label: String, extraBuildSettings: [String]) throws {
-        log("Building CrashE2E-macOS (\(label)).")
+        log("Building \(config.reporter.macOSScheme) (\(label)).")
         try xcodebuild([
             "-project", config.directories.crashE2EDir.appendingPathComponent("CrashE2E.xcodeproj").path,
-            "-scheme", "CrashE2E-macOS",
+            "-scheme", config.reporter.macOSScheme,
             "-configuration", "Debug",
             "-destination", "platform=macOS",
             "-derivedDataPath", derivedDataPath.path,

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
@@ -243,8 +243,11 @@ enum EventAssertions {
         if platform == "ios" {
             return lastPathComponent == "CrashE2E-iOS"
                 || lastPathComponent == "CrashE2E-iOS.debug.dylib"
+                || lastPathComponent == "CrashE2E-iOS-KSCrash"
+                || lastPathComponent == "CrashE2E-iOS-KSCrash.debug.dylib"
         }
         return lastPathComponent == "CrashE2E-macOS"
+            || lastPathComponent == "CrashE2E-macOS-KSCrash"
     }
 
     private static func isDyldImage(_ codeFile: String) -> Bool {

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+//swiftlint:disable:next type_body_length
 enum EventAssertions {
     private static let binaryImageMarkerFileName = "crash-e2e-binary-images.json"
 

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/IOSPlatformRunner.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/IOSPlatformRunner.swift
@@ -4,7 +4,6 @@ final class IOSPlatformRunner {
     private let config: Config
     private let processRunner: ProcessRunner
     private let fileManager = FileManager.default
-    private let bundleID = "io.sentry.tests.CrashE2E.iOS"
 
     private(set) var deviceID = ""
     private(set) var xcodebuildDestination = ""
@@ -31,12 +30,12 @@ final class IOSPlatformRunner {
 
     private func installApp(derivedDataPath: URL) throws {
         let appPath = derivedDataPath
-            .appendingPathComponent("Build/Products/Debug-iphonesimulator/CrashE2E-iOS.app", isDirectory: true)
+            .appendingPathComponent("Build/Products/Debug-iphonesimulator/\(config.reporter.iOSAppName)", isDirectory: true)
         guard fileManager.fileExists(atPath: appPath.path) else {
             try fail("iOS app not found: \(appPath.path)")
         }
 
-        log("Installing CrashE2E-iOS on \(deviceID).")
+        log("Installing \(config.reporter.iOSScheme) on \(deviceID).")
         try processRunner.run("xcrun", ["simctl", "terminate", deviceID, bundleID], captureOutput: true, allowFailure: true)
         try processRunner.run("xcrun", ["simctl", "uninstall", deviceID, bundleID], captureOutput: true, allowFailure: true)
         try processRunner.run("xcrun", ["simctl", "install", deviceID, appPath.path])
@@ -195,5 +194,9 @@ final class IOSPlatformRunner {
             allowFailure: true
         )
         return output.contains(bundleID)
+    }
+
+    private var bundleID: String {
+        config.reporter.iOSBundleID
     }
 }

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/MacOSPlatformRunner.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/MacOSPlatformRunner.swift
@@ -56,7 +56,7 @@ final class MacOSPlatformRunner {
 
     private func macOSExecutable(derivedDataPath: URL) throws -> URL {
         let executable = derivedDataPath
-            .appendingPathComponent("Build/Products/Debug/CrashE2E-macOS")
+            .appendingPathComponent("Build/Products/Debug/\(config.reporter.macOSExecutableName)")
         guard fileManager.isExecutableFile(atPath: executable.path) else {
             try fail("macOS executable not found: \(executable.path)")
         }


### PR DESCRIPTION
## :scroll: Description

Adds the Sentry+KSCrash to the CrashE2E tests via new targets and wires up the runner to run scenarios against it.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This will help us test crash scenarios using the CrashE2E app + runner with a KSCrash enabled Sentry 🎉 

## :green_heart: How did you test it?

Ran both variants - SentryCrash returns envelopes in line with what main shows and Sentry+KSCrash doesn't (yet!)

> Note: this PR requires that https://github.com/getsentry/sentry-cocoa/pull/8154 merges **first**. 

#skips-changelog

Closes #8331