### PR TITLE
test: fix CI by removing stale experimental flag

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -609,7 +609,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         options.dsn = "https://key@sentry.io/1234"
         options.sessionReplay.networkDetailAllowUrls = ["api.example.com"]
         options.sessionReplay.networkCaptureBodies = true
-        options.experimental.enableReplayNetworkDetailsCapturing = true
 
         let scope = Scope()
         let client = TestClient(options: options)


### PR DESCRIPTION
Fixes the broken test build on `main` since #8396.

#8396 removed the `enableReplayNetworkDetailsCapturing` flag but missed one reference in `SentryNetworkTrackerTests.swift`, breaking compilation of `SentryTests`:

```
value of type 'SentryExperimentalOptions' has no member 'enableReplayNetworkDetailsCapturing'
```

Removes that leftover line. Verified with `build-for-testing` → TEST BUILD SUCCEEDED.

#skip-changelog