### PR TITLE
ci: publish junit report on re-runs

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -141,6 +141,7 @@ jobs:
           unzip -o XCFrameworkBuildPath/Sentry.xcframework.zip -d XCFrameworkBuildPath/
 
       - name: Run Fastlane
+        id: run_fastlane
         env:
           FASTLANE_COMMAND: ${{ inputs.fastlane_command }}
           DEVICE: ${{ steps.resolve-test-destination.outputs.TEST_DEVICE }}
@@ -157,7 +158,7 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
-        if: ${{ failure() || github.run_attempt > 1 }}
+        if: ${{ failure() || (github.run_attempt > 1 && steps.run_fastlane.outcome != 'skipped') }}
         with:
           report_paths: build/reports/*junit.xml
           fail_on_failure: true

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
-        if: failure()
+        if: ${{ failure() || github.run_attempt > 1 }}
         with:
           report_paths: build/reports/*junit.xml
           fail_on_failure: true

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Publish Test Report
         id: publish_test_report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
-        if: ${{ always() && (steps.run_tests.outcome == 'failure' || steps.run_flaky_tests.outcome == 'failure') }}
+        if: ${{ always() && (steps.run_tests.outcome == 'failure' || steps.run_flaky_tests.outcome == 'failure' || github.run_attempt > 1) }}
         with:
           report_paths: "build/reports/junit.xml"
           fail_on_failure: true

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Publish Test Report
         id: publish_test_report
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
-        if: ${{ always() && (steps.run_tests.outcome == 'failure' || steps.run_flaky_tests.outcome == 'failure' || github.run_attempt > 1) }}
+        if: ${{ always() && (steps.run_tests.outcome == 'failure' || steps.run_flaky_tests.outcome == 'failure' || (github.run_attempt > 1 && steps.run_tests.outcome != 'skipped')) }}
         with:
           report_paths: "build/reports/junit.xml"
           fail_on_failure: true


### PR DESCRIPTION
## Summary
- Always publish the JUnit test report when a job is a re-run (`GITHUB_RUN_ATTEMPT > 1`), not only on failure
- Applies to both unit test and UI test workflows
- Should fix the problem where red checks aren't removed after a successful rerun

#skip-changelog

Closes #8345