### PR TITLE
ref: remove enableReplayNetworkDetailsCapturing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Mark opt in option `swiftAsyncStacktraces` as stable (#8373)
 - Add `dataCollection` option under `experimental` for configuring data scrubbing behavior (#8369)
 
+## Improvements
+
+- Remove `enableReplayNetworkDetailsCapturing` experimental flag; network detail capture is now enabled automatically when `networkDetailAllowUrls` is non-empty (#8396)
+
 ## 9.21.0
 
 ### Fixes

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -117,7 +117,6 @@ public enum SentrySDKOverrides: String, CaseIterable {
 
         case disableMaskAllImages = "--io.sentry.replay.disable-mask-all-images"
         case disableMaskAllText = "--io.sentry.replay.disable-mask-all-text"
-        case disableNetworkDetailsCapturing = "--io.sentry.replay.disable-network-details-capturing"
     }
     case replay = "Replay"
 
@@ -411,7 +410,7 @@ extension SentrySDKOverrides.Replay {
     public var overrideType: OverrideType {
         switch self {
         case .disable, .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText,
-             .disableMaskAllImages, .disableNetworkDetailsCapturing:
+             .disableMaskAllImages:
             return .boolean
         case .onErrorSampleRate, .sessionSampleRate: return .float
         case .quality: return .string
@@ -668,8 +667,7 @@ extension SentrySDKOverrides.Replay {
         switch self {
         case .disable: return false
         case .disableViewRendererV2, .enableFastViewRendering, .disableMaskAllText,
-             .disableMaskAllImages, .onErrorSampleRate, .sessionSampleRate, .quality,
-             .disableNetworkDetailsCapturing:
+             .disableMaskAllImages, .onErrorSampleRate, .sessionSampleRate, .quality:
             return true
         }
     }

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -107,8 +107,6 @@ public struct SentrySDKWrapper {
             let defaultReplayQuality = options.sessionReplay.quality
             options.sessionReplay.quality = SentryReplayOptions.SentryReplayQuality(rawValue: (SentrySDKOverrides.Replay.quality.stringValue as? NSString)?.integerValue ?? defaultReplayQuality.rawValue) ?? defaultReplayQuality
 
-            options.experimental.enableReplayNetworkDetailsCapturing =
-                !SentrySDKOverrides.Replay.disableNetworkDetailsCapturing.boolValue
         }
 
 #endif // !os(macOS) && !os(watchOS) && !os(visionOS)

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -604,10 +604,6 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
         return NO;
     }
 
-    if (!options.experimental.enableReplayNetworkDetailsCapturing) {
-        return NO;
-    }
-
     if (!urlString) {
         return NO;
     }

--- a/Sources/SentryObjC/Public/SentryObjCExperimentalOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCExperimentalOptions.h
@@ -24,16 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// When enabled, the SDK uses a more efficient mechanism for detecting watchdog terminations.
 @property (nonatomic) BOOL enableWatchdogTerminationsV2;
 
-/**
- * Enables network detail capture for Session Replay.
- *
- * When enabled, the SDK can capture request and response headers and bodies for network
- * requests during session replay. You must also configure
- * @c sessionReplay.networkDetailAllowUrls with URL patterns to specify which
- * requests should be captured.
- */
-@property (nonatomic) BOOL enableReplayNetworkDetailsCapturing;
-
 /// Configuration for what data the SDK collects automatically.
 @property (nonatomic, strong) SentryObjCDataCollectionOptions *dataCollection;
 

--- a/Sources/SentryObjCCompat/SentryObjCExperimentalOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCExperimentalOptions.swift
@@ -27,11 +27,6 @@ import Foundation
         set { wrapped.enableWatchdogTerminationsV2 = newValue }
     }
 
-    @objc public var enableReplayNetworkDetailsCapturing: Bool {
-        get { wrapped.enableReplayNetworkDetailsCapturing }
-        set { wrapped.enableReplayNetworkDetailsCapturing = newValue }
-    }
-
     @objc public var dataCollection: SentryObjCDataCollectionOptions {
         get { SentryObjCDataCollectionOptions(parent: wrapped) }
         set { wrapped.dataCollection = newValue.wrapped }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -35,6 +35,9 @@ import Foundation
         if options.sessionReplay.enableFastViewRendering {
             features.append("fastViewRendering")
         }
+        if options.sessionReplay.networkDetailHasUrls {
+            features.append("replayNetworkDetails")
+        }
 #endif // (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
 
         if options.enableDataSwizzling {
@@ -45,9 +48,6 @@ import Foundation
         }
         if options.experimental.enableUnhandledCPPExceptionsV2 {
             features.append("unhandledCPPExceptionsV2")
-        }
-        if options.experimental.enableReplayNetworkDetailsCapturing {
-            features.append("replayNetworkDetails")
         }
         if options.enableMetrics {
             features.append("metrics")

--- a/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
@@ -43,7 +43,7 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
         SentrySwizzleWrapperHelper.swizzleURLSessionTask(networkTracker)
 
         #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-         if options.experimental.enableReplayNetworkDetailsCapturing && options.sessionReplay.networkDetailHasUrls {
+         if options.sessionReplay.networkDetailHasUrls {
              SentrySwizzleWrapperHelper.swizzleURLSessionDataTasks(forResponseCapture: networkTracker)
          }
         #endif

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -335,7 +335,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * ```
      *
      * - Note: Request and response bodies are truncated to 150KB maximum.
-     * - Note: Requires `options.experimental.enableReplayNetworkDetailsCapturing` to be `true`.
      * - Note: See ``SentryReplayOptions.DefaultValues.networkDetailAllowUrls`` for the default value.
      */
     public var networkDetailAllowUrls: [SentryUrlMatchable]
@@ -358,7 +357,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * - NSRegularExpression patterns: Use try NSRegularExpression(pattern:) to create regex objects
      * - Mixed arrays are supported with both types
      *
-     * - Note: Requires `options.experimental.enableReplayNetworkDetailsCapturing` to be `true`.
      */
     public var networkDetailDenyUrls: [SentryUrlMatchable]
 
@@ -374,7 +372,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
      * - Note: Bodies are automatically truncated to 150KB to prevent excessive memory usage.
-     * - Note: Requires `options.experimental.enableReplayNetworkDetailsCapturing` to be `true`.
      */
     public var networkCaptureBodies: Bool
 
@@ -397,7 +394,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
      * - Note: Header names preserve the case seen on the request, not the case specified here.
-     * - Note: Requires `options.experimental.enableReplayNetworkDetailsCapturing` to be `true`.
      */
     public var networkRequestHeaders: [String] {
         get { _networkRequestHeaders }
@@ -424,7 +420,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: This setting only applies when ``networkDetailAllowUrls`` is non-empty.
      * - Note: Header names preserve the case seen on the response, not the case specified here.
-     * - Note: Requires `options.experimental.enableReplayNetworkDetailsCapturing` to be `true`.
      */
     public var networkResponseHeaders: [String] {
         get { _networkResponseHeaders }

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -16,16 +16,6 @@ public final class SentryExperimentalOptions: NSObject {
     /// When enabled, the SDK uses a more efficient mechanism for detecting watchdog terminations.
     public var enableWatchdogTerminationsV2 = false
 
-    /**
-     * Enables network detail capture for Session Replay.
-     *
-     * When enabled, the SDK can capture request and response headers and bodies for network
-     * requests during session replay. You must also configure
-     * `options.sessionReplay.networkDetailAllowUrls` with URL patterns to specify which
-     * requests should be captured.
-     */
-    public var enableReplayNetworkDetailsCapturing = false
-
     /// Configuration for what data the SDK collects automatically (e.g. headers, cookies, query params, bodies, user identity).
     ///
     /// - Important: Replaces `sendDefaultPii` with granular per-category control.

--- a/Tests/SentryObjCTests/SentryObjCExperimentalOptionsTests.m
+++ b/Tests/SentryObjCTests/SentryObjCExperimentalOptionsTests.m
@@ -76,29 +76,6 @@
     XCTAssertTrue(options.enableWatchdogTerminationsV2);
 }
 
-#pragma mark - enableReplayNetworkDetailsCapturing
-
-- (void)testEnableReplayNetworkDetailsCapturing_whenDefault_shouldBeFalse
-{
-    // -- Arrange --
-    SentryObjCExperimentalOptions *options = [[SentryObjCExperimentalOptions alloc] init];
-
-    // -- Assert --
-    XCTAssertFalse(options.enableReplayNetworkDetailsCapturing);
-}
-
-- (void)testEnableReplayNetworkDetailsCapturing_whenSetToYes_shouldReturnTrue
-{
-    // -- Arrange --
-    SentryObjCExperimentalOptions *options = [[SentryObjCExperimentalOptions alloc] init];
-
-    // -- Act --
-    options.enableReplayNetworkDetailsCapturing = YES;
-
-    // -- Assert --
-    XCTAssertTrue(options.enableReplayNetworkDetailsCapturing);
-}
-
 #pragma mark - dataCollection
 
 - (void)testDataCollection_whenDefault_shouldReturnNotNil

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkDetailSwizzlingTests.swift
@@ -23,54 +23,6 @@ class SentryNetworkDetailSwizzlingTests: XCTestCase {
     }
 
     // MARK: - Tests
-    func testDataNotCapturedIfExperimentalFlasNotEnabled() throws {
-        let options = Options()
-        options.dsn = TestConstants.dsnAsString(username: "SentryNetworkDetailSwizzlingTests")
-        options.tracesSampleRate = 1.0
-        options.enableNetworkBreadcrumbs = true
-        options.sessionReplay.networkDetailAllowUrls = ["postman-echo.com"]
-        options.sessionReplay.networkCaptureBodies = true
-        options.experimental.enableReplayNetworkDetailsCapturing = false
-        SentrySDK.start(options: options)
-        
-        let transaction = SentrySDK.startTransaction(
-            name: "Test", operation: "test", bindToScope: true
-        )
-
-        let expect = expectation(description: "Request completed")
-        expect.assertForOverFulfill = false
-
-        let session = URLSession(configuration: .default)
-        let request = URLRequest(url: echoURL)
-
-        var receivedData: Data?
-        var receivedResponse: URLResponse?
-        var receivedError: Error?
-
-        let task = session.dataTask(with: request) { data, response, error in
-            receivedData = data
-            receivedResponse = response
-            receivedError = error
-            expect.fulfill()
-        }
-        defer { task.cancel() }
-
-        task.resume()
-        wait(for: [expect], timeout: 5)
-
-        transaction.finish()
-
-        // Original completion handler received valid data
-        XCTAssertNil(receivedError, "Request should succeed")
-        XCTAssertNotNil(receivedData, "Should receive response data")
-        let httpResponse = try XCTUnwrap(receivedResponse as? HTTPURLResponse)
-        XCTAssertEqual(httpResponse.statusCode, 200)
-
-        // Network details were captured via the swizzled completion handler
-        let breadcrumb = try lastHTTPBreadcrumb(for: echoURL)
-        XCTAssertNil(breadcrumb.data?[SentryReplayNetworkDetails.replayNetworkDetailsKey], "Breadcrumbs should not contain any network details")
-    }
-
     /// Verifies the swizzle of `-[NSURLSession dataTaskWithRequest:completionHandler:]`
     /// captures response details into the breadcrumb.
     func testDataTaskWithRequest_completionHandler_capturesNetworkDetails() throws {
@@ -177,7 +129,6 @@ class SentryNetworkDetailSwizzlingTests: XCTestCase {
         options.enableNetworkBreadcrumbs = true
         options.sessionReplay.networkDetailAllowUrls = ["postman-echo.com"]
         options.sessionReplay.networkCaptureBodies = true
-        options.experimental.enableReplayNetworkDetailsCapturing = true
         SentrySDK.start(options: options)
     }
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -528,7 +528,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         options.sessionReplay.networkDetailAllowUrls = ["api.example.com"]
         options.sessionReplay.networkResponseHeaders = ["Cache-Control"]
         options.sessionReplay.networkCaptureBodies = false
-        options.experimental.enableReplayNetworkDetailsCapturing = true
 
         let scope = Scope()
         let client = TestClient(options: options)

--- a/develop-docs/DECISIONS.md
+++ b/develop-docs/DECISIONS.md
@@ -659,7 +659,7 @@ Truncation adds a warning (`MAYBE_JSON_TRUNCATED` or `TEXT_TRUNCATED`) so the Se
 
 ### Gating
 
-The feature requires explicit opt-in via `SentryReplayOptions.networkDetailAllowUrls` (URL allowlist) and the experimental flag `enableReplayNetworkDetailsCapturing`.
+The feature requires explicit opt-in via `SentryReplayOptions.networkDetailAllowUrls` (URL allowlist).
 Body capture within that gate is controlled by `networkCaptureBodies` (default `true`).
 The swizzling for response capture is skipped entirely when `networkDetailAllowUrls` is empty, so there is zero overhead for users who don't opt in.
 

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -942,6 +942,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Breadcrumb",
+                "printedName": "Sentry.Breadcrumb",
+                "usr": "c:objc(cs)SentryBreadcrumb"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -954,20 +960,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Breadcrumb?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Breadcrumb",
-                    "printedName": "Sentry.Breadcrumb",
-                    "usr": "c:objc(cs)SentryBreadcrumb"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Breadcrumb)",
-                "usr": "c:objc(cs)SentryBreadcrumb"
               }
             ],
             "kind": "TypeFunc",
@@ -993,17 +985,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1030,17 +1014,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1061,6 +1037,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Event",
+                "printedName": "Sentry.Event",
+                "usr": "c:objc(cs)SentryEvent"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -1073,20 +1055,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Event?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
-                "usr": "c:objc(cs)SentryEvent"
               }
             ],
             "kind": "TypeFunc",
@@ -1120,17 +1088,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
-                    "usr": "c:objc(pl)SentrySpan"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(any Sentry.Span)",
+                "name": "Span",
+                "printedName": "any Sentry.Span",
                 "usr": "c:objc(pl)SentrySpan"
               }
             ],
@@ -1181,23 +1141,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryAppStartMeasurement",
-                        "printedName": "Sentry.SentryAppStartMeasurement",
-                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                    "usr": "s:Sq"
+                    "name": "SentryAppStartMeasurement",
+                    "printedName": "Sentry.SentryAppStartMeasurement",
+                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                "name": "Optional",
+                "printedName": "Sentry.SentryAppStartMeasurement?",
                 "usr": "s:Sq"
               }
             ],
@@ -1230,17 +1182,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1275,23 +1219,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Error",
-                        "printedName": "any Swift.Error",
-                        "usr": "s:s5ErrorP"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "(any Swift.Error)?",
-                    "usr": "s:Sq"
+                    "name": "Error",
+                    "printedName": "any Swift.Error",
+                    "usr": "s:s5ErrorP"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "((any Swift.Error)?)",
+                "name": "Optional",
+                "printedName": "(any Swift.Error)?",
                 "usr": "s:Sq"
               }
             ],
@@ -1448,17 +1384,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SamplingContext",
-                    "printedName": "Sentry.SamplingContext",
-                    "usr": "c:objc(cs)SentrySamplingContext"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SamplingContext)",
+                "name": "SamplingContext",
+                "printedName": "Sentry.SamplingContext",
                 "usr": "c:objc(cs)SentrySamplingContext"
               }
             ],
@@ -1491,17 +1419,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryUserFeedbackConfiguration",
-                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1534,17 +1454,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryUserFeedbackConfiguration",
-                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1684,6 +1596,22 @@
         "name": "char32_t",
         "printedName": "char32_t",
         "usr": "c:@T@char32_t"
+      },
+      {
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "UInt8",
+            "printedName": "Swift.UInt8",
+            "usr": "s:s5UInt8V"
+          }
+        ],
+        "declKind": "TypeAlias",
+        "kind": "TypeAlias",
+        "moduleName": "Sentry",
+        "name": "char8_t",
+        "printedName": "char8_t",
+        "usr": "c:@T@char8_t"
       },
       {
         "children": [
@@ -16387,22 +16315,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16433,22 +16354,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16479,22 +16393,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16525,22 +16432,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16610,22 +16510,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16656,22 +16549,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -20677,6 +20563,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20689,20 +20581,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20744,6 +20622,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20756,20 +20640,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20815,6 +20685,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Breadcrumb",
+                            "printedName": "Sentry.Breadcrumb",
+                            "usr": "c:objc(cs)SentryBreadcrumb"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -20827,20 +20703,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Breadcrumb?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Breadcrumb)",
-                            "usr": "c:objc(cs)SentryBreadcrumb"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -20892,17 +20754,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20951,17 +20805,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21014,17 +20860,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21077,17 +20915,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21136,17 +20966,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21199,17 +21021,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21256,6 +21070,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21268,20 +21088,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21323,6 +21129,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21335,20 +21147,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21394,6 +21192,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
+                            "usr": "c:objc(cs)SentryEvent"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -21406,20 +21210,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Event?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
-                            "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -21477,23 +21267,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21537,23 +21319,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21601,23 +21375,15 @@
                         "usr": "s:Sq"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
-                            "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog)",
+                        "name": "SentryLog",
+                        "printedName": "Sentry.SentryLog",
                         "usr": "c:@M@Sentry@objc(cs)SentryLog"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21665,23 +21431,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21724,23 +21482,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21787,23 +21537,15 @@
                         "usr": "s:Sq"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryMetric)",
+                        "name": "SentryMetric",
+                        "printedName": "Sentry.SentryMetric",
                         "usr": "s:6Sentry0A6MetricV"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21852,17 +21594,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21919,17 +21653,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21990,17 +21716,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
-                                "usr": "c:objc(pl)SentrySpan"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Sentry.Span)",
+                            "name": "Span",
+                            "printedName": "any Sentry.Span",
                             "usr": "c:objc(pl)SentrySpan"
                           }
                         ],
@@ -22133,23 +21851,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -22190,23 +21900,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -22252,23 +21954,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
-                            "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions)",
+                        "name": "SentryProfileOptions",
+                        "printedName": "Sentry.SentryProfileOptions",
                         "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -22313,17 +22007,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryUserFeedbackConfiguration",
-                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22377,17 +22063,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryUserFeedbackConfiguration",
-                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22446,17 +22124,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -25531,17 +25201,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25575,17 +25237,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25623,17 +25277,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   },
                   {
@@ -25959,17 +25605,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -26024,17 +25662,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -26093,17 +25723,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -26190,8 +25812,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -26261,8 +25883,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -26336,8 +25958,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -27838,17 +27460,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27905,17 +27519,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27976,17 +27582,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
-                                "usr": "c:objc(cs)SentrySamplingContext"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SamplingContext)",
+                            "name": "SamplingContext",
+                            "printedName": "Sentry.SamplingContext",
                             "usr": "c:objc(cs)SentrySamplingContext"
                           }
                         ],
@@ -28130,17 +27728,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -28169,17 +27759,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -29974,17 +29556,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.String)",
+                    "name": "String",
+                    "printedName": "Swift.String",
                     "usr": "s:SS"
                   }
                 ],
@@ -30778,23 +30352,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30865,23 +30431,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30938,23 +30496,15 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
@@ -32898,22 +32448,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32944,22 +32487,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32990,22 +32526,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33036,22 +32565,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33121,22 +32643,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33827,22 +33342,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33912,22 +33420,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33958,22 +33459,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34249,22 +33743,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34334,22 +33821,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -35317,17 +34797,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -35344,22 +34816,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35384,23 +34849,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Bool",
-                                "printedName": "Swift.Bool",
-                                "usr": "s:Sb"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Bool]",
-                            "usr": "s:Sa"
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Bool])",
+                        "name": "Array",
+                        "printedName": "[Swift.Bool]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35417,22 +34874,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35455,17 +34905,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -35482,22 +34924,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35522,23 +34957,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Double",
-                                "printedName": "Swift.Double",
-                                "usr": "s:Sd"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Double]",
-                            "usr": "s:Sa"
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Double])",
+                        "name": "Array",
+                        "printedName": "[Swift.Double]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35555,22 +34982,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35630,17 +35050,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Int",
-                            "printedName": "Swift.Int",
-                            "usr": "s:Si"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Int)",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
                         "usr": "s:Si"
                       },
                       {
@@ -35657,22 +35069,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35697,23 +35102,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Int",
-                                "printedName": "Swift.Int",
-                                "usr": "s:Si"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Int]",
-                            "usr": "s:Sa"
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Int])",
+                        "name": "Array",
+                        "printedName": "[Swift.Int]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35730,22 +35127,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35768,24 +35158,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryAttributeContent",
                         "printedName": "Sentry.SentryAttributeContent",
                         "usr": "s:6Sentry0A16AttributeContentO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -35795,22 +35177,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35835,23 +35210,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.String]",
-                            "usr": "s:Sa"
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String])",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35868,22 +35235,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -38073,22 +37433,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -38145,22 +37498,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -38226,22 +37572,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -39386,22 +38725,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39432,22 +38764,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39478,22 +38803,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39524,22 +38842,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39570,22 +38881,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39616,22 +38920,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39662,22 +38959,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39708,22 +38998,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39793,22 +39076,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39839,22 +39115,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39885,22 +39154,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40471,22 +39733,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40517,22 +39772,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40563,22 +39811,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40648,22 +39889,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40694,22 +39928,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41014,22 +40241,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -41135,22 +40355,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -41400,17 +40613,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -41623,22 +40828,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41708,22 +40906,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41890,22 +41081,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41936,22 +41120,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41982,22 +41159,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42028,22 +41198,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42074,22 +41237,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42120,22 +41276,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42205,22 +41354,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42805,17 +41947,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -43903,23 +43037,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
+                        "name": "String",
+                        "printedName": "Swift.String",
                         "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Swift.String) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Swift.String) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -44810,29 +43936,21 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44871,29 +43989,21 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44936,29 +44046,21 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
-                            "usr": "s:Sq"
+                            "name": "SentryAppStartMeasurement",
+                            "printedName": "Sentry.SentryAppStartMeasurement",
+                            "usr": "c:objc(cs)SentryAppStartMeasurement"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                        "name": "Optional",
+                        "printedName": "Sentry.SentryAppStartMeasurement?",
                         "usr": "s:Sq"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -46269,8 +45371,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> ObjectiveC.IMP)"
+                    "name": "Function",
+                    "printedName": "() -> ObjectiveC.IMP"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46408,30 +45510,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46452,30 +45547,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46496,30 +45584,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46880,22 +45961,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46927,22 +46001,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47011,22 +46078,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47190,22 +46250,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47275,22 +46328,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47321,22 +46367,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47367,22 +46406,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47413,22 +46445,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47498,22 +46523,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47896,22 +46914,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47943,22 +46954,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47990,22 +46994,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -48037,22 +47034,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -48121,22 +47111,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -48205,22 +47188,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -51602,24 +50578,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "UInt",
-                            "printedName": "Swift.UInt",
-                            "usr": "s:Su"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.UInt)",
-                        "usr": "s:Su"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryMetricValue",
                         "printedName": "Sentry.SentryMetricValue",
                         "usr": "s:6Sentry0A11MetricValueO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "UInt",
+                        "printedName": "Swift.UInt",
+                        "usr": "s:Su"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -51629,22 +50597,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51667,17 +50628,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -51694,22 +50647,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51732,17 +50678,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -51759,22 +50697,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -52615,22 +51546,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52700,22 +51624,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52907,22 +51824,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -52991,22 +51901,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -53950,22 +52853,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53994,22 +52890,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -54038,22 +52927,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -54119,22 +53001,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -54163,22 +53038,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -55979,22 +54847,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -56026,22 +54887,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -56073,22 +54927,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -57958,22 +56805,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58004,22 +56844,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58050,22 +56883,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58271,22 +57097,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58356,22 +57175,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59558,17 +58370,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59731,17 +58535,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59904,17 +58700,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -60107,17 +58895,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -60233,17 +59013,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -60407,17 +59179,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.Span)",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -60565,17 +59329,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Options",
-                        "printedName": "Sentry.Options",
-                        "usr": "c:@M@Sentry@objc(cs)SentryOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Options)",
+                    "name": "Options",
+                    "printedName": "Sentry.Options",
                     "usr": "c:@M@Sentry@objc(cs)SentryOptions"
                   }
                 ],
@@ -61490,17 +60246,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Span",
-                            "printedName": "any Sentry.Span",
-                            "usr": "c:objc(pl)SentrySpan"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Sentry.Span)",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
                         "usr": "c:objc(pl)SentrySpan"
                       }
                     ],
@@ -61529,17 +60277,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.Span)",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -61698,22 +60438,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61783,22 +60516,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61829,22 +60555,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62954,22 +61673,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63000,22 +61712,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63046,22 +61751,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63092,22 +61790,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63138,22 +61829,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63184,22 +61868,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63230,22 +61907,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63276,22 +61946,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63322,22 +61985,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63368,22 +62024,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63414,22 +62063,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63460,22 +62102,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63545,22 +62180,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63591,22 +62219,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63637,22 +62258,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63683,22 +62297,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63729,22 +62336,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63775,22 +62375,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65590,22 +64183,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65638,22 +64224,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65723,22 +64302,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65771,22 +64343,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65819,22 +64384,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65867,22 +64425,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66256,22 +64807,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66300,22 +64844,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66344,22 +64881,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66388,22 +64918,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66432,22 +64955,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66476,24 +64992,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUnit",
                         "printedName": "Sentry.SentryUnit",
                         "usr": "s:6Sentry0A4UnitO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -66503,22 +65011,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -66541,22 +65042,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66585,22 +65079,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66629,22 +65116,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66673,22 +65153,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66717,22 +65190,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66761,22 +65227,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66805,22 +65264,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66849,22 +65301,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66893,22 +65338,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66937,22 +65375,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66981,22 +65412,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67025,22 +65449,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67069,22 +65486,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67113,22 +65523,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67157,22 +65560,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67240,22 +65636,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67284,22 +65673,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67328,22 +65710,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67372,22 +65747,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -67662,17 +66030,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "NSRegularExpression",
-                            "printedName": "Foundation.NSRegularExpression",
-                            "usr": "c:objc(cs)NSRegularExpression"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Foundation.NSRegularExpression)",
+                        "name": "NSRegularExpression",
+                        "printedName": "Foundation.NSRegularExpression",
                         "usr": "c:objc(cs)NSRegularExpression"
                       },
                       {
@@ -67689,22 +66049,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -67727,24 +66080,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUrlMatcher",
                         "printedName": "Sentry.SentryUrlMatcher",
                         "usr": "s:6Sentry0A10UrlMatcherO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -67754,22 +66099,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -67935,23 +66273,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67992,23 +66322,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68056,23 +66378,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                        "name": "SentryUserFeedbackThemeConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68115,23 +66429,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68173,23 +66479,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68235,23 +66533,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                        "name": "SentryUserFeedbackFormConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68297,23 +66587,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68355,23 +66637,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68417,23 +66691,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                        "name": "SentryUserFeedbackThemeConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68479,23 +66745,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackWidgetConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                            "name": "SentryUserFeedbackWidgetConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68536,23 +66794,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackWidgetConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                            "name": "SentryUserFeedbackWidgetConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68600,23 +66850,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackWidgetConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
+                        "name": "SentryUserFeedbackWidgetConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68764,8 +67006,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68813,8 +67055,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68866,8 +67108,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68919,8 +67161,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68968,8 +67210,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -69021,8 +67263,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -69068,23 +67310,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -69126,23 +67360,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -69188,23 +67414,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
-                            "usr": "s:s5ErrorP"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Swift.Error)",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
                         "usr": "s:s5ErrorP"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((any Swift.Error) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(any Swift.Error) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -69252,34 +67470,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -69323,34 +67533,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -69398,34 +67600,26 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
-                            "usr": "s:SD"
+                            "name": "ProtocolComposition",
+                            "printedName": "Any"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String : Any])",
+                        "name": "Dictionary",
+                        "printedName": "[Swift.String : Any]",
                         "usr": "s:SD"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "([Swift.String : Any]) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -71658,17 +69852,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -71702,17 +69888,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -71750,17 +69928,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
-                        "usr": "s:Sb"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.Bool)",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
                     "usr": "s:Sb"
                   },
                   {
@@ -71912,17 +70082,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -72487,17 +70649,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -83031,17 +81185,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -83149,17 +81295,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryRedactOptions",
-                        "printedName": "any Sentry.SentryRedactOptions",
-                        "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.SentryRedactOptions)",
+                    "name": "SentryRedactOptions",
+                    "printedName": "any Sentry.SentryRedactOptions",
                     "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
                   }
                 ],

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -942,12 +942,6 @@
           {
             "children": [
               {
-                "kind": "TypeNominal",
-                "name": "Breadcrumb",
-                "printedName": "Sentry.Breadcrumb",
-                "usr": "c:objc(cs)SentryBreadcrumb"
-              },
-              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -960,6 +954,20 @@
                 "name": "Optional",
                 "printedName": "Sentry.Breadcrumb?",
                 "usr": "s:Sq"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Breadcrumb",
+                    "printedName": "Sentry.Breadcrumb",
+                    "usr": "c:objc(cs)SentryBreadcrumb"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Paren",
+                "printedName": "(Sentry.Breadcrumb)",
+                "usr": "c:objc(cs)SentryBreadcrumb"
               }
             ],
             "kind": "TypeFunc",
@@ -985,9 +993,17 @@
                 "usr": "s:Sb"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1014,9 +1030,17 @@
                 "usr": "s:Sb"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1037,12 +1061,6 @@
           {
             "children": [
               {
-                "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
-                "usr": "c:objc(cs)SentryEvent"
-              },
-              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -1055,6 +1073,20 @@
                 "name": "Optional",
                 "printedName": "Sentry.Event?",
                 "usr": "s:Sq"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
+                "usr": "c:objc(cs)SentryEvent"
               }
             ],
             "kind": "TypeFunc",
@@ -1088,9 +1120,17 @@
                 "usr": "s:Sq"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
+                    "usr": "c:objc(pl)SentrySpan"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Span",
-                "printedName": "any Sentry.Span",
+                "name": "Paren",
+                "printedName": "(any Sentry.Span)",
                 "usr": "c:objc(pl)SentrySpan"
               }
             ],
@@ -1141,15 +1181,23 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryAppStartMeasurement",
+                        "printedName": "Sentry.SentryAppStartMeasurement",
+                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "SentryAppStartMeasurement",
-                    "printedName": "Sentry.SentryAppStartMeasurement",
-                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                    "name": "Optional",
+                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                    "usr": "s:Sq"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SentryAppStartMeasurement?",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                 "usr": "s:Sq"
               }
             ],
@@ -1182,9 +1230,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1219,15 +1275,23 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
+                        "usr": "s:s5ErrorP"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Error",
-                    "printedName": "any Swift.Error",
-                    "usr": "s:s5ErrorP"
+                    "name": "Optional",
+                    "printedName": "(any Swift.Error)?",
+                    "usr": "s:Sq"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "(any Swift.Error)?",
+                "name": "Paren",
+                "printedName": "((any Swift.Error)?)",
                 "usr": "s:Sq"
               }
             ],
@@ -1384,9 +1448,17 @@
                 "usr": "s:Sq"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SamplingContext",
+                    "printedName": "Sentry.SamplingContext",
+                    "usr": "c:objc(cs)SentrySamplingContext"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SamplingContext",
-                "printedName": "Sentry.SamplingContext",
+                "name": "Paren",
+                "printedName": "(Sentry.SamplingContext)",
                 "usr": "c:objc(cs)SentrySamplingContext"
               }
             ],
@@ -1419,9 +1491,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryUserFeedbackConfiguration",
+                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SentryUserFeedbackConfiguration",
-                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1454,9 +1534,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryUserFeedbackConfiguration",
+                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SentryUserFeedbackConfiguration",
-                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1596,22 +1684,6 @@
         "name": "char32_t",
         "printedName": "char32_t",
         "usr": "c:@T@char32_t"
-      },
-      {
-        "children": [
-          {
-            "kind": "TypeNominal",
-            "name": "UInt8",
-            "printedName": "Swift.UInt8",
-            "usr": "s:s5UInt8V"
-          }
-        ],
-        "declKind": "TypeAlias",
-        "kind": "TypeAlias",
-        "moduleName": "Sentry",
-        "name": "char8_t",
-        "printedName": "char8_t",
-        "usr": "c:@T@char8_t"
       },
       {
         "children": [
@@ -16315,15 +16387,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16354,15 +16433,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16393,15 +16479,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16432,15 +16525,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16510,15 +16610,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16549,15 +16656,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -20563,12 +20677,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20581,6 +20689,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Breadcrumb",
+                                    "printedName": "Sentry.Breadcrumb",
+                                    "usr": "c:objc(cs)SentryBreadcrumb"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Breadcrumb)",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20622,12 +20744,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20640,6 +20756,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Breadcrumb",
+                                    "printedName": "Sentry.Breadcrumb",
+                                    "usr": "c:objc(cs)SentryBreadcrumb"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Breadcrumb)",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20685,12 +20815,6 @@
                       {
                         "children": [
                           {
-                            "kind": "TypeNominal",
-                            "name": "Breadcrumb",
-                            "printedName": "Sentry.Breadcrumb",
-                            "usr": "c:objc(cs)SentryBreadcrumb"
-                          },
-                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -20703,6 +20827,20 @@
                             "name": "Optional",
                             "printedName": "Sentry.Breadcrumb?",
                             "usr": "s:Sq"
+                          },
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Breadcrumb)",
+                            "usr": "c:objc(cs)SentryBreadcrumb"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -20754,9 +20892,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20805,9 +20951,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20860,9 +21014,17 @@
                             "usr": "s:Sb"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -20915,9 +21077,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20966,9 +21136,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21021,9 +21199,17 @@
                             "usr": "s:Sb"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21070,12 +21256,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21088,6 +21268,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
+                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21129,12 +21323,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21147,6 +21335,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
+                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21192,12 +21394,6 @@
                       {
                         "children": [
                           {
-                            "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
-                            "usr": "c:objc(cs)SentryEvent"
-                          },
-                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -21210,6 +21406,20 @@
                             "name": "Optional",
                             "printedName": "Sentry.Event?",
                             "usr": "s:Sq"
+                          },
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
+                            "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -21267,15 +21477,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryLog",
+                                "printedName": "Sentry.SentryLog",
+                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryLog)",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21319,15 +21537,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryLog",
+                                "printedName": "Sentry.SentryLog",
+                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryLog)",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21375,15 +21601,23 @@
                         "usr": "s:Sq"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
+                            "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLog",
-                        "printedName": "Sentry.SentryLog",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog)",
                         "usr": "c:@M@Sentry@objc(cs)SentryLog"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21431,15 +21665,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryMetric)",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21482,15 +21724,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryMetric)",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21537,15 +21787,23 @@
                         "usr": "s:Sq"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
+                            "usr": "s:6Sentry0A6MetricV"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetric",
-                        "printedName": "Sentry.SentryMetric",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryMetric)",
                         "usr": "s:6Sentry0A6MetricV"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21594,9 +21852,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Span",
+                                    "printedName": "any Sentry.Span",
+                                    "usr": "c:objc(pl)SentrySpan"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
+                                "name": "Paren",
+                                "printedName": "(any Sentry.Span)",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21653,9 +21919,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Span",
+                                    "printedName": "any Sentry.Span",
+                                    "usr": "c:objc(pl)SentrySpan"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
+                                "name": "Paren",
+                                "printedName": "(any Sentry.Span)",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21716,9 +21990,17 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
+                                "usr": "c:objc(pl)SentrySpan"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Span",
-                            "printedName": "any Sentry.Span",
+                            "name": "Paren",
+                            "printedName": "(any Sentry.Span)",
                             "usr": "c:objc(pl)SentrySpan"
                           }
                         ],
@@ -21851,15 +22133,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileOptions",
+                                "printedName": "Sentry.SentryProfileOptions",
+                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryProfileOptions)",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21900,15 +22190,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileOptions",
+                                "printedName": "Sentry.SentryProfileOptions",
+                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryProfileOptions)",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21954,15 +22252,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
+                            "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileOptions",
-                        "printedName": "Sentry.SentryProfileOptions",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions)",
                         "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -22007,9 +22313,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryUserFeedbackConfiguration",
+                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22063,9 +22377,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryUserFeedbackConfiguration",
+                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22124,9 +22446,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -25201,9 +25531,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Scope",
+                            "printedName": "Sentry.Scope",
+                            "usr": "c:objc(cs)SentryScope"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
+                        "name": "Paren",
+                        "printedName": "(Sentry.Scope)",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25237,9 +25575,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Scope",
+                            "printedName": "Sentry.Scope",
+                            "usr": "c:objc(cs)SentryScope"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
+                        "name": "Paren",
+                        "printedName": "(Sentry.Scope)",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25277,9 +25623,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   },
                   {
@@ -25605,9 +25959,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -25662,9 +26024,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -25723,9 +26093,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -25812,8 +26190,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25883,8 +26261,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25958,8 +26336,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -27460,9 +27838,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SamplingContext",
+                                    "printedName": "Sentry.SamplingContext",
+                                    "usr": "c:objc(cs)SentrySamplingContext"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SamplingContext)",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27519,9 +27905,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SamplingContext",
+                                    "printedName": "Sentry.SamplingContext",
+                                    "usr": "c:objc(cs)SentrySamplingContext"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SamplingContext)",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27582,9 +27976,17 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
+                                "usr": "c:objc(cs)SentrySamplingContext"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SamplingContext",
-                            "printedName": "Sentry.SamplingContext",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SamplingContext)",
                             "usr": "c:objc(cs)SentrySamplingContext"
                           }
                         ],
@@ -27728,9 +28130,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "URLSessionDelegate",
+                            "printedName": "any Foundation.URLSessionDelegate",
+                            "usr": "c:objc(pl)NSURLSessionDelegate"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "URLSessionDelegate",
-                        "printedName": "any Foundation.URLSessionDelegate",
+                        "name": "Paren",
+                        "printedName": "(any Foundation.URLSessionDelegate)",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -27759,9 +28169,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "URLSessionDelegate",
+                            "printedName": "any Foundation.URLSessionDelegate",
+                            "usr": "c:objc(pl)NSURLSessionDelegate"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "URLSessionDelegate",
-                        "printedName": "any Foundation.URLSessionDelegate",
+                        "name": "Paren",
+                        "printedName": "(any Foundation.URLSessionDelegate)",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -29556,9 +29974,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
+                    "name": "Paren",
+                    "printedName": "(Swift.String)",
                     "usr": "s:SS"
                   }
                 ],
@@ -30352,15 +30778,23 @@
                               {
                                 "children": [
                                   {
+                                    "children": [
+                                      {
+                                        "kind": "TypeNominal",
+                                        "name": "SentryAppStartMeasurement",
+                                        "printedName": "Sentry.SentryAppStartMeasurement",
+                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                      }
+                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                    "name": "Optional",
+                                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                                    "usr": "s:Sq"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30431,15 +30865,23 @@
                               {
                                 "children": [
                                   {
+                                    "children": [
+                                      {
+                                        "kind": "TypeNominal",
+                                        "name": "SentryAppStartMeasurement",
+                                        "printedName": "Sentry.SentryAppStartMeasurement",
+                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                      }
+                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                    "name": "Optional",
+                                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                                    "usr": "s:Sq"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30496,15 +30938,23 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
@@ -32448,15 +32898,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32487,15 +32944,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32526,15 +32990,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32565,15 +33036,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32643,15 +33121,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33342,15 +33827,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33420,15 +33912,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33459,15 +33958,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33743,15 +34249,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttachmentType",
+                            "printedName": "Sentry.SentryAttachmentType",
+                            "usr": "c:@E@SentryAttachmentType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttachmentType",
-                        "printedName": "Sentry.SentryAttachmentType",
-                        "usr": "c:@E@SentryAttachmentType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttachmentType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttachmentType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttachmentType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33821,15 +34334,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttachmentType",
+                            "printedName": "Sentry.SentryAttachmentType",
+                            "usr": "c:@E@SentryAttachmentType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttachmentType",
-                        "printedName": "Sentry.SentryAttachmentType",
-                        "usr": "c:@E@SentryAttachmentType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttachmentType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttachmentType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttachmentType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34797,9 +35317,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -34816,15 +35344,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34849,15 +35384,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Bool",
+                                "printedName": "Swift.Bool",
+                                "usr": "s:Sb"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
+                            "name": "Array",
+                            "printedName": "[Swift.Bool]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Bool]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Bool])",
                         "usr": "s:Sa"
                       },
                       {
@@ -34874,15 +35417,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34905,9 +35455,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -34924,15 +35482,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34957,15 +35522,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Double",
+                                "printedName": "Swift.Double",
+                                "usr": "s:Sd"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
+                            "name": "Array",
+                            "printedName": "[Swift.Double]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Double]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Double])",
                         "usr": "s:Sa"
                       },
                       {
@@ -34982,15 +35555,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35050,9 +35630,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
+                        "name": "Paren",
+                        "printedName": "(Swift.Int)",
                         "usr": "s:Si"
                       },
                       {
@@ -35069,15 +35657,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35102,15 +35697,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Int",
+                                "printedName": "Swift.Int",
+                                "usr": "s:Si"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Int",
-                            "printedName": "Swift.Int",
-                            "usr": "s:Si"
+                            "name": "Array",
+                            "printedName": "[Swift.Int]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Int]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Int])",
                         "usr": "s:Sa"
                       },
                       {
@@ -35127,15 +35730,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35158,16 +35768,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryAttributeContent",
                         "printedName": "Sentry.SentryAttributeContent",
                         "usr": "s:6Sentry0A16AttributeContentO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -35177,15 +35795,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35210,15 +35835,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
+                            "name": "Array",
+                            "printedName": "[Swift.String]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.String]",
+                        "name": "Paren",
+                        "printedName": "([Swift.String])",
                         "usr": "s:Sa"
                       },
                       {
@@ -35235,15 +35868,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -37433,15 +38073,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -37498,15 +38145,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -37572,15 +38226,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -38725,15 +39386,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38764,15 +39432,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38803,15 +39478,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38842,15 +39524,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38881,15 +39570,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38920,15 +39616,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38959,15 +39662,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38998,15 +39708,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39076,15 +39793,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39115,15 +39839,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39154,15 +39885,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39368,82 +40106,6 @@
             "name": "dataCollection",
             "printedName": "dataCollection",
             "usr": "s:6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvp"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)enableReplayNetworkDetailsCapturing"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setEnableReplayNetworkDetailsCapturing:"
-              }
-            ],
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasStorage",
-              "ObjC"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvp",
-            "moduleName": "Sentry",
-            "name": "enableReplayNetworkDetailsCapturing",
-            "printedName": "enableReplayNetworkDetailsCapturing",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)enableReplayNetworkDetailsCapturing"
           },
           {
             "accessors": [
@@ -39809,15 +40471,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39848,15 +40517,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39887,15 +40563,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39965,15 +40648,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40004,15 +40694,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40317,15 +41014,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryFeedbackSource",
+                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -40431,15 +41135,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryFeedbackSource",
+                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -40689,9 +41400,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -40904,15 +41623,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedbackSource",
+                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryFeedbackSource",
-                        "printedName": "Sentry.SentryFeedbackSource",
-                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedbackSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryFeedbackSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40982,15 +41708,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedbackSource",
+                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryFeedbackSource",
-                        "printedName": "Sentry.SentryFeedbackSource",
-                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedbackSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryFeedbackSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41157,15 +41890,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41196,15 +41936,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41235,15 +41982,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41274,15 +42028,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41313,15 +42074,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41352,15 +42120,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41430,15 +42205,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42023,9 +42805,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -43113,15 +43903,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
                         "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Swift.String) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Swift.String) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -44012,21 +44810,29 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44065,21 +44871,29 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44122,21 +44936,29 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryAppStartMeasurement",
-                            "printedName": "Sentry.SentryAppStartMeasurement",
-                            "usr": "c:objc(cs)SentryAppStartMeasurement"
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Optional",
-                        "printedName": "Sentry.SentryAppStartMeasurement?",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?)",
                         "usr": "s:Sq"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -45447,8 +46269,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> ObjectiveC.IMP"
+                    "name": "Paren",
+                    "printedName": "(() -> ObjectiveC.IMP)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -45586,23 +46408,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45623,23 +46452,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45660,23 +46496,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46037,15 +46880,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46077,15 +46927,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46154,15 +47011,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46326,15 +47190,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46404,15 +47275,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46443,15 +47321,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46482,15 +47367,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46521,15 +47413,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46599,15 +47498,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46990,15 +47896,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47030,15 +47943,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47070,15 +47990,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47110,15 +48037,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47187,15 +48121,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47264,15 +48205,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -50654,16 +51602,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "UInt",
+                            "printedName": "Swift.UInt",
+                            "usr": "s:Su"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.UInt)",
+                        "usr": "s:Su"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryMetricValue",
                         "printedName": "Sentry.SentryMetricValue",
                         "usr": "s:6Sentry0A11MetricValueO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "UInt",
-                        "printedName": "Swift.UInt",
-                        "usr": "s:Su"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -50673,15 +51629,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -50704,9 +51667,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -50723,15 +51694,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -50754,9 +51732,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -50773,15 +51759,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51622,15 +52615,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileLifecycle",
+                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileLifecycle",
-                        "printedName": "Sentry.SentryProfileLifecycle",
-                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileLifecycle.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryProfileLifecycle.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -51700,15 +52700,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileLifecycle",
+                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileLifecycle",
-                        "printedName": "Sentry.SentryProfileLifecycle",
-                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileLifecycle.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryProfileLifecycle.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -51900,15 +52907,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileLifecycle",
+                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -51977,15 +52991,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileLifecycle",
+                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -52929,15 +53950,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52966,15 +53994,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53003,15 +54038,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53077,15 +54119,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53114,15 +54163,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -54923,15 +55979,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -54963,15 +56026,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -55003,15 +56073,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -56881,15 +57958,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56920,15 +58004,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56959,15 +58050,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57173,15 +58271,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayType",
+                            "printedName": "Sentry.SentryReplayType",
+                            "usr": "c:@M@Sentry@E@SentryReplayType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57251,15 +58356,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayType",
+                            "printedName": "Sentry.SentryReplayType",
+                            "usr": "c:@M@Sentry@E@SentryReplayType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58446,9 +59558,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58611,9 +59731,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58776,9 +59904,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58971,9 +60107,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59089,9 +60233,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59255,9 +60407,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
+                        "usr": "c:objc(pl)SentrySpan"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.Span)",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -59405,9 +60565,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Options",
+                        "printedName": "Sentry.Options",
+                        "usr": "c:@M@Sentry@objc(cs)SentryOptions"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Options",
-                    "printedName": "Sentry.Options",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Options)",
                     "usr": "c:@M@Sentry@objc(cs)SentryOptions"
                   }
                 ],
@@ -60322,9 +61490,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Span",
+                            "printedName": "any Sentry.Span",
+                            "usr": "c:objc(pl)SentrySpan"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
+                        "name": "Paren",
+                        "printedName": "(any Sentry.Span)",
                         "usr": "c:objc(pl)SentrySpan"
                       }
                     ],
@@ -60353,9 +61529,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
+                        "usr": "c:objc(pl)SentrySpan"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.Span)",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -60514,15 +61698,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60592,15 +61783,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -60631,15 +61829,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61749,15 +62954,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61788,15 +63000,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61827,15 +63046,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61866,15 +63092,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61905,15 +63138,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61944,15 +63184,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61983,15 +63230,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62022,15 +63276,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62061,15 +63322,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62100,15 +63368,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62139,15 +63414,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62178,15 +63460,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62256,15 +63545,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62295,15 +63591,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62334,15 +63637,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62373,15 +63683,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62412,15 +63729,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62451,15 +63775,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64259,15 +65590,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64300,15 +65638,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64378,15 +65723,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64419,15 +65771,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64460,15 +65819,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64501,15 +65867,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64883,15 +66256,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64920,15 +66300,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64957,15 +66344,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64994,15 +66388,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65031,15 +66432,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65068,16 +66476,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryUnit",
                         "printedName": "Sentry.SentryUnit",
                         "usr": "s:6Sentry0A4UnitO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -65087,15 +66503,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -65118,15 +66541,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65155,15 +66585,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65192,15 +66629,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65229,15 +66673,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65266,15 +66717,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65303,15 +66761,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65340,15 +66805,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65377,15 +66849,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65414,15 +66893,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65451,15 +66937,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65488,15 +66981,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65525,15 +67025,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65562,15 +67069,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65599,15 +67113,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65636,15 +67157,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65712,15 +67240,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65749,15 +67284,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65786,15 +67328,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65823,15 +67372,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66106,9 +67662,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "NSRegularExpression",
+                            "printedName": "Foundation.NSRegularExpression",
+                            "usr": "c:objc(cs)NSRegularExpression"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "NSRegularExpression",
-                        "printedName": "Foundation.NSRegularExpression",
+                        "name": "Paren",
+                        "printedName": "(Foundation.NSRegularExpression)",
                         "usr": "c:objc(cs)NSRegularExpression"
                       },
                       {
@@ -66125,15 +67689,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUrlMatcher",
+                            "printedName": "Sentry.SentryUrlMatcher",
+                            "usr": "s:6Sentry0A10UrlMatcherO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUrlMatcher",
-                        "printedName": "Sentry.SentryUrlMatcher",
-                        "usr": "s:6Sentry0A10UrlMatcherO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUrlMatcher.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUrlMatcher.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -66156,16 +67727,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryUrlMatcher",
                         "printedName": "Sentry.SentryUrlMatcher",
                         "usr": "s:6Sentry0A10UrlMatcherO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -66175,15 +67754,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUrlMatcher",
+                            "printedName": "Sentry.SentryUrlMatcher",
+                            "usr": "s:6Sentry0A10UrlMatcherO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUrlMatcher",
-                        "printedName": "Sentry.SentryUrlMatcher",
-                        "usr": "s:6Sentry0A10UrlMatcherO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUrlMatcher.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUrlMatcher.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -66349,15 +67935,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66398,15 +67992,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66454,15 +68056,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackThemeConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -66505,15 +68115,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackFormConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66555,15 +68173,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackFormConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66609,15 +68235,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackFormConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -66663,15 +68297,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66713,15 +68355,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66767,15 +68417,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackThemeConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -66821,15 +68479,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackWidgetConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackWidgetConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66870,15 +68536,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackWidgetConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackWidgetConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66926,15 +68600,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackWidgetConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackWidgetConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackWidgetConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackWidgetConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackWidgetConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67082,8 +68764,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67131,8 +68813,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67184,8 +68866,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(() -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67237,8 +68919,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67286,8 +68968,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67339,8 +69021,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(() -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67386,15 +69068,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Error",
+                                "printedName": "any Swift.Error",
+                                "usr": "s:s5ErrorP"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
+                            "name": "Paren",
+                            "printedName": "(any Swift.Error)",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(any Swift.Error) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((any Swift.Error) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67436,15 +69126,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Error",
+                                "printedName": "any Swift.Error",
+                                "usr": "s:s5ErrorP"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
+                            "name": "Paren",
+                            "printedName": "(any Swift.Error)",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(any Swift.Error) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((any Swift.Error) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67490,15 +69188,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
+                            "usr": "s:s5ErrorP"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Error",
-                        "printedName": "any Swift.Error",
+                        "name": "Paren",
+                        "printedName": "(any Swift.Error)",
                         "usr": "s:s5ErrorP"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(any Swift.Error) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((any Swift.Error) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67546,26 +69252,34 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "ProtocolComposition",
+                                    "printedName": "Any"
+                                  },
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
+                                "name": "Dictionary",
+                                "printedName": "[Swift.String : Any]",
+                                "usr": "s:SD"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
+                            "name": "Paren",
+                            "printedName": "([Swift.String : Any])",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "([Swift.String : Any]) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67609,26 +69323,34 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "ProtocolComposition",
+                                    "printedName": "Any"
+                                  },
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
+                                "name": "Dictionary",
+                                "printedName": "[Swift.String : Any]",
+                                "usr": "s:SD"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
+                            "name": "Paren",
+                            "printedName": "([Swift.String : Any])",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "([Swift.String : Any]) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67676,26 +69398,34 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "ProtocolComposition",
-                            "printedName": "Any"
-                          },
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
+                            "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Dictionary",
-                        "printedName": "[Swift.String : Any]",
+                        "name": "Paren",
+                        "printedName": "([Swift.String : Any])",
                         "usr": "s:SD"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "([Swift.String : Any]) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -69928,9 +71658,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -69964,9 +71702,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -70004,9 +71750,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
+                    "name": "Paren",
+                    "printedName": "(Swift.Bool)",
                     "usr": "s:Sb"
                   },
                   {
@@ -70158,9 +71912,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -70725,9 +72487,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -81261,9 +83031,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -81371,9 +83149,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryRedactOptions",
+                        "printedName": "any Sentry.SentryRedactOptions",
+                        "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "SentryRedactOptions",
-                    "printedName": "any Sentry.SentryRedactOptions",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.SentryRedactOptions)",
                     "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
                   }
                 ],

--- a/sdk_api_objc.diff.json
+++ b/sdk_api_objc.diff.json
@@ -671,7 +671,7 @@
       "kind": "ObjCMethodDecl",
       "name": "onCrashedLastRun",
       "parent": "SentryObjCOptions",
-      "returnType": "SWIFT_DEPRECATED_MSG(\"Use onLastRunStatusDetermined instead.\") void (^)(SentryObjCEvent * _Nonnull)",
+      "returnType": "SWIFT_DEPRECATED_MSG void (^)(SentryObjCEvent * _Nonnull)",
       "instance": true
     },
     {
@@ -814,7 +814,7 @@
       "kind": "ObjCPropertyDecl",
       "name": "onCrashedLastRun",
       "parent": "SentryObjCOptions",
-      "type": "SWIFT_DEPRECATED_MSG(\"Use onLastRunStatusDetermined instead.\") void (^)(SentryObjCEvent * _Nonnull)"
+      "type": "SWIFT_DEPRECATED_MSG void (^)(SentryObjCEvent * _Nonnull)"
     },
     {
       "kind": "ObjCPropertyDecl",

--- a/sdk_api_objc.diff.json
+++ b/sdk_api_objc.diff.json
@@ -671,7 +671,7 @@
       "kind": "ObjCMethodDecl",
       "name": "onCrashedLastRun",
       "parent": "SentryObjCOptions",
-      "returnType": "SWIFT_DEPRECATED_MSG void (^)(SentryObjCEvent * _Nonnull)",
+      "returnType": "SWIFT_DEPRECATED_MSG(\"Use onLastRunStatusDetermined instead.\") void (^)(SentryObjCEvent * _Nonnull)",
       "instance": true
     },
     {
@@ -814,7 +814,7 @@
       "kind": "ObjCPropertyDecl",
       "name": "onCrashedLastRun",
       "parent": "SentryObjCOptions",
-      "type": "SWIFT_DEPRECATED_MSG void (^)(SentryObjCEvent * _Nonnull)"
+      "type": "SWIFT_DEPRECATED_MSG(\"Use onLastRunStatusDetermined instead.\") void (^)(SentryObjCEvent * _Nonnull)"
     },
     {
       "kind": "ObjCPropertyDecl",

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2155,13 +2155,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "enableReplayNetworkDetailsCapturing",
-    "parent": "SentryObjCExperimentalOptions",
-    "returnType": "BOOL",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "enableReportNonFullyBlockingAppHangs",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -6082,13 +6075,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "setEnableReplayNetworkDetailsCapturing:",
-    "parent": "SentryObjCExperimentalOptions",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "setEnableReportNonFullyBlockingAppHangs:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9456,12 +9442,6 @@
     "kind": "ObjCPropertyDecl",
     "name": "enablePropagateTraceparent",
     "parent": "SentryObjCOptions",
-    "type": "BOOL"
-  },
-  {
-    "kind": "ObjCPropertyDecl",
-    "name": "enableReplayNetworkDetailsCapturing",
-    "parent": "SentryObjCExperimentalOptions",
     "type": "BOOL"
   },
   {

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -2141,13 +2141,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "enableReplayNetworkDetailsCapturing",
-    "parent": "SentryObjCExperimentalOptions",
-    "returnType": "BOOL",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "enableReportNonFullyBlockingAppHangs",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -6047,13 +6040,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "setEnableReplayNetworkDetailsCapturing:",
-    "parent": "SentryObjCExperimentalOptions",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "setEnableReportNonFullyBlockingAppHangs:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9395,12 +9381,6 @@
     "kind": "ObjCPropertyDecl",
     "name": "enablePropagateTraceparent",
     "parent": "SentryObjCOptions",
-    "type": "BOOL"
-  },
-  {
-    "kind": "ObjCPropertyDecl",
-    "name": "enableReplayNetworkDetailsCapturing",
-    "parent": "SentryObjCExperimentalOptions",
     "type": "BOOL"
   },
   {

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -942,12 +942,6 @@
           {
             "children": [
               {
-                "kind": "TypeNominal",
-                "name": "Breadcrumb",
-                "printedName": "Sentry.Breadcrumb",
-                "usr": "c:objc(cs)SentryBreadcrumb"
-              },
-              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -960,6 +954,20 @@
                 "name": "Optional",
                 "printedName": "Sentry.Breadcrumb?",
                 "usr": "s:Sq"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Breadcrumb",
+                    "printedName": "Sentry.Breadcrumb",
+                    "usr": "c:objc(cs)SentryBreadcrumb"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Paren",
+                "printedName": "(Sentry.Breadcrumb)",
+                "usr": "c:objc(cs)SentryBreadcrumb"
               }
             ],
             "kind": "TypeFunc",
@@ -985,9 +993,17 @@
                 "usr": "s:Sb"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1014,9 +1030,17 @@
                 "usr": "s:Sb"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1037,12 +1061,6 @@
           {
             "children": [
               {
-                "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
-                "usr": "c:objc(cs)SentryEvent"
-              },
-              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -1055,6 +1073,20 @@
                 "name": "Optional",
                 "printedName": "Sentry.Event?",
                 "usr": "s:Sq"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
+                "usr": "c:objc(cs)SentryEvent"
               }
             ],
             "kind": "TypeFunc",
@@ -1088,9 +1120,17 @@
                 "usr": "s:Sq"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
+                    "usr": "c:objc(pl)SentrySpan"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Span",
-                "printedName": "any Sentry.Span",
+                "name": "Paren",
+                "printedName": "(any Sentry.Span)",
                 "usr": "c:objc(pl)SentrySpan"
               }
             ],
@@ -1141,15 +1181,23 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryAppStartMeasurement",
+                        "printedName": "Sentry.SentryAppStartMeasurement",
+                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "SentryAppStartMeasurement",
-                    "printedName": "Sentry.SentryAppStartMeasurement",
-                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                    "name": "Optional",
+                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                    "usr": "s:Sq"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SentryAppStartMeasurement?",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                 "usr": "s:Sq"
               }
             ],
@@ -1182,9 +1230,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Event",
+                    "printedName": "Sentry.Event",
+                    "usr": "c:objc(cs)SentryEvent"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "Event",
-                "printedName": "Sentry.Event",
+                "name": "Paren",
+                "printedName": "(Sentry.Event)",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1219,15 +1275,23 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
+                        "usr": "s:s5ErrorP"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Error",
-                    "printedName": "any Swift.Error",
-                    "usr": "s:s5ErrorP"
+                    "name": "Optional",
+                    "printedName": "(any Swift.Error)?",
+                    "usr": "s:Sq"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "(any Swift.Error)?",
+                "name": "Paren",
+                "printedName": "((any Swift.Error)?)",
                 "usr": "s:Sq"
               }
             ],
@@ -1384,9 +1448,17 @@
                 "usr": "s:Sq"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SamplingContext",
+                    "printedName": "Sentry.SamplingContext",
+                    "usr": "c:objc(cs)SentrySamplingContext"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SamplingContext",
-                "printedName": "Sentry.SamplingContext",
+                "name": "Paren",
+                "printedName": "(Sentry.SamplingContext)",
                 "usr": "c:objc(cs)SentrySamplingContext"
               }
             ],
@@ -1419,9 +1491,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryUserFeedbackConfiguration",
+                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SentryUserFeedbackConfiguration",
-                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1454,9 +1534,17 @@
                 "printedName": "Swift.Void"
               },
               {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryUserFeedbackConfiguration",
+                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                  }
+                ],
                 "kind": "TypeNominal",
-                "name": "SentryUserFeedbackConfiguration",
-                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                "name": "Paren",
+                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1596,22 +1684,6 @@
         "name": "char32_t",
         "printedName": "char32_t",
         "usr": "c:@T@char32_t"
-      },
-      {
-        "children": [
-          {
-            "kind": "TypeNominal",
-            "name": "UInt8",
-            "printedName": "Swift.UInt8",
-            "usr": "s:s5UInt8V"
-          }
-        ],
-        "declKind": "TypeAlias",
-        "kind": "TypeAlias",
-        "moduleName": "Sentry",
-        "name": "char8_t",
-        "printedName": "char8_t",
-        "usr": "c:@T@char8_t"
       },
       {
         "children": [
@@ -16315,15 +16387,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16354,15 +16433,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16393,15 +16479,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16432,15 +16525,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16510,15 +16610,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16549,15 +16656,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Level",
+                            "printedName": "Sentry.Level",
+                            "usr": "c:@M@Sentry@E@SentryLogLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Level",
-                        "printedName": "Sentry.Level",
-                        "usr": "c:@M@Sentry@E@SentryLogLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.Level.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.Level.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.Level.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -20563,12 +20677,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20581,6 +20689,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Breadcrumb",
+                                    "printedName": "Sentry.Breadcrumb",
+                                    "usr": "c:objc(cs)SentryBreadcrumb"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Breadcrumb)",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20622,12 +20744,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20640,6 +20756,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Breadcrumb",
+                                    "printedName": "Sentry.Breadcrumb",
+                                    "usr": "c:objc(cs)SentryBreadcrumb"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Breadcrumb)",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20685,12 +20815,6 @@
                       {
                         "children": [
                           {
-                            "kind": "TypeNominal",
-                            "name": "Breadcrumb",
-                            "printedName": "Sentry.Breadcrumb",
-                            "usr": "c:objc(cs)SentryBreadcrumb"
-                          },
-                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -20703,6 +20827,20 @@
                             "name": "Optional",
                             "printedName": "Sentry.Breadcrumb?",
                             "usr": "s:Sq"
+                          },
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Breadcrumb)",
+                            "usr": "c:objc(cs)SentryBreadcrumb"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -20754,9 +20892,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20805,9 +20951,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20860,9 +21014,17 @@
                             "usr": "s:Sb"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -20915,9 +21077,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20966,9 +21136,17 @@
                                 "usr": "s:Sb"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21021,9 +21199,17 @@
                             "usr": "s:Sb"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21070,12 +21256,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21088,6 +21268,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
+                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21129,12 +21323,6 @@
                           {
                             "children": [
                               {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              },
-                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21147,6 +21335,20 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Event",
+                                    "printedName": "Sentry.Event",
+                                    "usr": "c:objc(cs)SentryEvent"
+                                  }
+                                ],
+                                "kind": "TypeNominal",
+                                "name": "Paren",
+                                "printedName": "(Sentry.Event)",
+                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21192,12 +21394,6 @@
                       {
                         "children": [
                           {
-                            "kind": "TypeNominal",
-                            "name": "Event",
-                            "printedName": "Sentry.Event",
-                            "usr": "c:objc(cs)SentryEvent"
-                          },
-                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -21210,6 +21406,20 @@
                             "name": "Optional",
                             "printedName": "Sentry.Event?",
                             "usr": "s:Sq"
+                          },
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Paren",
+                            "printedName": "(Sentry.Event)",
+                            "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -21267,15 +21477,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryLog",
+                                "printedName": "Sentry.SentryLog",
+                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryLog)",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21319,15 +21537,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryLog",
+                                "printedName": "Sentry.SentryLog",
+                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryLog)",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21375,15 +21601,23 @@
                         "usr": "s:Sq"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
+                            "usr": "c:@M@Sentry@objc(cs)SentryLog"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLog",
-                        "printedName": "Sentry.SentryLog",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog)",
                         "usr": "c:@M@Sentry@objc(cs)SentryLog"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21431,15 +21665,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryMetric)",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21482,15 +21724,23 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryMetric",
+                                "printedName": "Sentry.SentryMetric",
+                                "usr": "s:6Sentry0A6MetricV"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryMetric)",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21537,15 +21787,23 @@
                         "usr": "s:Sq"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
+                            "usr": "s:6Sentry0A6MetricV"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetric",
-                        "printedName": "Sentry.SentryMetric",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryMetric)",
                         "usr": "s:6Sentry0A6MetricV"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21594,9 +21852,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Span",
+                                    "printedName": "any Sentry.Span",
+                                    "usr": "c:objc(pl)SentrySpan"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
+                                "name": "Paren",
+                                "printedName": "(any Sentry.Span)",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21653,9 +21919,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "Span",
+                                    "printedName": "any Sentry.Span",
+                                    "usr": "c:objc(pl)SentrySpan"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
+                                "name": "Paren",
+                                "printedName": "(any Sentry.Span)",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21716,9 +21990,17 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
+                                "usr": "c:objc(pl)SentrySpan"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Span",
-                            "printedName": "any Sentry.Span",
+                            "name": "Paren",
+                            "printedName": "(any Sentry.Span)",
                             "usr": "c:objc(pl)SentrySpan"
                           }
                         ],
@@ -21851,15 +22133,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileOptions",
+                                "printedName": "Sentry.SentryProfileOptions",
+                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryProfileOptions)",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21900,15 +22190,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileOptions",
+                                "printedName": "Sentry.SentryProfileOptions",
+                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryProfileOptions)",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21954,15 +22252,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
+                            "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileOptions",
-                        "printedName": "Sentry.SentryProfileOptions",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions)",
                         "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -22007,9 +22313,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryUserFeedbackConfiguration",
+                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22063,9 +22377,17 @@
                                 "printedName": "Swift.Void"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryUserFeedbackConfiguration",
+                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22124,9 +22446,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -25201,9 +25531,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Scope",
+                            "printedName": "Sentry.Scope",
+                            "usr": "c:objc(cs)SentryScope"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
+                        "name": "Paren",
+                        "printedName": "(Sentry.Scope)",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25237,9 +25575,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Scope",
+                            "printedName": "Sentry.Scope",
+                            "usr": "c:objc(cs)SentryScope"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
+                        "name": "Paren",
+                        "printedName": "(Sentry.Scope)",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25277,9 +25623,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   },
                   {
@@ -25631,8 +25985,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25702,8 +26056,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -25777,8 +26131,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -27279,9 +27633,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SamplingContext",
+                                    "printedName": "Sentry.SamplingContext",
+                                    "usr": "c:objc(cs)SentrySamplingContext"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SamplingContext)",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27338,9 +27700,17 @@
                                 "usr": "s:Sq"
                               },
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SamplingContext",
+                                    "printedName": "Sentry.SamplingContext",
+                                    "usr": "c:objc(cs)SentrySamplingContext"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SamplingContext)",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27401,9 +27771,17 @@
                             "usr": "s:Sq"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
+                                "usr": "c:objc(cs)SentrySamplingContext"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SamplingContext",
-                            "printedName": "Sentry.SamplingContext",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SamplingContext)",
                             "usr": "c:objc(cs)SentrySamplingContext"
                           }
                         ],
@@ -27547,9 +27925,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "URLSessionDelegate",
+                            "printedName": "any Foundation.URLSessionDelegate",
+                            "usr": "c:objc(pl)NSURLSessionDelegate"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "URLSessionDelegate",
-                        "printedName": "any Foundation.URLSessionDelegate",
+                        "name": "Paren",
+                        "printedName": "(any Foundation.URLSessionDelegate)",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -27578,9 +27964,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "URLSessionDelegate",
+                            "printedName": "any Foundation.URLSessionDelegate",
+                            "usr": "c:objc(pl)NSURLSessionDelegate"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "URLSessionDelegate",
-                        "printedName": "any Foundation.URLSessionDelegate",
+                        "name": "Paren",
+                        "printedName": "(any Foundation.URLSessionDelegate)",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -29375,9 +29769,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
+                    "name": "Paren",
+                    "printedName": "(Swift.String)",
                     "usr": "s:SS"
                   }
                 ],
@@ -30171,15 +30573,23 @@
                               {
                                 "children": [
                                   {
+                                    "children": [
+                                      {
+                                        "kind": "TypeNominal",
+                                        "name": "SentryAppStartMeasurement",
+                                        "printedName": "Sentry.SentryAppStartMeasurement",
+                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                      }
+                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                    "name": "Optional",
+                                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                                    "usr": "s:Sq"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30250,15 +30660,23 @@
                               {
                                 "children": [
                                   {
+                                    "children": [
+                                      {
+                                        "kind": "TypeNominal",
+                                        "name": "SentryAppStartMeasurement",
+                                        "printedName": "Sentry.SentryAppStartMeasurement",
+                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                      }
+                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                    "name": "Optional",
+                                    "printedName": "Sentry.SentryAppStartMeasurement?",
+                                    "usr": "s:Sq"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "name": "Paren",
+                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30315,15 +30733,23 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
@@ -32267,15 +32693,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32306,15 +32739,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32345,15 +32785,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32384,15 +32831,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32462,15 +32916,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryANRType",
+                            "printedName": "Sentry.SentryANRType",
+                            "usr": "c:@M@Sentry@E@SentryANRType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryANRType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryANRType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33161,15 +33622,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33239,15 +33707,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33278,15 +33753,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAppStartType",
+                            "printedName": "Sentry.SentryAppStartType",
+                            "usr": "c:@E@SentryAppStartType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAppStartType",
-                        "printedName": "Sentry.SentryAppStartType",
-                        "usr": "c:@E@SentryAppStartType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAppStartType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAppStartType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAppStartType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33562,15 +34044,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttachmentType",
+                            "printedName": "Sentry.SentryAttachmentType",
+                            "usr": "c:@E@SentryAttachmentType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttachmentType",
-                        "printedName": "Sentry.SentryAttachmentType",
-                        "usr": "c:@E@SentryAttachmentType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttachmentType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttachmentType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttachmentType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33640,15 +34129,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttachmentType",
+                            "printedName": "Sentry.SentryAttachmentType",
+                            "usr": "c:@E@SentryAttachmentType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttachmentType",
-                        "printedName": "Sentry.SentryAttachmentType",
-                        "usr": "c:@E@SentryAttachmentType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttachmentType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttachmentType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttachmentType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34616,9 +35112,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -34635,15 +35139,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34668,15 +35179,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Bool",
+                                "printedName": "Swift.Bool",
+                                "usr": "s:Sb"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
+                            "name": "Array",
+                            "printedName": "[Swift.Bool]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Bool]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Bool])",
                         "usr": "s:Sa"
                       },
                       {
@@ -34693,15 +35212,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34724,9 +35250,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -34743,15 +35277,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34776,15 +35317,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Double",
+                                "printedName": "Swift.Double",
+                                "usr": "s:Sd"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
+                            "name": "Array",
+                            "printedName": "[Swift.Double]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Double]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Double])",
                         "usr": "s:Sa"
                       },
                       {
@@ -34801,15 +35350,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34869,9 +35425,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
+                        "name": "Paren",
+                        "printedName": "(Swift.Int)",
                         "usr": "s:Si"
                       },
                       {
@@ -34888,15 +35452,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34921,15 +35492,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Int",
+                                "printedName": "Swift.Int",
+                                "usr": "s:Si"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Int",
-                            "printedName": "Swift.Int",
-                            "usr": "s:Si"
+                            "name": "Array",
+                            "printedName": "[Swift.Int]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.Int]",
+                        "name": "Paren",
+                        "printedName": "([Swift.Int])",
                         "usr": "s:Sa"
                       },
                       {
@@ -34946,15 +35525,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -34977,16 +35563,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryAttributeContent",
                         "printedName": "Sentry.SentryAttributeContent",
                         "usr": "s:6Sentry0A16AttributeContentO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -34996,15 +35590,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35029,15 +35630,23 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
+                            "name": "Array",
+                            "printedName": "[Swift.String]",
+                            "usr": "s:Sa"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.String]",
+                        "name": "Paren",
+                        "printedName": "([Swift.String])",
                         "usr": "s:Sa"
                       },
                       {
@@ -35054,15 +35663,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryAttributeContent",
+                            "printedName": "Sentry.SentryAttributeContent",
+                            "usr": "s:6Sentry0A16AttributeContentO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryAttributeContent",
-                        "printedName": "Sentry.SentryAttributeContent",
-                        "usr": "s:6Sentry0A16AttributeContentO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryAttributeContent.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryAttributeContent.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryAttributeContent.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -37252,15 +37868,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -37317,15 +37940,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -37391,15 +38021,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "KeyValueCollectionBehavior",
+                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "KeyValueCollectionBehavior",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -38544,15 +39181,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38583,15 +39227,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38622,15 +39273,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38661,15 +39319,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38700,15 +39365,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38739,15 +39411,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38778,15 +39457,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38817,15 +39503,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38895,15 +39588,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38934,15 +39634,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -38973,15 +39680,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryError",
+                            "printedName": "Sentry.SentryError",
+                            "usr": "c:@E@SentryError"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryError",
-                        "printedName": "Sentry.SentryError",
-                        "usr": "c:@E@SentryError"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryError.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryError.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryError.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39187,82 +39901,6 @@
             "name": "dataCollection",
             "printedName": "dataCollection",
             "usr": "s:6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvp"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)enableReplayNetworkDetailsCapturing"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setEnableReplayNetworkDetailsCapturing:"
-              }
-            ],
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasStorage",
-              "ObjC"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC35enableReplayNetworkDetailsCapturingSbvp",
-            "moduleName": "Sentry",
-            "name": "enableReplayNetworkDetailsCapturing",
-            "printedName": "enableReplayNetworkDetailsCapturing",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)enableReplayNetworkDetailsCapturing"
           },
           {
             "accessors": [
@@ -39628,15 +40266,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39667,15 +40312,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39706,15 +40358,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39784,15 +40443,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39823,15 +40489,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryExtensionType",
+                            "printedName": "Sentry.SentryExtensionType",
+                            "usr": "c:@M@Sentry@E@SentryExtensionType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryExtensionType",
-                        "printedName": "Sentry.SentryExtensionType",
-                        "usr": "c:@M@Sentry@E@SentryExtensionType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryExtensionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryExtensionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryExtensionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40136,15 +40809,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryFeedbackSource",
+                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -40250,15 +40930,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryFeedbackSource",
+                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -40484,9 +41171,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -40675,15 +41370,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedbackSource",
+                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryFeedbackSource",
-                        "printedName": "Sentry.SentryFeedbackSource",
-                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedbackSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryFeedbackSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40753,15 +41455,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedbackSource",
+                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryFeedbackSource",
-                        "printedName": "Sentry.SentryFeedbackSource",
-                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedbackSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryFeedbackSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40928,15 +41637,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40967,15 +41683,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41006,15 +41729,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41045,15 +41775,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41084,15 +41821,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41123,15 +41867,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41201,15 +41952,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryHttpStatusCode",
+                            "printedName": "Sentry.SentryHttpStatusCode",
+                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryHttpStatusCode",
-                        "printedName": "Sentry.SentryHttpStatusCode",
-                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryHttpStatusCode.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryHttpStatusCode.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41794,9 +42552,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -42884,15 +43650,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
                         "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Swift.String) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Swift.String) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -43783,21 +44557,29 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -43836,21 +44618,29 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
+                                "usr": "s:Sq"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -43893,21 +44683,29 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryAppStartMeasurement",
-                            "printedName": "Sentry.SentryAppStartMeasurement",
-                            "usr": "c:objc(cs)SentryAppStartMeasurement"
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
+                            "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Optional",
-                        "printedName": "Sentry.SentryAppStartMeasurement?",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?)",
                         "usr": "s:Sq"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -45218,8 +46016,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> ObjectiveC.IMP"
+                    "name": "Paren",
+                    "printedName": "(() -> ObjectiveC.IMP)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -45357,23 +46155,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45394,23 +46199,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45431,23 +46243,30 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Mode",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                      },
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Mode",
+                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                              }
+                            ],
+                            "kind": "TypeNominal",
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -45808,15 +46627,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -45848,15 +46674,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -45925,15 +46758,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLastRunStatus",
+                            "printedName": "Sentry.SentryLastRunStatus",
+                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLastRunStatus",
-                        "printedName": "Sentry.SentryLastRunStatus",
-                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLastRunStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLastRunStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46097,15 +46937,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46175,15 +47022,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46214,15 +47068,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46253,15 +47114,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46292,15 +47160,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46370,15 +47245,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryLevel",
+                            "printedName": "Sentry.SentryLevel",
+                            "usr": "c:@E@SentryLevel"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryLevel",
-                        "printedName": "Sentry.SentryLevel",
-                        "usr": "c:@E@SentryLevel"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLevel.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryLevel.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryLevel.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46761,15 +47643,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46801,15 +47690,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46841,15 +47737,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46881,15 +47784,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46958,15 +47868,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47035,15 +47952,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Level",
+                                "printedName": "Sentry.SentryLog.Level",
+                                "usr": "s:6Sentry0A3LogC5LevelO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.SentryLog.Level",
-                            "usr": "s:6Sentry0A3LogC5LevelO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryLog.Level.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLog.Level.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryLog.Level.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -50425,16 +51349,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "UInt",
+                            "printedName": "Swift.UInt",
+                            "usr": "s:Su"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.UInt)",
+                        "usr": "s:Su"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryMetricValue",
                         "printedName": "Sentry.SentryMetricValue",
                         "usr": "s:6Sentry0A11MetricValueO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "UInt",
-                        "printedName": "Swift.UInt",
-                        "usr": "s:Su"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -50444,15 +51376,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -50475,9 +51414,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -50494,15 +51441,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -50525,9 +51479,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Double",
-                        "printedName": "Swift.Double",
+                        "name": "Paren",
+                        "printedName": "(Swift.Double)",
                         "usr": "s:Sd"
                       },
                       {
@@ -50544,15 +51506,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryMetricValue",
+                            "printedName": "Sentry.SentryMetricValue",
+                            "usr": "s:6Sentry0A11MetricValueO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryMetricValue",
-                        "printedName": "Sentry.SentryMetricValue",
-                        "usr": "s:6Sentry0A11MetricValueO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryMetricValue.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryMetricValue.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryMetricValue.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51393,15 +52362,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileLifecycle",
+                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileLifecycle",
-                        "printedName": "Sentry.SentryProfileLifecycle",
-                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileLifecycle.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryProfileLifecycle.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -51471,15 +52447,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileLifecycle",
+                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryProfileLifecycle",
-                        "printedName": "Sentry.SentryProfileLifecycle",
-                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileLifecycle.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryProfileLifecycle.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -51671,15 +52654,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileLifecycle",
+                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -51748,15 +52738,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryProfileLifecycle",
+                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -52700,15 +53697,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52737,15 +53741,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52774,15 +53785,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52848,15 +53866,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52885,15 +53910,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryRedactRegionType",
+                            "printedName": "Sentry.SentryRedactRegionType",
+                            "usr": "s:6Sentry0A16RedactRegionTypeO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryRedactRegionType",
-                        "printedName": "Sentry.SentryRedactRegionType",
-                        "usr": "s:6Sentry0A16RedactRegionTypeO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryRedactRegionType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryRedactRegionType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -54694,15 +55726,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -54734,15 +55773,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -54774,15 +55820,22 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryReplayQuality",
+                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
+                            "name": "Metatype",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
                       },
                       {
                         "kind": "TypeNominal",
@@ -56580,15 +57633,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56619,15 +57679,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56658,15 +57725,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayQuality",
+                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayQuality",
-                        "printedName": "Sentry.SentryReplayQuality",
-                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayQuality.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayQuality.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayQuality.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56872,15 +57946,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayType",
+                            "printedName": "Sentry.SentryReplayType",
+                            "usr": "c:@M@Sentry@E@SentryReplayType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -56950,15 +58031,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryReplayType",
+                            "printedName": "Sentry.SentryReplayType",
+                            "usr": "c:@M@Sentry@E@SentryReplayType"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayType.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryReplayType.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58105,9 +59193,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58258,9 +59354,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58411,9 +59515,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58589,9 +59701,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58697,9 +59817,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
+                        "usr": "c:objc(cs)SentryScope"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Scope",
-                    "printedName": "Sentry.Scope",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Scope)",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -58837,9 +59965,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
+                        "usr": "c:objc(pl)SentrySpan"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.Span)",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -58967,9 +60103,17 @@
                     "printedName": "Swift.Void"
                   },
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Options",
+                        "printedName": "Sentry.Options",
+                        "usr": "c:@M@Sentry@objc(cs)SentryOptions"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Options",
-                    "printedName": "Sentry.Options",
+                    "name": "Paren",
+                    "printedName": "(Sentry.Options)",
                     "usr": "c:@M@Sentry@objc(cs)SentryOptions"
                   }
                 ],
@@ -59734,9 +60878,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Span",
+                            "printedName": "any Sentry.Span",
+                            "usr": "c:objc(pl)SentrySpan"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
+                        "name": "Paren",
+                        "printedName": "(any Sentry.Span)",
                         "usr": "c:objc(pl)SentrySpan"
                       }
                     ],
@@ -59761,9 +60913,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
+                        "usr": "c:objc(pl)SentrySpan"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.Span)",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -59868,15 +61028,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59946,15 +61113,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59985,15 +61159,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySampleDecision",
+                            "printedName": "Sentry.SentrySampleDecision",
+                            "usr": "c:@E@SentrySampleDecision"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySampleDecision",
-                        "printedName": "Sentry.SentrySampleDecision",
-                        "usr": "c:@E@SentrySampleDecision"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySampleDecision.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySampleDecision.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySampleDecision.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61027,15 +62208,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61066,15 +62254,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61105,15 +62300,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61144,15 +62346,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61183,15 +62392,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61222,15 +62438,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61261,15 +62484,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61300,15 +62530,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61339,15 +62576,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61378,15 +62622,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61417,15 +62668,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61456,15 +62714,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61534,15 +62799,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61573,15 +62845,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61612,15 +62891,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61651,15 +62937,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61690,15 +62983,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61729,15 +63029,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentrySpanStatus",
+                            "printedName": "Sentry.SentrySpanStatus",
+                            "usr": "c:@E@SentrySpanStatus"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentrySpanStatus",
-                        "printedName": "Sentry.SentrySpanStatus",
-                        "usr": "c:@E@SentrySpanStatus"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentrySpanStatus.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentrySpanStatus.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentrySpanStatus.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63416,15 +64723,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63457,15 +64771,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63535,15 +64856,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63576,15 +64904,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63617,15 +64952,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63658,15 +65000,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryTransactionNameSource",
+                            "printedName": "Sentry.SentryTransactionNameSource",
+                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryTransactionNameSource",
-                        "printedName": "Sentry.SentryTransactionNameSource",
-                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryTransactionNameSource.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryTransactionNameSource.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64040,15 +65389,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64077,15 +65433,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64114,15 +65477,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64151,15 +65521,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64188,15 +65565,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64225,16 +65609,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryUnit",
                         "printedName": "Sentry.SentryUnit",
                         "usr": "s:6Sentry0A4UnitO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -64244,15 +65636,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -64275,15 +65674,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64312,15 +65718,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64349,15 +65762,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64386,15 +65806,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64423,15 +65850,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64460,15 +65894,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64497,15 +65938,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64534,15 +65982,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64571,15 +66026,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64608,15 +66070,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64645,15 +66114,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64682,15 +66158,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64719,15 +66202,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64756,15 +66246,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64793,15 +66290,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64869,15 +66373,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64906,15 +66417,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64943,15 +66461,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64980,15 +66505,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUnit",
+                            "printedName": "Sentry.SentryUnit",
+                            "usr": "s:6Sentry0A4UnitO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUnit",
-                        "printedName": "Sentry.SentryUnit",
-                        "usr": "s:6Sentry0A4UnitO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUnit.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUnit.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUnit.Type)"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65263,9 +66795,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "NSRegularExpression",
+                            "printedName": "Foundation.NSRegularExpression",
+                            "usr": "c:objc(cs)NSRegularExpression"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "NSRegularExpression",
-                        "printedName": "Foundation.NSRegularExpression",
+                        "name": "Paren",
+                        "printedName": "(Foundation.NSRegularExpression)",
                         "usr": "c:objc(cs)NSRegularExpression"
                       },
                       {
@@ -65282,15 +66822,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUrlMatcher",
+                            "printedName": "Sentry.SentryUrlMatcher",
+                            "usr": "s:6Sentry0A10UrlMatcherO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUrlMatcher",
-                        "printedName": "Sentry.SentryUrlMatcher",
-                        "usr": "s:6Sentry0A10UrlMatcherO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUrlMatcher.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUrlMatcher.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -65313,16 +66860,24 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Paren",
+                        "printedName": "(Swift.String)",
+                        "usr": "s:SS"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "SentryUrlMatcher",
                         "printedName": "Sentry.SentryUrlMatcher",
                         "usr": "s:6Sentry0A10UrlMatcherO"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -65332,15 +66887,22 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUrlMatcher",
+                            "printedName": "Sentry.SentryUrlMatcher",
+                            "usr": "s:6Sentry0A10UrlMatcherO"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUrlMatcher",
-                        "printedName": "Sentry.SentryUrlMatcher",
-                        "usr": "s:6Sentry0A10UrlMatcherO"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryUrlMatcher.Type"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryUrlMatcher.Type"
+                    "name": "Paren",
+                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -65506,15 +67068,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackFormConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65556,15 +67126,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackFormConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65610,15 +67188,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackFormConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -65664,15 +67250,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65714,15 +67308,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackThemeConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65768,15 +67370,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "SentryUserFeedbackThemeConfiguration",
-                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
+                        "name": "Paren",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -65828,8 +67438,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65877,8 +67487,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -65930,8 +67540,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(() -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -65983,8 +67593,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66032,8 +67642,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "() -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(() -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66085,8 +67695,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "() -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(() -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -66132,15 +67742,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Error",
+                                "printedName": "any Swift.Error",
+                                "usr": "s:s5ErrorP"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
+                            "name": "Paren",
+                            "printedName": "(any Swift.Error)",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(any Swift.Error) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((any Swift.Error) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66182,15 +67800,23 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "Error",
+                                "printedName": "any Swift.Error",
+                                "usr": "s:s5ErrorP"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
+                            "name": "Paren",
+                            "printedName": "(any Swift.Error)",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "(any Swift.Error) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "((any Swift.Error) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66236,15 +67862,23 @@
                         "printedName": "Swift.Void"
                       },
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
+                            "usr": "s:s5ErrorP"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Error",
-                        "printedName": "any Swift.Error",
+                        "name": "Paren",
+                        "printedName": "(any Swift.Error)",
                         "usr": "s:s5ErrorP"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "(any Swift.Error) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "((any Swift.Error) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -66292,26 +67926,34 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "ProtocolComposition",
+                                    "printedName": "Any"
+                                  },
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
+                                "name": "Dictionary",
+                                "printedName": "[Swift.String : Any]",
+                                "usr": "s:SD"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
+                            "name": "Paren",
+                            "printedName": "([Swift.String : Any])",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "([Swift.String : Any]) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66355,26 +67997,34 @@
                           {
                             "children": [
                               {
+                                "children": [
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "ProtocolComposition",
+                                    "printedName": "Any"
+                                  },
+                                  {
+                                    "kind": "TypeNominal",
+                                    "name": "String",
+                                    "printedName": "Swift.String",
+                                    "usr": "s:SS"
+                                  }
+                                ],
                                 "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
+                                "name": "Dictionary",
+                                "printedName": "[Swift.String : Any]",
+                                "usr": "s:SD"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
+                            "name": "Paren",
+                            "printedName": "([Swift.String : Any])",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Function",
-                        "printedName": "([Swift.String : Any]) -> Swift.Void"
+                        "name": "Paren",
+                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -66422,26 +68072,34 @@
                       {
                         "children": [
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "ProtocolComposition",
-                            "printedName": "Any"
-                          },
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
+                            "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Dictionary",
-                        "printedName": "[Swift.String : Any]",
+                        "name": "Paren",
+                        "printedName": "([Swift.String : Any])",
                         "usr": "s:SD"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Function",
-                    "printedName": "([Swift.String : Any]) -> Swift.Void"
+                    "name": "Paren",
+                    "printedName": "(([Swift.String : Any]) -> Swift.Void)"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -68674,9 +70332,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -68710,9 +70376,17 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
+                          }
+                        ],
                         "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
+                        "name": "Paren",
+                        "printedName": "(Swift.Bool)",
                         "usr": "s:Sb"
                       },
                       {
@@ -68750,9 +70424,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
+                        "usr": "s:Sb"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
+                    "name": "Paren",
+                    "printedName": "(Swift.Bool)",
                     "usr": "s:Sb"
                   },
                   {
@@ -68904,9 +70586,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -69471,9 +71161,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -80007,9 +81705,17 @@
                             "printedName": "Swift.Void"
                           },
                           {
+                            "children": [
+                              {
+                                "kind": "TypeNominal",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
+                              }
+                            ],
                             "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
+                            "name": "Paren",
+                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -80117,9 +81823,17 @@
               {
                 "children": [
                   {
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryRedactOptions",
+                        "printedName": "any Sentry.SentryRedactOptions",
+                        "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
+                      }
+                    ],
                     "kind": "TypeNominal",
-                    "name": "SentryRedactOptions",
-                    "printedName": "any Sentry.SentryRedactOptions",
+                    "name": "Paren",
+                    "printedName": "(any Sentry.SentryRedactOptions)",
                     "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
                   }
                 ],

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -942,6 +942,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Breadcrumb",
+                "printedName": "Sentry.Breadcrumb",
+                "usr": "c:objc(cs)SentryBreadcrumb"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -954,20 +960,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Breadcrumb?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Breadcrumb",
-                    "printedName": "Sentry.Breadcrumb",
-                    "usr": "c:objc(cs)SentryBreadcrumb"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Breadcrumb)",
-                "usr": "c:objc(cs)SentryBreadcrumb"
               }
             ],
             "kind": "TypeFunc",
@@ -993,17 +985,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1030,17 +1014,9 @@
                 "usr": "s:Sb"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1061,6 +1037,12 @@
           {
             "children": [
               {
+                "kind": "TypeNominal",
+                "name": "Event",
+                "printedName": "Sentry.Event",
+                "usr": "c:objc(cs)SentryEvent"
+              },
+              {
                 "children": [
                   {
                     "kind": "TypeNominal",
@@ -1073,20 +1055,6 @@
                 "name": "Optional",
                 "printedName": "Sentry.Event?",
                 "usr": "s:Sq"
-              },
-              {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
-                "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
-                "usr": "c:objc(cs)SentryEvent"
               }
             ],
             "kind": "TypeFunc",
@@ -1120,17 +1088,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Span",
-                    "printedName": "any Sentry.Span",
-                    "usr": "c:objc(pl)SentrySpan"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(any Sentry.Span)",
+                "name": "Span",
+                "printedName": "any Sentry.Span",
                 "usr": "c:objc(pl)SentrySpan"
               }
             ],
@@ -1181,23 +1141,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryAppStartMeasurement",
-                        "printedName": "Sentry.SentryAppStartMeasurement",
-                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                    "usr": "s:Sq"
+                    "name": "SentryAppStartMeasurement",
+                    "printedName": "Sentry.SentryAppStartMeasurement",
+                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                "name": "Optional",
+                "printedName": "Sentry.SentryAppStartMeasurement?",
                 "usr": "s:Sq"
               }
             ],
@@ -1230,17 +1182,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.Event)",
+                "name": "Event",
+                "printedName": "Sentry.Event",
                 "usr": "c:objc(cs)SentryEvent"
               }
             ],
@@ -1275,23 +1219,15 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Error",
-                        "printedName": "any Swift.Error",
-                        "usr": "s:s5ErrorP"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "(any Swift.Error)?",
-                    "usr": "s:Sq"
+                    "name": "Error",
+                    "printedName": "any Swift.Error",
+                    "usr": "s:s5ErrorP"
                   }
                 ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "((any Swift.Error)?)",
+                "name": "Optional",
+                "printedName": "(any Swift.Error)?",
                 "usr": "s:Sq"
               }
             ],
@@ -1448,17 +1384,9 @@
                 "usr": "s:Sq"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SamplingContext",
-                    "printedName": "Sentry.SamplingContext",
-                    "usr": "c:objc(cs)SentrySamplingContext"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SamplingContext)",
+                "name": "SamplingContext",
+                "printedName": "Sentry.SamplingContext",
                 "usr": "c:objc(cs)SentrySamplingContext"
               }
             ],
@@ -1491,17 +1419,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryUserFeedbackConfiguration",
-                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1534,17 +1454,9 @@
                 "printedName": "Swift.Void"
               },
               {
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryUserFeedbackConfiguration",
-                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                  }
-                ],
                 "kind": "TypeNominal",
-                "name": "Paren",
-                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                "name": "SentryUserFeedbackConfiguration",
+                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
               }
             ],
@@ -1684,6 +1596,22 @@
         "name": "char32_t",
         "printedName": "char32_t",
         "usr": "c:@T@char32_t"
+      },
+      {
+        "children": [
+          {
+            "kind": "TypeNominal",
+            "name": "UInt8",
+            "printedName": "Swift.UInt8",
+            "usr": "s:s5UInt8V"
+          }
+        ],
+        "declKind": "TypeAlias",
+        "kind": "TypeAlias",
+        "moduleName": "Sentry",
+        "name": "char8_t",
+        "printedName": "char8_t",
+        "usr": "c:@T@char8_t"
       },
       {
         "children": [
@@ -16387,22 +16315,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16433,22 +16354,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16479,22 +16393,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16525,22 +16432,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16610,22 +16510,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -16656,22 +16549,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Level",
-                            "printedName": "Sentry.Level",
-                            "usr": "c:@M@Sentry@E@SentryLogLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.Level.Type"
+                        "name": "Level",
+                        "printedName": "Sentry.Level",
+                        "usr": "c:@M@Sentry@E@SentryLogLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Level.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.Level.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -20677,6 +20563,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20689,20 +20581,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20744,6 +20622,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Breadcrumb",
+                                "printedName": "Sentry.Breadcrumb",
+                                "usr": "c:objc(cs)SentryBreadcrumb"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -20756,20 +20640,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Breadcrumb?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Breadcrumb",
-                                    "printedName": "Sentry.Breadcrumb",
-                                    "usr": "c:objc(cs)SentryBreadcrumb"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Breadcrumb)",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -20815,6 +20685,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Breadcrumb",
+                            "printedName": "Sentry.Breadcrumb",
+                            "usr": "c:objc(cs)SentryBreadcrumb"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -20827,20 +20703,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Breadcrumb?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Breadcrumb",
-                                "printedName": "Sentry.Breadcrumb",
-                                "usr": "c:objc(cs)SentryBreadcrumb"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Breadcrumb)",
-                            "usr": "c:objc(cs)SentryBreadcrumb"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -20892,17 +20754,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -20951,17 +20805,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21014,17 +20860,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21077,17 +20915,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21136,17 +20966,9 @@
                                 "usr": "s:Sb"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
                                 "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
@@ -21199,17 +21021,9 @@
                             "usr": "s:Sb"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
                             "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
@@ -21256,6 +21070,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21268,20 +21088,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21323,6 +21129,12 @@
                           {
                             "children": [
                               {
+                                "kind": "TypeNominal",
+                                "name": "Event",
+                                "printedName": "Sentry.Event",
+                                "usr": "c:objc(cs)SentryEvent"
+                              },
+                              {
                                 "children": [
                                   {
                                     "kind": "TypeNominal",
@@ -21335,20 +21147,6 @@
                                 "name": "Optional",
                                 "printedName": "Sentry.Event?",
                                 "usr": "s:Sq"
-                              },
-                              {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Event",
-                                    "printedName": "Sentry.Event",
-                                    "usr": "c:objc(cs)SentryEvent"
-                                  }
-                                ],
-                                "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.Event)",
-                                "usr": "c:objc(cs)SentryEvent"
                               }
                             ],
                             "kind": "TypeFunc",
@@ -21394,6 +21192,12 @@
                       {
                         "children": [
                           {
+                            "kind": "TypeNominal",
+                            "name": "Event",
+                            "printedName": "Sentry.Event",
+                            "usr": "c:objc(cs)SentryEvent"
+                          },
+                          {
                             "children": [
                               {
                                 "kind": "TypeNominal",
@@ -21406,20 +21210,6 @@
                             "name": "Optional",
                             "printedName": "Sentry.Event?",
                             "usr": "s:Sq"
-                          },
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Event",
-                                "printedName": "Sentry.Event",
-                                "usr": "c:objc(cs)SentryEvent"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.Event)",
-                            "usr": "c:objc(cs)SentryEvent"
                           }
                         ],
                         "kind": "TypeFunc",
@@ -21477,23 +21267,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21537,23 +21319,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryLog",
-                                "printedName": "Sentry.SentryLog",
-                                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryLog)",
+                            "name": "SentryLog",
+                            "printedName": "Sentry.SentryLog",
                             "usr": "c:@M@Sentry@objc(cs)SentryLog"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21601,23 +21375,15 @@
                         "usr": "s:Sq"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLog",
-                            "printedName": "Sentry.SentryLog",
-                            "usr": "c:@M@Sentry@objc(cs)SentryLog"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog)",
+                        "name": "SentryLog",
+                        "printedName": "Sentry.SentryLog",
                         "usr": "c:@M@Sentry@objc(cs)SentryLog"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLog) -> Sentry.SentryLog?)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLog) -> Sentry.SentryLog?"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21665,23 +21431,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21724,23 +21482,15 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryMetric",
-                                "printedName": "Sentry.SentryMetric",
-                                "usr": "s:6Sentry0A6MetricV"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryMetric)",
+                            "name": "SentryMetric",
+                            "printedName": "Sentry.SentryMetric",
                             "usr": "s:6Sentry0A6MetricV"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -21787,23 +21537,15 @@
                         "usr": "s:Sq"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetric",
-                            "printedName": "Sentry.SentryMetric",
-                            "usr": "s:6Sentry0A6MetricV"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryMetric)",
+                        "name": "SentryMetric",
+                        "printedName": "Sentry.SentryMetric",
                         "usr": "s:6Sentry0A6MetricV"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryMetric) -> Sentry.SentryMetric?)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryMetric) -> Sentry.SentryMetric?"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -21852,17 +21594,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21919,17 +21653,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "Span",
-                                    "printedName": "any Sentry.Span",
-                                    "usr": "c:objc(pl)SentrySpan"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(any Sentry.Span)",
+                                "name": "Span",
+                                "printedName": "any Sentry.Span",
                                 "usr": "c:objc(pl)SentrySpan"
                               }
                             ],
@@ -21990,17 +21716,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Span",
-                                "printedName": "any Sentry.Span",
-                                "usr": "c:objc(pl)SentrySpan"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Sentry.Span)",
+                            "name": "Span",
+                            "printedName": "any Sentry.Span",
                             "usr": "c:objc(pl)SentrySpan"
                           }
                         ],
@@ -22133,23 +21851,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -22190,23 +21900,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileOptions",
-                                "printedName": "Sentry.SentryProfileOptions",
-                                "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryProfileOptions)",
+                            "name": "SentryProfileOptions",
+                            "printedName": "Sentry.SentryProfileOptions",
                             "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -22252,23 +21954,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileOptions",
-                            "printedName": "Sentry.SentryProfileOptions",
-                            "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions)",
+                        "name": "SentryProfileOptions",
+                        "printedName": "Sentry.SentryProfileOptions",
                         "usr": "c:@M@Sentry@objc(cs)SentryProfileOptions"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryProfileOptions) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryProfileOptions) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -22313,17 +22007,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryUserFeedbackConfiguration",
-                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22377,17 +22063,9 @@
                                 "printedName": "Swift.Void"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryUserFeedbackConfiguration",
-                                    "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                    "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                                "name": "SentryUserFeedbackConfiguration",
+                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
                                 "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                               }
                             ],
@@ -22446,17 +22124,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -25531,17 +25201,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25575,17 +25237,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Scope",
-                            "printedName": "Sentry.Scope",
-                            "usr": "c:objc(cs)SentryScope"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.Scope)",
+                        "name": "Scope",
+                        "printedName": "Sentry.Scope",
                         "usr": "c:objc(cs)SentryScope"
                       },
                       {
@@ -25623,17 +25277,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   },
                   {
@@ -25985,8 +25631,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -26056,8 +25702,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -26131,8 +25777,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryLastRunStatus, Sentry.Event?) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -27633,17 +27279,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27700,17 +27338,9 @@
                                 "usr": "s:Sq"
                               },
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SamplingContext",
-                                    "printedName": "Sentry.SamplingContext",
-                                    "usr": "c:objc(cs)SentrySamplingContext"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SamplingContext)",
+                                "name": "SamplingContext",
+                                "printedName": "Sentry.SamplingContext",
                                 "usr": "c:objc(cs)SentrySamplingContext"
                               }
                             ],
@@ -27771,17 +27401,9 @@
                             "usr": "s:Sq"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SamplingContext",
-                                "printedName": "Sentry.SamplingContext",
-                                "usr": "c:objc(cs)SentrySamplingContext"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SamplingContext)",
+                            "name": "SamplingContext",
+                            "printedName": "Sentry.SamplingContext",
                             "usr": "c:objc(cs)SentrySamplingContext"
                           }
                         ],
@@ -27925,17 +27547,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -27964,17 +27578,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLSessionDelegate",
-                            "printedName": "any Foundation.URLSessionDelegate",
-                            "usr": "c:objc(pl)NSURLSessionDelegate"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Foundation.URLSessionDelegate)",
+                        "name": "URLSessionDelegate",
+                        "printedName": "any Foundation.URLSessionDelegate",
                         "usr": "c:objc(pl)NSURLSessionDelegate"
                       }
                     ],
@@ -29769,17 +29375,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.String)",
+                    "name": "String",
+                    "printedName": "Swift.String",
                     "usr": "s:SS"
                   }
                 ],
@@ -30573,23 +30171,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30660,23 +30250,15 @@
                               {
                                 "children": [
                                   {
-                                    "children": [
-                                      {
-                                        "kind": "TypeNominal",
-                                        "name": "SentryAppStartMeasurement",
-                                        "printedName": "Sentry.SentryAppStartMeasurement",
-                                        "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                      }
-                                    ],
                                     "kind": "TypeNominal",
-                                    "name": "Optional",
-                                    "printedName": "Sentry.SentryAppStartMeasurement?",
-                                    "usr": "s:Sq"
+                                    "name": "SentryAppStartMeasurement",
+                                    "printedName": "Sentry.SentryAppStartMeasurement",
+                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
                                   }
                                 ],
                                 "kind": "TypeNominal",
-                                "name": "Paren",
-                                "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                                "name": "Optional",
+                                "printedName": "Sentry.SentryAppStartMeasurement?",
                                 "usr": "s:Sq"
                               }
                             ],
@@ -30733,23 +30315,15 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
@@ -32693,22 +32267,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32739,22 +32306,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32785,22 +32345,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32831,22 +32384,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -32916,22 +32462,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryANRType",
-                            "printedName": "Sentry.SentryANRType",
-                            "usr": "c:@M@Sentry@E@SentryANRType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryANRType.Type"
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryANRType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33622,22 +33161,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33707,22 +33239,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -33753,22 +33278,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAppStartType",
-                            "printedName": "Sentry.SentryAppStartType",
-                            "usr": "c:@E@SentryAppStartType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAppStartType.Type"
+                        "name": "SentryAppStartType",
+                        "printedName": "Sentry.SentryAppStartType",
+                        "usr": "c:@E@SentryAppStartType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAppStartType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAppStartType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34044,22 +33562,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -34129,22 +33640,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttachmentType",
-                            "printedName": "Sentry.SentryAttachmentType",
-                            "usr": "c:@E@SentryAttachmentType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttachmentType.Type"
+                        "name": "SentryAttachmentType",
+                        "printedName": "Sentry.SentryAttachmentType",
+                        "usr": "c:@E@SentryAttachmentType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttachmentType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttachmentType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -35112,17 +34616,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -35139,22 +34635,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35179,23 +34668,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Bool",
-                                "printedName": "Swift.Bool",
-                                "usr": "s:Sb"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Bool]",
-                            "usr": "s:Sa"
+                            "name": "Bool",
+                            "printedName": "Swift.Bool",
+                            "usr": "s:Sb"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Bool])",
+                        "name": "Array",
+                        "printedName": "[Swift.Bool]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35212,22 +34693,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35250,17 +34724,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -35277,22 +34743,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35317,23 +34776,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Double",
-                                "printedName": "Swift.Double",
-                                "usr": "s:Sd"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Double]",
-                            "usr": "s:Sa"
+                            "name": "Double",
+                            "printedName": "Swift.Double",
+                            "usr": "s:Sd"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Double])",
+                        "name": "Array",
+                        "printedName": "[Swift.Double]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35350,22 +34801,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35425,17 +34869,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Int",
-                            "printedName": "Swift.Int",
-                            "usr": "s:Si"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Int)",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
                         "usr": "s:Si"
                       },
                       {
@@ -35452,22 +34888,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35492,23 +34921,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Int",
-                                "printedName": "Swift.Int",
-                                "usr": "s:Si"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.Int]",
-                            "usr": "s:Sa"
+                            "name": "Int",
+                            "printedName": "Swift.Int",
+                            "usr": "s:Si"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.Int])",
+                        "name": "Array",
+                        "printedName": "[Swift.Int]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35525,22 +34946,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35563,24 +34977,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryAttributeContent",
                         "printedName": "Sentry.SentryAttributeContent",
                         "usr": "s:6Sentry0A16AttributeContentO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -35590,22 +34996,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -35630,23 +35029,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Array",
-                            "printedName": "[Swift.String]",
-                            "usr": "s:Sa"
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String])",
+                        "name": "Array",
+                        "printedName": "[Swift.String]",
                         "usr": "s:Sa"
                       },
                       {
@@ -35663,22 +35054,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryAttributeContent",
-                            "printedName": "Sentry.SentryAttributeContent",
-                            "usr": "s:6Sentry0A16AttributeContentO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryAttributeContent.Type"
+                        "name": "SentryAttributeContent",
+                        "printedName": "Sentry.SentryAttributeContent",
+                        "usr": "s:6Sentry0A16AttributeContentO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryAttributeContent.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryAttributeContent.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -37868,22 +37252,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -37940,22 +37317,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -38021,22 +37391,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "KeyValueCollectionBehavior",
-                                "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
-                                "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
+                            "name": "KeyValueCollectionBehavior",
+                            "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior",
+                            "usr": "s:6Sentry0A14DataCollectionO08KeyValueC8BehaviorO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryDataCollection.KeyValueCollectionBehavior.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -39181,22 +38544,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39227,22 +38583,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39273,22 +38622,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39319,22 +38661,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39365,22 +38700,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39411,22 +38739,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39457,22 +38778,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39503,22 +38817,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39588,22 +38895,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39634,22 +38934,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -39680,22 +38973,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryError",
-                            "printedName": "Sentry.SentryError",
-                            "usr": "c:@E@SentryError"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryError.Type"
+                        "name": "SentryError",
+                        "printedName": "Sentry.SentryError",
+                        "usr": "c:@E@SentryError"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryError.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryError.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40266,22 +39552,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40312,22 +39591,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40358,22 +39630,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40443,22 +39708,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40489,22 +39747,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryExtensionType",
-                            "printedName": "Sentry.SentryExtensionType",
-                            "usr": "c:@M@Sentry@E@SentryExtensionType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryExtensionType.Type"
+                        "name": "SentryExtensionType",
+                        "printedName": "Sentry.SentryExtensionType",
+                        "usr": "c:@M@Sentry@E@SentryExtensionType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryExtensionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryExtensionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -40809,22 +40060,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -40930,22 +40174,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryFeedbackSource",
-                                "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
-                                "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
+                            "name": "SentryFeedbackSource",
+                            "printedName": "Sentry.SentryFeedback.SentryFeedbackSource",
+                            "usr": "s:6Sentry0A8FeedbackC0aB6SourceO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryFeedback.SentryFeedbackSource.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryFeedback.SentryFeedbackSource.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -41171,17 +40408,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -41370,22 +40599,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41455,22 +40677,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryFeedbackSource",
-                            "printedName": "Sentry.SentryFeedbackSource",
-                            "usr": "c:@M@Sentry@E@SentryFeedbackSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryFeedbackSource.Type"
+                        "name": "SentryFeedbackSource",
+                        "printedName": "Sentry.SentryFeedbackSource",
+                        "usr": "c:@M@Sentry@E@SentryFeedbackSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryFeedbackSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryFeedbackSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41637,22 +40852,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41683,22 +40891,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41729,22 +40930,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41775,22 +40969,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41821,22 +41008,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41867,22 +41047,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -41952,22 +41125,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryHttpStatusCode",
-                            "printedName": "Sentry.SentryHttpStatusCode",
-                            "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryHttpStatusCode.Type"
+                        "name": "SentryHttpStatusCode",
+                        "printedName": "Sentry.SentryHttpStatusCode",
+                        "usr": "c:@M@Sentry@E@SentryHttpStatusCode"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryHttpStatusCode.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryHttpStatusCode.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -42552,17 +41718,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -43650,23 +42808,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
+                        "name": "String",
+                        "printedName": "Swift.String",
                         "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Swift.String) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Swift.String) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -44557,29 +43707,21 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44618,29 +43760,21 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "SentryAppStartMeasurement",
-                                    "printedName": "Sentry.SentryAppStartMeasurement",
-                                    "usr": "c:objc(cs)SentryAppStartMeasurement"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Optional",
-                                "printedName": "Sentry.SentryAppStartMeasurement?",
-                                "usr": "s:Sq"
+                                "name": "SentryAppStartMeasurement",
+                                "printedName": "Sentry.SentryAppStartMeasurement",
+                                "usr": "c:objc(cs)SentryAppStartMeasurement"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                            "name": "Optional",
+                            "printedName": "Sentry.SentryAppStartMeasurement?",
                             "usr": "s:Sq"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -44683,29 +43817,21 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryAppStartMeasurement",
-                                "printedName": "Sentry.SentryAppStartMeasurement",
-                                "usr": "c:objc(cs)SentryAppStartMeasurement"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Optional",
-                            "printedName": "Sentry.SentryAppStartMeasurement?",
-                            "usr": "s:Sq"
+                            "name": "SentryAppStartMeasurement",
+                            "printedName": "Sentry.SentryAppStartMeasurement",
+                            "usr": "c:objc(cs)SentryAppStartMeasurement"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryAppStartMeasurement?)",
+                        "name": "Optional",
+                        "printedName": "Sentry.SentryAppStartMeasurement?",
                         "usr": "s:Sq"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryAppStartMeasurement?) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryAppStartMeasurement?) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -46016,8 +45142,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> ObjectiveC.IMP)"
+                    "name": "Function",
+                    "printedName": "() -> ObjectiveC.IMP"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46155,30 +45281,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46199,30 +45318,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46243,30 +45355,23 @@
                   {
                     "children": [
                       {
+                        "children": [
+                          {
+                            "kind": "TypeNominal",
+                            "name": "Mode",
+                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
+                            "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
+                          }
+                        ],
+                        "kind": "TypeNominal",
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
+                      },
+                      {
                         "kind": "TypeNominal",
                         "name": "Mode",
                         "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
                         "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                      },
-                      {
-                        "children": [
-                          {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Mode",
-                                "printedName": "Sentry.SentryInternalSwizzleApi.Mode",
-                                "usr": "s:6Sentry0A18InternalSwizzleApiV4ModeO"
-                              }
-                            ],
-                            "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryInternalSwizzleApi.Mode.Type"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryInternalSwizzleApi.Mode.Type)"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -46627,22 +45732,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46674,22 +45772,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46758,22 +45849,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLastRunStatus",
-                            "printedName": "Sentry.SentryLastRunStatus",
-                            "usr": "c:@M@Sentry@E@SentryLastRunStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLastRunStatus.Type"
+                        "name": "SentryLastRunStatus",
+                        "printedName": "Sentry.SentryLastRunStatus",
+                        "usr": "c:@M@Sentry@E@SentryLastRunStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLastRunStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLastRunStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -46937,22 +46021,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47022,22 +46099,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47068,22 +46138,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47114,22 +46177,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47160,22 +46216,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47245,22 +46294,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryLevel",
-                            "printedName": "Sentry.SentryLevel",
-                            "usr": "c:@E@SentryLevel"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryLevel.Type"
+                        "name": "SentryLevel",
+                        "printedName": "Sentry.SentryLevel",
+                        "usr": "c:@E@SentryLevel"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryLevel.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryLevel.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -47643,22 +46685,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47690,22 +46725,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47737,22 +46765,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47784,22 +46805,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47868,22 +46882,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -47952,22 +46959,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Level",
-                                "printedName": "Sentry.SentryLog.Level",
-                                "usr": "s:6Sentry0A3LogC5LevelO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryLog.Level.Type"
+                            "name": "Level",
+                            "printedName": "Sentry.SentryLog.Level",
+                            "usr": "s:6Sentry0A3LogC5LevelO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryLog.Level.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryLog.Level.Type"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -51349,24 +50349,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "UInt",
-                            "printedName": "Swift.UInt",
-                            "usr": "s:Su"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.UInt)",
-                        "usr": "s:Su"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryMetricValue",
                         "printedName": "Sentry.SentryMetricValue",
                         "usr": "s:6Sentry0A11MetricValueO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "UInt",
+                        "printedName": "Swift.UInt",
+                        "usr": "s:Su"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -51376,22 +50368,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51414,17 +50399,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -51441,22 +50418,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -51479,17 +50449,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Double",
-                            "printedName": "Swift.Double",
-                            "usr": "s:Sd"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Double)",
+                        "name": "Double",
+                        "printedName": "Swift.Double",
                         "usr": "s:Sd"
                       },
                       {
@@ -51506,22 +50468,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMetricValue",
-                            "printedName": "Sentry.SentryMetricValue",
-                            "usr": "s:6Sentry0A11MetricValueO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryMetricValue.Type"
+                        "name": "SentryMetricValue",
+                        "printedName": "Sentry.SentryMetricValue",
+                        "usr": "s:6Sentry0A11MetricValueO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryMetricValue.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryMetricValue.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -52362,22 +51317,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52447,22 +51395,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryProfileLifecycle",
-                            "printedName": "Sentry.SentryProfileLifecycle",
-                            "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryProfileLifecycle.Type"
+                        "name": "SentryProfileLifecycle",
+                        "printedName": "Sentry.SentryProfileLifecycle",
+                        "usr": "c:@M@Sentry@E@SentryProfileLifecycle"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryProfileLifecycle.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryProfileLifecycle.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -52654,22 +51595,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -52738,22 +51672,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryProfileLifecycle",
-                                "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
-                                "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
+                            "name": "SentryProfileLifecycle",
+                            "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle",
+                            "usr": "s:6Sentry0A14ProfileOptionsC0aB9LifecycleO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryProfileOptions.SentryProfileLifecycle.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryProfileOptions.SentryProfileLifecycle.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -53697,22 +52624,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53741,22 +52661,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53785,22 +52698,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53866,22 +52772,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -53910,22 +52809,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryRedactRegionType",
-                            "printedName": "Sentry.SentryRedactRegionType",
-                            "usr": "s:6Sentry0A16RedactRegionTypeO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryRedactRegionType.Type"
+                        "name": "SentryRedactRegionType",
+                        "printedName": "Sentry.SentryRedactRegionType",
+                        "usr": "s:6Sentry0A16RedactRegionTypeO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryRedactRegionType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryRedactRegionType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -55726,22 +54618,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -55773,22 +54658,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -55820,22 +54698,15 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryReplayQuality",
-                                "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
-                                "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Metatype",
-                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
+                            "name": "SentryReplayQuality",
+                            "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality",
+                            "usr": "s:6Sentry0A13ReplayOptionsC0aB7QualityO"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryReplayOptions.SentryReplayQuality.Type)"
+                        "name": "Metatype",
+                        "printedName": "Sentry.SentryReplayOptions.SentryReplayQuality.Type"
                       },
                       {
                         "kind": "TypeNominal",
@@ -57633,22 +56504,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57679,22 +56543,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57725,22 +56582,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayQuality",
-                            "printedName": "Sentry.SentryReplayQuality",
-                            "usr": "c:@M@Sentry@E@SentryReplayQuality"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayQuality.Type"
+                        "name": "SentryReplayQuality",
+                        "printedName": "Sentry.SentryReplayQuality",
+                        "usr": "c:@M@Sentry@E@SentryReplayQuality"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayQuality.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayQuality.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -57946,22 +56796,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -58031,22 +56874,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryReplayType",
-                            "printedName": "Sentry.SentryReplayType",
-                            "usr": "c:@M@Sentry@E@SentryReplayType"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryReplayType.Type"
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryReplayType.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -59193,17 +58029,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59354,17 +58182,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59515,17 +58335,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59701,17 +58513,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59817,17 +58621,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Scope",
-                        "printedName": "Sentry.Scope",
-                        "usr": "c:objc(cs)SentryScope"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Scope)",
+                    "name": "Scope",
+                    "printedName": "Sentry.Scope",
                     "usr": "c:objc(cs)SentryScope"
                   }
                 ],
@@ -59965,17 +58761,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.Span)",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -60103,17 +58891,9 @@
                     "printedName": "Swift.Void"
                   },
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Options",
-                        "printedName": "Sentry.Options",
-                        "usr": "c:@M@Sentry@objc(cs)SentryOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.Options)",
+                    "name": "Options",
+                    "printedName": "Sentry.Options",
                     "usr": "c:@M@Sentry@objc(cs)SentryOptions"
                   }
                 ],
@@ -60878,17 +59658,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Span",
-                            "printedName": "any Sentry.Span",
-                            "usr": "c:objc(pl)SentrySpan"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Sentry.Span)",
+                        "name": "Span",
+                        "printedName": "any Sentry.Span",
                         "usr": "c:objc(pl)SentrySpan"
                       }
                     ],
@@ -60913,17 +59685,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.Span)",
+                    "name": "Span",
+                    "printedName": "any Sentry.Span",
                     "usr": "c:objc(pl)SentrySpan"
                   }
                 ],
@@ -61028,22 +59792,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61113,22 +59870,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -61159,22 +59909,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySampleDecision",
-                            "printedName": "Sentry.SentrySampleDecision",
-                            "usr": "c:@E@SentrySampleDecision"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySampleDecision.Type"
+                        "name": "SentrySampleDecision",
+                        "printedName": "Sentry.SentrySampleDecision",
+                        "usr": "c:@E@SentrySampleDecision"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySampleDecision.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySampleDecision.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62208,22 +60951,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62254,22 +60990,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62300,22 +61029,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62346,22 +61068,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62392,22 +61107,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62438,22 +61146,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62484,22 +61185,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62530,22 +61224,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62576,22 +61263,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62622,22 +61302,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62668,22 +61341,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62714,22 +61380,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62799,22 +61458,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62845,22 +61497,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62891,22 +61536,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62937,22 +61575,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -62983,22 +61614,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -63029,22 +61653,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentrySpanStatus",
-                            "printedName": "Sentry.SentrySpanStatus",
-                            "usr": "c:@E@SentrySpanStatus"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentrySpanStatus.Type"
+                        "name": "SentrySpanStatus",
+                        "printedName": "Sentry.SentrySpanStatus",
+                        "usr": "c:@E@SentrySpanStatus"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentrySpanStatus.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentrySpanStatus.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64723,22 +63340,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64771,22 +63381,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64856,22 +63459,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64904,22 +63500,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -64952,22 +63541,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65000,22 +63582,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryTransactionNameSource",
-                            "printedName": "Sentry.SentryTransactionNameSource",
-                            "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryTransactionNameSource.Type"
+                        "name": "SentryTransactionNameSource",
+                        "printedName": "Sentry.SentryTransactionNameSource",
+                        "usr": "c:@M@Sentry@E@SentryTransactionNameSource"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryTransactionNameSource.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryTransactionNameSource.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65389,22 +63964,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65433,22 +64001,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65477,22 +64038,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65521,22 +64075,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65565,22 +64112,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65609,24 +64149,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUnit",
                         "printedName": "Sentry.SentryUnit",
                         "usr": "s:6Sentry0A4UnitO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -65636,22 +64168,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -65674,22 +64199,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65718,22 +64236,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65762,22 +64273,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65806,22 +64310,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65850,22 +64347,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65894,22 +64384,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65938,22 +64421,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -65982,22 +64458,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66026,22 +64495,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66070,22 +64532,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66114,22 +64569,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66158,22 +64606,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66202,22 +64643,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66246,22 +64680,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66290,22 +64717,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66373,22 +64793,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66417,22 +64830,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66461,22 +64867,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66505,22 +64904,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUnit",
-                            "printedName": "Sentry.SentryUnit",
-                            "usr": "s:6Sentry0A4UnitO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUnit.Type"
+                        "name": "SentryUnit",
+                        "printedName": "Sentry.SentryUnit",
+                        "usr": "s:6Sentry0A4UnitO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUnit.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUnit.Type"
                   },
                   {
                     "kind": "TypeNominal",
@@ -66795,17 +65187,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "NSRegularExpression",
-                            "printedName": "Foundation.NSRegularExpression",
-                            "usr": "c:objc(cs)NSRegularExpression"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Foundation.NSRegularExpression)",
+                        "name": "NSRegularExpression",
+                        "printedName": "Foundation.NSRegularExpression",
                         "usr": "c:objc(cs)NSRegularExpression"
                       },
                       {
@@ -66822,22 +65206,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -66860,24 +65237,16 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.String)",
-                        "usr": "s:SS"
-                      },
-                      {
                         "kind": "TypeNominal",
                         "name": "SentryUrlMatcher",
                         "printedName": "Sentry.SentryUrlMatcher",
                         "usr": "s:6Sentry0A10UrlMatcherO"
+                      },
+                      {
+                        "kind": "TypeNominal",
+                        "name": "String",
+                        "printedName": "Swift.String",
+                        "usr": "s:SS"
                       }
                     ],
                     "kind": "TypeFunc",
@@ -66887,22 +65256,15 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUrlMatcher",
-                            "printedName": "Sentry.SentryUrlMatcher",
-                            "usr": "s:6Sentry0A10UrlMatcherO"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Metatype",
-                        "printedName": "Sentry.SentryUrlMatcher.Type"
+                        "name": "SentryUrlMatcher",
+                        "printedName": "Sentry.SentryUrlMatcher",
+                        "usr": "s:6Sentry0A10UrlMatcherO"
                       }
                     ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Sentry.SentryUrlMatcher.Type)"
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryUrlMatcher.Type"
                   }
                 ],
                 "kind": "TypeFunc",
@@ -67068,23 +65430,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67126,23 +65480,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackFormConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                            "name": "SentryUserFeedbackFormConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67188,23 +65534,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackFormConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackFormConfiguration)",
+                        "name": "SentryUserFeedbackFormConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackFormConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackFormConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackFormConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67250,23 +65588,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67308,23 +65638,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackThemeConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                            "name": "SentryUserFeedbackThemeConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67370,23 +65692,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryUserFeedbackThemeConfiguration",
-                            "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
-                            "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration)",
+                        "name": "SentryUserFeedbackThemeConfiguration",
+                        "printedName": "Sentry.SentryUserFeedbackThemeConfiguration",
                         "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackThemeConfiguration"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(Sentry.SentryUserFeedbackThemeConfiguration) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67438,8 +65752,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67487,8 +65801,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67540,8 +65854,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67593,8 +65907,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67642,8 +65956,8 @@
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(() -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "() -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67695,8 +66009,8 @@
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(() -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "() -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67742,23 +66056,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67800,23 +66106,15 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "Error",
-                                "printedName": "any Swift.Error",
-                                "usr": "s:s5ErrorP"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(any Swift.Error)",
+                            "name": "Error",
+                            "printedName": "any Swift.Error",
                             "usr": "s:s5ErrorP"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "((any Swift.Error) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "(any Swift.Error) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67862,23 +66160,15 @@
                         "printedName": "Swift.Void"
                       },
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Error",
-                            "printedName": "any Swift.Error",
-                            "usr": "s:s5ErrorP"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(any Swift.Error)",
+                        "name": "Error",
+                        "printedName": "any Swift.Error",
                         "usr": "s:s5ErrorP"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "((any Swift.Error) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "(any Swift.Error) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -67926,34 +66216,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -67997,34 +66279,26 @@
                           {
                             "children": [
                               {
-                                "children": [
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "ProtocolComposition",
-                                    "printedName": "Any"
-                                  },
-                                  {
-                                    "kind": "TypeNominal",
-                                    "name": "String",
-                                    "printedName": "Swift.String",
-                                    "usr": "s:SS"
-                                  }
-                                ],
                                 "kind": "TypeNominal",
-                                "name": "Dictionary",
-                                "printedName": "[Swift.String : Any]",
-                                "usr": "s:SD"
+                                "name": "ProtocolComposition",
+                                "printedName": "Any"
+                              },
+                              {
+                                "kind": "TypeNominal",
+                                "name": "String",
+                                "printedName": "Swift.String",
+                                "usr": "s:SS"
                               }
                             ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "([Swift.String : Any])",
+                            "name": "Dictionary",
+                            "printedName": "[Swift.String : Any]",
                             "usr": "s:SD"
                           }
                         ],
                         "kind": "TypeFunc",
-                        "name": "Paren",
-                        "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                        "name": "Function",
+                        "printedName": "([Swift.String : Any]) -> Swift.Void"
                       }
                     ],
                     "kind": "TypeNominal",
@@ -68072,34 +66346,26 @@
                       {
                         "children": [
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "ProtocolComposition",
-                                "printedName": "Any"
-                              },
-                              {
-                                "kind": "TypeNominal",
-                                "name": "String",
-                                "printedName": "Swift.String",
-                                "usr": "s:SS"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Dictionary",
-                            "printedName": "[Swift.String : Any]",
-                            "usr": "s:SD"
+                            "name": "ProtocolComposition",
+                            "printedName": "Any"
+                          },
+                          {
+                            "kind": "TypeNominal",
+                            "name": "String",
+                            "printedName": "Swift.String",
+                            "usr": "s:SS"
                           }
                         ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "([Swift.String : Any])",
+                        "name": "Dictionary",
+                        "printedName": "[Swift.String : Any]",
                         "usr": "s:SD"
                       }
                     ],
                     "kind": "TypeFunc",
-                    "name": "Paren",
-                    "printedName": "(([Swift.String : Any]) -> Swift.Void)"
+                    "name": "Function",
+                    "printedName": "([Swift.String : Any]) -> Swift.Void"
                   }
                 ],
                 "kind": "TypeNominal",
@@ -70332,17 +68598,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -70376,17 +68634,9 @@
                   {
                     "children": [
                       {
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "Bool",
-                            "printedName": "Swift.Bool",
-                            "usr": "s:Sb"
-                          }
-                        ],
                         "kind": "TypeNominal",
-                        "name": "Paren",
-                        "printedName": "(Swift.Bool)",
+                        "name": "Bool",
+                        "printedName": "Swift.Bool",
                         "usr": "s:Sb"
                       },
                       {
@@ -70424,17 +68674,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
-                        "usr": "s:Sb"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(Swift.Bool)",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
                     "usr": "s:Sb"
                   },
                   {
@@ -70586,17 +68828,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -71161,17 +69395,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -81705,17 +79931,9 @@
                             "printedName": "Swift.Void"
                           },
                           {
-                            "children": [
-                              {
-                                "kind": "TypeNominal",
-                                "name": "SentryUserFeedbackConfiguration",
-                                "printedName": "Sentry.SentryUserFeedbackConfiguration",
-                                "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
-                              }
-                            ],
                             "kind": "TypeNominal",
-                            "name": "Paren",
-                            "printedName": "(Sentry.SentryUserFeedbackConfiguration)",
+                            "name": "SentryUserFeedbackConfiguration",
+                            "printedName": "Sentry.SentryUserFeedbackConfiguration",
                             "usr": "c:@M@Sentry@objc(cs)SentryUserFeedbackConfiguration"
                           }
                         ],
@@ -81823,17 +80041,9 @@
               {
                 "children": [
                   {
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryRedactOptions",
-                        "printedName": "any Sentry.SentryRedactOptions",
-                        "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
-                      }
-                    ],
                     "kind": "TypeNominal",
-                    "name": "Paren",
-                    "printedName": "(any Sentry.SentryRedactOptions)",
+                    "name": "SentryRedactOptions",
+                    "printedName": "any Sentry.SentryRedactOptions",
                     "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions"
                   }
                 ],


### PR DESCRIPTION
## Description

Remove the `enableReplayNetworkDetailsCapturing` experimental boolean flag. Network detail capture is now gated solely by whether `networkDetailAllowUrls` is non-empty, which was already checked independently at every runtime path.

The dual-gate (`enableReplayNetworkDetailsCapturing && networkDetailHasUrls`) was redundant — there's no realistic scenario where a user configures allow URLs but doesn't want the feature.

## Changes

* Remove `enableReplayNetworkDetailsCapturing` from `SentryExperimentalOptions`, `SentryObjCExperimentalOptions.h`, and `SentryObjCExperimentalOptions.swift`
* Simplify swizzling gate in `SentryNetworkTrackingIntegration` to only check `networkDetailHasUrls`
* Remove boolean guard from `SentryNetworkTracker.m`
* Move feature telemetry check to `options.sessionReplay.networkDetailHasUrls` (inside platform `#if` guard)
* Remove `- Note: Requires ...` doc comments from 5 properties in `SentryReplayOptions`
* Remove `disableNetworkDetailsCapturing` SDK override from sample app
* Update tests and regenerate `sdk_api*.json`

Closes getsentry/sentry-cocoa#8397