### PR TITLE
ci: prewarm CoreSimulator in all CI workflows

### DIFF
--- a/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: macos-26
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/assemble-sentryobjc-static-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-static-xcframework.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/assemble-sentryobjc-static-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-static-xcframework.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: macos-26
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -70,6 +70,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/build-sentryobjc-slices.yml
+++ b/.github/workflows/build-sentryobjc-slices.yml
@@ -27,6 +27,8 @@ jobs:
         sdk: ${{ fromJson(inputs.sdk-list) }}
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/build-sentryobjc-slices.yml
+++ b/.github/workflows/build-sentryobjc-slices.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/build-v10.yml
+++ b/.github/workflows/build-v10.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/build-v10.yml
+++ b/.github/workflows/build-v10.yml
@@ -54,6 +54,8 @@ jobs:
             make-target: build-watchos-v10
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # We use Xcode 16 (latest installed minor) for building XCFrameworks. The setup-xcode action
       # picks the newest 16.x available on the macos-15 runner image.

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -65,6 +65,8 @@ jobs:
         sdk: ${{ fromJson(inputs.sdk-list) }}
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # We use Xcode 16 (latest installed minor) for building XCFrameworks. The setup-xcode action
       # picks the newest 16.x available on the macos-15 runner image.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # As the DistributionSample project uses local SPM, xcodebuild resolves SPM dependencies for all
       # sample projects. The Package.swift references binary targets, which in release branch commits points
@@ -120,6 +122,8 @@ jobs:
             config: Debug
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Some sample projects use local SPM references. xcodebuild resolves SPM dependencies for the
       # workspace, so Package.swift binary targets can be resolved even when building another scheme.
@@ -178,6 +182,8 @@ jobs:
           - scheme: iOS-ObjectiveC-Static
             config: Debug
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -229,6 +235,8 @@ jobs:
           - name: visionOS
             make-target: build-sample-visionOS-SwiftUI-SPM
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -267,6 +275,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Xcode
@@ -302,6 +312,8 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -332,6 +344,8 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_build_for_prs == 'true')
     needs: files-changed
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -370,6 +384,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -411,6 +427,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -452,6 +470,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -493,6 +513,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -534,6 +556,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -572,6 +596,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -614,6 +640,8 @@ jobs:
     needs: files-changed
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
       - name: Async Safe Log Level is Error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # As the DistributionSample project uses local SPM, xcodebuild resolves SPM dependencies for all
       # sample projects. The Package.swift references binary targets, which in release branch commits points
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Some sample projects use local SPM references. xcodebuild resolves SPM dependencies for the
       # workspace, so Package.swift binary targets can be resolved even when building another scheme.
@@ -183,7 +183,7 @@ jobs:
             config: Debug
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -236,7 +236,7 @@ jobs:
             make-target: build-sample-visionOS-SwiftUI-SPM
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -276,7 +276,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Xcode
@@ -313,7 +313,7 @@ jobs:
     needs: files-changed
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -345,7 +345,7 @@ jobs:
     needs: files-changed
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -385,7 +385,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -428,7 +428,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -471,7 +471,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -514,7 +514,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -557,7 +557,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -597,7 +597,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -641,7 +641,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
       - name: Async Safe Log Level is Error

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,8 @@ jobs:
         language: ["cpp"]
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL

--- a/.github/workflows/lint-xcode-analyze.yml
+++ b/.github/workflows/lint-xcode-analyze.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/lint-xcode-analyze.yml
+++ b/.github/workflows/lint-xcode-analyze.yml
@@ -41,6 +41,8 @@ jobs:
     needs: files-changed
     runs-on: macos-15
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -214,7 +214,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -259,7 +259,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -304,7 +304,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -348,7 +348,7 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -415,7 +415,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - name: Git checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,8 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -211,6 +213,8 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -254,6 +258,8 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -297,6 +303,8 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -339,6 +347,8 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -404,6 +414,8 @@ jobs:
       )
     timeout-minutes: 20
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - name: Git checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -69,6 +69,8 @@ jobs:
     needs: files-changed
     timeout-minutes: 20
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -60,7 +60,7 @@ jobs:
         runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -98,7 +98,7 @@ jobs:
         ]
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -59,6 +59,8 @@ jobs:
       matrix:
         runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode
@@ -95,6 +97,8 @@ jobs:
           "SentryPulse",
         ]
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/test-v10.yml
+++ b/.github/workflows/test-v10.yml
@@ -100,6 +100,8 @@ jobs:
             make-target: test-visionos-v10
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -153,6 +155,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/test-v10.yml
+++ b/.github/workflows/test-v10.yml
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,8 @@ jobs:
             xcode: "16"
 
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -72,6 +72,8 @@ jobs:
     name: Build and Upload iOS-Swift to Testflight
     runs-on: macos-26
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ${{ inputs.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', inputs.macos_version)) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', inputs.macos_version, github.run_id)) }}
     timeout-minutes: 40
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -84,6 +84,8 @@ jobs:
         runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
     timeout-minutes: 15
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -67,6 +67,8 @@ jobs:
     timeout-minutes: ${{inputs.timeout}}
     if: ${{!inputs.should_skip}}
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -68,7 +68,7 @@ jobs:
     if: ${{!inputs.should_skip}}
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         id: setup-xcode

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -61,6 +61,8 @@ jobs:
             sdk: xros
             destination: "generic/platform=visionOS"
     steps:
+      - name: Warm CoreSimulator
+        run: xcrun simctl list runtimes > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -62,7 +62,7 @@ jobs:
             destination: "generic/platform=visionOS"
     steps:
       - name: Warm CoreSimulator
-        run: xcrun simctl list runtimes > /dev/null 2>&1 &
+        run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Xcode
         uses: ./.github/actions/setup-xcode

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -32,6 +32,11 @@ set -euo pipefail
 # shellcheck source=./scripts/ci-utils.sh disable=SC1091
 source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
+SCRIPT_START=$(date +%s)
+_elapsed() { echo $(( $(date +%s) - SCRIPT_START )); }
+
+log_with_timestamp() { log_info "[+$(_elapsed)s] $1"; }
+
 # Export to GITHUB_ENV. Skip any var that's already set so a caller's env: block
 # (job- or step-level) can pin a specific OS without being clobbered here.
 emit_env_if_unset() {
@@ -122,15 +127,12 @@ resolve_simulator_os() {
 # See https://github.com/getsentry/sentry-cocoa/pull/6053 for context.
 list_available_simulators() {
     begin_group "List Available Simulators"
-
-    local start_time end_time duration
-    start_time=$(date +%s)
+    
+    log_with_timestamp "Running xcrun simctl list..."
     xcrun simctl list
-    end_time=$(date +%s)
-    duration=$((end_time - start_time))
+    log_with_timestamp "List Available Simulators completed"
 
     end_group
-    log_info "List Available Simulators completed in ${duration} seconds"
 }
 
 # Usage: resolve_and_export_simulator_oses --xcode-version <version>
@@ -156,11 +158,10 @@ resolve_and_export_simulator_oses() {
     # actually exists, we anchor on the SDK's major.minor and pick the newest
     # installed runtime in that line. If no matching runtime is installed, we
     # fall back to the SDK version so callers still get a useful default.
-    log_info "Querying simctl runtimes JSON..."
-    local runtimes_json runtimes_count
-    runtimes_json=$(xcrun simctl list runtimes -j 2>/dev/null || echo '{"runtimes":[]}')
-    runtimes_count=$(echo "$runtimes_json" | jq -r '.runtimes | length' 2>/dev/null || echo "?")
-    log_info "simctl returned $runtimes_count runtimes"
+    log_with_timestamp "Querying simctl runtimes JSON..."
+    RUNTIMES_JSON=$(xcrun simctl list runtimes -j 2>/dev/null || echo '{"runtimes":[]}')
+    RUNTIMES_COUNT=$(echo "$RUNTIMES_JSON" | jq -r '.runtimes | length' 2>/dev/null || echo "?")
+    log_with_timestamp "simctl returned $RUNTIMES_COUNT runtimes"
 
     log_available_simulator_runtimes --runtimes-json "$runtimes_json"
 
@@ -173,7 +174,7 @@ resolve_and_export_simulator_oses() {
         --sdk xrsimulator --platform-a visionOS --platform-b xrOS --runtimes-json "$runtimes_json")
     log_info "Per-platform resolution complete"
 
-    log_info "SDK versions for Xcode $xcode_version -- iOS: ${ios_os:-none}, tvOS: ${tvos_os:-none}, watchOS: ${watchos_os:-none}, visionOS: ${visionos_os:-none}"
+    log_with_timestamp "SDK versions for Xcode $RESOLVED -- iOS: ${IOS_OS:-none}, tvOS: ${TVOS_OS:-none}, watchOS: ${WATCHOS_OS:-none}, visionOS: ${VISIONOS_OS:-none}"
 
     set_output ios-simulator-os      "$ios_os"
     set_output tvos-simulator-os     "$tvos_os"
@@ -184,6 +185,8 @@ resolve_and_export_simulator_oses() {
     emit_env_if_unset TVOS_SIMULATOR_OS     "$tvos_os"
     emit_env_if_unset WATCHOS_SIMULATOR_OS  "$watchos_os"
     emit_env_if_unset VISIONOS_SIMULATOR_OS "$visionos_os"
+
+    log_with_timestamp "Exports complete"
 
     list_available_simulators
 }
@@ -206,6 +209,7 @@ fi
 
 XCODE_INPUT="${POSITIONAL_ARGS[0]}"
 
+log_with_timestamp "Listing installed Xcode versions..."
 # `xcodes installed` prints one Xcode per line; the first whitespace-separated
 # token is the version (the `(Selected)` marker, build number, and path follow).
 if [[ "$ALLOW_PRERELEASE" == true ]]; then
@@ -220,6 +224,7 @@ else
         | awk '{print $1}' \
         | sort -V)
 fi
+log_with_timestamp "xcodes installed done"
 
 if [[ -z "$INSTALLED" ]]; then
     log_error "'xcodes installed' returned no Xcode versions."
@@ -247,17 +252,20 @@ if [[ -z "${RESOLVED:-}" ]]; then
     exit 1
 fi
 
-log_info "Resolved Xcode '$XCODE_INPUT' -> $RESOLVED"
+log_with_timestamp "Resolved Xcode '$XCODE_INPUT' -> $RESOLVED"
 
 # We prefer this over `sudo xcode-select` because it fails fast if the version
 # is not installed. `xcodes` is preinstalled on GH-hosted runners.
+log_with_timestamp "xcodes select $RESOLVED ..."
 xcodes select "$RESOLVED"
+log_with_timestamp "xcodes select done"
+
 # Diagnostic only. A freshly-selected Xcode that hasn't been "first-launched"
 # may make the first `swiftc` invocation slow and/or non-zero; don't let that
 # abort the rest of the script (env/outputs export still needs to happen).
-log_info "Running swiftc --version (may take a while on first launch of a fresh Xcode)..."
+log_with_timestamp "Running swiftc --version (may take a while on first launch of a fresh Xcode)..."
 swiftc --version || log_warning "swiftc --version exited non-zero (continuing — diagnostic only)"
-log_info "swiftc --version returned"
+log_with_timestamp "swiftc --version done"
 
 set_env "XCODE_VERSION" "$RESOLVED"
 set_output xcode-version "$RESOLVED"
@@ -267,3 +275,4 @@ if [[ "$SKIP_SIMULATORS" == true ]]; then
 else
     resolve_and_export_simulator_oses --xcode-version "$RESOLVED"
 fi
+log_with_timestamp "ci-select-xcode.sh finished (total: $(_elapsed)s)"

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -159,9 +159,10 @@ resolve_and_export_simulator_oses() {
     # installed runtime in that line. If no matching runtime is installed, we
     # fall back to the SDK version so callers still get a useful default.
     log_with_timestamp "Querying simctl runtimes JSON..."
-    RUNTIMES_JSON=$(xcrun simctl list runtimes -j 2>/dev/null || echo '{"runtimes":[]}')
-    RUNTIMES_COUNT=$(echo "$RUNTIMES_JSON" | jq -r '.runtimes | length' 2>/dev/null || echo "?")
-    log_with_timestamp "simctl returned $RUNTIMES_COUNT runtimes"
+    local runtimes_json runtimes_count
+    runtimes_json=$(xcrun simctl list runtimes -j 2>/dev/null || echo '{"runtimes":[]}')
+    runtimes_count=$(echo "$runtimes_json" | jq -r '.runtimes | length' 2>/dev/null || echo "?")
+    log_with_timestamp "simctl returned $runtimes_count runtimes"
 
     log_available_simulator_runtimes --runtimes-json "$runtimes_json"
 
@@ -174,7 +175,7 @@ resolve_and_export_simulator_oses() {
         --sdk xrsimulator --platform-a visionOS --platform-b xrOS --runtimes-json "$runtimes_json")
     log_info "Per-platform resolution complete"
 
-    log_with_timestamp "SDK versions for Xcode $RESOLVED -- iOS: ${IOS_OS:-none}, tvOS: ${TVOS_OS:-none}, watchOS: ${WATCHOS_OS:-none}, visionOS: ${VISIONOS_OS:-none}"
+    log_with_timestamp "SDK versions for Xcode $xcode_version -- iOS: ${ios_os:-none}, tvOS: ${tvos_os:-none}, watchOS: ${watchos_os:-none}, visionOS: ${visionos_os:-none}"
 
     set_output ios-simulator-os      "$ios_os"
     set_output tvos-simulator-os     "$tvos_os"


### PR DESCRIPTION
## Summary
- Add a background `xcrun simctl list runtimes` step as the first step in every CI job that uses Setup Xcode
- This prewarms the CoreSimulator framework so it's already loaded by the time the workflow needs it
- Applied to all 19 workflow files (38 jobs total)

#skip-changelog

Closes #8378