### PR TITLE
lint: group imports by attribute

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -119,6 +119,10 @@ missing_docs:
   excludes_trivial_init: false
   severity: error
 
+sorted_imports:
+  grouping:
+    attributes
+
 custom_rules:
   no_try_optional_in_tests:
     name: "No try? in tests"

--- a/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
+++ b/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
@@ -1,14 +1,14 @@
+@_spi(Private) @testable import SentryCocoaLumberjack
 import CocoaLumberjackSwift
 import Sentry
-@_spi(Private) @testable import SentryCocoaLumberjack
 import XCTest
 
 // swiftlint:disable cyclomatic_complexity file_length type_body_length
 
 final class SentryCocoaLumberjackLoggerTests: XCTestCase {
-    
+
     private var capturedLogs: [SentryLog] = []
-    
+
     override func setUp() {
         super.setUp()
         capturedLogs = []
@@ -21,20 +21,20 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             }
         }
     }
-    
+
     override func tearDown() {
         super.tearDown()
         DDLog.removeAllLoggers()
         SentrySDK.close()
         capturedLogs = []
     }
-    
+
     private func getSut() -> SentryCocoaLumberjackLogger {
         return SentryCocoaLumberjackLogger()
     }
-    
+
     // MARK: - Basic Logging Tests
-    
+
     func testLog_WithErrorLevel() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -50,9 +50,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .error,
             "Test error message",
@@ -66,7 +66,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     func testLog_WithWarningLevel() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -82,9 +82,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .warn,
             "Test warning message",
@@ -98,7 +98,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     func testLog_WithInfoLevel() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -114,9 +114,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .info,
             "Test info message",
@@ -130,7 +130,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     func testLog_WithDebugLevel() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -146,9 +146,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .debug,
             "Test debug message",
@@ -162,7 +162,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     func testLog_WithVerboseLevel() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -178,9 +178,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .trace,
             "Test verbose message",
@@ -194,9 +194,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     // MARK: - Metadata Tests
-    
+
     func testLog_WithThreadName() throws {
         let sut = getSut()
         let logMessage = DDLogMessage(
@@ -212,20 +212,20 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         // Thread name is automatically captured by DDLogMessage
         sut.log(message: logMessage)
-        
+
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured")
-        
+
         let capturedLog = try XCTUnwrap(capturedLogs.last)
         XCTAssertEqual(capturedLog.level, .info)
         XCTAssertEqual(capturedLog.body, "Test with thread name")
-        
+
         // Verify thread ID is present
         XCTAssertNotNil(capturedLog.attributes["cocoalumberjack.threadID"])
     }
-    
+
     func testLog_WithContext() throws {
         let sut = getSut()
         let customContext = 12_345
@@ -242,9 +242,9 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         try assertLogCaptured(
             .info,
             "Test with context",
@@ -258,7 +258,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             ]
         )
     }
-    
+
     func testLog_WithTimestamp() throws {
         let sut = getSut()
         let customTimestamp = Date(timeIntervalSince1970: 1_234_567_890.123)
@@ -275,28 +275,28 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: customTimestamp
         )
-        
+
         sut.log(message: logMessage)
-        
+
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured")
-        
+
         let capturedLog = try XCTUnwrap(capturedLogs.last)
         XCTAssertEqual(capturedLog.level, .info)
         XCTAssertEqual(capturedLog.body, "Test with timestamp")
-        
+
         // Verify timestamp is captured
         let timestampAttribute = try XCTUnwrap(capturedLog.attributes["cocoalumberjack.timestamp"], "Missing cocoalumberjack.timestamp attribute")
-        
+
         XCTAssertEqual(timestampAttribute.type, "double")
         let timestampValue = try XCTUnwrap(timestampAttribute.value as? Double, "Expected cocoalumberjack.timestamp to be a Double")
         XCTAssertEqual(timestampValue, 1_234_567_890.123, accuracy: 0.001)
     }
-    
+
     // MARK: - SDK State Tests
-    
+
     func testLog_whenSentrySDKNotEnabled_shouldNotLog() {
         SentrySDK.close()
-        
+
         let sut = getSut()
         let logMessage = DDLogMessage(
             format: "Test message",
@@ -311,14 +311,14 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             options: [],
             timestamp: Date()
         )
-        
+
         sut.log(message: logMessage)
-        
+
         XCTAssertEqual(capturedLogs.count, 0, "Expected no logs when SentrySDK is not enabled")
     }
-    
+
     // MARK: - Helper Methods
-    
+
     private func assertLogCaptured(
         _ expectedLevel: SentryLog.Level,
         _ expectedBody: String,
@@ -327,16 +327,16 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
         line: UInt = #line
     ) throws {
         let capturedLog = getLastCapturedLog(file: file, line: line)
-        
+
         XCTAssertEqual(capturedLog.level, expectedLevel, "Log level mismatch", file: file, line: line)
         XCTAssertEqual(capturedLog.body, expectedBody, "Log body mismatch", file: file, line: line)
-        
+
         // Only verify the user-provided attributes, not the auto-enriched ones
         for (key, expectedAttribute) in expectedAttributes {
             let actualAttribute = try XCTUnwrap(capturedLog.attributes[key], "Missing attribute key: \(key)", file: file, line: line)
-            
+
             XCTAssertEqual(actualAttribute.type, expectedAttribute.type, "Attribute type mismatch for key: \(key)", file: file, line: line)
-            
+
             // Compare values based on type
             switch expectedAttribute.type {
             case "string":
@@ -360,7 +360,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
             }
         }
     }
-    
+
     private func getLastCapturedLog(file: StaticString = #filePath, line: UInt = #line) -> SentryLog {
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured", file: file, line: line)
         guard let lastLog = capturedLogs.last else {

--- a/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
+++ b/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
@@ -1,23 +1,23 @@
+@testable import SentryPulse
 import Pulse
 import Sentry
-@testable import SentryPulse
 import XCTest
 
 // swiftlint:disable cyclomatic_complexity
 
 final class SentryPulseTests: XCTestCase {
-    
+
     private var capturedLogs: [SentryLog] = []
     private var loggerStore: LoggerStore!
-    
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         capturedLogs = []
-        
+
         // Create in-memory LoggerStore for testing
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         loggerStore = try LoggerStore(storeURL: tempURL, options: [.inMemory])
-        
+
         SentrySDK.start { options in
             options.dsn = "https://test@test.ingest.sentry.io/123456"
             options.enableLogs = true
@@ -27,7 +27,7 @@ final class SentryPulseTests: XCTestCase {
             }
         }
     }
-    
+
     override func tearDown() {
         super.tearDown()
         SentryPulse.stop()
@@ -35,12 +35,12 @@ final class SentryPulseTests: XCTestCase {
         capturedLogs = []
         loggerStore = nil
     }
-    
+
     // MARK: - Basic Logging Tests
-    
+
     func testLog_WithTraceLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .trace,
@@ -50,7 +50,7 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured")
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .trace)
@@ -62,10 +62,10 @@ final class SentryPulseTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 1)
     }
-    
+
     func testLog_WithDebugLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .debug,
@@ -75,17 +75,17 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .debug)
         XCTAssertEqual(log.body, "Test debug message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "debug")
     }
-    
+
     func testLog_WithInfoLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .info,
@@ -95,17 +95,17 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .info)
         XCTAssertEqual(log.body, "Test info message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "info")
     }
-    
+
     func testLog_WithNoticeLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .notice,
@@ -115,7 +115,7 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         // Notice should map to info
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
@@ -123,10 +123,10 @@ final class SentryPulseTests: XCTestCase {
         XCTAssertEqual(log.body, "Test notice message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "notice")
     }
-    
+
     func testLog_WithWarningLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .warning,
@@ -136,17 +136,17 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .warn)
         XCTAssertEqual(log.body, "Test warning message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "warning")
     }
-    
+
     func testLog_WithErrorLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .error,
@@ -156,17 +156,17 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .error)
         XCTAssertEqual(log.body, "Test error message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "error")
     }
-    
+
     func testLog_WithCriticalLevel() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .critical,
@@ -176,24 +176,24 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .fatal)
         XCTAssertEqual(log.body, "Test critical message")
         XCTAssertEqual(log.attributes["pulse.level"]?.value as? String, "critical")
     }
-    
+
     // MARK: - Metadata Tests
-    
+
     func testLog_WithMetadata() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         let metadata: [String: LoggerStore.MetadataValue] = [
             "user_id": .string("12345"),
             "session_id": .string("abc-def-ghi")
         ]
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .info,
@@ -203,22 +203,22 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["pulse.user_id"]?.value as? String, "12345")
         XCTAssertEqual(log.attributes["pulse.session_id"]?.value as? String, "abc-def-ghi")
     }
-    
+
     func testLog_WithComplexMetadata() throws {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
-        
+
         let metadata: [String: LoggerStore.MetadataValue] = [
             "count": .string("42"),
             "enabled": .stringConvertible(true),
             "score": .stringConvertible(3.14159)
         ]
-        
+
         loggerStore.storeMessage(
             label: "test",
             level: .info,
@@ -228,16 +228,16 @@ final class SentryPulseTests: XCTestCase {
             function: "testFunction",
             line: 1
         )
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["pulse.count"]?.value as? String, "42")
         XCTAssertEqual(log.attributes["pulse.enabled"]?.value as? String, "true")
         XCTAssertEqual(log.attributes["pulse.score"]?.value as? String, "3.14159")
     }
-    
+
     // MARK: - Integration Lifecycle Tests
-    
+
     func testStaticAPI_CanStartAndStop() {
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
         loggerStore.storeMessage(
@@ -250,7 +250,7 @@ final class SentryPulseTests: XCTestCase {
             line: 1
         )
         XCTAssertEqual(capturedLogs.count, 1, "Should capture log after start")
-        
+
         SentryPulse.stop()
         loggerStore.storeMessage(
             label: "test",
@@ -262,7 +262,7 @@ final class SentryPulseTests: XCTestCase {
             line: 1
         )
         XCTAssertEqual(capturedLogs.count, 1, "Should not capture additional log after stop")
-        
+
         SentryPulse.startInternal(loggerStore: loggerStore, sentryLogger: SentrySDK.logger)
         loggerStore.storeMessage(
             label: "test",

--- a/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
+++ b/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
@@ -1,12 +1,12 @@
+@testable import SentrySwiftLog
 import Logging
 import Sentry
-@testable import SentrySwiftLog
 import XCTest
 
 final class SentryLogHandlerTests: XCTestCase {
-    
+
     private var capturedLogs: [SentryLog] = []
-    
+
     override func setUp() {
         super.setUp()
         capturedLogs = []
@@ -19,19 +19,19 @@ final class SentryLogHandlerTests: XCTestCase {
             }
         }
     }
-    
+
     override func tearDown() {
         super.tearDown()
         SentrySDK.close()
         capturedLogs = []
     }
-    
+
     // MARK: - Basic Logging Tests
-    
+
     func testLog_WithInfoLevel() throws {
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .info, message: "Test info message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 42)
-        
+
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured")
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .info)
@@ -43,66 +43,66 @@ final class SentryLogHandlerTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 42)
     }
-    
+
     func testLog_WithErrorLevel() throws {
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .error, message: "Test error message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 100)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .error)
         XCTAssertEqual(log.body, "Test error message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "error")
     }
-    
+
     func testLog_WithTraceLevel() throws {
         let sut = SentryLogHandler(logLevel: .trace)
         sut.log(level: .trace, message: "Test trace message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 1)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .trace)
         XCTAssertEqual(log.body, "Test trace message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "trace")
     }
-    
+
     func testLog_WithDebugLevel() throws {
         let sut = SentryLogHandler(logLevel: .debug)
         sut.log(level: .debug, message: "Test debug message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 50)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .debug)
         XCTAssertEqual(log.body, "Test debug message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "debug")
     }
-    
+
     func testLog_WithWarningLevel() throws {
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .warning, message: "Test warning message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 75)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .warn)
         XCTAssertEqual(log.body, "Test warning message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "warning")
     }
-    
+
     func testLog_WithCriticalLevel() throws {
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .critical, message: "Test critical message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 200)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .fatal)
         XCTAssertEqual(log.body, "Test critical message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "critical")
     }
-    
+
     func testLog_WithNoticeLevel() throws {
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .notice, message: "Test notice message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 150)
-        
+
         // Notice should map to info
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
@@ -110,54 +110,54 @@ final class SentryLogHandlerTests: XCTestCase {
         XCTAssertEqual(log.body, "Test notice message")
         XCTAssertEqual(log.attributes["swift-log.level"]?.value as? String, "notice")
     }
-    
+
     // MARK: - Metadata Tests
-    
+
     func testLog_WithStringMetadata() throws {
         let sut = SentryLogHandler(logLevel: .info)
         let metadata: Logger.Metadata = [
             "user_id": "12345",
             "session_id": "abc-def-ghi"
         ]
-        
+
         sut.log(level: .info, message: "Test with metadata", metadata: metadata, source: "test", file: "TestFile.swift", function: "testFunction", line: 10)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["swift-log.user_id"]?.value as? String, "12345")
         XCTAssertEqual(log.attributes["swift-log.session_id"]?.value as? String, "abc-def-ghi")
     }
-    
+
     func testLog_WithHandlerMetadata() throws {
         var sut = SentryLogHandler(logLevel: .info)
         sut.metadata["app_version"] = "1.0.0"
         sut.metadata["environment"] = "test"
-        
+
         sut.log(level: .info, message: "Test with handler metadata", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 20)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["swift-log.app_version"]?.value as? String, "1.0.0")
         XCTAssertEqual(log.attributes["swift-log.environment"]?.value as? String, "test")
     }
-    
+
     func testLog_WithMergedMetadata() throws {
         var sut = SentryLogHandler(logLevel: .info)
         sut.metadata["app_version"] = "1.0.0"
-        
+
         let logMetadata: Logger.Metadata = [
             "user_id": "12345",
             "app_version": "2.0.0" // This should override handler metadata
         ]
-        
+
         sut.log(level: .info, message: "Test with merged metadata", metadata: logMetadata, source: "test", file: "TestFile.swift", function: "testFunction", line: 30)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["swift-log.user_id"]?.value as? String, "12345")
         XCTAssertEqual(log.attributes["swift-log.app_version"]?.value as? String, "2.0.0") // Should be overridden
     }
-    
+
     func testLog_WithStringConvertibleMetadata() throws {
         let sut = SentryLogHandler(logLevel: .info)
         let metadata: Logger.Metadata = [
@@ -165,16 +165,16 @@ final class SentryLogHandlerTests: XCTestCase {
             "enabled": Logger.MetadataValue.stringConvertible(true),
             "score": Logger.MetadataValue.stringConvertible(3.14159)
         ]
-        
+
         sut.log(level: .info, message: "Test with string convertible metadata", metadata: metadata, source: "test", file: "TestFile.swift", function: "testFunction", line: 40)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.attributes["swift-log.count"]?.value as? String, "42")
         XCTAssertEqual(log.attributes["swift-log.enabled"]?.value as? String, "true")
         XCTAssertEqual(log.attributes["swift-log.score"]?.value as? String, "3.14159")
     }
-    
+
     func testLog_WithDictionaryMetadata() throws {
         let sut = SentryLogHandler(logLevel: .info)
         let metadata: Logger.Metadata = [
@@ -183,9 +183,9 @@ final class SentryLogHandlerTests: XCTestCase {
                 "name": "John Doe"
             ])
         ]
-        
+
         sut.log(level: .info, message: "Test with dictionary metadata", metadata: metadata, source: "test", file: "TestFile.swift", function: "testFunction", line: 50)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         let userString = log.attributes["swift-log.user"]?.value as? String
@@ -193,7 +193,7 @@ final class SentryLogHandlerTests: XCTestCase {
         XCTAssertTrue(userString?.contains("\"id\": \"12345\"") ?? false)
         XCTAssertTrue(userString?.contains("\"name\": \"John Doe\"") ?? false)
     }
-    
+
     func testLog_WithArrayMetadata() throws {
         let sut = SentryLogHandler(logLevel: .info)
         let metadata: Logger.Metadata = [
@@ -203,9 +203,9 @@ final class SentryLogHandlerTests: XCTestCase {
                 Logger.MetadataValue.stringConvertible(42)
             ])
         ]
-        
+
         sut.log(level: .info, message: "Test with array metadata", metadata: metadata, source: "test", file: "TestFile.swift", function: "testFunction", line: 60)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         let tagsString = log.attributes["swift-log.tags"]?.value as? String
@@ -214,90 +214,90 @@ final class SentryLogHandlerTests: XCTestCase {
         XCTAssertTrue(tagsString?.contains("\"api\"") ?? false)
         XCTAssertTrue(tagsString?.contains("\"42\"") ?? false)
     }
-    
+
     // MARK: - SDK State Tests
-    
+
     func testLog_whenSentrySDKNotEnabled_shouldNotLog() {
         SentrySDK.close()
-        
+
         let sut = SentryLogHandler(logLevel: .info)
         sut.log(level: .info, message: "Test message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 1)
-        
+
         XCTAssertEqual(capturedLogs.count, 0, "Expected no logs when SentrySDK is not enabled")
     }
-    
+
     // MARK: - Log Level Configuration Tests
-    
+
     func testLogLevelConfiguration() {
         let sut = SentryLogHandler(logLevel: .info)
         XCTAssertEqual(sut.logLevel, .info)
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_FiltersTraceAndDebug() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .trace, message: "Trace message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 1)
         sut.log(level: .debug, message: "Debug message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 2)
-        
+
         XCTAssertEqual(capturedLogs.count, 0, "Expected no logs to be captured")
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_CapturesInfo() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .info, message: "Info message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 3)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         XCTAssertEqual(capturedLogs.first?.level, .info)
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_CapturesNotice() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .notice, message: "Notice message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 4)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         XCTAssertEqual(capturedLogs.first?.level, .info) // Notice maps to info
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_CapturesWarning() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .warning, message: "Warning message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 5)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         XCTAssertEqual(capturedLogs.first?.level, .warn)
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_CapturesError() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .error, message: "Error message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 6)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         XCTAssertEqual(capturedLogs.first?.level, .error)
     }
-    
+
     func testLogLevelFiltering_InfoThreshold_CapturesCritical() {
         let sut = SentryLogHandler(logLevel: .info)
-        
+
         sut.log(level: .critical, message: "Critical message", metadata: nil, source: "test", file: "TestFile.swift", function: "testFunction", line: 7)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         XCTAssertEqual(capturedLogs.first?.level, .fatal)
     }
-    
+
     func testMetadataSubscript() {
         var sut = SentryLogHandler(logLevel: .info)
         XCTAssertNil(sut.metadata["test_key"])
         XCTAssertNil(sut[metadataKey: "test_key_2"])
-        
+
         sut.metadata["test_key"] = "test_value"
         XCTAssertEqual(sut.metadata["test_key"], .string("test_value"))
 
         sut[metadataKey: "test_key_2"] = "test_value_2"
         XCTAssertEqual(sut[metadataKey: "test_key_2"], .string("test_value_2"))
-        
+
         sut.metadata["test_key"] = nil
         XCTAssertNil(sut.metadata["test_key"])
 

--- a/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
@@ -1,12 +1,12 @@
-import Sentry
 @testable import SentrySwiftyBeaver
+import Sentry
 import SwiftyBeaver
 import XCTest
 
 final class SentryDestinationTests: XCTestCase {
-    
+
     private var capturedLogs: [SentryLog] = []
-    
+
     override func setUp() {
         super.setUp()
         capturedLogs = []
@@ -19,19 +19,19 @@ final class SentryDestinationTests: XCTestCase {
             }
         }
     }
-    
+
     override func tearDown() {
         super.tearDown()
         SentrySDK.close()
         capturedLogs = []
     }
-    
+
     // MARK: - Basic Logging Tests
-    
+
     func testVerboseMapsToTrace() throws {
         let sut = SentryDestination()
         let result = sut.send(.verbose, msg: "Verbose message", thread: "main", file: "Test.swift", function: "testFunction", line: 42)
-        
+
         XCTAssertEqual(capturedLogs.count, 1, "Expected exactly one log to be captured")
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .trace)
@@ -42,14 +42,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 42)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testDebugMapsToDebug() throws {
         let sut = SentryDestination()
         let result = sut.send(.debug, msg: "Debug message", thread: "main", file: "Test.swift", function: "testFunction", line: 50)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .debug)
@@ -60,14 +60,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 50)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testInfoMapsToInfo() throws {
         let sut = SentryDestination()
         let result = sut.send(.info, msg: "Info message", thread: "main", file: "Test.swift", function: "testFunction", line: 100)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .info)
@@ -78,14 +78,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 100)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testWarningMapsToWarn() throws {
         let sut = SentryDestination()
         let result = sut.send(.warning, msg: "Warning message", thread: "main", file: "Test.swift", function: "testFunction", line: 75)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .warn)
@@ -96,14 +96,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 75)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testErrorMapsToError() throws {
         let sut = SentryDestination()
         let result = sut.send(.error, msg: "Error message", thread: "main", file: "Test.swift", function: "testFunction", line: 200)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .error)
@@ -114,14 +114,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 200)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testCriticalMapsToFatal() throws {
         let sut = SentryDestination()
         let result = sut.send(.critical, msg: "Critical message", thread: "main", file: "Test.swift", function: "testFunction", line: 250)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .fatal)
@@ -132,14 +132,14 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 250)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testFaultMapsToFatal() throws {
         let sut = SentryDestination()
         let result = sut.send(.fault, msg: "Fault message", thread: "main", file: "Test.swift", function: "testFunction", line: 300)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
         XCTAssertEqual(log.level, .fatal)
@@ -150,10 +150,10 @@ final class SentryDestinationTests: XCTestCase {
         XCTAssertEqual(log.attributes["code.file.path"]?.value as? String, "Test.swift")
         XCTAssertEqual(log.attributes["code.function.name"]?.value as? String, "testFunction")
         XCTAssertEqual(log.attributes["code.line.number"]?.value as? Int, 300)
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testContextDictionary_WithAllSupportedTypes() throws {
         let sut = SentryDestination()
         let context: [String: Any] = [
@@ -165,60 +165,60 @@ final class SentryDestinationTests: XCTestCase {
             "tags": ["production", "api", "v2"] // Array
         ]
         let result = sut.send(.error, msg: "Payment failed", thread: "main", file: "Test.swift", function: "testFunction", line: 150, context: context)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
-        
+
         // Verify all attribute types are preserved correctly
         XCTAssertEqual(log.attributes["swiftybeaver.context.userId"]?.type, "string")
         XCTAssertEqual(log.attributes["swiftybeaver.context.userId"]?.value as? String, "12345")
-        
+
         XCTAssertEqual(log.attributes["swiftybeaver.context.isActive"]?.type, "boolean")
         XCTAssertEqual(log.attributes["swiftybeaver.context.isActive"]?.value as? Bool, true)
-        
+
         XCTAssertEqual(log.attributes["swiftybeaver.context.errorCode"]?.type, "integer")
         XCTAssertEqual(log.attributes["swiftybeaver.context.errorCode"]?.value as? Int, 500)
-        
+
         XCTAssertEqual(log.attributes["swiftybeaver.context.amount"]?.type, "double")
         if let amountValue = log.attributes["swiftybeaver.context.amount"]?.value as? Double {
             XCTAssertEqual(amountValue, 99.99, accuracy: 0.001)
         } else {
             XCTFail("Amount value should be a Double")
         }
-        
+
         XCTAssertEqual(log.attributes["swiftybeaver.context.temperature"]?.type, "double")
         if let tempValue = log.attributes["swiftybeaver.context.temperature"]?.value as? Double {
             XCTAssertEqual(tempValue, 36.6, accuracy: 0.01)
         } else {
             XCTFail("Temperature value should be a Double")
         }
-        
+
         XCTAssertEqual(log.attributes["swiftybeaver.context.tags"]?.type, "string[]")
         XCTAssertEqual(log.attributes["swiftybeaver.context.tags"]?.value as? [String], ["production", "api", "v2"])
-        
+
         XCTAssertNil(result)
     }
-    
+
     func testContextNonDictionary_ConvertsToString() throws {
         let sut = SentryDestination()
         let context = "simple string context"
         _ = sut.send(.info, msg: "Test message", thread: "main", file: "Test.swift", function: "testFunction", line: 10, context: context)
-        
+
         XCTAssertEqual(capturedLogs.count, 1)
         let log = try XCTUnwrap(capturedLogs.first)
-        
+
         XCTAssertNotNil(log.attributes["swiftybeaver.context"])
         XCTAssertEqual(log.attributes["swiftybeaver.context"]?.value as? String, "simple string context")
     }
-    
+
     // MARK: - SDK State Tests
-    
+
     func testSend_whenSentrySDKNotEnabled_shouldNotLog() {
         SentrySDK.close()
-        
+
         let sut = SentryDestination()
         _ = sut.send(.info, msg: "Test message", thread: "main", file: "Test.swift", function: "testFunction", line: 1)
-        
+
         XCTAssertEqual(capturedLogs.count, 0, "Expected no logs when SentrySDK is not enabled")
     }
 }

--- a/Samples/iOS-Swift/ActionExtension/Sources/ActionViewController.swift
+++ b/Samples/iOS-Swift/ActionExtension/Sources/ActionViewController.swift
@@ -1,5 +1,5 @@
-import Sentry
 @_spi(Private) import Sentry
+import Sentry
 import SentrySampleShared
 import UIKit
 import UniformTypeIdentifiers

--- a/Samples/iOS-Swift/App/Sources/ExtraViewController.swift
+++ b/Samples/iOS-Swift/App/Sources/ExtraViewController.swift
@@ -1,9 +1,9 @@
 // swiftlint:disable file_length type_body_length force_try force_unwrapping unused_optional_binding private_outlet
+@_spi(Private) import Sentry
 import AuthenticationServices
 import Foundation
 import PhotosUI
 import SafariServices
-@_spi(Private) import Sentry
 import SentrySampleShared
 import UIKit
 
@@ -17,10 +17,10 @@ class ExtraViewController: UIViewController {
     @IBOutlet weak var dataMarshalingField: UITextField!
     @IBOutlet weak var dataMarshalingStatusLabel: UILabel!
     @IBOutlet weak var dataMarshalingErrorLabel: UILabel!
-    
+
     private let dispatchQueue = DispatchQueue(label: "ExtraViewControllers", attributes: .concurrent)
     private var batteryConsumer: BatteryConsumer?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -30,7 +30,7 @@ class ExtraViewController: UIViewController {
             uiTestNameLabel.text = uiTestName
             uiTestNameLabel.isHidden = false
         }
-        
+
         Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
             self.framesLabel?.text = "Frames Total:\(PrivateSentrySDKOnly.currentScreenFrames.total) Slow:\(PrivateSentrySDKOnly.currentScreenFrames.slow) Frozen:\(PrivateSentrySDKOnly.currentScreenFrames.frozen)"
         }
@@ -55,27 +55,27 @@ class ExtraViewController: UIViewController {
             self.breadcrumbLabel?.text = "{ category: \(breadcrumb["category"] ?? "nil"), parentViewController: \(data["parentViewController"] ?? "nil"), beingPresented: \(data["beingPresented"] ?? "nil"), window_isKeyWindow: \(data["window_isKeyWindow"] ?? "nil"), is_window_rootViewController: \(data["is_window_rootViewController"] ?? "nil") }"
 
         }
-        
+
         SentrySDK.reportFullyDisplayed()
     }
-  
+
   @IBAction func highEnergyCPU(_ sender: UIButton) {
     highlightButton(sender)
     batteryConsumer = BatteryConsumer(qos: .userInitiated)
     batteryConsumer?.start()
   }
-  
+
   @IBAction func lowEnergyCPU(_ sender: UIButton) {
     highlightButton(sender)
     batteryConsumer = BatteryConsumer(qos: .background)
     batteryConsumer?.start()
   }
-  
+
   @IBAction func stopUsingEnergy(_ sender: UIButton) {
     highlightButton(sender)
     batteryConsumer?.stop()
   }
-    
+
     @IBAction func anrDeadlock(_ sender: UIButton) {
         SentrySDK.logger.info("ExtraViewController.anrDeadlock")
 
@@ -120,19 +120,19 @@ class ExtraViewController: UIViewController {
 
     @IBAction func getPasteBoardString(_ sender: Any) {
         SentrySDK.pauseAppHangTracking()
-        
+
         // Getting the pasteboard string asks for permission
         // and the SDK would detect an ANR if we don't pause it.
         // Make sure to copy something into the pasteboard, cause
         // iOS only opens the system permission dialog if you do.
-        
+
         if let clipboard = UIPasteboard.general.string {
             SentrySDK.capture(message: clipboard)
         }
-        
+
         SentrySDK.resumeAppHangTracking()
     }
-    
+
     @IBAction func start100Threads(_ sender: UIButton) {
         SentrySDK.logger.info("ExtraViewController.start100Threads")
 
@@ -170,7 +170,7 @@ class ExtraViewController: UIViewController {
         // otherwise nil
         print("\(String(describing: eventId))")
     }
-    
+
     @IBAction func openWeb(_ sender: UIButton) {
         navigationController?.pushViewController(WebViewController(), animated: true)
     }
@@ -221,7 +221,7 @@ class ExtraViewController: UIViewController {
         highlightButton(sender)
         SentrySDK.flush(timeout: 5)
     }
-    
+
     @IBAction func showTopVCInspector(_ sender: UIButton) {
         TopViewControllerInspector.show()
     }
@@ -260,18 +260,18 @@ class ExtraViewController: UIViewController {
 
         return pi
     }
-    
+
     enum EnvelopeContent {
         /// String contents are base64 encoded image data
         case image(String)
-        
+
         case rawText(String)
         case json([String: Any])
-        
+
         /// String contents are base64 encoded image data
         case feedbackAttachment(String)
     }
-    
+
     func displayError(message: String) {
         dataMarshalingStatusLabel.isHidden = false
         dataMarshalingStatusLabel.text = "❌"
@@ -279,13 +279,13 @@ class ExtraViewController: UIViewController {
         dataMarshalingErrorLabel.text = message
         print("[iOS-Swift] \(message)")
     }
-    
+
     @IBAction func getLatestEnvelope(_ sender: Any) {
         guard let latestEnvelopePath = latestEnvelopePath() else { return }
         guard let base64String = base64EncodedStructuredUITestData(envelopePath: latestEnvelopePath) else { return }
         displayStringForUITest(string: base64String)
     }
-    
+
     @IBAction func getApplicationSupportPath(_ sender: Any) {
         guard let appSupportDirectory = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first else {
             print("[iOS-Swift] Couldn't retrieve path to application support directory.")
@@ -293,11 +293,11 @@ class ExtraViewController: UIViewController {
         }
         displayStringForUITest(string: appSupportDirectory)
     }
-    
+
     @IBAction func showMaskingPreview(_ sender: Any) {
         SentrySDK.replay.showMaskPreview(0.5)
     }
-    
+
     func displayStringForUITest(string: String) {
         dataMarshalingField.text = string
         dataMarshalingField.isHidden = false
@@ -305,7 +305,7 @@ class ExtraViewController: UIViewController {
         dataMarshalingStatusLabel.text = "✅"
         dataMarshalingErrorLabel.isHidden = true
     }
-    
+
     func latestEnvelopePath() -> String? {
         guard let cachesDirectory = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first else {
             displayError(message: "No user caches directory found on device.")
@@ -334,7 +334,7 @@ class ExtraViewController: UIViewController {
         }
         return "\(dir)/\(latest.0)"
     }
-    
+
     func base64EncodedStructuredUITestData(envelopePath: String) -> String? {
         guard let envelopeFileContents = try? String(contentsOfFile: envelopePath) else {
             displayError(message: "\(envelopePath) had no contents.")
@@ -369,10 +369,10 @@ class ExtraViewController: UIViewController {
             displayError(message: "Couldn't serialize marshaling dictionary.")
             return nil
         }
-        
+
         return data.base64EncodedString()
     }
-    
+
     func insertValues(from json: [String: Any], into result: inout [String: Any]) {
         if let eventContexts = json["contexts"] as? [String: Any] {
             result["event_type"] = json["type"]
@@ -421,13 +421,13 @@ class ExtraViewController: UIViewController {
         picker.delegate = self
         self.present(picker, animated: true, completion: nil)
     }
-    
+
     @IBAction func testNetworkCapture(_ sender: UIButton) {
         highlightButton(sender)
         let networkTestingVC = NetworkTestingViewController()
         navigationController?.pushViewController(networkTestingVC, animated: true)
     }
-    
+
     @IBAction func checkLaunchVCTransactions() {
         displayStringForUITest(string: LaunchVCTransactionCapture.shared.serialized())
     }

--- a/Samples/iOS-Swift/App/Sources/ViewControllers/InfoForBreadcrumbController.swift
+++ b/Samples/iOS-Swift/App/Sources/ViewControllers/InfoForBreadcrumbController.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) import Sentry
+import Foundation
 import UIKit
 
 // swiftlint:disable private_outlet
@@ -7,7 +7,7 @@ class InfoForBreadcrumbController: UIViewController {
 
     @IBOutlet var button: UIButton!
     @IBOutlet var label: UILabel!
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         SentrySDK.reportFullyDisplayed()

--- a/Samples/iOS-Swift/IntentExtension/Sources/IntentHandler.swift
+++ b/Samples/iOS-Swift/IntentExtension/Sources/IntentHandler.swift
@@ -1,6 +1,6 @@
+@_spi(Private) import Sentry
 import Intents
 import Sentry
-@_spi(Private) import Sentry
 import SentrySampleShared
 
 class IntentHandler: INExtension, INSendMessageIntentHandling {
@@ -21,7 +21,7 @@ class IntentHandler: INExtension, INSendMessageIntentHandling {
         guard !SentrySDK.isEnabled else {
             return
         }
-        
+
         // For this extension we need a specific configuration set, therefore we do not use the shared sample initializer
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
@@ -31,9 +31,9 @@ class IntentHandler: INExtension, INSendMessageIntentHandling {
             options.enableAppHangTracking = true
         }
     }
-    
+
     // MARK: - INSendMessageIntentHandling
-    
+
     func resolveRecipients(for intent: INSendMessageIntent, with completion: @escaping ([INSendMessageRecipientResolutionResult]) -> Void) {
         let person = INPerson(
             personHandle: INPersonHandle(value: "john-snow", type: .unknown),
@@ -45,7 +45,7 @@ class IntentHandler: INExtension, INSendMessageIntentHandling {
         )
         completion([INSendMessageRecipientResolutionResult.success(with: person)])
     }
-    
+
     func resolveContent(for intent: INSendMessageIntent, with completion: @escaping (INStringResolutionResult) -> Void) {
         let message = """
         Sentry Enabled? \(isSentryEnabled ? "✅" : "❌")
@@ -53,12 +53,12 @@ class IntentHandler: INExtension, INSendMessageIntentHandling {
         """
         completion(INStringResolutionResult.success(with: message))
     }
-    
+
     func confirm(intent: INSendMessageIntent, completion: @escaping (INSendMessageIntentResponse) -> Void) {
         let userActivity = NSUserActivity(activityType: NSStringFromClass(INSendMessageIntent.self))
         completion(INSendMessageIntentResponse(code: .ready, userActivity: userActivity))
     }
-    
+
     func handle(intent: INSendMessageIntent, completion: @escaping (INSendMessageIntentResponse) -> Void) {
         SentrySDK.capture(message: "iOS-Swift-IntentExtension: handle intent called")
 

--- a/Samples/iOS-Swift/NotificationServiceExtension/Sources/NotificationService.swift
+++ b/Samples/iOS-Swift/NotificationServiceExtension/Sources/NotificationService.swift
@@ -1,5 +1,5 @@
-import Sentry
 @_spi(Private) import Sentry
+import Sentry
 import SentrySampleShared
 import UserNotifications
 

--- a/SentryTestUtils/Sources/ClearTestState.swift
+++ b/SentryTestUtils/Sources/ClearTestState.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 public func clearTestState() {
     TestCleanup.clearTestState()

--- a/SentryTestUtils/Sources/SentryLogExtensions.swift
+++ b/SentryTestUtils/Sources/SentryLogExtensions.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 extension SentrySDKLog {
 

--- a/SentryTestUtils/Sources/TestClient.swift
+++ b/SentryTestUtils/Sources/TestClient.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 /// `open` because subclassed in test targets, e.g. to override `getTelemetryProcessor()`.
 open class TestClient: SentryClientInternal {

--- a/SentryTestUtils/Sources/TestCurrentDateProvider.swift
+++ b/SentryTestUtils/Sources/TestCurrentDateProvider.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 @_spi(Private) public class TestCurrentDateProvider: SentryCurrentDateProvider {
 

--- a/SentryTestUtils/Sources/TestDebugImageProvider.swift
+++ b/SentryTestUtils/Sources/TestDebugImageProvider.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 @_spi(Private) public class TestDebugImageProvider: SentryDebugImageProvider {
     public var debugImages: [DebugMeta]?

--- a/SentryTestUtils/Sources/TestDispatchFactory.swift
+++ b/SentryTestUtils/Sources/TestDispatchFactory.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 @_spi(Private) public class TestDispatchFactory: SentryDispatchFactory {
     public var vendedSourceHandler: ((TestDispatchSourceWrapper) -> Void)?

--- a/SentryTestUtils/Sources/TestDispatchSourceWrapper.swift
+++ b/SentryTestUtils/Sources/TestDispatchSourceWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 @_spi(Private) public class TestDispatchSourceWrapper: SentryDispatchSourceWrapper {
     public struct Override {

--- a/SentryTestUtils/Sources/TestDisplayLinkWrapper.swift
+++ b/SentryTestUtils/Sources/TestDisplayLinkWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 

--- a/SentryTestUtils/Sources/TestEventContextEnricher.swift
+++ b/SentryTestUtils/Sources/TestEventContextEnricher.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 @_spi(Private) public class TestEventContextEnricher: SentryEventContextEnricher {
     public init() {}

--- a/SentryTestUtils/Sources/TestFileManager.swift
+++ b/SentryTestUtils/Sources/TestFileManager.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 @_spi(Private) public class TestFileManager: SentryFileManager {
     var timestampLastInForeground: Date?

--- a/SentryTestUtils/Sources/TestHub.swift
+++ b/SentryTestUtils/Sources/TestHub.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 public class TestHub: SentryHubInternal {
 

--- a/SentryTestUtils/Sources/TestMetricsApi.swift
+++ b/SentryTestUtils/Sources/TestMetricsApi.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 @objc(SentryTestMetricsApi)
 public final class TestMetricsApi: NSObject, SentryMetricsApiProtocol {

--- a/SentryTestUtils/Sources/TestNSNotificationCenterWrapper.swift
+++ b/SentryTestUtils/Sources/TestNSNotificationCenterWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) import Sentry
+import Foundation
 
 #if (os(iOS) || os(tvOS) || os(visionOS))
 import UIKit

--- a/SentryTestUtils/Sources/TestRandom.swift
+++ b/SentryTestUtils/Sources/TestRandom.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 @_spi(Private) public class TestRandom: SentryRandomProtocol {
 

--- a/SentryTestUtils/Sources/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/Sources/TestSentryDispatchQueueWrapper.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) @testable import Sentry
 
 /// A wrapper around `SentryDispatchQueueWrapper` that memoized invocations to its methods and allows customization of async logic, specifically: dispatch-after calls can be made to run immediately, or not at all.
 @_spi(Private) public final class TestSentryDispatchQueueWrapper: SentryDispatchQueueWrapper {

--- a/SentryTestUtils/Sources/TestSentryNSTimerFactory.swift
+++ b/SentryTestUtils/Sources/TestSentryNSTimerFactory.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 // We must not subclass NSTimer, see https://developer.apple.com/documentation/foundation/nstimer#1770465.
 // Therefore we return a NSTimer instance here with TimeInterval.infinity.

--- a/SentryTestUtils/Sources/TestTransportAdapter.swift
+++ b/SentryTestUtils/Sources/TestTransportAdapter.swift
@@ -1,6 +1,6 @@
+@_spi(Private) import Sentry
 import _SentryPrivate
 import Foundation
-@_spi(Private) import Sentry
 
 @_spi(Private) public class TestTransportAdapter: SentryTransportAdapter {
     @_spi(Private)

--- a/SentryTestUtilsTests/Sources/TestConstantTests.swift
+++ b/SentryTestUtilsTests/Sources/TestConstantTests.swift
@@ -1,6 +1,6 @@
-import Foundation
 @_spi(Private) import Sentry
 @_spi(Private) @testable import SentryTestUtils
+import Foundation
 import XCTest
 
 class TestConstantTests: XCTestCase {
@@ -54,22 +54,22 @@ class TestConstantTests: XCTestCase {
     func testDsnAsString_shouldReturnExpectedValue() {
         // -- Act --
         let dsn = TestConstants.dsnAsString(username: "testUser")
-        
+
         // -- Assert --
         XCTAssertEqual(dsn, "https://testUser:password@app.getsentry.com/12345")
     }
-    
+
     func testDsn_shouldReturnValidDsn() throws {
         // -- Arrange --
         let expectedUrl = try XCTUnwrap(URL(string: "https://testUser:password@app.getsentry.com/12345"))
 
         // -- Act --
         let dsn = try TestConstants.dsn(username: "testUser")
-        
+
         // -- Assert --
         XCTAssertEqual(dsn.url, expectedUrl)
     }
-    
+
     func testEventWithSerializationError_shouldReturnEventWithEmptyMessage() throws {
         // -- Act --
         let event = TestConstants.eventWithSerializationError
@@ -101,7 +101,7 @@ class TestConstantTests: XCTestCase {
     func testEnvelope_shouldReturnValidEnvelopeWithOneItem() throws {
         // -- Act --
         let envelope = TestConstants.envelope
-        
+
         // -- Assert --
         XCTAssertNotNil(envelope.header.eventId)
         XCTAssertEqual(envelope.items.count, 1)

--- a/Sources/SentryDistributionTests/DistributionReleaseInfoTests.swift
+++ b/Sources/SentryDistributionTests/DistributionReleaseInfoTests.swift
@@ -1,35 +1,35 @@
-import Foundation
 @testable import SentryDistribution
+import Foundation
 import Testing
 
 @Test func testParseDateWithFractionalSecondsWorks() async throws {
   let dateString = "2025-01-31T12:34:56.000Z"
   let expectedDate = Date(timeIntervalSince1970: 1_738_326_896) // Friday, 31 January 2025 12:34:56 GMT
   let date = Date.fromString(dateString)
-  
+
   #expect(date == expectedDate, "Invalid parser")
 }
 
 @Test func testParserUpToMiliseconds() async throws {
   let dateString = "2025-02-24T01:07:51.101Z"
   let date = Date.fromString(dateString)
-  
+
   guard let date else {
     Issue.record("Failed to parse date")
     return
   }
-  
+
   var calendar = Calendar.current
   calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
   let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date)
-  
+
   #expect(dateComponents.year == 2_025, "Different year")
   #expect(dateComponents.month == 2, "Different month")
   #expect(dateComponents.day == 24, "Different day")
   #expect(dateComponents.hour == 1, "Different hour")
   #expect(dateComponents.minute == 7, "Different minute")
   #expect(dateComponents.second == 51, "Different second")
-  
+
   // Nanoseconds is the closest floating point number
   let miliseconds = try #require(dateComponents.nanosecond) / 1_000_000
   #expect(miliseconds == 101, "Different nanosecond")

--- a/Sources/SentryDistributionTests/UpdaterTests.swift
+++ b/Sources/SentryDistributionTests/UpdaterTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import SentryDistribution
+import Foundation
 import Testing
 
 @Test func testUpdaterReturnsErrorForInvalidHostname() async throws {
@@ -40,7 +40,7 @@ import Testing
       confirm()
       return (response, Data(jsonString.utf8))
     }
-    
+
     await withCheckedContinuation { continuation in
       Updater(session: session).getUpdatesFromBackend(params: params) { result in
         switch result {

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
 
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 #if os(iOS) || os(macOS)

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -1,6 +1,6 @@
-import _SentryPrivate
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import _SentryPrivate
 import XCTest
 
 #if os(iOS) || os(macOS)

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -1,6 +1,6 @@
-import _SentryPrivate
 @_spi(Private) @testable import Sentry
 @_spi(Private) @testable import SentryTestUtils
+import _SentryPrivate
 import XCTest
 
 #if os(iOS) || os(macOS)

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(macOS)

--- a/Tests/SentryTests/Extensions/StringExtensionsTests.swift
+++ b/Tests/SentryTests/Extensions/StringExtensionsTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import Sentry
+import Foundation
 import XCTest
 
 class StringExtensionsTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Helper/SentryBaggageSerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentryBaggageSerializationTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryBaggageSerializationTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
+++ b/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryCurrentDateTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryDependencyContainerTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryDispatchSourceWrapperTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryDispatchSourceWrapperTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryExtraContextProviderTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryFileManagerTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryMobileProvisionParserTests.swift
+++ b/Tests/SentryTests/Helper/SentryMobileProvisionParserTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryMobileProvisionParserTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentrySDKLogTests.swift
+++ b/Tests/SentryTests/Helper/SentrySDKLogTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentrySDKLogTests: XCTestCase {

--- a/Tests/SentryTests/Helper/SentryTestThreadWrapper.swift
+++ b/Tests/SentryTests/Helper/SentryTestThreadWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Helper/TestSentrySwizzleWrapper.swift
+++ b/Tests/SentryTests/Helper/TestSentrySwizzleWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 #if os(iOS) || os(tvOS)
 class TestSentrySwizzleWrapper: SentrySwizzleWrapper {

--- a/Tests/SentryTests/Helper/TestSysctl.swift
+++ b/Tests/SentryTests/Helper/TestSysctl.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 class TestSysctl: SentrySysctl {
     

--- a/Tests/SentryTests/HybridSDK/SentryInternalDebugApiTests.swift
+++ b/Tests/SentryTests/HybridSDK/SentryInternalDebugApiTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryInternalDebugApiTests: XCTestCase {

--- a/Tests/SentryTests/HybridSDK/SentryInternalEnvelopeApiIntegrationTests.swift
+++ b/Tests/SentryTests/HybridSDK/SentryInternalEnvelopeApiIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryInternalEnvelopeApiIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV1Tests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryDefaultAppHangTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryDefaultAppHangTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryRunLoopDelayTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryRunLoopDelayTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryRunLoopDelayTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackingIntegrationTests.swift
@@ -1,6 +1,6 @@
 @_spi(Private) import _SentryPrivate
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryBreadcrumbTrackingIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentrySystemEventBreadcrumbsTest: XCTestCase {

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryFeedbackTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Feedback/UserFeedbackIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/UserFeedbackIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS)

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(macOS) || os(visionOS)

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 /// End-to-end tests for the SentryMetricsApi. These tests use the public API

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiTests.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 /// This test suite tests the SentryMetricsApi on a unit test level to verify the logic without bootstrapping an entire SDK setup.

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryMetricsIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // swiftlint:disable file_length type_body_length

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -1,6 +1,6 @@
-import _SentryPrivate
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import _SentryPrivate
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataSwizzlingHelperTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataSwizzlingHelperTests.swift
@@ -1,7 +1,7 @@
 @_spi(Private) import _SentryPrivate
+@_spi(Private) @testable import Sentry
 import CoreData
 import Foundation
-@_spi(Private) @testable import Sentry
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -1,6 +1,6 @@
-import CoreData
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import CoreData
 import XCTest
 
 class SentryCoreDataTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -1,6 +1,6 @@
 @_spi(Private) import _SentryPrivate
-import CoreData
 @_spi(Private) @testable import Sentry
+import CoreData
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -1,6 +1,6 @@
-@testable import _SentryPrivate
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+@testable import _SentryPrivate
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS) || os(visionOS)

--- a/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class DataSentryTracingIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
@@ -1,6 +1,6 @@
+@_spi(Private) import SentryTestUtils
 // swiftlint:disable file_length
 @_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 import XCTest
 
 class FileManagerSentryTracingIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
@@ -1,6 +1,6 @@
+@_spi(Private) import SentryTestUtils
 // swiftlint:disable file_length
 @_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 import XCTest
 
 class SentryFileIOTrackerSwiftHelpersTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryFileIOTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataSwizzlingHelperTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataSwizzlingHelperTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingHelperTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingHelperTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 /// Integration tests that verify the completion-handler swizzling for replay's

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -1,5 +1,5 @@
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 /// You have to start the test server before running this test. You can do this by calling

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 /// Tests with a running test server to validate our swizzling doesn't break the HTTP requests are in

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -503,7 +503,7 @@ class SentryNetworkTrackerTests: XCTestCase {
     /// serialized network details in the breadcrumb data.
     func testAddBreadcrumb_withNetworkDetails_shouldIncludeSerializedDetailsInBreadcrumbData() throws {
         guard #available(iOS 16.0, tvOS 16.0, *) else { return }
-        
+
         // -- Arrange --
         let testUrl = URL(string: "https://api.example.com/users")!
         let options = Options()
@@ -753,7 +753,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(breadcrumbs?.count, 0)
     }
-    
+
     func test_Breadcrumb_HTTP200_HasLevelInfo() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -761,10 +761,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 200))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -774,14 +774,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .info)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(200, data["status_code"] as? Int)
         XCTAssertEqual("no error", data["reason"] as? String)
     }
-    
+
     func test_Breadcrumb_HTTP399_HasLevelInfo() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -789,10 +789,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 399))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -802,14 +802,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .info)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(399, data["status_code"] as? Int)
         XCTAssertEqual("redirected", data["reason"] as? String)
     }
-    
+
     func test_Breadcrumb_HTTP400_HasLevelWarning() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -817,10 +817,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 400))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -830,14 +830,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .warning)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(400, data["status_code"] as? Int)
         XCTAssertEqual("bad request", data["reason"] as? String)
     }
-    
+
     func test_Breadcrumb_HTTP499_HasLevelWarning() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -845,10 +845,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 499))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -858,14 +858,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .warning)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(499, data["status_code"] as? Int)
         XCTAssertEqual("client error", data["reason"] as? String)
     }
-    
+
     func testBreadcrumb_SessionTaskError_HTTP400_HasLevelError() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -874,10 +874,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         task.setResponse(try createResponse(code: 400))
         task.setError(NSError(domain: "Some Error", code: 1, userInfo: nil))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -887,14 +887,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .error)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(400, data["status_code"] as? Int)
         XCTAssertEqual("bad request", data["reason"] as? String)
     }
-    
+
     func test_Breadcrumb_HTTP500_HasLevelError() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -902,10 +902,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 500))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -915,14 +915,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .error)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
         XCTAssertEqual(500, data["status_code"] as? Int)
         XCTAssertEqual("internal server error", data["reason"] as? String)
     }
-    
+
     func test_Breadcrumb_HTTP599_HasLevelError() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false
@@ -930,10 +930,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         task.setResponse(try createResponse(code: 599))
         let _ = try XCTUnwrap(spanForTask(task: task))
-        
+
         //Act
         try setTaskState(task, state: .completed)
-        
+
         //Assert
         let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
@@ -943,7 +943,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb.category, "http")
         XCTAssertEqual(breadcrumb.level, .error)
         XCTAssertEqual(breadcrumb.type, "http")
-        
+
         let data = try XCTUnwrap(breadcrumb.data)
         XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
         XCTAssertEqual("GET", data["method"] as? String)
@@ -1042,66 +1042,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertTrue(span.isFinished)
         //Test if it has observers. Nil means no observers
         XCTAssertNil(task.observationInfo)
-    }
-
-    /// Regression test for the fatal app hang in SDK-CRASHES-COCOA-MMJ
-    /// (getsentry/sentry-cocoa#8355).
-    ///
-    /// `-[NSURLSessionTask cancel]` invoked on the main thread (e.g. a Combine chain being
-    /// cancelled) synchronously runs the swizzled `setState:`, which calls
-    /// `urlSessionTask:setState:` -> `addBreadcrumbForSessionTask:` and takes
-    /// `@synchronized(sessionTask)`. The tracker synchronizes on the same per-task lock from
-    /// several code paths (`urlSessionTaskResume:`, `captureRequestDetails:`,
-    /// `captureResponseDetails:`, ...), which run on `com.apple.NSURLSession-work` threads. When
-    /// one of those holds the lock, the calling thread — here the main thread — stalls, and once
-    /// it stalls > 2s the app-hang watchdog reports a *Fatal App Hang*.
-    ///
-    /// Desired behavior: driving a task to a terminal state must not block the calling thread on a
-    /// per-task lock held by another thread. Against the current code this test FAILS: the
-    /// `urlSessionTask:setState:` call never returns while the lock is held.
-    func testSetState_whenAnotherThreadHoldsTaskLock_doesNotBlockCallingThread() {
-        // -- Arrange --
-        let task = createDataTask()
-        let sut = fixture.getSut()
-        _ = startTransaction()
-        sut.urlSessionTaskResume(task)
-        task.state = .running
-
-        let lockAcquired = DispatchSemaphore(value: 0)
-        let releaseLock = DispatchSemaphore(value: 0)
-
-        // Another thread holds the SAME per-task lock the tracker synchronizes on. This stands in
-        // for a concurrent NSURLSession-work thread inside one of the tracker's other
-        // `@synchronized(sessionTask)` sections.
-        DispatchQueue.global().async {
-            objc_sync_enter(task)
-            lockAcquired.signal()
-            releaseLock.wait()
-            objc_sync_exit(task)
-        }
-        XCTAssertEqual(lockAcquired.wait(timeout: .now() + 5), .success,
-            "Precondition: background thread must hold the per-task lock before we continue.")
-
-        // -- Act -- simulate the main thread inside `-[NSURLSessionTask cancel]`.
-        let setStateReturned = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            sut.urlSessionTask(task, setState: .completed)
-            setStateReturned.signal()
-        }
-
-        // -- Assert -- the tracking work must not stall waiting on the other thread's lock.
-        let result = setStateReturned.wait(timeout: .now() + 2)
-
-        // Cleanup: release the holder and let the blocked call drain before teardown.
-        releaseLock.signal()
-        if result == .timedOut {
-            _ = setStateReturned.wait(timeout: .now() + 5)
-        }
-
-        XCTAssertEqual(result, .success,
-            "urlSessionTask:setState: blocked on @synchronized(sessionTask) while another thread "
-            + "held the per-task lock. On the main thread during -[NSURLSessionTask cancel] this "
-            + "is the fatal app hang in SDK-CRASHES-COCOA-MMJ.")
     }
 
     func testBaggageHeader() throws {
@@ -1259,13 +1199,13 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(sentryRequest.fragment, "myFragment")
         XCTAssertEqual(sentryRequest.queryString, "query=myQuery")
     }
-    
+
     func testCaptureHTTPClientErrorRequest_graphQLEnabled() throws {
         let sut = fixture.getSut()
-        
+
         let task = createDataTask {
             var request = $0
-            
+
             request.httpMethod = "POST"
             request.httpBody = Data("""
             {
@@ -1275,13 +1215,13 @@ class SentryNetworkTrackerTests: XCTestCase {
             }
             """.utf8)
             request.allHTTPHeaderFields = ["content-type": "application/json"]
-            
+
             return request
         }
         task.setResponse(try createResponse(code: 500))
 
         sut.urlSessionTask(task, setState: .completed)
-        
+
         XCTAssertEqual(self.fixture.hub.capturedErrorEvents.count, 1, "Expected only one error event to be captured")
         let capturedErrorEvent = try XCTUnwrap(fixture.hub.capturedErrorEvents.first)
 
@@ -1289,13 +1229,13 @@ class SentryNetworkTrackerTests: XCTestCase {
             capturedErrorEvent.context?["graphql"],
             "Expected 'graphql' object in context"
         )
-        
+
         XCTAssertEqual(graphQLContext.count, 1)
         let operationName = try XCTUnwrap(
             graphQLContext["operation_name"] as? String,
             "Expected graphql.operation_name to be a String"
         )
-        
+
         XCTAssertEqual(operationName, "someOperationName")
     }
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1,6 +1,6 @@
-import ObjectiveC
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import ObjectiveC
 import XCTest
 
 // swiftlint:disable file_length
@@ -1042,6 +1042,66 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertTrue(span.isFinished)
         //Test if it has observers. Nil means no observers
         XCTAssertNil(task.observationInfo)
+    }
+
+    /// Regression test for the fatal app hang in SDK-CRASHES-COCOA-MMJ
+    /// (getsentry/sentry-cocoa#8355).
+    ///
+    /// `-[NSURLSessionTask cancel]` invoked on the main thread (e.g. a Combine chain being
+    /// cancelled) synchronously runs the swizzled `setState:`, which calls
+    /// `urlSessionTask:setState:` -> `addBreadcrumbForSessionTask:` and takes
+    /// `@synchronized(sessionTask)`. The tracker synchronizes on the same per-task lock from
+    /// several code paths (`urlSessionTaskResume:`, `captureRequestDetails:`,
+    /// `captureResponseDetails:`, ...), which run on `com.apple.NSURLSession-work` threads. When
+    /// one of those holds the lock, the calling thread — here the main thread — stalls, and once
+    /// it stalls > 2s the app-hang watchdog reports a *Fatal App Hang*.
+    ///
+    /// Desired behavior: driving a task to a terminal state must not block the calling thread on a
+    /// per-task lock held by another thread. Against the current code this test FAILS: the
+    /// `urlSessionTask:setState:` call never returns while the lock is held.
+    func testSetState_whenAnotherThreadHoldsTaskLock_doesNotBlockCallingThread() {
+        // -- Arrange --
+        let task = createDataTask()
+        let sut = fixture.getSut()
+        _ = startTransaction()
+        sut.urlSessionTaskResume(task)
+        task.state = .running
+
+        let lockAcquired = DispatchSemaphore(value: 0)
+        let releaseLock = DispatchSemaphore(value: 0)
+
+        // Another thread holds the SAME per-task lock the tracker synchronizes on. This stands in
+        // for a concurrent NSURLSession-work thread inside one of the tracker's other
+        // `@synchronized(sessionTask)` sections.
+        DispatchQueue.global().async {
+            objc_sync_enter(task)
+            lockAcquired.signal()
+            releaseLock.wait()
+            objc_sync_exit(task)
+        }
+        XCTAssertEqual(lockAcquired.wait(timeout: .now() + 5), .success,
+            "Precondition: background thread must hold the per-task lock before we continue.")
+
+        // -- Act -- simulate the main thread inside `-[NSURLSessionTask cancel]`.
+        let setStateReturned = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            sut.urlSessionTask(task, setState: .completed)
+            setStateReturned.signal()
+        }
+
+        // -- Assert -- the tracking work must not stall waiting on the other thread's lock.
+        let result = setStateReturned.wait(timeout: .now() + 2)
+
+        // Cleanup: release the holder and let the blocked call drain before teardown.
+        releaseLock.signal()
+        if result == .timedOut {
+            _ = setStateReturned.wait(timeout: .now() + 5)
+        }
+
+        XCTAssertEqual(result, .success,
+            "urlSessionTask:setState: blocked on @synchronized(sessionTask) while another thread "
+            + "held the per-task lock. On the main thread during -[NSURLSessionTask cancel] this "
+            + "is the fatal app hang in SDK-CRASHES-COCOA-MMJ.")
     }
 
     func testBaggageHeader() throws {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackingIntegrationSwiftTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackingIntegrationSwiftTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryNetworkTrackingIntegrationSwiftTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryPerformanceTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -1,6 +1,6 @@
-import ObjectiveC
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
+import ObjectiveC
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 #if os(iOS) || os(tvOS) || os(visionOS)

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -1,8 +1,8 @@
 #if os(iOS) || os(tvOS) || os(visionOS)
 
-import ObjectiveC
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import ObjectiveC
 import XCTest
 
 class TestViewController: UIViewController {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingHelperTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingHelperTests.swift
@@ -1,7 +1,7 @@
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryUIViewControllerSwizzlingHelperTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -1,7 +1,7 @@
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import SentryTestUtilsDynamic
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryVCTrackerLaunchProfilingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryVCTrackerLaunchProfilingTests.swift
@@ -1,9 +1,9 @@
 // Profiling is only supported on iOS
 #if os(iOS)
 
-import ObjectiveC
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import ObjectiveC
 import XCTest
 
 class SentryVCTrackerLaunchProfilingTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotOptionsTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryViewScreenshotOptionsTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryCrashIntegrationTests: NotificationCenterTestCase {

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentrySwiftIntegrationInstallerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Session/SentryAutoSessionTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentryAutoSessionTrackingIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryAutoSessionTrackingIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 /**

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if !os(watchOS)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -1,8 +1,8 @@
+@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import AVFoundation
 import CoreMedia
 import Foundation
-@_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayApiTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayApiTests.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayEventTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayEventTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryReplayEventTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsNetworkTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsNetworkTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryReplayOptionsNetworkTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
@@ -1,6 +1,6 @@
+@_spi(Private) @testable import Sentry
 // swiftlint:disable file_length
 import Foundation
-@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryReplayOptionsTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryReplayRecordingTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -1,7 +1,7 @@
+@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 // swiftlint:disable file_length
 import Foundation
-@_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -1,7 +1,7 @@
+@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 // swiftlint:disable file_length
 import Foundation
-@_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 #if canImport(UIKit)
 import UIKit
 #endif

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -1,7 +1,7 @@
 #if os(iOS)
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryTouchTrackerTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
@@ -1,8 +1,8 @@
+@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import AVFoundation
 import CoreGraphics
 import Foundation
-@_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationAttributesProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationAttributesProcessorTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryWatchdogTerminationAttributesProcessorTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationLogicTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationLogicTests.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryWatchdogTerminationLogicTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationScopeObserverTests.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryWatchdogTerminationScopeObserverTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
 
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryWatchdogTerminationIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationAttributesProcessor.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationAttributesProcessor.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 
 // Note: This file should ideally live in SentryTestUtils, but this would lead to circular imports.
 // When refactoring the project structure, consider moving this to SentryTestUtils.

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationAttributesProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationAttributesProcessorTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // This test is used to verify the functionality of the mock of TestSentryWatchdogTerminationAttributesProcessor.

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationBreadcrumbProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationBreadcrumbProcessorTests.swift
@@ -1,5 +1,5 @@
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 // This test is used to verify the functionality of the mock of TestSentryWatchdogTerminationBreadcrumbProcessor.

--- a/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
@@ -1,5 +1,5 @@
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 class ConcurrentRateLimitsDictionaryTests: XCTestCase {

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryDefaultRateLimitsTests: XCTestCase {

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryRateLimitsParserTests: XCTestCase {

--- a/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryRetryAfterHeaderParserTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryDispatchQueueWrapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDispatchQueueWrapperTests.swift
@@ -1,5 +1,5 @@
-import _SentryPrivate
 @_spi(Private) @testable import Sentry
+import _SentryPrivate
 import XCTest
 
 class SentryDispatchQueueWrapperSwiftTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryHttpDateParserTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryHttpTransportFlushIntegrationTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentrySpotlightTransportTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryTransportAdapterTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryTransportFactoryTests: XCTestCase {

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryTransportInitializerTests: XCTestCase {

--- a/Tests/SentryTests/Networking/TestRateLimits.swift
+++ b/Tests/SentryTests/Networking/TestRateLimits.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) import Sentry
+import Foundation
 
 @_spi(Private)
 public class TestRateLimits: NSObject, RateLimits {

--- a/Tests/SentryTests/Persistence/SentryScopePersistentStoreTests.swift
+++ b/Tests/SentryTests/Persistence/SentryScopePersistentStoreTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryScopePersistentStoreTests: XCTestCase {

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class PrivateSentrySDKOnlyTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/Codable/ArbitraryDataTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/ArbitraryDataTests.swift
@@ -1,5 +1,5 @@
-@testable import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 class ArbitraryDataTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/SentryClientReportTests.swift
+++ b/Tests/SentryTests/Protocol/SentryClientReportTests.swift
@@ -1,6 +1,6 @@
-@testable import Sentry
 @_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
+@testable import Sentry
 import XCTest
 
 class SentryClientReportTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryEnvelopeTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryEventTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryMechanismTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/SentryMetricTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMetricTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryMetricTests: XCTestCase {

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -1,6 +1,6 @@
-import Sentry
 @_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
+import Sentry
 
 #if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 private let externalAddedCallbackInvocations = Invocations<Void>()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 extension SentryClientInternal {

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentryCrashInstallationReporterTests: XCTestCase {

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 /** Some of the test parameters are copied during debbuging a working implementation.

--- a/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryDefaultCrashReporterTests: XCTestCase {

--- a/Tests/SentryTests/SentryCrash/SentryUIDeviceWrapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryUIDeviceWrapperTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS)

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.swift
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 /// Protocol-based test double for SentryCrashReporter.
 /// Implements the protocol directly -- no subclassing of the concrete class.

--- a/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
+++ b/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 
 class TestDefaultThreadInspector: SentryDefaultThreadInspector {
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // swiftlint:disable file_length

--- a/Tests/SentryTests/SentryLevelTests.swift
+++ b/Tests/SentryTests/SentryLevelTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import Sentry
+import Foundation
 import XCTest
 
 class SentryLevelTests: XCTestCase {

--- a/Tests/SentryTests/SentryLoggerTests.swift
+++ b/Tests/SentryTests/SentryLoggerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // swiftlint:disable cyclomatic_complexity

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -1,6 +1,6 @@
-import Foundation
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 // swiftlint:disable test_case_accessibility

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 // swiftlint:disable file_length
@@ -645,7 +645,7 @@ class SentrySDKInternalTests: XCTestCase {
 
         XCTAssertEqual(fixture.client.captureLogInvocations.count, 0)
     }
-    
+
     func testFlush_CallsFlushCorrectlyOnTransport() throws {
         SentrySDK.start { options in
             options.dsn = SentrySDKInternalTests.dsnAsString

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentrySDKTests: XCTestCase {

--- a/Tests/SentryTests/SentryScreenshotSourceTests.swift
+++ b/Tests/SentryTests/SentryScreenshotSourceTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentrySessionTestsSwift: XCTestCase {

--- a/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
+++ b/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS)

--- a/Tests/SentryTests/Swift/Core/Tools/LoadValidatorTests.swift
+++ b/Tests/SentryTests/Swift/Core/Tools/LoadValidatorTests.swift
@@ -1,6 +1,6 @@
-import ObjectiveC
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import ObjectiveC
 import XCTest
 
 class LoadValidatorTests: XCTestCase {

--- a/Tests/SentryTests/TelemetryBuffer/DefaultTelemetryBufferDataForwardingTriggersTests.swift
+++ b/Tests/SentryTests/TelemetryBuffer/DefaultTelemetryBufferDataForwardingTriggersTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS) || os(macOS)

--- a/Tests/SentryTests/TelemetryBuffer/InMemoryInternalTelemetryBufferTests.swift
+++ b/Tests/SentryTests/TelemetryBuffer/InMemoryInternalTelemetryBufferTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class InMemoryInternalTelemetryBufferTests: XCTestCase {

--- a/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
+++ b/Tests/SentryTests/TelemetryBuffer/TelemetryBufferTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 private struct TestItem: TelemetryItem {

--- a/Tests/SentryTests/TelemetryProcessor/DefaultTelemetrySchedulerTests.swift
+++ b/Tests/SentryTests/TelemetryProcessor/DefaultTelemetrySchedulerTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class DefaultTelemetrySchedulerTests: XCTestCase {

--- a/Tests/SentryTests/TelemetryProcessor/SentryDefaultTelemetryProcessorTests.swift
+++ b/Tests/SentryTests/TelemetryProcessor/SentryDefaultTelemetryProcessorTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryDefaultTelemetryProcessorTests: XCTestCase {

--- a/Tests/SentryTests/TelemetryProcessor/SentryTelemetryProcessorFactoryTests.swift
+++ b/Tests/SentryTests/TelemetryProcessor/SentryTelemetryProcessorFactoryTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class SentryTelemetryProcessorFactoryTests: XCTestCase {

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 final class TelemetryScopeApplierTests: XCTestCase {

--- a/Tests/SentryTests/TestLogOutput.swift
+++ b/Tests/SentryTests/TestLogOutput.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import Sentry
+import Foundation
 import XCTest
 
 final class TestLogOutput {

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -1,5 +1,5 @@
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
 import XCTest
 
 class SentrySpanTests: XCTestCase {

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1,6 +1,6 @@
-import _SentryPrivate
-@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import _SentryPrivate
 import XCTest
 
 // swiftlint:disable file_length type_body_length

--- a/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import Sentry
+import Foundation
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/UIImageHelperTests.swift
+++ b/Tests/SentryTests/UIImageHelperTests.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
 #if os(iOS) || os(tvOS)
-import Foundation
 @testable import Sentry
+import Foundation
 import XCTest
 
 class UIImageHelperTests: XCTestCase {

--- a/Tests/SentryTests/URLSessionTaskHelperTests.swift
+++ b/Tests/SentryTests/URLSessionTaskHelperTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 final class URLSessionTaskHelperTests: XCTestCase {

--- a/Tests/SentryTests/UrlSanitizedTests.swift
+++ b/Tests/SentryTests/UrlSanitizedTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import XCTest
 
 class UrlSanitizedTests: XCTestCase {

--- a/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+Common.swift
+++ b/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+Common.swift
@@ -1,10 +1,10 @@
 // swiftlint:disable file_length
 #if os(iOS) && !targetEnvironment(macCatalyst)
+@_spi(Private) @testable import Sentry
 import AVKit
 import Foundation
 import PDFKit
 import SafariServices
-@_spi(Private) @testable import Sentry
 import SentryTestUtils
 import SwiftUI
 import UIKit

--- a/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+EdgeCases.swift
+++ b/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+EdgeCases.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length type_body_length
 #if os(iOS) && !targetEnvironment(macCatalyst)
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import SentryTestUtils
 import SwiftUI
 import UIKit

--- a/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+ReactNative.swift
+++ b/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+ReactNative.swift
@@ -1,9 +1,9 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
+@_spi(Private) @testable import Sentry
 import AVKit
 import Foundation
 import PDFKit
 import SafariServices
-@_spi(Private) @testable import Sentry
 import SentryTestUtils
 import SwiftUI
 import UIKit

--- a/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+UIKit.swift
+++ b/Tests/SentryTests/ViewCapture/SentryUIRedactBuilderTests+UIKit.swift
@@ -1,9 +1,9 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
+@_spi(Private) @testable import Sentry
 import AVKit
 import Foundation
 import PDFKit
 import SafariServices
-@_spi(Private) @testable import Sentry
 import SentryTestUtils
 import SwiftUI
 import UIKit

--- a/Tests/SentryTests/ViewCapture/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewPhotographerTests.swift
@@ -1,6 +1,6 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
-import Foundation
 @_spi(Private) @testable import Sentry
+import Foundation
 import SentryTestUtils
 import UIKit
 import XCTest


### PR DESCRIPTION
## :scroll: Description

Adopt the 'grouped by attribute' SwiftLint modifier for the `sorted_imports` rule. This groups imports with attributes (such as `@testable import Something` or `@_spi(Private) import Sentry` together which is more pleasing for the reader.

## :bulb: Motivation and Context

While this change is not _required_ it's much more pleasant to read, it harmonizes the world and restores order.

## :green_heart: How did you test it?

Purely visual change, but build locally just in case.

Closes #8367

#skip-changelog