### PR TITLE
chore: add SwiftLint rule for allHeaderFields

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -129,8 +129,8 @@ custom_rules:
     included:
       - "./Tests/.*\\.swift"
   avoid_all_header_fields:
-    name: "Avoid allHeaderFields"
-    message: "Don't read headers via allHeaderFields: its subscripting is case-sensitive, but HTTP/2 and HTTP/3 lowercase field names, causing missed headers (see #8322). Use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in DefaultRateLimits.swift."
+    name: "Careful with allHeaderFields"
+    message: "Double-check how you use allHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but its subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see #8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in DefaultRateLimits.swift. If your usage is intentional, suppress this rule with a comment explaining why."
     regex: "allHeaderFields"
     match_kinds:
       - identifier

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -128,3 +128,10 @@ custom_rules:
     severity: error
     included:
       - "./Tests/.*\\.swift"
+  avoid_all_header_fields:
+    name: "Avoid allHeaderFields"
+    message: "Don't read headers via allHeaderFields: its subscripting is case-sensitive, but HTTP/2 and HTTP/3 lowercase field names, causing missed headers (see #8322). Use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in DefaultRateLimits.swift."
+    regex: "allHeaderFields"
+    match_kinds:
+      - identifier
+    severity: error

--- a/Samples/iOS-Swift/App/Sources/NetworkTestingViewController.swift
+++ b/Samples/iOS-Swift/App/Sources/NetworkTestingViewController.swift
@@ -129,10 +129,14 @@ class NetworkTestingViewController: UIViewController {
         responseStatusLabel.text = "Status: \(emoji) \(code) \(HTTPURLResponse.localizedString(forStatusCode: code))"
         responseStatusLabel.textColor = (200..<300).contains(code) ? .systemGreen : .systemOrange
         
+        // Here we deliberately display all response headers for debugging, so reading
+        // allHeaderFields is intended rather than a case-sensitive single-header lookup.
+        // swiftlint:disable avoid_all_header_fields
         responseHeadersTextView.text = httpResponse.allHeaderFields
             .sorted { "\($0.key)" < "\($1.key)" }
             .map { "\($0.key): \($0.value)" }
             .joined(separator: "\n")
+        // swiftlint:enable avoid_all_header_fields
         
         guard let data = data else { return }
         

--- a/Sources/Swift/Networking/DefaultRateLimits.swift
+++ b/Sources/Swift/Networking/DefaultRateLimits.swift
@@ -94,11 +94,18 @@ extension HTTPURLResponse {
     /// response headers.
     func sentryCaseInsensitiveHeaderValue(forName name: String) -> String? {
         let lowercasedName = name.lowercased()
+        // The linter forbids `allHeaderFields` because its subscript is case-sensitive, and it points
+        // callers to `value(forHTTPHeaderField:)`. That API is only available on macOS 10.15+, so this
+        // pre-10.15 fallback has to iterate `allHeaderFields` instead. The case-sensitivity bug the
+        // linter guards against doesn't apply here: we don't subscript, we compare every key against
+        // `name` with both sides lowercased.
+        // swiftlint:disable avoid_all_header_fields
         for (key, value) in allHeaderFields {
             if let key = key as? String, key.lowercased() == lowercasedName {
                 return value as? String
             }
         }
+        // swiftlint:enable avoid_all_header_fields
         return nil
     }
 }


### PR DESCRIPTION
Adds a SwiftLint rule (`avoid_all_header_fields`) that flags `allHeaderFields` as a caution. It's not a ban — reading all headers is fine. The hazard is a single-header lookup: the subscript is case-sensitive, but HTTP/2 and HTTP/3 lowercase field names, so a lookup can silently miss the header (the over-rate-limiting bug #8322). The message links the Apple docs and points to `value(forHTTPHeaderField:)` / the `value(forHTTPHeaderFieldCaseInsensitive:)` extension for lookups.

Covers the Swift part of #8377. Level is `error`; intentional uses (the pre-macOS-10.15 fallback in `DefaultRateLimits.swift` and the sample's debug header dump) are wrapped in `swiftlint:disable`/`enable` with a rationale.

#skip-changelog