### PR TITLE
feat(data-collection): Enable V10 user info defaults

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -4,11 +4,11 @@
 
 ### Features
 
-- Enable automatic user information for logs, metrics, and IP inference by default; configure it with `options.dataCollection.userInfo` (#8254)
 - Add `options.dataCollection` to configure data collection behaviour (#8448)
   - Allows dictionary initialization for `options.dataCollection` (#8371)
   - Renamed `options.dataCollection.queryParams` to `options.dataCollection.urlQueryParams` (#8414)
   - Add query parameter filtering for network spans, breadcrumbs, and failed requests using `options.dataCollection.urlQueryParams` (#8414)
+  - Enable automatic user information for logs, metrics, and IP inference by default; configure it with `options.dataCollection.userInfo` (#8254)
 
 ### Breaking Changes
 

--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Enable automatic user information for logs, metrics, and IP inference by default; configure it with `options.dataCollection.userInfo` (#8254)
 - Add `options.dataCollection` to configure data collection behaviour (#8448)
   - Allows dictionary initialization for `options.dataCollection` (#8371)
   - Renamed `options.dataCollection.queryParams` to `options.dataCollection.urlQueryParams` (#8414)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -56,12 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const DropSessionLogMessage = @"Session has no release name. Won't send it.";
 
-#if SDK_V10
-@interface SentryOptions (DataCollection)
-@property (nonatomic, readonly) BOOL dataCollectionUserInfo;
-@end
-#endif // SDK_V10
-
 @implementation SentryClientInternal
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
@@ -141,7 +135,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                          dependencies:SentryDependencyContainer.sharedInstance];
 
 #if SDK_V10
-        BOOL shouldAddDefaultUserId = options.dataCollectionUserInfo;
+        BOOL shouldAddDefaultUserId = options.dataCollectionObjC.userInfo;
 #else
         BOOL shouldAddDefaultUserId = options.sendDefaultPii;
 #endif // SDK_V10
@@ -981,6 +975,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (void)setUserIdIfNoUserSet:(SentryEvent *)event
 {
+#if SDK_V10
+    if (!self.options.dataCollectionObjC.userInfo) {
+        return;
+    }
+#endif // SDK_V10
     // We only want to set the id if the customer didn't set a user so we at least set something to
     // identify the user.
     if (event.user == nil) {

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -141,15 +141,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                          dependencies:SentryDependencyContainer.sharedInstance];
 
 #if SDK_V10
-        BOOL sendDefaultPii = options.dataCollectionUserInfo;
+        BOOL shouldAddDefaultUserId = options.dataCollectionUserInfo;
 #else
-        BOOL sendDefaultPii = options.sendDefaultPii;
+        BOOL shouldAddDefaultUserId = options.sendDefaultPii;
 #endif // SDK_V10
         self.logScopeApplier =
             [[SentryDefaultLogScopeApplier alloc] initWithEnvironment:options.environment
                                                           releaseName:options.releaseName
                                                    cacheDirectoryPath:options.cacheDirectoryPath
-                                                       sendDefaultPii:sendDefaultPii];
+                                               shouldAddDefaultUserId:shouldAddDefaultUserId];
 
         [crashWrapper startBinaryImageCache];
         [binaryImageCache start:options.debug];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const DropSessionLogMessage = @"Session has no release name. Won't send it.";
 
+#if SDK_V10
+@interface SentryOptions (DataCollection)
+@property (nonatomic, readonly) BOOL dataCollectionUserInfo;
+@end
+#endif // SDK_V10
+
 @implementation SentryClientInternal
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
@@ -134,11 +140,16 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                                           initWithTransportAdapter:transportAdapter]
                          dependencies:SentryDependencyContainer.sharedInstance];
 
+#if SDK_V10
+        BOOL sendDefaultPii = options.dataCollectionUserInfo;
+#else
+        BOOL sendDefaultPii = options.sendDefaultPii;
+#endif // SDK_V10
         self.logScopeApplier =
             [[SentryDefaultLogScopeApplier alloc] initWithEnvironment:options.environment
                                                           releaseName:options.releaseName
                                                    cacheDirectoryPath:options.cacheDirectoryPath
-                                                       sendDefaultPii:options.sendDefaultPii];
+                                                       sendDefaultPii:sendDefaultPii];
 
         [crashWrapper startBinaryImageCache];
         [binaryImageCache start:options.debug];

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -4,12 +4,6 @@
 #import "SentrySDK+Private.h"
 #import "SentrySwift.h"
 
-#if SDK_V10
-@interface SentryOptions (DataCollection)
-@property (nonatomic, readonly) BOOL dataCollectionUserInfo;
-@end
-#endif // SDK_V10
-
 @implementation SentryDependencyContainerSwiftHelper
 
 #if SENTRY_HAS_UIKIT
@@ -54,15 +48,6 @@
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptions *)options
 {
     return [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:options];
-}
-
-+ (BOOL)sendDefaultPii:(SentryOptions *)options
-{
-#if SDK_V10
-    return options.dataCollectionUserInfo;
-#else
-    return options.sendDefaultPii;
-#endif // SDK_V10
 }
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -4,6 +4,12 @@
 #import "SentrySDK+Private.h"
 #import "SentrySwift.h"
 
+#if SDK_V10
+@interface SentryOptions (DataCollection)
+@property (nonatomic, readonly) BOOL dataCollectionUserInfo;
+@end
+#endif // SDK_V10
+
 @implementation SentryDependencyContainerSwiftHelper
 
 #if SENTRY_HAS_UIKIT
@@ -52,7 +58,11 @@
 
 + (BOOL)sendDefaultPii:(SentryOptions *)options
 {
+#if SDK_V10
+    return options.dataCollectionUserInfo;
+#else
     return options.sendDefaultPii;
+#endif // SDK_V10
 }
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -42,7 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSObject *_Nullable)beforeSendLog:(NSObject *)beforeSendLog options:(SentryOptionsObjC *)options;
 + (BOOL)enableLogs:(SentryOptionsObjC *)options;
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptionsObjC *)options;
-+ (BOOL)sendDefaultPii:(SentryOptionsObjC *)options;
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block;

--- a/Sources/Swift/DataCollection/SentryDataCollectionObjCOptions.swift
+++ b/Sources/Swift/DataCollection/SentryDataCollectionObjCOptions.swift
@@ -3,6 +3,11 @@
 @_spi(Private) @objcMembers public final class SentryDataCollectionObjCOptions: NSObject {
     let wrapped: SentryDataCollection.Options
 
+    /// Whether automatic user information collection is enabled.
+    @_spi(Private) @objc public var userInfo: Bool {
+        wrapped.userInfo
+    }
+
     init(wrapped: SentryDataCollection.Options) {
         self.wrapped = wrapped
     }

--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -59,7 +59,11 @@ struct SentrySdkInfo {
     
     init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+#if SDK_V10
+        self.init(withEnabledFeatures: features, sendDefaultPii: options?.dataCollection.userInfo ?? false)
+#else
         self.init(withEnabledFeatures: features, sendDefaultPii: options?.sendDefaultPii ?? false)
+#endif // SDK_V10
     }
 
     init(withEnabledFeatures features: [String], sendDefaultPii: Bool) {

--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -8,27 +8,34 @@ import Foundation
  * @see https://develop.sentry.dev/sdk/event-payloads/sdk/
  */
 struct SentrySdkInfo {
-    
+
     static func global() -> Self {
-        if let options = SentrySDKInternal.currentHub().getClient()?.getOptions() {
-            let enabledFeatures = SentryDependencyContainerSwiftHelper.enabledFeatures(options)
-            return Self(withEnabledFeatures: enabledFeatures, sendDefaultPii: SentryDependencyContainerSwiftHelper.sendDefaultPii(options))
+        guard let options = SentrySDKInternal.currentHub().getClient()?.getOptions() as? Options else {
+            return Self(withEnabledFeatures: [], autoInferIP: false)
         }
-        return Self(withEnabledFeatures: [], sendDefaultPii: false)
+
+        let enabledFeatures = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+#if SDK_V10
+        let autoInferIP = options.dataCollection.userInfo
+#else
+        let autoInferIP = options.sendDefaultPii
+#endif // SDK_V10
+        return Self(withEnabledFeatures: enabledFeatures, autoInferIP: autoInferIP)
     }
-    
+
     /**
      * The name of the SDK. Examples: sentry.cocoa, sentry.cocoa.vapor, ...
      */
     let name: String
-    
+
     /**
      * The version of the SDK. It should have the Semantic Versioning format MAJOR.MINOR.PATCH, without
      * any prefix (no v or anything else in front of the major version number). Examples:
      * 0.1.0, 1.0.0, 2.0.0-beta0
      */
     let version: String
-    
+
     /**
      * A list of names identifying enabled integrations. The list should
      * have all enabled integrations, including default integrations. Default
@@ -36,7 +43,7 @@ struct SentrySdkInfo {
      * default integrations.
      */
     let integrations: [String]
-    
+
     /**
      * A list of feature names identifying enabled SDK features. This list
      * should contain all enabled SDK features. On some SDKs, enabling a feature in the
@@ -44,29 +51,30 @@ struct SentrySdkInfo {
      * integrations or features but not both to reduce the payload size.
      */
     let features: [String]
-    
+
     /**
      * A list of packages that were installed as part of this SDK or the
      * activated integrations. Each package consists of a name in the format
      * source:identifier and version.
      */
     let packages: [[String: String]]
-    
+
     /**
      * A set of settings as part of this SDK.
      */
     let settings: SentrySDKSettings
-    
+
     init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 #if SDK_V10
-        self.init(withEnabledFeatures: features, sendDefaultPii: options?.dataCollection.userInfo ?? false)
+        let autoInferIP = options?.dataCollection.userInfo ?? false
 #else
-        self.init(withEnabledFeatures: features, sendDefaultPii: options?.sendDefaultPii ?? false)
+        let autoInferIP = options?.sendDefaultPii ?? false
 #endif // SDK_V10
+        self.init(withEnabledFeatures: features, autoInferIP: autoInferIP)
     }
 
-    init(withEnabledFeatures features: [String], sendDefaultPii: Bool) {
+    init(withEnabledFeatures features: [String], autoInferIP: Bool) {
         let integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()
         var packages = SentryExtraPackages.getPackages()
         let sdkPackage = SentrySdkPackage.global()
@@ -79,9 +87,9 @@ struct SentrySdkInfo {
             integrations: integrations,
             features: features,
             packages: Array(packages),
-            settings: SentrySDKSettings(sendDefaultPii: sendDefaultPii))
+            settings: SentrySDKSettings(autoInferIP: autoInferIP))
     }
-    
+
     init(name: String?, version: String?, integrations: [String]?, features: [String]?, packages: [[String: String]]?, settings: SentrySDKSettings) {
         self.name = name ?? ""
         self.version = version ?? ""
@@ -90,7 +98,7 @@ struct SentrySdkInfo {
         self.packages = packages ?? []
         self.settings = settings
     }
-    
+
     // swiftlint:disable cyclomatic_complexity
     init(dict: [AnyHashable: Any]?) {
         var name = ""
@@ -148,7 +156,7 @@ struct SentrySdkInfo {
         )
     }
     // swiftlint:enable cyclomatic_complexity
-    
+
     func serialize() -> [String: Any] {
         [
             "name": self.name,
@@ -162,10 +170,10 @@ struct SentrySdkInfo {
 }
 
 @_spi(Private) @objc public final class SentrySdkInfoObjC: NSObject {
-    
+
     @objc public static func optionsToDict(_ options: Options) -> [String: Any] {
         SentrySdkInfo(withOptions: options).serialize()
     }
-    
+
 }
 // swiftlint:enable missing_docs

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -15,15 +15,15 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
         guard options.enableMetrics else { return nil }
 
 #if SDK_V10
-        let sendDefaultPii = options.dataCollection.userInfo
+        let shouldAddDefaultUserId = options.dataCollection.userInfo
 #else
-        let sendDefaultPii = options.sendDefaultPii
+        let shouldAddDefaultUserId = options.sendDefaultPii
 #endif // SDK_V10
         self.scopeMetaData = SentryDefaultScopeApplyingMetadata(
             environment: options.environment,
             releaseName: options.releaseName,
             cacheDirectoryPath: options.cacheDirectoryPath,
-            sendDefaultPii: sendDefaultPii
+            shouldAddDefaultUserId: shouldAddDefaultUserId
         )
 
         self.beforeSendMetric = options.beforeSendMetric

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -14,11 +14,16 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     init?(with options: Options, dependencies _: Dependencies) {
         guard options.enableMetrics else { return nil }
 
+#if SDK_V10
+        let sendDefaultPii = options.dataCollection.userInfo
+#else
+        let sendDefaultPii = options.sendDefaultPii
+#endif // SDK_V10
         self.scopeMetaData = SentryDefaultScopeApplyingMetadata(
             environment: options.environment,
             releaseName: options.releaseName,
             cacheDirectoryPath: options.cacheDirectoryPath,
-            sendDefaultPii: options.sendDefaultPii
+            sendDefaultPii: sendDefaultPii
         )
 
         self.beforeSendMetric = options.beforeSendMetric

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
 /// Configuration options for the Sentry SDK.
 @objc(SentryOptions) public final class Options: NSObject {
-    
+
     @objc public override init() {
         super.init()
         #if os(macOS)
@@ -16,7 +16,7 @@
         }
         #endif
     }
-    
+
     /// The DSN tells the SDK where to send the events to. If this value is not provided, the SDK will
     /// not send any events.
     @objc public var dsn: String? {
@@ -270,7 +270,7 @@
     /// this, or create your own scope instead.
     /// @note The default simply returns the passed in scope.
     @objc public var initialScope: ((Scope) -> Scope) = { return $0 }
-    
+
     #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
     /// When enabled, the SDK tracks performance for UIViewController subclasses.
@@ -332,27 +332,27 @@
     ///
     /// @note Default value is @c true.
     @objc public var enablePreWarmedAppStartTracing: Bool = true
-    
+
     /// When enabled the SDK reports non-fully-blocking app hangs. A non-fully-blocking app hang is when
     /// the app appears stuck to the user but can still render a few frames.
     ///
     /// @note The default is @c true.
     @objc public var enableReportNonFullyBlockingAppHangs: Bool = true
-    
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public func isAppHangTrackingDisabled() -> Bool {
         !enableAppHangTracking || appHangTimeoutInterval <= 0
     }
-    
+
     #endif
-    
+
     #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-    
+
     /// Configuration options for Session Replay.
     @objc public var sessionReplay = SentryReplayOptions()
 
     #endif
-    
+
     /// When enabled, the SDK tracks performance for HTTP requests if auto performance tracking and
     /// @c enableSwizzling are enabled.
     /// @note The default is @c true.
@@ -421,7 +421,7 @@
         }
         return []
     }()
-    
+
     /// Adds an item to the list of inAppIncludes.
     /// - Parameter inAppInclude: The prefix of the framework name.
     @objc public func add(inAppInclude: String) {
@@ -456,7 +456,7 @@
     /// performance monitoring. The default is @c true.
     /// See: https://docs.sentry.io/platforms/apple/performance/
     @objc public var enableCoreDataTracing: Bool = true
-    
+
 #if !(os(watchOS) || os(tvOS) || os(visionOS))
 
     /// Configuration for the Sentry profiler.
@@ -476,7 +476,7 @@
 
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public var profiling: SentryProfileOptions?
-    
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public func isContinuousProfilingEnabled() -> Bool {
         profiling != nil
@@ -487,7 +487,7 @@
         profiling?.lifecycle == .trace
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
-    
+
     /// Whether to send client reports, which contain statistics about discarded events.
     /// @note The default is @c true.
     /// @see <https://develop.sentry.dev/sdk/client-reports/>
@@ -533,7 +533,7 @@
     ///
     /// @note Default value is @c false.
     @objc public var enablePropagateTraceparent: Bool = false
-    
+
     static let everythingAllowedRegex = try? NSRegularExpression(pattern: ".*", options: .caseInsensitive)
 
     /// An array of hosts or regexes that determines if outgoing HTTP requests will get
@@ -579,9 +579,9 @@
             }
         }
     }
-    
+
     #if canImport(MetricKit) && !os(tvOS)
-    
+
     /// Use this feature to enable the Sentry MetricKit integration.
     ///
     /// @brief When enabled, the SDK sends @c MXDiskWriteExceptionDiagnostic, @c MXCPUExceptionDiagnostic
@@ -591,15 +591,15 @@
     /// allows the Sentry SDK to apply the current data from the scope.
     /// @note This feature is disabled by default.
     @objc public var enableMetricKit = false
-    
+
     /// When enabled, the SDK adds the raw MXDiagnosticPayloads as an attachment to the converted
     /// SentryEvent. You need to enable @c enableMetricKit for this flag to work.
     ///
     /// @note Default value is @c false.
     @objc public var enableMetricKitRawPayload = false
-    
+
     #endif
-    
+
     /// @warning This is an experimental feature and may still have bugs.
     /// @brief By enabling this, every UIViewController tracing transaction will wait
     /// for a call to @c SentrySDK.reportFullyDisplayed().
@@ -673,12 +673,12 @@
 
     /// Options for experimental features that are subject to change.
     @objc public var experimental = SentryExperimentalOptions()
-    
+
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
-    
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public var userFeedbackConfiguration: SentryUserFeedbackConfiguration?
-    
+
     /// A block that configures the user feedback feature.
     ///
     /// Use this to customize the form shown by `SentrySDK.feedback.show()`,
@@ -693,12 +693,12 @@
         }
     }
     #endif
-    
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public static func isValidSampleRate(_ rate: NSNumber) -> Bool {
         rate.isValidSampleRate()
     }
-    
+
     // swiftlint:disable:next missing_docs
     @_spi(Private) @objc public static let defaultEnvironment = "production"
 
@@ -710,7 +710,6 @@
     /// - Important: Replaces `sendDefaultPii` with granular per-category control.
     /// - SeeAlso: https://docs.sentry.io/platforms/apple/configuration/options/#dataCollection
     public var dataCollection = SentryDataCollection.Options()
-
 #endif // SDK_V10
 
     // MARK: - Integration: Metrics

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -710,6 +710,10 @@
     /// - Important: Replaces `sendDefaultPii` with granular per-category control.
     /// - SeeAlso: https://docs.sentry.io/platforms/apple/configuration/options/#dataCollection
     public var dataCollection = SentryDataCollection.Options()
+
+    @objc internal var dataCollectionUserInfo: Bool {
+        dataCollection.userInfo
+    }
 #endif // SDK_V10
 
     // MARK: - Integration: Metrics

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -711,9 +711,6 @@
     /// - SeeAlso: https://docs.sentry.io/platforms/apple/configuration/options/#dataCollection
     public var dataCollection = SentryDataCollection.Options()
 
-    @objc internal var dataCollectionUserInfo: Bool {
-        dataCollection.userInfo
-    }
 #endif // SDK_V10
 
     // MARK: - Integration: Metrics

--- a/Sources/Swift/Protocol/SentrySDKSettings.swift
+++ b/Sources/Swift/Protocol/SentrySDKSettings.swift
@@ -8,8 +8,8 @@ struct SentrySDKSettings {
         autoInferIP = false
     }
 
-    init(sendDefaultPii: Bool) {
-        autoInferIP = sendDefaultPii
+    init(autoInferIP: Bool) {
+        self.autoInferIP = autoInferIP
     }
     
     init(dict: NSDictionary) {

--- a/Sources/Swift/Tools/TelemetryScopeApplier/SentryLogScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/SentryLogScopeApplier.swift
@@ -15,8 +15,8 @@ public protocol SentryLogScopeApplier {
 public class SentryDefaultLogScopeApplier: NSObject, SentryLogScopeApplier {
     private let metadata: TelemetryScopeMetadata
 
-    @objc public init(environment: String, releaseName: String?, cacheDirectoryPath: String, sendDefaultPii: Bool) {
-        self.metadata = SentryDefaultScopeApplyingMetadata(environment: environment, releaseName: releaseName, cacheDirectoryPath: cacheDirectoryPath, sendDefaultPii: sendDefaultPii)
+    @objc public init(environment: String, releaseName: String?, cacheDirectoryPath: String, shouldAddDefaultUserId: Bool) {
+        self.metadata = SentryDefaultScopeApplyingMetadata(environment: environment, releaseName: releaseName, cacheDirectoryPath: cacheDirectoryPath, shouldAddDefaultUserId: shouldAddDefaultUserId)
     }
 
     @objc public func applyScope(_ scope: Scope, toLog log: SentryLog) -> SentryLog {

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
@@ -133,6 +133,11 @@ extension TelemetryScopeApplier {
             return
         }
 
+#if SDK_V10
+        guard metadata.sendDefaultPii else {
+            return
+        }
+#endif // SDK_V10
         if let installationId = metadata.installationId {
             // We only want to set the id if the customer didn't set a user so we at least set something to
             // identify the user.

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
@@ -134,7 +134,7 @@ extension TelemetryScopeApplier {
         }
 
 #if SDK_V10
-        guard metadata.sendDefaultPii else {
+        guard metadata.shouldAddDefaultUserId else {
             return
         }
 #endif // SDK_V10

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeMetadata.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeMetadata.swift
@@ -6,21 +6,21 @@ protocol TelemetryScopeMetadata {
     var environment: String { get }
     var releaseName: String? { get }
     var installationId: String? { get }
-    var sendDefaultPii: Bool { get }
+    var shouldAddDefaultUserId: Bool { get }
 }
 
 struct SentryDefaultScopeApplyingMetadata: TelemetryScopeMetadata {
     let environment: String
     let releaseName: String?
-    let sendDefaultPii: Bool
+    let shouldAddDefaultUserId: Bool
 
     private let cacheDirectoryPath: String
 
-    init(environment: String, releaseName: String?, cacheDirectoryPath: String, sendDefaultPii: Bool) {
+    init(environment: String, releaseName: String?, cacheDirectoryPath: String, shouldAddDefaultUserId: Bool) {
         self.environment = environment
         self.releaseName = releaseName
         self.cacheDirectoryPath = cacheDirectoryPath
-        self.sendDefaultPii = sendDefaultPii
+        self.shouldAddDefaultUserId = shouldAddDefaultUserId
     }
 
     /// Returns the installation ID lazily to avoid file I/O on the calling thread.

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -59,8 +59,10 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(capturedMetric.value, .counter(1))
     }
 
-    #if SDK_V10
     func testAddMetric_whenDataCollectionUserInfoDisabled_shouldKeepUserProvidedEmail() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
         // -- Arrange --
         let client = try givenSdkWithHub { options in
             options.sendDefaultPii = true
@@ -86,8 +88,8 @@ class SentryMetricsIntegrationTests: XCTestCase {
         // -- Assert --
         let capturedMetric = try XCTUnwrap(client.testMetricsBuffer.addInvocations.first)
         XCTAssertEqual(capturedMetric.attributes["user.email"], .string("jane@example.com"))
+#endif
     }
-    #endif // SDK_V10
 
     func testAddMetric_whenNoClientAvailable_shouldDropMetricsSilently() throws {
         // -- Arrange --

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -59,6 +59,36 @@ class SentryMetricsIntegrationTests: XCTestCase {
         XCTAssertEqual(capturedMetric.value, .counter(1))
     }
 
+    #if SDK_V10
+    func testAddMetric_whenDataCollectionUserInfoDisabled_shouldKeepUserProvidedEmail() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub { options in
+            options.sendDefaultPii = true
+            options.dataCollection.userInfo = false
+        }
+        let integration = try getSut()
+        let user = User()
+        user.email = "jane@example.com"
+        let scope = Scope()
+        scope.setUser(user)
+        let metric = SentryMetric(
+            timestamp: Date(),
+            traceId: SentryId(),
+            name: "test.metric",
+            value: .counter(1),
+            unit: nil,
+            attributes: [:]
+        )
+
+        // -- Act --
+        integration.addMetric(metric, scope: scope)
+
+        // -- Assert --
+        let capturedMetric = try XCTUnwrap(client.testMetricsBuffer.addInvocations.first)
+        XCTAssertEqual(capturedMetric.attributes["user.email"], .string("jane@example.com"))
+    }
+    #endif // SDK_V10
+
     func testAddMetric_whenNoClientAvailable_shouldDropMetricsSilently() throws {
         // -- Arrange --
         try givenSdkWithHub()

--- a/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
@@ -82,7 +82,7 @@ class SentrySDKSettingsTests: XCTestCase {
     }
     
     func testSerialize_WhenAutoInferIPIsSetDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings(sendDefaultPii: true)
+        let settings = SentrySDKSettings(autoInferIP: true)
         
         let serialized = settings.serialize()
         
@@ -91,7 +91,7 @@ class SentrySDKSettingsTests: XCTestCase {
     }
     
     func testSerialize_WhenAutoInferIPIsSetToFalseDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings(sendDefaultPii: false)
+        let settings = SentrySDKSettings(autoInferIP: false)
         
         let serialized = settings.serialize()
         
@@ -108,11 +108,11 @@ class SentrySDKSettingsTests: XCTestCase {
         XCTAssertFalse(settings.autoInferIP)
         
         // Test setting to true
-        settings = SentrySDKSettings(sendDefaultPii: true)
+        settings = SentrySDKSettings(autoInferIP: true)
         XCTAssertTrue(settings.autoInferIP)
         
         // Test setting to false
-        settings = SentrySDKSettings(sendDefaultPii: false)
+        settings = SentrySDKSettings(autoInferIP: false)
         XCTAssertFalse(settings.autoInferIP)
     }
     

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -171,7 +171,7 @@ class SentrySdkInfoTests: XCTestCase {
     
     func testInitWithDict_SdkInfo() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings(sendDefaultPii: true)
+        let settings = SentrySDKSettings(autoInferIP: true)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,
@@ -291,7 +291,7 @@ class SentrySdkInfoTests: XCTestCase {
 
     func testInitWithDict_WrongTypesInArrays() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings(sendDefaultPii: false)
+        let settings = SentrySDKSettings(autoInferIP: false)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,
@@ -367,6 +367,25 @@ class SentrySdkInfoTests: XCTestCase {
         XCTAssertEqual(actual.packages.count, 2)
         XCTAssertTrue(actual.packages.contains(extraPackage))
         XCTAssertTrue(actual.packages.contains(["name": "cocoapods:getsentry/\(SentryMeta.sdkName)", "version": SentryMeta.versionString]))
+    }
+
+    func testInitWithOptions_whenDataCollectionUserInfoIsEnabledByDefault_shouldAutoInferIP() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        XCTAssertTrue(SentrySdkInfo(withOptions: Options()).settings.autoInferIP)
+#endif
+    }
+
+    func testInitWithOptions_whenDataCollectionUserInfoIsDisabled_shouldNotAutoInferIP() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        let options = Options()
+        options.dataCollection.userInfo = false
+
+        XCTAssertFalse(SentrySdkInfo(withOptions: options).settings.autoInferIP)
+#endif
     }
 
     func testSerializationIncludesSettings() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2227,8 +2227,10 @@ final class SentryClientTests: XCTestCase {
         XCTAssertEqual(fixture.user.email, actual.user?.email)
     }
     
-    #if !SDK_V10
     func testSendDefaultPiiEnabled_GivenNoIP_sdkIPIsAuto() throws {
+#if SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
         fixture.getSut(configureOptions: { options in
             options.sendDefaultPii = true
         }).capture(message: "any")
@@ -2239,20 +2241,26 @@ final class SentryClientTests: XCTestCase {
         XCTAssertNotNil(sdk["settings"])
         let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
         XCTAssertEqual(settings["infer_ip"] as? String, "auto")
+#endif
     }
-    #endif // !SDK_V10
 
-    #if SDK_V10
     func testDataCollectionUserInfoEnabledByDefault_GivenNoIP_sdkIPIsAuto() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
         fixture.getSut().capture(message: "any")
 
         let actual = try lastSentEvent()
         let sdk = try XCTUnwrap(actual.sdk)
         let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
         XCTAssertEqual(settings["infer_ip"] as? String, "auto")
+#endif
     }
 
     func testDataCollectionUserInfoDisabled_GivenSendDefaultPiiEnabled_sdkIPIsNever() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
         fixture.getSut(configureOptions: { options in
             options.sendDefaultPii = true
             options.dataCollection.userInfo = false
@@ -2262,8 +2270,8 @@ final class SentryClientTests: XCTestCase {
         let sdk = try XCTUnwrap(actual.sdk)
         let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
         XCTAssertEqual(settings["infer_ip"] as? String, "never")
+#endif
     }
-    #endif // SDK_V10
     
     func testSendDefaultPiiEnabled_GivenIP_IPAddressNotChanged() throws {
         let scope = Scope()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2205,6 +2205,37 @@ final class SentryClientTests: XCTestCase {
         XCTAssertEqual(SentryInstallation.id(withCacheDirectoryPath: options.cacheDirectoryPath), actual.user?.userId)
     }
     
+    func testInstallationIdNotSetWhenDataCollectionUserInfoDisabled() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        fixture.getSut(configureOptions: { options in
+            options.dataCollection.userInfo = false
+        }).capture(message: "any message")
+
+        let actual = try lastSentEvent()
+        XCTAssertNil(actual.user)
+#endif
+    }
+
+    func testExplicitUserIsSetWhenDataCollectionUserInfoDisabled() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        let scope = Scope()
+        let user = User()
+        user.email = "jane@example.com"
+        scope.setUser(user)
+
+        fixture.getSut(configureOptions: { options in
+            options.dataCollection.userInfo = false
+        }).capture(message: "any message", scope: scope)
+
+        let actual = try lastSentEvent()
+        XCTAssertEqual(actual.user?.email, "jane@example.com")
+#endif
+    }
+
     func testInstallationIdNotSetWhenUserIsSetWithoutId() throws {
         let scope = fixture.scope
         scope.setUser(fixture.user)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2227,6 +2227,7 @@ final class SentryClientTests: XCTestCase {
         XCTAssertEqual(fixture.user.email, actual.user?.email)
     }
     
+    #if !SDK_V10
     func testSendDefaultPiiEnabled_GivenNoIP_sdkIPIsAuto() throws {
         fixture.getSut(configureOptions: { options in
             options.sendDefaultPii = true
@@ -2239,6 +2240,30 @@ final class SentryClientTests: XCTestCase {
         let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
         XCTAssertEqual(settings["infer_ip"] as? String, "auto")
     }
+    #endif // !SDK_V10
+
+    #if SDK_V10
+    func testDataCollectionUserInfoEnabledByDefault_GivenNoIP_sdkIPIsAuto() throws {
+        fixture.getSut().capture(message: "any")
+
+        let actual = try lastSentEvent()
+        let sdk = try XCTUnwrap(actual.sdk)
+        let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
+        XCTAssertEqual(settings["infer_ip"] as? String, "auto")
+    }
+
+    func testDataCollectionUserInfoDisabled_GivenSendDefaultPiiEnabled_sdkIPIsNever() throws {
+        fixture.getSut(configureOptions: { options in
+            options.sendDefaultPii = true
+            options.dataCollection.userInfo = false
+        }).capture(message: "any")
+
+        let actual = try lastSentEvent()
+        let sdk = try XCTUnwrap(actual.sdk)
+        let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
+        XCTAssertEqual(settings["infer_ip"] as? String, "never")
+    }
+    #endif // SDK_V10
     
     func testSendDefaultPiiEnabled_GivenIP_IPAddressNotChanged() throws {
         let scope = Scope()

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -542,7 +542,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertNil(item.attributesDict["user.id"])
     }
 
-    func testApplyToItem_whenSendDefaultPiiFalse_withoutUser_shouldStillAddInstallationIdAsUserId() {
+    func testApplyToItem_whenSendDefaultPiiFalse_withoutUser_shouldHandleInstallationIdForBuild() {
         // -- Arrange --
         let scope = TestScope(propagationContextTraceId: SentryId())
         let metadata = createTestMetadata(
@@ -555,7 +555,11 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata)
 
         // -- Assert --
+#if SDK_V10
+        XCTAssertNil(item.attributesDict["user.id"])
+#else
         XCTAssertEqual(item.attributesDict["user.id"], .string("installation-456"))
+#endif // SDK_V10
         XCTAssertNil(item.attributesDict["user.name"])
         XCTAssertNil(item.attributesDict["user.email"])
     }

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -30,7 +30,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         let environment: String
         let releaseName: String?
         let installationId: String?
-        let sendDefaultPii: Bool
+        let shouldAddDefaultUserId: Bool
     }
 
     private struct TestScope: TelemetryScopeApplier {
@@ -420,7 +420,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertNil(item.attributesDict["user.email"])
     }
 
-    func testApplyToItem_whenSendDefaultPiiFalse_shouldStillAddUserAttributes() {
+    func testApplyToItem_whenDefaultUserIdDisabled_shouldStillAddUserAttributes() {
         // -- Arrange --
         let user = User(userId: "user-123")
         user.name = "John Doe"
@@ -431,7 +431,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         )
         let metadata = createTestMetadata(
             installationId: "installation-123",
-            sendDefaultPii: false
+            shouldAddDefaultUserId: false
         )
         var item = createTestItem()
 
@@ -439,7 +439,7 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata)
 
         // -- Assert --
-        // User attributes are applied regardless of sendDefaultPII
+        // Explicit user attributes are applied regardless of automatic user-ID enrichment.
         XCTAssertEqual(item.attributesDict["user.id"], .string("user-123"))
         XCTAssertEqual(item.attributesDict["user.name"], .string("John Doe"))
         XCTAssertEqual(item.attributesDict["user.email"], .string("john@example.com"))
@@ -542,12 +542,12 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertNil(item.attributesDict["user.id"])
     }
 
-    func testApplyToItem_whenSendDefaultPiiFalse_withoutUser_shouldHandleInstallationIdForBuild() {
+    func testApplyToItem_whenDefaultUserIdDisabled_withoutUser_shouldHandleInstallationIdForBuild() {
         // -- Arrange --
         let scope = TestScope(propagationContextTraceId: SentryId())
         let metadata = createTestMetadata(
             installationId: "installation-456",
-            sendDefaultPii: false
+            shouldAddDefaultUserId: false
         )
         var item = createTestItem()
 
@@ -798,13 +798,13 @@ final class TelemetryScopeApplierTests: XCTestCase {
         environment: String = "test-environment",
         releaseName: String? = "test-release",
         installationId: String? = "test-installation-id",
-        sendDefaultPii: Bool = true
+        shouldAddDefaultUserId: Bool = true
     ) -> TestMetadata {
         return TestMetadata(
             environment: environment,
             releaseName: releaseName,
             installationId: installationId,
-            sendDefaultPii: sendDefaultPii
+            shouldAddDefaultUserId: shouldAddDefaultUserId
         )
     }
 }


### PR DESCRIPTION
## 📜 Description

Enable the V10 `options.dataCollection` defaults for automatic user information and URL query parameter collection.

`dataCollection.userInfo` now controls generated installation-ID enrichment for events, logs, and metrics, plus `sdk.settings.infer_ip`. Explicit user data supplied through `setUser()` remains attached. Network spans, breadcrumbs, and failed-request events apply `dataCollection.urlQueryParams` filtering.

## 💡 Motivation and Context

This implements the user-identity and query-parameter portions of the [default collection behavior](<https://develop.sentry.dev/sdk/foundations/client/data-collection/#collection-defaults>) and the [`dataCollection` options](<https://develop.sentry.dev/sdk/foundations/client/data-collection/#datacollection-options>).

Automatic user data is gated at collection time, while [user-set data remains attached](<https://develop.sentry.dev/sdk/foundations/client/data-collection/#user-set-data-scrubbing>). Query parameter values use the [sensitive denylist](<https://develop.sentry.dev/sdk/foundations/client/data-collection/#sensitive-denylist>) and configured allow or deny behavior.

V10 reads `dataCollection` directly. V9 continues to use `sendDefaultPii` unchanged.

Fixes getsentry/sentry-cocoa#8254  <br>Fixes getsentry/sentry-cocoa#8249

## 💚 How did you test it?

* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySdkInfoTests,SentryTests/SentrySDKSettingsTests,SentryTests/SentryClientTests`
* `make test-ios-v10 FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryClientTests,SentryTests/SentryMetricsIntegrationTests,SentryTests/TelemetryScopeApplierTests,SentryTests/SentrySdkInfoTests,SentryTests/SentrySDKSettingsTests`
* `make format`
* `make generate-public-api`

## :pencil: Checklist

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

#skip-changelog