### PR TITLE
docs: Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `dataCollection` option under `experimental` for configuring data scrubbing behavior (#8369)
+
 ## 9.21.0
 
 ### Fixes
@@ -8,7 +14,6 @@
 
 ### Features
 
-- Add `dataCollection` option under `experimental` for configuring data scrubbing behavior (#8369)
 - Attach feature flag evaluations to active spans (#8158)
 - Add feature flag scope ObjC API (#8160)
 


### PR DESCRIPTION
Due to merge-conflict resolving the changelog entry was added to a released version. This moves it back to the unreleased changes

#skip-changelog

Closes #8376