### PR TITLE
test: Fix flaky dispatch source timer test

### DIFF
--- a/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
@@ -14,8 +14,9 @@ final class SentryDispatchSourceWrapperTests: XCTestCase {
         let expectedEventInvocationCount = 100
 
         let expectation = self.expectation(description: "EventHandler Called")
+        let queue = SentryDispatchQueueWrapper()
 
-        let sut = SentryDispatchSourceWrapper(interval: nanoInterval, leeway: leeway, queue: SentryDispatchQueueWrapper(), eventHandler: {
+        let sut = SentryDispatchSourceWrapper(interval: nanoInterval, leeway: leeway, queue: queue, eventHandler: {
             eventInvocations.append(dateProvider.systemTime())
 
             if eventInvocations.count == expectedEventInvocationCount {
@@ -25,20 +26,16 @@ final class SentryDispatchSourceWrapperTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5)
         sut.cancel()
+        // Drain any event handler already queued before reading eventInvocations.
+        queue.queue.sync {}
 
         // There are usually more than 100 invocations, because calling cancel on the DispatchSource only
         // cancels further invocations, but not the one that's already in progress and it can take a little while until we
-        // cancel it after fulfilling the expectation.
-        let expectedMaxEventInvocationCount = expectedEventInvocationCount + 10
+        // cancel it after fulfilling the expectation. CI can also delay the test thread before it cancels the source.
         XCTAssertGreaterThanOrEqual(
             eventInvocations.count,
             expectedEventInvocationCount,
             "Event handler must be called at least \(expectedEventInvocationCount) times, but was called \(eventInvocations.count) times"
-        )
-        XCTAssertLessThanOrEqual(
-            eventInvocations.count,
-             expectedMaxEventInvocationCount,
-             "Event handler must be called at most \(expectedMaxEventInvocationCount) times, but was called \(eventInvocations.count) times"
         )
 
         // We have to be quite lenient with the leeway, because GH actions can be quite slow sometimes.
@@ -50,18 +47,18 @@ final class SentryDispatchSourceWrapperTests: XCTestCase {
         let minExpectedInterval = nanoInterval - assertionLeeway
         let maxExpectedInterval = nanoInterval + assertionLeeway
         var accurateIntervals = 0
-        
+
         for i in 1..<eventInvocations.count {
             let timeDifference = eventInvocations[i] - eventInvocations[i - 1]
-            
+
             if timeDifference >= minExpectedInterval && timeDifference <= maxExpectedInterval {
                 accurateIntervals += 1
             }
         }
-        
+
         let totalIntervals = eventInvocations.count - 1
         let requiredAccurateIntervals = max(1, Int(Double(totalIntervals) * 0.8)) // At least 80%
-        
+
         XCTAssertGreaterThanOrEqual(accurateIntervals, requiredAccurateIntervals,
             "Only \(accurateIntervals) out of \(totalIntervals) intervals were accurate (expected >= \(requiredAccurateIntervals)). Expected interval: \(nanosToSeconds(minExpectedInterval)) - \(nanosToSeconds(maxExpectedInterval))")
     }

--- a/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
@@ -26,16 +26,17 @@ final class SentryDispatchSourceWrapperTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5)
         sut.cancel()
-        // Drain any event handler already queued before reading eventInvocations.
-        queue.queue.sync {}
+        // Wait for an event handler that's already running or queued before reading eventInvocations.
+        // This doesn't bound the invocation count; it only makes the assertions use a stable snapshot.
+        let recordedEventInvocations = queue.queue.sync { eventInvocations }
 
         // There are usually more than 100 invocations, because calling cancel on the DispatchSource only
         // cancels further invocations, but not the one that's already in progress and it can take a little while until we
         // cancel it after fulfilling the expectation. CI can also delay the test thread before it cancels the source.
         XCTAssertGreaterThanOrEqual(
-            eventInvocations.count,
+            recordedEventInvocations.count,
             expectedEventInvocationCount,
-            "Event handler must be called at least \(expectedEventInvocationCount) times, but was called \(eventInvocations.count) times"
+            "Event handler must be called at least \(expectedEventInvocationCount) times, but was called \(recordedEventInvocations.count) times"
         )
 
         // We have to be quite lenient with the leeway, because GH actions can be quite slow sometimes.
@@ -48,15 +49,15 @@ final class SentryDispatchSourceWrapperTests: XCTestCase {
         let maxExpectedInterval = nanoInterval + assertionLeeway
         var accurateIntervals = 0
 
-        for i in 1..<eventInvocations.count {
-            let timeDifference = eventInvocations[i] - eventInvocations[i - 1]
+        for i in 1..<recordedEventInvocations.count {
+            let timeDifference = recordedEventInvocations[i] - recordedEventInvocations[i - 1]
 
             if timeDifference >= minExpectedInterval && timeDifference <= maxExpectedInterval {
                 accurateIntervals += 1
             }
         }
 
-        let totalIntervals = eventInvocations.count - 1
+        let totalIntervals = recordedEventInvocations.count - 1
         let requiredAccurateIntervals = max(1, Int(Double(totalIntervals) * 0.8)) // At least 80%
 
         XCTAssertGreaterThanOrEqual(accurateIntervals, requiredAccurateIntervals,


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

<!--- Describe your changes in detail -->

This fixes a flaky V10 visionOS test failure in SentryDispatchSourceWrapperTests.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Flaky run: https://github.com/getsentry/sentry-cocoa/actions/runs/28784039407/job/85346665542

> testDispatchSourceWrapper_Repeats, XCTAssertLessThanOrEqual failed: ("129") is greater than ("110") - Event handler must be called at most 110 times, but was called 129 times

The test waited until a repeating timer fired 100 times, then expected the final invocation count to be at most 110. On slower CI runs, the test thread can be delayed before it cancels the timer, allowing more timer events to run.

The fix removes the brittle upper-bound assertion and drains the dispatch queue after cancelling the timer before checking the recorded invocations. The test still verifies that the timer fires at least 100 times and that most intervals match the expected timing.

## :green_heart: How did you test it?

CI

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).


Closes #8358