### PR TITLE
Fix SentrySubClassFinder crash on OS-gated Swift classes by using objc_lookUpClass

### DIFF
--- a/Sources/Swift/Core/Integrations/Performance/SentrySubClassFinder.swift
+++ b/Sources/Swift/Core/Integrations/Performance/SentrySubClassFinder.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+import ObjectiveC.runtime
 import UIKit
 
 class SentrySubClassFinder: NSObject {
@@ -76,7 +77,13 @@ class SentrySubClassFinder: NSObject {
                     continue
                 }
 
-                guard let cls = NSClassFromString(className) else { continue }
+                // Use objc_lookUpClass instead of NSClassFromString to avoid
+                // realizing OS-gated Swift classes on older OS versions, which
+                // crashes when their Swift metadata references unavailable
+                // protocol descriptors (e.g. UIGestureRecognizerRepresentable
+                // on iOS < 18). objc_lookUpClass returns nil for unrealized
+                // classes without triggering realization.
+                guard let cls = objc_lookUpClass(className) else { continue }
                 if self.isClass(cls, subClassOf: viewControllerClass) {
                     classesToSwizzle.append(className)
                 }
@@ -86,7 +93,7 @@ class SentrySubClassFinder: NSObject {
 
             self.dispatchQueue.dispatchAsyncOnMainQueueIfNotMainThread {
                 for className in classesToSwizzle {
-                    if let cls = NSClassFromString(className) {
+                    if let cls = objc_lookUpClass(className) {
                         block(cls)
                     }
                 }


### PR DESCRIPTION
Fixes #8152

## Problem

`SentrySubClassFinder.actOnSubclassesOfViewController` calls `NSClassFromString(className)` for every class name returned by `objc_copyClassNamesForImage`. `NSClassFromString` triggers ObjC class realization. For Swift classes with `@available(iOS 18+, *)` protocol conformances (e.g. `UIGestureRecognizerRepresentable`), realization walks Swift protocol descriptors that don't exist on the iOS 17 runtime → `EXC_BAD_ACCESS`.

## Fix

Replace both `NSClassFromString` calls with `objc_lookUpClass`, which performs a lookup **without** triggering realization. It returns `nil` for any class that hasn't already been realized, so OS-gated Swift classes are safely skipped on older OS versions.

```swift
// Before
guard let cls = NSClassFromString(className) else { continue }
// ...
if let cls = NSClassFromString(className) {

// After
guard let cls = objc_lookUpClass(className) else { continue }
// ...
if let cls = objc_lookUpClass(className) {
```

**Trade-off**: A `UIViewController` subclass that has never been loaded by the app at startup returns `nil` and won't be swizzled. This is the correct behaviour — you cannot interact with an unrealized class — and it matches the existing `swizzleClassNameExcludes` workaround semantics (those classes are also simply skipped).