### PR TITLE
ci: include Gemfile.lock in Ruby cache key

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -74,7 +74,9 @@ jobs:
           path: |
             ~/.rbenv/versions
             ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
+          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -100,7 +100,9 @@ jobs:
           path: |
             ~/.rbenv/versions
             ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
+          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-
 
       - name: Install Ruby (Bitrise)
         if: inputs.runner_provider == 'bitrise'


### PR DESCRIPTION
## Summary
- The Ruby cache key only hashed `.ruby-version`, not `Gemfile.lock`. Since `actions/cache` is write-once, gem updates (like faraday 1.10.5 → 1.10.6 in #8241) were never picked up — `bundle install` re-fetched them on every run.
- Added `Gemfile.lock` to the cache key in both `ui-tests-common.yml` and `unit-test-common.yml`, with a `restore-keys` fallback so Ruby is still reused when only gems change.

## Test plan
- [ ] First CI run after merge will create a new cache (partial hit via restore-keys reuses Ruby, installs all gems once, saves fresh cache)
- [ ] Subsequent runs should show zero `Installing` lines from `bundle install`

#skip-changelog