### PR TITLE
ci: cache Homebrew and skip auto-update in CI

### DIFF
--- a/.github/actions/cache-homebrew/action.yml
+++ b/.github/actions/cache-homebrew/action.yml
@@ -1,4 +1,4 @@
-name: "Cache Homebrew"
+name: "Cache Homebrew or Update"
 description: >-
   Caches Homebrew downloads and installed formulae. The cache key rotates
   weekly so formulae stay reasonably fresh without downloading on every run.
@@ -21,9 +21,8 @@ runs:
         path: |
           ~/Library/Caches/Homebrew/downloads
           ~/Library/Caches/Homebrew/api
-        key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-${{ steps.week.outputs.week }}
-        restore-keys: |
-          homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-
+        # Add here any relevant lockfiles
+        key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-${{ steps.week.outputs.week }}-${{ hashFiles('.clang-format', '.ruby-version') }}
 
     - name: Update Homebrew formulae
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/cache-homebrew/action.yml
+++ b/.github/actions/cache-homebrew/action.yml
@@ -1,0 +1,31 @@
+name: "Cache Homebrew"
+description: >-
+  Caches Homebrew downloads and installed formulae. The cache key rotates
+  weekly so formulae stay reasonably fresh without downloading on every run.
+inputs:
+  brewfile:
+    description: "Path to the Brewfile to hash for the cache key."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Get week number
+      id: week
+      shell: bash
+      run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      id: cache
+      name: Cache Homebrew
+      with:
+        path: |
+          ~/Library/Caches/Homebrew/downloads
+          ~/Library/Caches/Homebrew/api
+        key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-${{ steps.week.outputs.week }}
+        restore-keys: |
+          homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-
+
+    - name: Update Homebrew formulae
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: brew update

--- a/.github/actions/cache-homebrew/action.yml
+++ b/.github/actions/cache-homebrew/action.yml
@@ -2,10 +2,6 @@ name: "Cache Homebrew or Update"
 description: >-
   Caches Homebrew downloads and installed formulae. The cache key rotates
   weekly so formulae stay reasonably fresh without downloading on every run.
-inputs:
-  brewfile:
-    description: "Path to the Brewfile to hash for the cache key."
-    required: true
 runs:
   using: "composite"
   steps:
@@ -22,7 +18,7 @@ runs:
           ~/Library/Caches/Homebrew/downloads
           ~/Library/Caches/Homebrew/api
         # Add here any relevant lockfiles
-        key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles(inputs.brewfile) }}-${{ steps.week.outputs.week }}-${{ hashFiles('.clang-format', '.ruby-version') }}
+        key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ steps.week.outputs.week }}-${{ hashFiles('scripts/.clang-format-version', 'scripts/.swiftlint-version', '.ruby-version', 'Brewfile*') }}
 
     - name: Update Homebrew formulae
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -79,10 +79,18 @@ jobs:
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
       - name: Install Sentry CLI
         if: needs.files-changed.outputs.is_dependabot != 'true'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: brew install getsentry/tools/sentry-cli
 
       # When running the workflows for dependabot PRs, we need to skip code signing, because the code signing secrets are not available for dependabot PRs.

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -79,7 +79,7 @@ jobs:
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -81,8 +81,6 @@ jobs:
           bundler-cache: true
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,13 @@ jobs:
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
       - name: Run Fastlane
         # We only need to archive, not package the IPA, so we skip codesigning.
@@ -127,7 +133,13 @@ jobs:
         uses: ./.github/actions/setup-xcode
         with:
           version: "26"
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
 
       # Note: Due to complexity in implementing the CODE_SIGNING_ALLOWED flag in the sentry-xcodebuild.sh script,
@@ -173,7 +185,13 @@ jobs:
         uses: ./.github/actions/setup-xcode
         with:
           version: "26"
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
       - run: |
           set -o pipefail && NSUnbufferedIO=YES xcodebuild \
@@ -229,7 +247,13 @@ jobs:
         with:
           platform: iOS
 
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - name: Install xcodegen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: brew install xcodegen
 
       - name: Build Sample

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build
@@ -133,7 +133,7 @@ jobs:
         uses: ./.github/actions/setup-xcode
         with:
           version: "26"
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build
@@ -185,7 +185,7 @@ jobs:
         uses: ./.github/actions/setup-xcode
         with:
           version: "26"
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build
@@ -247,14 +247,13 @@ jobs:
         with:
           platform: iOS
 
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build
-      - name: Install xcodegen
+      - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
-        run: brew install xcodegen
 
       - name: Build Sample
         run: make ${{ matrix.make-target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,6 @@ jobs:
           bundler-cache: true
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -135,8 +133,6 @@ jobs:
           version: "26"
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -187,8 +183,6 @@ jobs:
           version: "26"
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -249,8 +243,6 @@ jobs:
 
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-format

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -44,7 +44,13 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-format
       - name: Install tooling
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           make init-ci-format
           clang-format --version

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -46,8 +46,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-format
       - name: Install tooling
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -42,7 +42,13 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-format
       - name: Install tooling
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: make init-ci-format
 
       - name: Run SwiftLint

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-format

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -44,8 +44,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-format
       - name: Install tooling
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -41,7 +41,13 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-format
       - name: Install tooling
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: make init-ci-format
       - run: swiftlint --version
       - name: Run SwiftLint

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-format

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -43,8 +43,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-format
       - name: Install tooling
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/objc-conversion-analysis.yml
+++ b/.github/workflows/objc-conversion-analysis.yml
@@ -51,6 +51,8 @@ jobs:
           bundler-cache: true
 
       - name: Install Graphviz
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: brew install graphviz
 
       - name: Run Objective-C conversion analyzer

--- a/.github/workflows/objc-conversion-analysis.yml
+++ b/.github/workflows/objc-conversion-analysis.yml
@@ -49,7 +49,8 @@ jobs:
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           bundler-cache: true
-
+      - name: Cache or Update Homebrew
+        uses: ./.github/actions/cache-homebrew
       - name: Install Graphviz
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -81,7 +81,13 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
 
       # This needs to be done before xcode-ci because it makes the Sentry framework to be static.
       # Or Xcode will try to embed an empty framework.

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -83,8 +83,6 @@ jobs:
 
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Only keep distribution lib and target in Package.swift
         run: ./scripts/prepare-package.sh --remove-binary-targets true
 
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -94,8 +94,6 @@ jobs:
 
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -92,7 +92,13 @@ jobs:
       - name: Only keep distribution lib and target in Package.swift
         run: ./scripts/prepare-package.sh --remove-binary-targets true
 
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
 
       # We upload a new version to TestFlight on every commit on main

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -119,8 +119,15 @@ jobs:
           OS_VERSION: ${{ steps.resolve-test-destination.outputs.TEST_OS }}
         run: ./scripts/ci-boot-simulator.sh --xcode "$XCODE_VERSION" --device "$DEVICE_NAME" --os-version "$OS_VERSION"
 
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        if: ${{ inputs.build_with_make }}
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         if: ${{ inputs.build_with_make }}
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
 
       - run: make xcode-ci
         if: ${{ inputs.build_with_make }}

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -122,8 +122,6 @@ jobs:
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         if: ${{ inputs.build_with_make }}
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         if: ${{ inputs.build_with_make }}
         env:

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -119,7 +119,7 @@ jobs:
           OS_VERSION: ${{ steps.resolve-test-destination.outputs.TEST_OS }}
         run: ./scripts/ci-boot-simulator.sh --xcode "$XCODE_VERSION" --device "$DEVICE_NAME" --os-version "$OS_VERSION"
 
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         if: ${{ inputs.build_with_make }}
         with:

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           version: "16"
 
-      - name: Cache Homebrew
+      - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
         with:
           brewfile: Brewfile-ci-build

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -93,8 +93,6 @@ jobs:
 
       - name: Cache or Update Homebrew
         uses: ./.github/actions/cache-homebrew
-        with:
-          brewfile: Brewfile-ci-build
       - run: make init-ci-build
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -91,7 +91,13 @@ jobs:
         with:
           version: "16"
 
+      - name: Cache Homebrew
+        uses: ./.github/actions/cache-homebrew
+        with:
+          brewfile: Brewfile-ci-build
       - run: make init-ci-build
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
       - run: make xcode-ci
 
       - name: Enable screenshots permissions

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ init-local:
 # Installs tools needed for CI build tasks using Brewfile-ci-build.
 .PHONY: init-ci-build
 init-ci-build:
-	brew update && brew bundle --file Brewfile-ci-build
+	brew bundle --file Brewfile-ci-build
 
 ## Install CI format dependencies
 #
 # Installs tools needed to run CI format tasks locally using Brewfile-ci-format.
 .PHONY: init-ci-format
 init-ci-format:
-	brew update && brew bundle --file Brewfile-ci-format
+	brew bundle --file Brewfile-ci-format
 
 ## Update tooling versions
 #


### PR DESCRIPTION
## Summary
- Add `HOMEBREW_NO_AUTO_UPDATE: 1` env to all CI workflow steps that use Homebrew, preventing implicit `brew update` on every `brew install`/`brew bundle`
- Remove explicit `brew update` from `init-ci-build` and `init-ci-format` Makefile targets (CI-only; `init-local` unchanged)
- Add a new `cache-homebrew` composite action that caches `~/Library/Caches/Homebrew/{downloads,api}` with a weekly key rotation. On cache miss, runs `brew update` to refresh the formula index

## Test plan
- [ ] Verify CI workflows pass on first run (cache miss — `brew update` runs via composite action)
- [ ] Verify subsequent runs in the same week hit the cache and skip `brew update`
- [ ] Verify Brewfile formula changes bust the cache correctly
- [ ] Verify `make init-local` still runs `brew update` for local dev

#skip-changelog

Closes #8365