### PR TITLE
lint: update lint-staged's dprint run to only take staged files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,8 @@ repos:
         language: system
         args:
           - "fmt"
+          # allow no files in cases where the only staged file is excluded by dprint.json
+          - "--allow-no-files"
 
       - id: lint
         name: Run Linters

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         language: system
         types_or: ["objective-c", "objective-c++", "c", "c++"]
         args:
-          - "format-clang"
+          - "format-clang-staged"
 
       - id: format-swift
         name: Format Swift
@@ -59,34 +59,35 @@ repos:
         name: Format Markdown
         description: "Format Markdown"
         files: ^.*\.md$
+        pass_filenames: false
         types_or: [markdown]
-        entry: dprint
+        entry: make
         language: system
         args:
-          - "fmt"
+          - "format-markdown-staged"
 
       - id: format-json
         name: Format JSON
         description: "Format JSON"
         files: ^.*\.json$
+        pass_filenames: false
         types_or: [json]
-        entry: dprint
+        entry: make
         language: system
         exclude: ^sdk_api.*\.json$
         args:
-          - "fmt"
+          - "format-json-staged"
 
       - id: format-yaml
         name: Format YAML
         description: "Format YAML"
         files: ^.*\.(yaml|yml)$
+        pass_filenames: false
         types_or: [yaml]
-        entry: dprint
+        entry: make
         language: system
         args:
-          - "fmt"
-          # allow no files in cases where the only staged file is excluded by dprint.json
-          - "--allow-no-files"
+          - "format-yaml-staged"
 
       - id: lint
         name: Run Linters

--- a/Makefile
+++ b/Makefile
@@ -1339,6 +1339,21 @@ STAGED_SWIFT_FILES := $(shell git diff --cached --diff-filter=d --name-only | gr
 # Get staged Markdown, JSON, and YAML files
 STAGED_DPRINT_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep -E '\.(md|json|ya?ml)$$' | awk '{printf "\"%s\" ", $$0}')
 
+# Get staged Markdown files
+STAGED_MARKDOWN_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.md$$' | awk '{printf "\"%s\" ", $$0}')
+
+# Get staged JSON files
+STAGED_JSON_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.json$$' | awk '{printf "\"%s\" ", $$0}')
+
+# Get staged YAML files
+STAGED_YAML_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep -E '\.ya?ml$$' | awk '{printf "\"%s\" ", $$0}')
+
+# Get staged Objective-C, Objective-C++, C, and C++ files
+STAGED_CLANG_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep -E '\.(h|hpp|c|cpp|m|mm)$$' | awk '{printf "\"%s\" ", $$0}')
+
+# Get staged Objective-C header files
+STAGED_OBJC_HEADER_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.h$$' | awk '{printf "\"%s\" ", $$0}')
+
 ## Run linting checks on all files
 #
 # Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, and dprint checks without modifying files.
@@ -1356,8 +1371,12 @@ lint:
 .PHONY: lint-staged
 lint-staged:
 	@echo "--> Running Swiftlint, dprint, and Clang-Format on staged files"
-	./scripts/check-clang-format.py -r Sources Tests
-	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
+	@if [ -n "$(STAGED_CLANG_FILES)" ]; then \
+		./scripts/check-clang-format.py $(STAGED_CLANG_FILES); \
+	fi
+	@if [ -n "$(STAGED_OBJC_HEADER_FILES)" ]; then \
+		ruby ./scripts/check-objc-id-usage.rb $(STAGED_OBJC_HEADER_FILES); \
+	fi
 	@if [ -n "$(STAGED_SWIFT_FILES)" ]; then \
 		swiftlint --strict --quiet $(STAGED_SWIFT_FILES); \
 	fi
@@ -1388,6 +1407,15 @@ format-clang:
 		! \( -path "**.build/*" -or -path "**Build/*"  -or -path "**/libs/**" -or -path "**/Pods/**" -or -path "**/*.xcarchive/*" \) \
 		-print0 | xargs -0 -P $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 8) -n 32 clang-format -i -style=file
 
+## Format staged Objective-C, C, and C++ files
+#
+# Formats only staged Objective-C, Objective-C++, C, and C++ files using clang-format.
+.PHONY: format-clang-staged
+format-clang-staged:
+	@if [ -n "$(STAGED_CLANG_FILES)" ]; then \
+		clang-format -i -style=file $(STAGED_CLANG_FILES); \
+	fi
+
 ## Format all Swift files
 #
 # Formats all Swift files using SwiftLint auto-fix.
@@ -1411,6 +1439,15 @@ format-swift-staged:
 format-markdown:
 	dprint fmt "**/*.md"
 
+## Format staged Markdown files
+#
+# Formats only staged Markdown files using dprint.
+.PHONY: format-markdown-staged
+format-markdown-staged:
+	@if [ -n "$(STAGED_MARKDOWN_FILES)" ]; then \
+		dprint fmt --allow-no-files $(STAGED_MARKDOWN_FILES); \
+	fi
+
 ## Format JSON files
 #
 # Formats all JSON files using dprint.
@@ -1418,12 +1455,30 @@ format-markdown:
 format-json:
 	dprint fmt "**/*.json"
 
+## Format staged JSON files
+#
+# Formats only staged JSON files using dprint.
+.PHONY: format-json-staged
+format-json-staged:
+	@if [ -n "$(STAGED_JSON_FILES)" ]; then \
+		dprint fmt --allow-no-files $(STAGED_JSON_FILES); \
+	fi
+
 ## Format YAML files
 #
 # Formats all YAML and YML files using dprint.
 .PHONY: format-yaml
 format-yaml:
 	dprint fmt --allow-no-files "**/*.{yaml,yml}"
+
+## Format staged YAML files
+#
+# Formats only staged YAML and YML files using dprint.
+.PHONY: format-yaml-staged
+format-yaml-staged:
+	@if [ -n "$(STAGED_YAML_FILES)" ]; then \
+		dprint fmt --allow-no-files $(STAGED_YAML_FILES); \
+	fi
 
 # ============================================================================
 # ANALYSIS

--- a/Makefile
+++ b/Makefile
@@ -1336,6 +1336,9 @@ test-sample-tvOS-Swift-ui: xcode-ci-tvOS-Swift
 # Get staged Swift files
 STAGED_SWIFT_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | awk '{printf "\"%s\" ", $$0}')
 
+# Get staged Markdown, JSON, and YAML files
+STAGED_DPRINT_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep -E '\.(md|json|ya?ml)$$' | awk '{printf "\"%s\" ", $$0}')
+
 ## Run linting checks on all files
 #
 # Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, and dprint checks without modifying files.
@@ -1352,13 +1355,15 @@ lint:
 # Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, and dprint checks on staged files only.
 .PHONY: lint-staged
 lint-staged:
-	@echo "--> Running Swiftlint and Clang-Format on staged files"
+	@echo "--> Running Swiftlint, dprint, and Clang-Format on staged files"
 	./scripts/check-clang-format.py -r Sources Tests
 	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
 	@if [ -n "$(STAGED_SWIFT_FILES)" ]; then \
 		swiftlint --strict --quiet $(STAGED_SWIFT_FILES); \
 	fi
-	dprint check "**/*.{md,json,yaml,yml}"
+	@if [ -n "$(STAGED_DPRINT_FILES)" ]; then \
+		dprint check $(STAGED_DPRINT_FILES); \
+	fi
 
 ## Format all files
 #

--- a/Makefile
+++ b/Makefile
@@ -1362,7 +1362,7 @@ lint-staged:
 		swiftlint --strict --quiet $(STAGED_SWIFT_FILES); \
 	fi
 	@if [ -n "$(STAGED_DPRINT_FILES)" ]; then \
-		dprint check $(STAGED_DPRINT_FILES); \
+		dprint check --allow-no-files $(STAGED_DPRINT_FILES); \
 	fi
 
 ## Format all files
@@ -1423,7 +1423,7 @@ format-json:
 # Formats all YAML and YML files using dprint.
 .PHONY: format-yaml
 format-yaml:
-	dprint fmt "**/*.{yaml,yml}"
+	dprint fmt --allow-no-files "**/*.{yaml,yml}"
 
 # ============================================================================
 # ANALYSIS


### PR DESCRIPTION
## :scroll: Description

Changes the behaviour of `make lint-staged`'s `dprint` run to only run against files staged for commit. This makes it's behaviour align with the intention of the target.

## :bulb: Motivation and Context

The precommit running linting on unstaged files annoyed me one too many times today - my motivation is annoyance, _but_ we shouldn't lint files in a precommit that the user isn't committing. This will make it less annoying to commit files :) 

## :green_heart: How did you test it?

Ran it locally with a staged 'bad' file and a non-staged 'bad' file.

Fixes: #8372

#skip-changelog