### PR TITLE
dx(lint): add common worktree paths to swiftlint excludes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,8 @@ excluded:
   # Exclude auto-generated files from sample app builds
   - "**/Build/Intermediates.noindex/iOS-Swift.build/**/DerivedSources/**"
   - "**/Build/Intermediates.noindex/iOS-SwiftClip.build/**/DerivedSources/**"
+  - "**/worktree/**"
+  - "**/worktrees/**"
 
 only_rules:
   - class_delegate_protocol


### PR DESCRIPTION
## 📜 Description

Add common worktree paths to SwiftLint's exclude path.

## 💡 Motivation and Context

git worktrees that are in the same folder (i.e. when created by some AI tooling or through personal preference) would have swiftlints rules run against them - this can mean that builds (since they invoke swiftlint) fail due to an unrelated change in another copy of the code.

## 💚 How did you test it?

Ran without the change and a worktree in the same folder with a lint error -> blocked build  <br>Ran with the change and a worktree in the same folder -> unblocked build, much happiness.

#skip-changelog

Closes getsentry/sentry-cocoa#8419