### PR TITLE
build: make Sentry-Dynamic mergeable metadata opt-in

### DIFF
--- a/scripts/build-xcframework-slice.sh
+++ b/scripts/build-xcframework-slice.sh
@@ -66,9 +66,11 @@ fi
 
 rm -rf XCFrameworkBuildPath/DerivedData
 
+## -make_mergeable adds LC_ATOM_INFO metadata that is only used by consumers who merge
+## the framework at link time. Consumers who embed the dylib normally ship it as dead
+## weight (~7.6 MB on ios-arm64 for 9.11.0). Off by default; set MERGEABLE=1 to opt in.
 ## watchos and watchsimulator don't support make_mergeable: ld: unknown option: -make_mergeable
-## For other dynamic frameworks, add -make_mergeable (append to existing flags)
-if [[ "$sdk" != "watchos" && "$sdk" != "watchsimulator" ]] && [ "$MACH_O_TYPE" != "staticlib" ]; then
+if [ "${MERGEABLE:-0}" = "1" ] && [[ "$sdk" != "watchos" && "$sdk" != "watchsimulator" ]] && [ "$MACH_O_TYPE" != "staticlib" ]; then
     OTHER_LDFLAGS="$OTHER_LDFLAGS -Wl,-make_mergeable"
 fi
 


### PR DESCRIPTION
This PR makes the `-Wl,-make_mergeable` linker flag opt-in for the dynamic XCFramework build (`scripts/build-xcframework-slice.sh`), so the released `Sentry-Dynamic.xcframework` ships as a normal dylib by default. Setting `MERGEABLE=1` restores today's behavior for anyone who wants a mergeable library. Related: #8342.

## Why

`-make_mergeable` (added in #4381) turns each dynamic slice into a mergeable library. Its metadata is stored in the binary as an `LC_ATOM_INFO` load command whose `__LINKEDIT` payload is large, and it is only useful to a consumer that merges the framework into its own binary at link time with a `-merge*` option. A consumer that embeds the dylib normally, which is the default for Swift Package Manager `.product(name: "Sentry-Dynamic")` and for most manual integrations, gains nothing from the metadata but ships all of it. For prebuilt dynamic frameworks that ends up in the app bundle and counts toward App Store download and install size.

## What LC_ATOM_INFO is

It is atom-placement metadata emitted by the linker (ld_prime) that records atom and symbol boundaries so the library can later be merged into another binary. It is not mapped or used at runtime. Removing it does not change any code, data, or the exported interface.

## Evidence (9.11.0, stock `Sentry-Dynamic.xcframework`)

Per consumable slice, `LC_ATOM_INFO` payload as a share of the framework binary:

| Slice | Arch | Binary bytes | LC_ATOM_INFO bytes | Share |
|-------|------|-------------:|-------------------:|------:|
| ios-arm64 | arm64 | 11,324,072 | 8,011,392 | 71% |
| ios-arm64_x86_64-simulator | arm64 | 11,406,880 | 8,003,984 | 70% |
| ios-arm64_x86_64-simulator | x86_64 | 10,439,664 | 7,221,328 | 69% |
| ios-arm64_x86_64-maccatalyst | arm64 | 14,020,232 | 8,110,720 | 58% |
| ios-arm64_x86_64-maccatalyst | x86_64 | 12,891,168 | 7,343,552 | 57% |
| macos-arm64_x86_64 | arm64 | 8,388,072 | 5,837,968 | 70% |
| macos-arm64_x86_64 | x86_64 | 7,702,784 | 5,311,728 | 69% |
| tvos-arm64 | arm64 | 9,828,256 | 6,935,792 | 71% |
| xros-arm64 | arm64 | 8,681,064 | 6,142,992 | 71% |

For the ios-arm64 slice that ships in the App Store: 11,324,072 bytes total, of which 8,011,392 (about 71%) is `LC_ATOM_INFO`. The real code and data is about 2.5 MB (`__TEXT` about 2.0 MB) plus the normal linkedit tables. watchOS slices are already unaffected because the script excludes them (`ld` there rejects `-make_mergeable`).

## Why not strip it post-build

`strip` does not remove `LC_ATOM_INFO` (verified with Xcode 26.5: the load command and its payload remain, only local symbols come off). `llvm-objcopy` refuses the binary outright with `unsupported load command (cmd=0x36)`. So there is no clean post-build removal; the only lever is at link time, which is why this PR changes the flag rather than adding a strip step.

## Verification

Building a 9.11.0 ios-arm64 slice without `-make_mergeable` (equivalently, removing the `LC_ATOM_INFO` load command and its payload from the shipped slice and fixing the `__LINKEDIT` offsets) produces a binary that is behaviorally identical:

- Exported symbols byte-identical: `dyld_info -exports` returns the same 4,839 entries before and after; `nm -g` returns the same 5,478 global symbols.
- Signs cleanly: `codesign -v` passes after re-signing.
- Links green: a stub that references an exported symbol links against the reduced framework and produces a valid arm64 image with `@rpath/Sentry.framework/Sentry` as its dependency.
- The reduced ios-arm64 binary is about 3.3 MB versus 11.3 MB.

## Reproduction

```bash
# show the load command and its payload size on any dynamic slice
otool -l Sentry.framework/Sentry | grep -A3 LC_ATOM_INFO

# confirm the flag is the cause (minimal dylib)
echo 'int f(void){return 0;}' > t.c
clang -target arm64-apple-ios15.0 -isysroot "$(xcrun --sdk iphoneos --show-sdk-path)" -dynamiclib t.c -o plain.dylib
clang -target arm64-apple-ios15.0 -isysroot "$(xcrun --sdk iphoneos --show-sdk-path)" -dynamiclib -Wl,-make_mergeable t.c -o merge.dylib
otool -l plain.dylib | grep -c LC_ATOM_INFO   # 0
otool -l merge.dylib | grep -c LC_ATOM_INFO   # 1
```

## Alternatives considered

- Keep it mergeable and document that consumers must enable merging to avoid the overhead. Leaves the default heavy for the common embed case.
- Publish a separate lean, non-mergeable variant alongside the mergeable one. More assets to build, validate, and host, and it splits the ecosystem across product names.
- Post-build strip. Not possible with `strip` or `llvm-objcopy` as shown above.

Making the flag opt-in keeps mergeable support for those who ask for it while giving every other consumer the smaller default. I could not exercise the release pipeline from a fork, so the produced artifact is not verified end to end here; marking this draft and happy to take it in whichever direction you prefer, including a separate variant instead of flipping the default.