### PR TITLE
chore(ci): Skip rbenv install if ruby version is cached

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -67,6 +67,7 @@ jobs:
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Cache Ruby
+        id: cache-ruby
         with:
           path: |
             ~/.rbenv/versions
@@ -75,9 +76,17 @@ jobs:
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          CACHE_HIT: ${{ steps.cache-ruby.outputs.cache-hit }}
         run: |
-          brew upgrade ruby-build
-          rbenv install -s
+          # Only touch Homebrew / build Ruby when the cache missed.
+          if [ "$CACHE_HIT" != "true" ]; then
+            brew upgrade ruby-build
+            rbenv install -s
+          else
+            echo "Ruby cache hit — skipping brew upgrade ruby-build and rbenv install"
+          fi
           bundle install
 
       - name: Setup Ruby

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -86,6 +86,7 @@ jobs:
             rbenv install -s
           else
             echo "Ruby cache hit — skipping brew upgrade ruby-build and rbenv install"
+            rbenv rehash
           fi
           bundle install
 

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -93,6 +93,7 @@ jobs:
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Cache Ruby
+        id: cache-ruby
         with:
           path: |
             ~/.rbenv/versions
@@ -101,9 +102,17 @@ jobs:
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          CACHE_HIT: ${{ steps.cache-ruby.outputs.cache-hit }}
         run: |
-          brew upgrade ruby-build
-          rbenv install -s
+          # Only touch Homebrew / build Ruby when the cache missed.
+          if [ "$CACHE_HIT" != "true" ]; then
+            brew upgrade ruby-build
+            rbenv install -s
+          else
+            echo "Ruby cache hit — skipping brew upgrade ruby-build and rbenv install"
+          fi
           bundle install
 
       - name: Setup Ruby

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -112,6 +112,7 @@ jobs:
             rbenv install -s
           else
             echo "Ruby cache hit — skipping brew upgrade ruby-build and rbenv install"
+            rbenv rehash
           fi
           bundle install
 


### PR DESCRIPTION
## :scroll: Description

Skips homebrew update & rbenv install if our ruby cache is hit

## :bulb: Motivation and Context

Improve CI times :)

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] CI should pass green and be faster

#skip-changelog

Closes #8359