### PR TITLE
fix: Log actual error in SpotlightTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Session Replay now correctly reads the response `Content-Type` for HTTP/2 and HTTP/3, so it captures HTTP response bodies as it was supposed to (when body capturing is enabled via `options.sessionReplay.networkCaptureBodies`) (#8390)
+- Log the actual request error instead of `(null)` when a Spotlight request fails (#8401)
 
 ## Features
 

--- a/Sources/Sentry/SentrySpotlightTransport.m
+++ b/Sources/Sentry/SentrySpotlightTransport.m
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
                addRequest:request
         completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
             if (error) {
-                SENTRY_LOG_ERROR(@"Error while performing request %@", requestError);
+                SENTRY_LOG_ERROR(@"Error while performing request %@", error);
             }
         }];
 }

--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -18,7 +18,15 @@ final class SentrySpotlightTransportTests: XCTestCase {
 
         requestBuilder = TestNSURLRequestBuilder()
     }
-    
+
+    override func tearDown() {
+        // Reset any log capture set up via `givenCapturedLogs()` so it doesn't leak into other tests.
+        SentrySDKLog.setOutput(nil)
+        SentrySDKLog.configureLog(false, diagnosticLevel: .error)
+
+        super.tearDown()
+    }
+
     private func givenSut(spotlightUrl: String? = nil) -> SentrySpotlightTransport {
         if spotlightUrl != nil {
             options.spotlightUrl = spotlightUrl ?? ""
@@ -45,98 +53,220 @@ final class SentrySpotlightTransportTests: XCTestCase {
     private func givenTransactionEnvelope() throws -> SentryEnvelope {
         let transaction = Transaction(level: .debug)
         transaction.type = SentryEnvelopeItemTypes.transaction
-        
+
         return SentryEnvelope(id: transaction.eventId, items: [SentryEnvelopeItem(event: transaction)])
     }
 
+    private func givenTransactionItem() -> SentryEnvelopeItem {
+        let transaction = Transaction(level: .debug)
+        transaction.type = SentryEnvelopeItemTypes.transaction
+        return SentryEnvelopeItem(event: transaction)
+    }
+
+    private func givenAttachmentItem() throws -> SentryEnvelopeItem {
+        return try XCTUnwrap(SentryEnvelopeItem(attachment: TestData.dataAttachment, maxAttachmentSize: 5 * 1_024 * 1_024))
+    }
+
+    /// Captures the SDK logs so tests can assert on them. `tearDown()` restores the default log
+    /// configuration so the captured output doesn't leak into other tests.
+    ///
+    /// Note: we reset in `tearDown()` rather than `addTeardownBlock`, because the latter is only
+    /// available on macOS 10.15+ while the test target deploys down to macOS 10.14.
+    private func givenCapturedLogs() -> TestLogOutput {
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+        SentrySDKLog.configureLog(true, diagnosticLevel: .debug)
+        return logOutput
+    }
+
     func testShouldSendEventEnvelope() throws {
+        // -- Arrange --
         let eventEnvelope = try givenEventEnvelope()
         let sut = givenSut()
-        
+
+        // -- Act --
         sut.send(envelope: eventEnvelope)
-        
+
+        // -- Assert --
         XCTAssertEqual(self.requestManager.requests.count, 1)
-        
+
         let request = try XCTUnwrap(requestManager.requests.first)
         XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
-        
+
         let expectedData = try getSerializedGzippedData(envelope: eventEnvelope)
         try compareEnvelopes(request.httpBody, expectedData, message: "Envelopes should be equal")
     }
-    
+
     func testShouldSendTransactionEnvelope() throws {
+        // -- Arrange --
         let transactionEnvelope = try givenTransactionEnvelope()
         let sut = givenSut()
-        
+
+        // -- Act --
         sut.send(envelope: transactionEnvelope)
-        
+
+        // -- Assert --
         XCTAssertEqual(self.requestManager.requests.count, 1)
-        
+
         let request = try XCTUnwrap(requestManager.requests.first)
         XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
-        
+
         let expectedData = try getSerializedGzippedData(envelope: transactionEnvelope)
         try compareEnvelopes(request.httpBody, expectedData, message: "Envelopes should be equal")
     }
-    
+
     func testShouldRemoveAttachmentsFromEventEnvelope() throws {
+        // -- Arrange --
         let eventEnvelope = try givenEventEnvelope(withAttachment: true)
         let sut = givenSut()
-        
+
+        // -- Act --
         sut.send(envelope: eventEnvelope)
-        
+
+        // -- Assert --
         XCTAssertEqual(self.requestManager.requests.count, 1)
-        
+
         let request = try XCTUnwrap(requestManager.requests.first)
         XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
-        
+
         let expectedData = try getSerializedGzippedData(envelope: givenEventEnvelope())
         let expectedDataCountLower = expectedData.count - 40
         let expectedDataCountUpper = expectedData.count + 40
-        
+
         // Compressing with GZip doesn't always produce the same results
         // We only want to know if the attachment got removed. Therefore, a comparison with a range is acceptable.
         let expectedBodyCountRange = (expectedDataCountLower...expectedDataCountUpper)
         let actualBodyCount = try XCTUnwrap(request.httpBody?.count)
         XCTAssertTrue(expectedBodyCountRange.contains(actualBodyCount), "Expected body size to be in range of \(expectedBodyCountRange), but was \(actualBodyCount)")
     }
-    
-    func testShouldNotSendEnvelope_WhenMalformedURL() throws {
+
+    func testShouldKeepEventAndTransaction_AndStripAttachment_WhenEnvelopeHasMixedItems() throws {
+        // -- Arrange --
+        let eventItem = SentryEnvelopeItem(event: TestData.event)
+        let transactionItem = givenTransactionItem()
+        let attachmentItem = try givenAttachmentItem()
+
+        // Order matters: the transport preserves the original item order while filtering.
+        let envelope = SentryEnvelope(id: TestData.event.eventId, items: [eventItem, attachmentItem, transactionItem])
+        let sut = givenSut()
+
+        // -- Act --
+        sut.send(envelope: envelope)
+
+        // -- Assert --
+        XCTAssertEqual(self.requestManager.requests.count, 1)
+
+        let request = try XCTUnwrap(requestManager.requests.first)
+        XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
+
+        let expectedEnvelope = SentryEnvelope(header: envelope.header, items: [eventItem, transactionItem])
+        let expectedData = try getSerializedGzippedData(envelope: expectedEnvelope)
+        try compareEnvelopes(request.httpBody, expectedData, message: "Should keep event and transaction and strip the attachment")
+    }
+
+    func testShouldKeepAllEventItems_WhenEnvelopeHasMultipleEvents() throws {
+        // -- Arrange --
+        let firstEventItem = SentryEnvelopeItem(event: TestData.event)
+        let secondEventItem = SentryEnvelopeItem(event: TestData.event)
+
+        let envelope = SentryEnvelope(id: TestData.event.eventId, items: [firstEventItem, secondEventItem])
+        let sut = givenSut()
+
+        // -- Act --
+        sut.send(envelope: envelope)
+
+        // -- Assert --
+        XCTAssertEqual(self.requestManager.requests.count, 1)
+
+        let request = try XCTUnwrap(requestManager.requests.first)
+        let expectedData = try getSerializedGzippedData(envelope: envelope)
+        try compareEnvelopes(request.httpBody, expectedData, message: "Should keep all event items")
+    }
+
+    func testShouldSendEnvelopeWithoutItems_WhenNoItemsAreAllowed() throws {
+        // -- Arrange --
+        let sessionItem = SentryEnvelopeItem(session: SentrySession(releaseName: "release", distinctId: "some-id"))
+        let attachmentItem = try givenAttachmentItem()
+
+        let envelope = SentryEnvelope(id: TestData.event.eventId, items: [sessionItem, attachmentItem])
+        let sut = givenSut()
+
+        // -- Act --
+        sut.send(envelope: envelope)
+
+        // -- Assert --
+        // Spotlight strips all non-allowed items but still sends the envelope, now with an empty item list.
+        XCTAssertEqual(self.requestManager.requests.count, 1)
+
+        let request = try XCTUnwrap(requestManager.requests.first)
+        let expectedEnvelope = SentryEnvelope(header: envelope.header, items: [])
+        let expectedData = try getSerializedGzippedData(envelope: expectedEnvelope)
+        try compareEnvelopes(request.httpBody, expectedData, message: "Should send an envelope without items when no items are allowed")
+    }
+
+    func testShouldNotSendEnvelopeAndLogWarning_WhenMalformedURL() throws {
+        // -- Arrange --
+        // Guard the test's premise: the transport only takes the malformed-URL path when
+        // `NSURL` rejects the string. URL parsing strictness varies by deployment target, so
+        // assert up front that the string is actually unparseable on this platform.
+        XCTAssertNil(URL(string: TestData.malformedURLString), "Test URL must be unparseable")
+
+        let logOutput = givenCapturedLogs()
         let eventEnvelope = try givenEventEnvelope()
-        requestBuilder.shouldFailWithError = true
         let sut = givenSut(spotlightUrl: TestData.malformedURLString)
-        
+
+        // -- Act --
         sut.send(envelope: eventEnvelope)
 
+        // -- Assert --
         XCTAssertEqual(self.requestManager.requests.count, 0)
+
+        let warnings = logOutput.loggedMessages.filter {
+            $0.contains("[Sentry] [warning]") &&
+            $0.contains("Malformed Spotlight URL")
+        }
+        XCTAssertEqual(warnings.count, 1)
     }
-    
-    func testShouldNotSendEnvelope_WhenRequestError() throws {
+
+    func testShouldNotSendEnvelopeAndLogError_WhenRequestBuildFails() throws {
+        // -- Arrange --
+        let logOutput = givenCapturedLogs()
         let eventEnvelope = try givenEventEnvelope()
         requestBuilder.shouldFailWithError = true
         let sut = givenSut()
-        
+
+        // -- Act --
         sut.send(envelope: eventEnvelope)
 
+        // -- Assert --
         XCTAssertEqual(self.requestManager.requests.count, 0)
+
+        let errors = logOutput.loggedMessages.filter {
+            $0.contains("[Sentry] [error]") &&
+            $0.contains("Unable to build envelope request")
+        }
+        XCTAssertEqual(errors.count, 1)
     }
-    
+
     func testShouldLogError_WhenRequestManagerCompletesWithError() throws {
-        let logOutput = TestLogOutput()
-        SentrySDKLog.setLogOutput(logOutput)
-        SentrySDKLog.configureLog(true, diagnosticLevel: .debug)
-        
+        // -- Arrange --
+        let logOutput = givenCapturedLogs()
+
         let eventEnvelope = try givenEventEnvelope()
         requestManager.nextError = NSError(domain: "error", code: 47)
         let sut = givenSut()
-        
+
+        // -- Act --
         sut.send(envelope: eventEnvelope)
-        
+
+        // -- Assert --
         let logMessages = logOutput.loggedMessages.filter {
             $0.contains("[Sentry] [error]") &&
-            $0.contains("Error while performing request")
+            $0.contains("Error while performing request") &&
+            // The completion handler must log the actual error, not the (nil) request-build error.
+            $0.contains("Code=47")
         }
-        
+
         XCTAssertEqual(logMessages.count, 1)
     }
     

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -17,7 +17,11 @@ class TestData {
     static let context: [String: [String: Any]] = ["context": ["c": "a", "date": timestamp]]
     static let traceContext: [String: [String: Any]] = ["trace": ["trace_id": "1234567890", "span_id": "1234567890"]]
     
-    static let malformedURLString = "http://example.com:-80/"
+    // A space in the host is rejected by every Foundation URL parser (both the strict parser used
+    // on iOS and the legacy CFURL parser used by binaries with an old deployment target, e.g. macOS).
+    // A negative port like "http://example.com:-80/" only fails on the strict parser, so it isn't
+    // portably malformed.
+    static let malformedURLString = "http://exa mple.com"
     
     static var crumb: Breadcrumb {
         let crumb = Breadcrumb()


### PR DESCRIPTION
## :scroll: Description

- Fix: the completion handler logged `requestError` (always `nil` there) instead of its own `error`, so failed Spotlight requests logged `(null)`.
- Add `sendEnvelope:` test coverage before porting the class to Swift: item filtering/order, empty result, malformed URL warning, and error-logging paths. Tests use Arrange-Act-Assert.

## :green_heart: How did you test it?

`make test-ios ONLY_TESTING=SentryTests/SentrySpotlightTransportTests` (9 pass); `make analyze` clean.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added.
- [x] No breaking change; changelog entry added.


Closes #8407