### PR TITLE
ci: Add file filter to Xcode 27 workflow

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -542,6 +542,23 @@ run_size_analysis_for_prs: &run_size_analysis_for_prs
   - "Makefile"
   - "Brewfile*"
 
+run_xcode27_for_prs: &run_xcode27_for_prs
+  - "Sources/**"
+
+  # GH Actions
+  - ".github/workflows/xcode27-test.yml"
+  - ".github/file-filters.yml"
+
+  # Scripts & actions
+  - ".github/actions/setup-xcode/**"
+  - ".github/actions/ci-diagnostics/**"
+  - "scripts/sentry-xcodebuild.sh"
+  - "scripts/ci-diagnostics.sh"
+  - "scripts/ci-utils.sh"
+
+  # Project files
+  - "Package*.swift"
+
 run_3rd_party_integrations_tests_for_prs: &run_3rd_party_integrations_tests_for_prs
   - "Sources/**"
   - "3rd-party-integrations/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -554,6 +554,7 @@ run_xcode27_for_prs: &run_xcode27_for_prs
   - ".github/actions/ci-diagnostics/**"
   - "scripts/sentry-xcodebuild.sh"
   - "scripts/ci-diagnostics.sh"
+  - "scripts/ci-select-xcode.sh"
   - "scripts/ci-utils.sh"
 
   # Project files

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -84,3 +84,21 @@ jobs:
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics
         if: ${{ failure() || cancelled() }}
+
+  # Validates that all Xcode 27 SPM builds passed or were skipped, so this
+  # workflow can be a required check without running on unrelated PR changes.
+  build-spm-required-check:
+    needs:
+      [
+        ready-to-merge-gate,
+        files-changed,
+        build-spm,
+      ]
+    name: Xcode 27
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the Xcode 27 SPM build jobs has failed." && exit 1

--- a/.github/workflows/xcode27-test.yml
+++ b/.github/workflows/xcode27-test.yml
@@ -15,8 +15,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  ready-to-merge-gate:
+    name: Ready-to-merge gate
+    uses: ./.github/workflows/ready-to-merge-workflow.yml
+
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    needs: ready-to-merge-gate
+    outputs:
+      run_xcode27_for_prs: ${{ steps.changes.outputs.run_xcode27_for_prs }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   build-spm:
     name: Build SPM ${{ matrix.platform }}
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_xcode27_for_prs == 'true'
+    needs: files-changed
     runs-on:
       - bitrise_pool_name:xcode-beta
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
- Add `run_xcode27_for_prs` file filter to `.github/file-filters.yml` matching `Sources/**`, `Package*.swift`, the workflow file, and related CI scripts/actions
- Gate the `build-spm` job behind the file filter so Xcode 27 builds are skipped on PRs that don't touch relevant files
- Add `ready-to-merge` label gate consistent with other CI workflows

#skip-changelog

Closes #8360