### PR TITLE
ref: pass snapshotted request to addBaggageHeader

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -152,7 +152,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     }
 
     if (!self.isNetworkTrackingEnabled) {
-        [self addTraceWithoutTransactionToTask:sessionTask];
+        [self addTraceWithoutTransactionToTask:sessionTask request:currentRequest];
         return;
     }
 
@@ -192,7 +192,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         // otherwise we have nothing else to do here.
         if (netSpan == nil || [netSpan isKindOfClass:[SentryNoOpSpan class]]) {
             SENTRY_LOG_DEBUG(@"No transaction bound to scope. Won't track network operation.");
-            [self addTraceWithoutTransactionToTask:sessionTask];
+            [self addTraceWithoutTransactionToTask:sessionTask request:currentRequest];
             return;
         }
 
@@ -203,7 +203,8 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
                                         SentryTraceHeader, [netSpan toTraceHeader])
                propagateTraceparent:SentrySDKInternal.options.enablePropagateTraceparent
             tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
-                          toRequest:sessionTask];
+                         forRequest:currentRequest
+                             onTask:sessionTask];
 
         SENTRY_LOG_DEBUG(
             @"SentryNetworkTracker automatically started HTTP span for sessionTask: %@",
@@ -215,6 +216,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 }
 
 - (void)addTraceWithoutTransactionToTask:(NSURLSessionTask *)sessionTask
+                                 request:(NSURLRequest *)request
 {
     SentryPropagationContext *propagationContext
         = SentrySDKInternal.currentHub.scope.propagationContext;
@@ -229,7 +231,8 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
                                  traceHeader:[propagationContext traceHeader]
                         propagateTraceparent:SentrySDKInternal.options.enablePropagateTraceparent
                      tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
-                                   toRequest:sessionTask];
+                                  forRequest:request
+                                      onTask:sessionTask];
 }
 
 - (void)urlSessionTask:(NSURLSessionTask *)sessionTask setState:(NSURLSessionTaskState)newState

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -13,11 +13,9 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
                 traceHeader:(SentryTraceHeader *)traceHeader
        propagateTraceparent:(BOOL)propagateTraceparent
     tracePropagationTargets:(NSArray *_Nullable)tracePropagationTargets
-                  toRequest:(NSURLSessionTask *)sessionTask
+                 forRequest:(NSURLRequest *_Nullable)request
+                     onTask:(NSURLSessionTask *)sessionTask
 {
-    // Snapshot currentRequest once — the property is volatile and can become a zombie
-    // between repeated accesses if the task completes on another thread.
-    NSURLRequest *request = sessionTask.currentRequest;
     if (request == nil) {
         return;
     }
@@ -39,25 +37,23 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
         }
     }
 
+    NSMutableURLRequest *mutableRequest;
     if ([request isKindOfClass:[NSMutableURLRequest class]]) {
-        NSMutableURLRequest *mutableRequest = (NSMutableURLRequest *)request;
-        [SentryTracePropagation addHeaderFieldsToRequest:mutableRequest
-                                             traceHeader:traceHeader
-                                           baggageHeader:baggageHeader
-                                    propagateTraceparent:propagateTraceparent];
+        mutableRequest = (NSMutableURLRequest *)request;
     } else {
-        SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
-        if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {
-            NSMutableURLRequest *newRequest = [request mutableCopy];
-            [SentryTracePropagation addHeaderFieldsToRequest:newRequest
-                                                 traceHeader:traceHeader
-                                               baggageHeader:baggageHeader
-                                        propagateTraceparent:propagateTraceparent];
+        mutableRequest = [request mutableCopy];
+    }
 
-            void (*func)(id, SEL, id param)
-                = (void *)[sessionTask methodForSelector:setCurrentRequestSelector];
-            func(sessionTask, setCurrentRequestSelector, newRequest);
-        }
+    [SentryTracePropagation addHeaderFieldsToRequest:mutableRequest
+                                         traceHeader:traceHeader
+                                       baggageHeader:baggageHeader
+                                propagateTraceparent:propagateTraceparent];
+
+    SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
+    if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {
+        void (*func)(id, SEL, id param)
+            = (void *)[sessionTask methodForSelector:setCurrentRequestSelector];
+        func(sessionTask, setCurrentRequestSelector, mutableRequest);
     }
 }
 

--- a/Sources/Sentry/include/SentryTracePropagation.h
+++ b/Sources/Sentry/include/SentryTracePropagation.h
@@ -11,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
                 traceHeader:(SentryTraceHeader *)traceHeader
        propagateTraceparent:(BOOL)propagateTraceparent
     tracePropagationTargets:(NSArray *_Nullable)tracePropagationTargets
-                  toRequest:(NSURLSessionTask *)sessionTask;
+                 forRequest:(NSURLRequest *_Nullable)request
+                     onTask:(NSURLSessionTask *)sessionTask;
 
 + (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets;
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
@@ -13,7 +13,7 @@ final class SentryTracePropagationTests: XCTestCase {
         let traceHeader = TraceHeader(trace: traceID, spanId: spanID, sampled: SentrySampleDecision.yes)
 
         // Act
-        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], toRequest: sessionTask)
+        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], for: sessionTask.currentRequest, on: sessionTask)
 
         // Assert
         let traceParent = try XCTUnwrap(sessionTask.currentRequest?.allHTTPHeaderFields?["traceparent"])
@@ -31,7 +31,7 @@ final class SentryTracePropagationTests: XCTestCase {
         let traceHeader = TraceHeader(trace: traceID, spanId: spanID, sampled: SentrySampleDecision.no)
 
         // Act
-        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], toRequest: sessionTask)
+        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], for: sessionTask.currentRequest, on: sessionTask)
 
         // Assert
         let traceParent = try XCTUnwrap(sessionTask.currentRequest?.allHTTPHeaderFields?["traceparent"])
@@ -49,7 +49,7 @@ final class SentryTracePropagationTests: XCTestCase {
         let traceHeader = TraceHeader(trace: traceID, spanId: spanID, sampled: SentrySampleDecision.undecided)
 
         // Act
-        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], toRequest: sessionTask)
+        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: [defaultRegex], for: sessionTask.currentRequest, on: sessionTask)
 
         // Assert
         let traceParent = try XCTUnwrap(sessionTask.currentRequest?.allHTTPHeaderFields?["traceparent"])
@@ -66,7 +66,7 @@ final class SentryTracePropagationTests: XCTestCase {
         let traceHeader = TraceHeader(trace: traceID, spanId: spanID, sampled: SentrySampleDecision.no)
 
         // Act
-        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: ["localhost"], toRequest: sessionTask)
+        SentryTracePropagation.addBaggageHeader(emptyBaggage, traceHeader: traceHeader, propagateTraceparent: true, tracePropagationTargets: ["localhost"], for: sessionTask.currentRequest, on: sessionTask)
 
         // Assert
         XCTAssertNil(sessionTask.currentRequest?.allHTTPHeaderFields?["traceparent"])
@@ -164,7 +164,8 @@ final class SentryTracePropagationTests: XCTestCase {
             traceHeader: traceHeader,
             propagateTraceparent: true,
             tracePropagationTargets: [try XCTUnwrap(NSRegularExpression(pattern: ".*"))],
-            toRequest: task
+            for: task.currentRequest,
+            on: task
         )
 
         XCTAssertNil(task.currentRequest?.value(forHTTPHeaderField: "sentry-trace"))

--- a/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.h
+++ b/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.h
@@ -43,6 +43,8 @@ static int64_t const DATA_BYTES_SENT = 652;
 
 - (void)setResponse:(NSURLResponse *)response;
 
+- (void)setCurrentRequest:(NSURLRequest *)request;
+
 @end
 
 @interface URLSessionUploadTaskMock : NSURLSessionUploadTask <URLSessionTaskMock>

--- a/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
@@ -96,6 +96,7 @@
 
 @implementation URLSessionDownloadTaskMock {
     NSURLRequest *_request;
+    NSURLRequest *_currentRequest;
     NSURLResponse *_response;
     NSURLSessionTaskState _state;
     NSError *_error;
@@ -127,7 +128,12 @@
 
 - (NSURLRequest *)currentRequest
 {
-    return _request;
+    return _currentRequest;
+}
+
+- (void)setCurrentRequest:(NSURLRequest *)request
+{
+    _currentRequest = request;
 }
 
 - (NSURLResponse *)response
@@ -156,6 +162,7 @@
 {
     if (self = [super init]) {
         _request = request;
+        _currentRequest = [_request mutableCopy];
     }
     return self;
 }


### PR DESCRIPTION
## Summary
- Pass the already-snapshotted `currentRequest` as a parameter to `SentryTracePropagation.addBaggageHeader` instead of re-reading the volatile property inside the method
- Simplify the header-injection logic: always call `setCurrentRequest:` after adding headers, since the passed-in request may be a different object than the task's `currentRequest` (e.g. due to Swift/ObjC bridging)
- Update `URLSessionDownloadTaskMock` to properly support `setCurrentRequest:` (matching `URLSessionDataTaskMock`), fixing the Swift↔ObjC bridging issue in tests

Follows up on #8058 ([review comment](https://github.com/getsentry/sentry-cocoa/pull/8058#discussion_r3550532675)).

#skip-changelog

## Test plan
- [x] `SentryTracePropagationTests` — all 11 tests pass
- [x] `SentryNetworkTrackerTests` — all 75 tests pass
- [x] `make build-ios` succeeds