### PR TITLE
chore: Backfill dates and contributors in DECISIONS.md

### DIFF
--- a/develop-docs/DECISIONS.md
+++ b/develop-docs/DECISIONS.md
@@ -85,6 +85,9 @@ For the benefit of OOM crashes, we write breadcrumbs to disk; see https://github
 
 ## Bump min Xcode version to 13
 
+Date: December 5th, 2022
+Contributors: @philipphofmann, @kevinrenskers
+
 With adding the [MetricKit integration](https://github.com/getsentry/sentry-cocoa/issues/1661), we need to bump the min Xcode version to 13,
 as MetricKit is unavailable on previous Xcode versions. As Xcode 12 doesn't run on macOS 12, and the current Xcode version is 14, we are OK
 with that change. With that change, we also have to drop support for
@@ -98,6 +101,7 @@ since version 0.37.0, released in January 2021. Therefore, it's acceptable to us
 ## Remove the permissions feature
 
 Date: December 14, 2022
+Contributors: @kevinrenskers, @philipphofmann
 
 We [removed](https://github.com/getsentry/sentry-cocoa/pull/2529) the permissions feature that we added in [7.24.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.24.0). Multiple people reported getting denied in app review because of permission access without the corresponding Info.plist entry: see [#2528](https://github.com/getsentry/sentry-cocoa/issues/2528) and [2065](https://github.com/getsentry/sentry-cocoa/issues/2065).
 
@@ -117,12 +121,18 @@ We release experimental SentrySwiftUI cocoa package with the version 8.0.0 becau
 
 ## Tracking package managers
 
+Date: March 29th, 2023
+Contributors: @brustolin, @armcknight, @philipphofmann
+
 To be able to identify the package manager(PM) being used by the user, we need that the PM identify itself.
 Luckily all of the 3 PMs we support do this in some way, mostly by exposing a compiler directive (SPM, COCOA)
 or a build setting (CARTHAGE). With this information we can create a conditional compilation that injects the name of
 the PM. You can find this in `SentrySDKInfo.m`.
 
 ## Usage of `__has_include`
+
+Date: March 20th, 2023
+Contributors: @brustolin, @philipphofmann
 
 Some private headers add a dependency of a public header, when those private headers are used in a sample project, or referenced from a hybrid SDK, it is treated as part of the project using it, therefore, if it points to a header that is not part of said project, a compilation error will occur. To solve this we make use of `__has_include` to try to point to the SDK version of the header, or to fallback to the direct reference when compiling the SDK.
 
@@ -432,6 +442,9 @@ See previous discussion at https://github.com/getsentry/sentry-cocoa/issues/3846
 
 ## Use preinstalled GH actions simulators
 
+Date: April 2nd, 2025
+Contributors: @philipphofmann, @philprime
+
 Creating simulators in GH actions can take up to five minutes or more. Instead, we use the preinstalled simulators for unit and UI tests to speed up CI. We also noticed that tests are more likely to flake due to being unable to launch the app for UI tests and such. We don't have hard evidence to prove this, and these problems could vanish if GH action runners improve. It makes sense to work with what's preinstalled instead and not messing around with the CI environment. If we need to test on a specific OS version, we should use a GH action image with an Xcode version tied to that specific OS version.
 
 ## Do not use Swift String constants in ObjC code
@@ -450,6 +463,9 @@ Related links:
 
 ## Decodable conformances to ObjC types
 
+Date: June 24th, 2025
+Contributors: @noahsmartin, @philipphofmann
+
 A few types that are defined in ObjC have Decodable conformances in "Sources/Swift/Protocol/Codable/". This works for xcodebuild where ObjC and Swift are in the same target
 but not for SPM where ObjC and Swift have to be in different targets. This is because Swift does not support adding a protocol conformance to a type in a different module
 than the one the type/protocol is defined in. To work around this Swift code subclasses the ObjC type and adds the conformance to the subclass. It is then decoded as a
@@ -459,6 +475,9 @@ major version bump to change.
 Future types conforming to Decodable can be written in Swift from the start and therefore have the conformance added directly to the type.
 
 ## v9
+
+Date: July 9th, 2025
+Contributors: @noahsmartin, @philipphofmann
 
 Work on the v9 SDK is being done behind the compiler flag `SDK_V9`. CI builds the SDK with this flag enabled to ensure it does not break during the course of non-v9 development. This SDK version will focus on quality and be a part of Sentry’s quality quarter initiative. Notably, the minimum supported OS version will be bumped in this release. The changelog for this release is being tracked in [CHANGELOG-v9.md](../CHANGELOG-v9.md).
 
@@ -513,6 +532,9 @@ Related:
 - Fix for multiple files in Releases (stale for months): https://github.com/Carthage/Carthage/pull/3398
 
 ## 3rd Party Library Integrations
+
+Date: December 4th, 2025
+Contributors: @itaybre, @philipphofmann
 
 ### Background
 


### PR DESCRIPTION
Eight decision-log entries were missing a `Date:` and/or `Contributors:` line. This backfills them retrospectively.

## How the info was recovered

For each dateless section I found the PR that introduced it, then used its **merge date** as the decision date and its **author + approving reviewer(s)** as the contributors. The log used to live in `develop-docs/README.md` before it was split out (#2940), so a plain `git log` on the current file was not enough — the headings had to be traced across that move.

| Section | PR | Date | Contributors |
| --- | --- | --- | --- |
| Bump min Xcode version to 13 | #2483 | Dec 5th, 2022 | @philipphofmann, @kevinrenskers |
| Remove the permissions feature | #2529 | (had date) | @kevinrenskers, @philipphofmann |
| Usage of `__has_include` | #2743 | Mar 20th, 2023 | @brustolin, @philipphofmann |
| Tracking package managers | #2778 | Mar 29th, 2023 | @brustolin, @armcknight, @philipphofmann |
| Use preinstalled GH actions simulators | #5030 | Apr 2nd, 2025 | @philipphofmann, @philprime |
| Decodable conformances to ObjC types | #5359 | Jun 24th, 2025 | @noahsmartin, @philipphofmann |
| v9 | #5591 | Jul 9th, 2025 | @noahsmartin, @philipphofmann |
| 3rd Party Library Integrations | #6902 | Dec 4th, 2025 | @itaybre, @philipphofmann |

<details>
<summary>How to reproduce this with Claude Code</summary>

This was done end-to-end by Claude Code. The steps, if you want to redo or extend it:

**1. Find sections missing a `Date:`/`Contributors:` line.** Ask Claude to scan `develop-docs/DECISIONS.md` and list every `##` heading that has no `Date:` or `Contributors:` line in its body. (Under the hood it walks the headings and checks the lines beneath each.)

**2. Trace the introducing PR for each heading.** The log was split out of `README.md`, so search the *whole* history, not just the current file:

\`\`\`bash
# earliest commit that added the exact heading text, across all files/renames
git log --reverse --format='%h %ad %an | %s' --date=short -S'## Tracking package managers'
\`\`\`

The commit subject ends in the PR number, e.g. \`(#2778)\`.

**3. Pull author, merge date, and approver(s) from GitHub via the \`gh\` CLI:**

\`\`\`bash
gh pr view 2778 --json author,mergedAt,reviews \
  --jq '{author: .author.login, mergedAt, approvers: [.reviews[] | select(.state=="APPROVED") | .author.login] | unique}'
\`\`\`

Map that to \`Date:\` (merge date) and \`Contributors:\` (author first, then approvers).

**4. Let Claude apply the edits, format, and open the PR** — it inserts the two lines under each heading, runs \`make format\`, and verifies every section now has both fields before committing.

The Sentry-specific conventions Claude followed (docs need `#skip-changelog`, `chore:` prefix, no AI attribution in commits) live in the repo's `AGENTS.md`/`CLAUDE.md`, so it picks them up automatically.

</details>

#skip-changelog