### PR TITLE
chore: add Objective-C linter for allHeaderFields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1354,20 +1354,27 @@ STAGED_CLANG_FILES := $(shell git diff --cached --diff-filter=d --name-only | gr
 # Get staged Objective-C header files
 STAGED_OBJC_HEADER_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.h$$' | awk '{printf "\"%s\" ", $$0}')
 
+# Message for the allHeaderFields banned-pattern lint, aligned with the SwiftLint
+# rule in PR #8387 (rule id avoid_all_header_fields).
+AVOID_ALL_HEADER_FIELDS_MSG := Double-check how you use allHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but its subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see \#8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in DefaultRateLimits.swift. If your usage is intentional, suppress this rule with a comment explaining why.
+
 ## Run linting checks on all files
 #
-# Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, and dprint checks without modifying files.
+# Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, Objective-C banned-pattern checks, and dprint checks without modifying files.
 .PHONY: lint
 lint:
 	@echo "--> Running Swiftlint and Clang-Format"
 	./scripts/check-clang-format.py -r Sources Tests
 	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
+	./scripts/check-objc-banned-pattern.sh --path Sources \
+		--rule avoid_all_header_fields --pattern 'allHeaderFields' \
+		--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"
 	swiftlint --strict --quiet
 	dprint check "**/*.{md,json,yaml,yml}"
 
 ## Run linting checks on staged files only
 #
-# Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, and dprint checks on staged files only.
+# Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, Objective-C banned-pattern checks, and dprint checks on staged files only.
 .PHONY: lint-staged
 lint-staged:
 	@echo "--> Running Swiftlint, dprint, and Clang-Format on staged files"
@@ -1376,6 +1383,11 @@ lint-staged:
 	fi
 	@if [ -n "$(STAGED_OBJC_HEADER_FILES)" ]; then \
 		ruby ./scripts/check-objc-id-usage.rb $(STAGED_OBJC_HEADER_FILES); \
+	fi
+	@if [ -n "$(STAGED_CLANG_FILES)" ]; then \
+		./scripts/check-objc-banned-pattern.sh --path Sources \
+			--rule avoid_all_header_fields --pattern 'allHeaderFields' \
+			--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"; \
 	fi
 	@if [ -n "$(STAGED_SWIFT_FILES)" ]; then \
 		swiftlint --strict --quiet $(STAGED_SWIFT_FILES); \

--- a/Makefile
+++ b/Makefile
@@ -1385,9 +1385,11 @@ lint-staged:
 		ruby ./scripts/check-objc-id-usage.rb $(STAGED_OBJC_HEADER_FILES); \
 	fi
 	@if [ -n "$(STAGED_CLANG_FILES)" ]; then \
-		./scripts/check-objc-banned-pattern.sh --path Sources \
-			--rule avoid_all_header_fields --pattern 'allHeaderFields' \
-			--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"; \
+		for f in $(STAGED_CLANG_FILES); do \
+			./scripts/check-objc-banned-pattern.sh --path "$$f" \
+				--rule avoid_all_header_fields --pattern 'allHeaderFields' \
+				--message "$(AVOID_ALL_HEADER_FIELDS_MSG)" || exit 1; \
+		done; \
 	fi
 	@if [ -n "$(STAGED_SWIFT_FILES)" ]; then \
 		swiftlint --strict --quiet $(STAGED_SWIFT_FILES); \

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -394,11 +394,14 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     NSMutableDictionary<NSString *, id> *response = [[NSMutableDictionary alloc] init];
 
     [response setValue:responseStatusCode forKey:@"status_code"];
+    // Safe: reading the whole dictionary, not a case-sensitive single-header lookup.
+    // sentry-lint:disable avoid_all_header_fields
     if (nil != myResponse.allHeaderFields) {
         NSDictionary<NSString *, NSString *> *headers =
             [HTTPHeaderSanitizer sanitizeHeaders:myResponse.allHeaderFields];
         [response setValue:headers forKey:@"headers"];
     }
+    // sentry-lint:enable avoid_all_header_fields
     if (sessionTask.countOfBytesReceived != 0) {
         [response setValue:[NSNumber numberWithLongLong:sessionTask.countOfBytesReceived]
                     forKey:@"body_size"];
@@ -643,8 +646,13 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
         if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
             NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
             statusCode = httpResponse.statusCode;
+            // sentry-lint:disable avoid_all_header_fields
+            // Safe: reading the whole dictionary, not a case-sensitive lookup.
             allHeaders = httpResponse.allHeaderFields;
+            // Unsafe: subscript is case-sensitive and can miss the header; needs fixing (see
+            // #8388).
             contentType = httpResponse.allHeaderFields[@"Content-Type"];
+            // sentry-lint:enable avoid_all_header_fields
         }
 
         NSData *bodyData

--- a/scripts/check-objc-banned-pattern.sh
+++ b/scripts/check-objc-banned-pattern.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generic banned-pattern linter for Objective-C sources (.m/.mm/.h).
+#
+# Flags every line matching --pattern that is not inside a suppression region:
+#
+#   // sentry-lint:disable <rule>
+#   ... intentionally-banned code ...
+#   // sentry-lint:enable <rule>
+#
+# A disable without a matching enable suppresses to end of file; state resets per
+# file. The rule id is chosen by the caller via --rule, so several patterns can be
+# checked independently with their own suppression markers.
+
+# Source CI utilities for proper logging
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+# Parse named arguments
+PATTERN=""
+RULE=""
+SEARCH_PATH=""
+MESSAGE=""
+
+usage() {
+    log_notice "Usage: $0 --pattern <ere> --rule <id> --path <dir> [--message <text>]"
+    log_notice "  --pattern <ere>   Extended regex to ban (plain strings match literally) (required)"
+    log_notice "  --rule <id>       Suppression marker id: // sentry-lint:disable <id> (required)"
+    log_notice "  --path <dir>      Directory scanned recursively for .m/.mm/.h sources (required)"
+    log_notice "  --message <text>  Custom guidance shown on violations (optional)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --pattern) PATTERN="$2"; shift 2 ;;
+        --rule)    RULE="$2";    shift 2 ;;
+        --path)    SEARCH_PATH="$2"; shift 2 ;;
+        --message) MESSAGE="$2"; shift 2 ;;
+        *)         usage ;;
+    esac
+done
+
+[ -z "$PATTERN" ]     && { log_error "Error: --pattern is required"; usage; }
+[ -z "$RULE" ]        && { log_error "Error: --rule is required"; usage; }
+[ -z "$SEARCH_PATH" ] && { log_error "Error: --path is required"; usage; }
+[ -z "$MESSAGE" ] && MESSAGE="Banned pattern '$PATTERN' found."
+
+# Pre-filter to candidate files so awk never reads from stdin on an empty match set.
+FILES=$(grep -rlE "$PATTERN" "$SEARCH_PATH" \
+    --include='*.m' --include='*.mm' --include='*.h' || true)
+[ -z "$FILES" ] && exit 0
+
+# Report lines matching PATTERN outside a // sentry-lint:disable/enable <rule> region.
+# Disable/enable lines are consumed before the pattern check, so a marker line is
+# never itself reported even for broad patterns.
+# shellcheck disable=SC2086  # intentional word-splitting; source paths have no spaces
+OFFENDING=$(awk -v pat="$PATTERN" -v rule="$RULE" '
+    BEGIN { dis="sentry-lint:disable[[:space:]]+" rule; ena="sentry-lint:enable[[:space:]]+" rule }
+    FNR==1 { off=0 }
+    $0 ~ dis { off=1; next }
+    $0 ~ ena { off=0; next }
+    off { next }
+    $0 ~ pat { print FILENAME":"FNR": "$0 }
+' $FILES)
+
+if [ -n "$OFFENDING" ]; then
+    log_error "$MESSAGE"
+    log_error "Wrap intentional use in // sentry-lint:disable $RULE ... // sentry-lint:enable $RULE."
+    echo "$OFFENDING"
+    exit 1
+fi

--- a/scripts/check-objc-banned-pattern.sh
+++ b/scripts/check-objc-banned-pattern.sh
@@ -25,7 +25,7 @@ SEARCH_PATH=""
 MESSAGE=""
 
 usage() {
-    log_notice "Usage: $0 --pattern <ere> --rule <id> --path <dir> [--message <text>]"
+    log_notice "Usage: $0 --pattern <ere> --rule <id> --path <path> [--message <text>]"
     log_notice "  --pattern <ere>   Extended regex to ban (plain strings match literally) (required)"
     log_notice "  --rule <id>       Suppression marker id: // sentry-lint:disable <id> (required)"
     log_notice "  --path <path>     File or directory scanned recursively for .m/.mm/.h sources (required)"

--- a/scripts/check-objc-banned-pattern.sh
+++ b/scripts/check-objc-banned-pattern.sh
@@ -48,6 +48,16 @@ done
 [ -z "$SEARCH_PATH" ] && { log_error "Error: --path is required"; usage; }
 [ -z "$MESSAGE" ] && MESSAGE="Banned pattern '$PATTERN' found."
 
+# grep's --include only filters files discovered during recursive directory traversal;
+# an explicitly-passed file is always searched (GNU grep). lint-staged hands us individual
+# files including .c/.cpp/.hpp, so guard the ObjC extension ourselves for the file case.
+if [ -f "$SEARCH_PATH" ]; then
+    case "$SEARCH_PATH" in
+        *.m | *.mm | *.h) ;;
+        *) exit 0 ;;
+    esac
+fi
+
 # Pre-filter to candidate files so awk never reads from stdin on an empty match set.
 FILES=$(grep -rlE "$PATTERN" "$SEARCH_PATH" \
     --include='*.m' --include='*.mm' --include='*.h' || true)

--- a/scripts/check-objc-banned-pattern.sh
+++ b/scripts/check-objc-banned-pattern.sh
@@ -56,15 +56,21 @@ FILES=$(grep -rlE "$PATTERN" "$SEARCH_PATH" \
 # Report lines matching PATTERN outside a // sentry-lint:disable/enable <rule> region.
 # Disable/enable lines are consumed before the pattern check, so a marker line is
 # never itself reported even for broad patterns.
+# The rule id is anchored with a trailing non-word class so a disable/enable for a
+# rule whose name merely starts with $RULE (e.g. avoid_all_header_fields_v2) does
+# not toggle this rule.
+# `|| true`: awk exits non-zero if a listed file vanished between grep and this pass
+# (e.g. a concurrent clean); detection is by output, not exit code, so don't let
+# `set -e` abort on it.
 # shellcheck disable=SC2086  # intentional word-splitting; source paths have no spaces
 OFFENDING=$(awk -v pat="$PATTERN" -v rule="$RULE" '
-    BEGIN { dis="sentry-lint:disable[[:space:]]+" rule; ena="sentry-lint:enable[[:space:]]+" rule }
+    BEGIN { end="([^_[:alnum:]]|$)"; dis="sentry-lint:disable[[:space:]]+" rule end; ena="sentry-lint:enable[[:space:]]+" rule end }
     FNR==1 { off=0 }
     $0 ~ dis { off=1; next }
     $0 ~ ena { off=0; next }
     off { next }
     $0 ~ pat { print FILENAME":"FNR": "$0 }
-' $FILES)
+' $FILES || true)
 
 if [ -n "$OFFENDING" ]; then
     log_error "$MESSAGE"

--- a/scripts/check-objc-banned-pattern.sh
+++ b/scripts/check-objc-banned-pattern.sh
@@ -28,7 +28,7 @@ usage() {
     log_notice "Usage: $0 --pattern <ere> --rule <id> --path <dir> [--message <text>]"
     log_notice "  --pattern <ere>   Extended regex to ban (plain strings match literally) (required)"
     log_notice "  --rule <id>       Suppression marker id: // sentry-lint:disable <id> (required)"
-    log_notice "  --path <dir>      Directory scanned recursively for .m/.mm/.h sources (required)"
+    log_notice "  --path <path>     File or directory scanned recursively for .m/.mm/.h sources (required)"
     log_notice "  --message <text>  Custom guidance shown on violations (optional)"
     exit 1
 }


### PR DESCRIPTION
Second part of #8377 — the Objective-C counterpart to the Swift SwiftLint rule in #8387.

**Why both?** SwiftLint is built on SourceKit and can only lint Swift, so it cannot cover the Objective-C code (e.g. `SentryNetworkTracker`, the site of #8322/#8388). The two rules scan disjoint file sets — SwiftLint for `.swift`, this script for `.m`/`.mm`/`.h` — and share the same rule id/message, giving full-language coverage of the same bug class. SwiftLint stays the preferred mechanism (semantic, IDE-surfaced); this script only fills the ObjC gap it leaves.

- New generic script `scripts/check-objc-banned-pattern.sh`: flags a `--pattern` in `.m`/`.mm`/`.h` with SwiftLint-style `// sentry-lint:disable/enable <rule>` suppression.
- Wired into `make lint` / `make lint-staged` (pre-commit); no new CI workflow.
- First rule bans direct `allHeaderFields` access, aligned with #8387.
- Annotated existing `SentryNetworkTracker` usages; the unsafe `Content-Type` subscript is tracked in #8388.

#skip-changelog

Fixes https://github.com/getsentry/sentry-cocoa/issues/8377