### PR TITLE
chore: Cancel pending saucelabs jobs

### DIFF
--- a/.github/actions/saucelabs-run/action.yml
+++ b/.github/actions/saucelabs-run/action.yml
@@ -1,0 +1,101 @@
+name: Run SauceLabs tests
+description: >-
+  Run saucectl, extract the SauceLabs test ID from CLI output, and cancel
+  pending RDC jobs when the run is cancelled.
+inputs:
+  sauce-username:
+    description: SauceLabs username
+    required: true
+  sauce-access-key:
+    description: SauceLabs access key
+    required: true
+  select-suite:
+    description: saucectl suite to run
+    required: true
+  config:
+    description: saucectl config file path
+    required: true
+  tags:
+    description: saucectl tags
+    required: true
+  warning-message:
+    description: Optional workflow warning emitted before the run
+    required: false
+    default: ""
+outputs:
+  test_id:
+    description: Extracted SauceLabs test ID
+    value: ${{ steps.extract-test-id.outputs.test_id }}
+runs:
+  using: composite
+  steps:
+    - name: Generate unique output log file name
+      id: generate-output-log-file-name
+      shell: bash
+      run: |
+        unique_suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RANDOM}"
+        echo "output_log_file=output-${unique_suffix}.log" >> "$GITHUB_OUTPUT"
+    - name: Print warning message
+      if: ${{ inputs.warning-message != '' }}
+      shell: bash
+      run: |
+        echo "::warning ${inputs.warning-message}"
+    - name: Run saucectl
+      id: run
+      env:
+        SAUCE_USERNAME: ${{ inputs.sauce-username }}
+        SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
+        SELECT_SUITE: ${{ inputs.select-suite }}
+        CONFIG: ${{ inputs.config }}
+        TAGS: ${{ inputs.tags }}
+        OUTPUT_LOG_FILE: ${{ steps.generate-output-log-file-name.outputs.output_log_file }}
+        WARNING_MESSAGE: ${{ inputs.warning-message }}
+      shell: bash
+      # Note: We are not setting continue-on-error here, because we want the step to be marked as failed.
+      run: |
+        set -o pipefail && saucectl run \
+          --select-suite "$SELECT_SUITE" \
+          --config "$CONFIG" \
+          --tags "$TAGS" \
+          --verbose \
+          2>&1 | tee "$OUTPUT_LOG_FILE"
+
+    - name: Extract Test ID from output
+      id: extract-test-id
+      if: ${{ always() && (steps.run.outcome == 'failure' || steps.run.outcome == 'cancelled') }}
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        OUTPUT_LOG_FILE: ${{ steps.generate-output-log-file-name.outputs.output_log_file }}
+      with:
+        script: |
+          const fs = require('fs');
+
+          console.log('Extracting test ID from output log');
+          let testId = '';
+
+          if (fs.existsSync(process.env.OUTPUT_LOG_FILE)) {
+            const outputLog = fs.readFileSync(process.env.OUTPUT_LOG_FILE, 'utf8');
+            // Note: The CLI output might change over time, so this might need to be updated.
+            const match = outputLog.match(/https:\/\/app\.saucelabs\.com\/tests\/([^\s]+)/);
+            testId = match?.[1] ?? '';
+          }
+
+          if (!testId) {
+            core.warning('No SauceLabs test ID found in CLI output');
+          }
+
+          core.setOutput('test_id', testId);
+
+    - name: Cancel pending jobs if cancelled
+      if: >-
+        ${{ always()
+        && steps.run.outcome == 'cancelled'
+        && steps.extract-test-id.outputs.test_id != '' }}
+      env:
+        SAUCE_USERNAME: ${{ inputs.sauce-username }}
+        SAUCE_ACCESS_KEY: ${{ inputs.sauce-access-key }}
+        TEST_ID: ${{ steps.extract-test-id.outputs.test_id }}
+      shell: bash
+      run: |
+        echo "Cancelling pending jobs"
+        curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X PUT "https://api.us-west-1.saucelabs.com/v1/rdc/jobs/$TEST_ID/stop"

--- a/.github/actions/saucelabs-run/action.yml
+++ b/.github/actions/saucelabs-run/action.yml
@@ -37,9 +37,11 @@ runs:
         echo "output_log_file=output-${unique_suffix}.log" >> "$GITHUB_OUTPUT"
     - name: Print warning message
       if: ${{ inputs.warning-message != '' }}
+      env:
+        WARNING_MESSAGE: ${{ inputs.warning-message }}
       shell: bash
       run: |
-        echo "::warning ${inputs.warning-message}"
+        echo "::warning $WARNING_MESSAGE"
     - name: Run saucectl
       id: run
       env:

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -98,8 +98,9 @@ run_benchmarking_for_prs: &run_benchmarking_for_prs # GH Actions
 
   # Scripts & actions
   - "scripts/ci-select-xcode.sh"
-  - ".github/actions/setup-xcode/**"
   - "scripts/ci-utils.sh"
+  - ".github/actions/saucelabs-run/**"
+  - ".github/actions/setup-xcode/**"
 
   # Benchmarking test target and implementation
   - "Samples/iOS-Swift/iOS-Benchmarking/**"

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -183,7 +183,7 @@ jobs:
             const testId = match?.[1] ?? '';
 
             if (!testId) {
-              core.setFailed('No SauceLabs test ID found in CLI output');
+              core.warning('No SauceLabs test ID found in CLI output');
             }
 
             core.setOutput('TEST_ID', testId);

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -189,7 +189,7 @@ jobs:
             core.setOutput('TEST_ID', testId);
 
       - name: Cancel pending jobs if cancelled
-        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled' }}
+        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled' && steps.extract-test-id.outputs.TEST_ID != '' }}
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -152,50 +152,13 @@ jobs:
       - run: npm install -g saucectl@0.197.2
       - name: Run Benchmarks in SauceLab
         id: run-benchmarks-in-sauce-lab
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        # Note: We are not setting continue-on-error here, because we want the step to be marked as failed.
-        run: |
-          set -o pipefail && saucectl run \
-            --select-suite "${{matrix.suite}}" \
-            --config .sauce/benchmarking-config.yml \
-            --tags benchmark \
-            --verbose \
-            2>&1 | tee output.log
-
-      - name: Extract Test ID from output
-        id: extract-test-id
-        # Note: We need to use always() here, because the previous run step might be marked as failed.
-        if: ${{ always() && (steps.run-benchmarks-in-sauce-lab.outcome == 'failure' || steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled') }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: ./.github/actions/saucelabs-run
         with:
-          script: |
-            const fs = require('fs');
-
-            console.log("Extracting test ID from output log");
-            const outputLog = fs.readFileSync('output.log', 'utf8');
-
-            // Lookup for the test ID in the output log
-            // Note: The CLI output might change over time, so this might need to be updated.
-            const match = outputLog.match(/https:\/\/app\.saucelabs\.com\/tests\/([^\s]+)/);
-            const testId = match?.[1] ?? '';
-
-            if (!testId) {
-              core.warning('No SauceLabs test ID found in CLI output');
-            }
-
-            core.setOutput('TEST_ID', testId);
-
-      - name: Cancel pending jobs if cancelled
-        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled' && steps.extract-test-id.outputs.TEST_ID != '' }}
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          TEST_ID: ${{ steps.extract-test-id.outputs.TEST_ID }}
-        run: |
-          echo "Cancelling pending jobs"
-          curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X PUT "https://api.us-west-1.saucelabs.com/v1/rdc/jobs/$TEST_ID/stop"
+          select-suite: ${{ matrix.suite }}
+          config: .sauce/benchmarking-config.yml
+          tags: benchmark
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
 
       - name: Should Retry Test
         id: should-retry-test
@@ -205,21 +168,22 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          TEST_ID: ${{ steps.extract-test-id.outputs.TEST_ID }}
+          TEST_ID: ${{ steps.run-benchmarks-in-sauce-lab.outputs.test_id }}
         with:
           # Retry Logic: This step only runs when the benchmark test has failed.
           # We determine if the failure was due to SauceLabs infrastructure issues
           # (which can be fixed by retrying) or legitimate test failures (which cannot).
           # SauceLabs internal errors frequently cause CI failures that can be resolved
-          # by re-running the test. See scripts/saucelabs-helpers.js for detailed logic.
+          # by re-running the test.
           script: |
             const { execSync } = require('child_process');
             const testId = process.env.TEST_ID;
 
             if (!testId) {
-              core.warning("No SauceLabs test ID found in CLI output, it might have changed, retrying...");
+              core.warning(
+                'No SauceLabs test ID found in CLI output, it might have changed, retrying...'
+              );
               core.setOutput('RETRY_TEST', 'true');
-
               return;
             }
 
@@ -227,13 +191,13 @@ jobs:
               console.log(`Checking if the test exists in SauceLabs: ${testId}`);
               execSync(`saucectl jobs get ${testId}`, {
                 env: process.env,
-                stdio: 'inherit'
+                stdio: 'inherit',
               });
 
-              console.log("Test exists but failed, not retrying.");
+              console.log('Test exists but failed, not retrying.');
               core.setFailed('Test exists but failed');
             } catch (error) {
-              console.log("Failed to get job, retrying...");
+              console.log('Failed to get job, retrying...');
               core.setOutput('RETRY_TEST', 'true');
             }
 
@@ -241,16 +205,14 @@ jobs:
         id: run-benchmarks-in-sauce-lab-retry-1
         # Note: We need to use always() here, because the previous run step might be marked as failed.
         if: ${{ always() && steps.should-retry-test.outputs.RETRY_TEST == 'true' }}
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: |
-          echo "::warning SauceLabs benchmark tests need to be retried"
-          saucectl run \
-            --select-suite "${{matrix.suite}}" \
-            --config .sauce/benchmarking-config.yml \
-            --tags benchmark \
-            --verbose
+        uses: ./.github/actions/saucelabs-run
+        with:
+          select-suite: ${{ matrix.suite }}
+          config: .sauce/benchmarking-config.yml
+          tags: benchmark
+          warning-message: SauceLabs benchmark tests need to be retried
+          sauce-username: ${{ secrets.SAUCE_USERNAME }}
+          sauce-access-key: ${{ secrets.SAUCE_ACCESS_KEY }}
 
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -164,20 +164,12 @@ jobs:
             --verbose \
             2>&1 | tee output.log
 
-      - name: Recovery - Extract Test ID from output
-        id: should-retry-test
+      - name: Extract Test ID from output
+        id: extract-test-id
         # Note: We need to use always() here, because the previous run step might be marked as failed.
-        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
+        if: ${{ always() && (steps.run-benchmarks-in-sauce-lab.outcome == 'failure' || steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled') }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         with:
-          # Retry Logic: This step only runs when the benchmark test has failed.
-          # We determine if the failure was due to SauceLabs infrastructure issues
-          # (which can be fixed by retrying) or legitimate test failures (which cannot).
-          # SauceLabs internal errors frequently cause CI failures that can be resolved
-          # by re-running the test. See scripts/saucelabs-helpers.js for detailed logic.
           script: |
             const fs = require('fs');
             const { execSync } = require('child_process');
@@ -189,6 +181,40 @@ jobs:
             // Note: The CLI output might change over time, so this might need to be updated.
             const match = outputLog.match(/https:\/\/app\.saucelabs\.com\/tests\/([^\s]+)/);
             const testId = match?.[1] ?? '';
+
+            if (!testId) {
+              core.setFailed('No SauceLabs test ID found in CLI output');
+            }
+
+            core.setOutput('TEST_ID', testId);
+
+      - name: Cancel pending jobs if cancelled
+        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'cancelled' }}
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          TEST_ID: ${{ steps.extract-test-id.outputs.TEST_ID }}
+        run: |
+          echo "Cancelling pending jobs"
+          curl -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" -X PUT "https://api.us-west-1.saucelabs.com/v1/rdc/jobs/$TEST_ID/stop"
+
+      - name: Should Retry Test
+        id: should-retry-test
+        # Note: We need to use always() here, because the previous run step might be marked as failed.
+        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          TEST_ID: ${{ steps.extract-test-id.outputs.TEST_ID }}
+        with:
+          # Retry Logic: This step only runs when the benchmark test has failed.
+          # We determine if the failure was due to SauceLabs infrastructure issues
+          # (which can be fixed by retrying) or legitimate test failures (which cannot).
+          # SauceLabs internal errors frequently cause CI failures that can be resolved
+          # by re-running the test. See scripts/saucelabs-helpers.js for detailed logic.
+          script: |
+            testId = process.env.TEST_ID;
 
             if (!testId) {
               core.warning("No SauceLabs test ID found in CLI output, it might have changed, retrying...");

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -172,7 +172,6 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { execSync } = require('child_process');
 
             console.log("Extracting test ID from output log");
             const outputLog = fs.readFileSync('output.log', 'utf8');
@@ -214,7 +213,8 @@ jobs:
           # SauceLabs internal errors frequently cause CI failures that can be resolved
           # by re-running the test. See scripts/saucelabs-helpers.js for detailed logic.
           script: |
-            testId = process.env.TEST_ID;
+            const { execSync } = require('child_process');
+            const testId = process.env.TEST_ID;
 
             if (!testId) {
               core.warning("No SauceLabs test ID found in CLI output, it might have changed, retrying...");


### PR DESCRIPTION
## :scroll: Description

Cancels pending saucelabs jobs if they already started or are queued

## :bulb: Motivation and Context

PRs are getting delayed because of benchmarks, and this could be a reason for this

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).


Closes #8363