### PR TITLE
fix: CI on main breaking due to linting

### DIFF
--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrashIntegration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrashIntegration.swift
@@ -1,7 +1,7 @@
 #if ENABLE_KSCRASH
 @_implementationOnly import _SentryPrivate
-import Foundation
 @_implementationOnly import KSCrashInstallations
+import Foundation
 
 // MARK: - Dependency Provider
 


### PR DESCRIPTION
#8154 merged before #8366 meaning the linting rules didn't align with the change in #8366. This fixes that.

#skip-changelog