### PR TITLE
test: Fix app hang tracking test flake

### DIFF
--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryHangTrackingIntegrationTests.swift
@@ -270,8 +270,8 @@ class SentryHangTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
     }
 
     func testANRDetected_DetectingPausedResumed_EventCaptured() throws {
-        givenInitializedTracker()
         setUpThreadInspector()
+        givenInitializedTracker()
         try XCTUnwrap(sut).pauseAppHangTracking()
         try XCTUnwrap(sut).resumeAppHangTracking()
 


### PR DESCRIPTION
The macOS pause-and-resume app hang test now injects its deterministic thread inspector before constructing the integration.

The integration snapshots the inspector during initialization. The previous setup order left it using the production inspector, which can return no threads when the full test process exceeds its thread inspection limit and cause the expected event capture to be skipped.

#skip-changelog

Closes #8403