### PR TITLE
chore: Align deinit handler of hang and runloop delay tracker

### DIFF
--- a/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryAppHangTracker.swift
@@ -63,7 +63,8 @@ final class SentryDefaultAppHangTracker {
     ///
     /// - Precondition: Must be called on main queue
     func removeObserver(token: SentryAppHangTrackerObserverToken) {
-        // Return the removed entry out of the lock so its closure is destroyed outside the critical region.
+        // Prevent the removed handler from being deallocated inside `withLock`. Its deinit chain could re-enter the lock and deadlock.
+        // Returning the reference to the removed handler from `withLock` ensures that it is deallocated outside the critical section.
         let (_, isEmpty) = observers.withLock {
             ($0.removeValue(forKey: token), $0.isEmpty)
         }

--- a/Sources/Swift/Integrations/AppHangTracking/SentryRunLoopDelayTracker.swift
+++ b/Sources/Swift/Integrations/AppHangTracking/SentryRunLoopDelayTracker.swift
@@ -134,12 +134,11 @@ final class SentryDefaultRunLoopDelayTracker<T: SentryRunLoopObserver, Dependenc
     ///
     /// - Precondition: Must be called on main queue
     func removeObserver(token: SentryRunLoopDelayTrackerObserverToken) {
-        // Prevent the removed handler from being deallocated inside `withLock`; its deinit chain could
-        // re-enter the lock and deadlock.
-        let (removed, isEmpty) = observers.withLock {
+        // Prevent the removed handler from being deallocated inside `withLock`. Its deinit chain could re-enter the lock and deadlock.
+        // Returning the reference to the removed handler from `withLock` ensures that it is deallocated outside the critical section.
+        let (_, isEmpty) = observers.withLock {
             ($0.removeValue(forKey: token), $0.isEmpty)
         }
-        _ = removed
 
         if isEmpty {
             stop()


### PR DESCRIPTION
Aligns the two code patterns between `SentryDefaultAppHangTracker` and `SentryDefaultRunLoopTracker`. Both need to hold a reference to the observer until after the critical section but used a different syntax. These changes should reduce confusion about the two approaches.

#skip-changelog

Closes #8353