### PR TITLE
ref: track explicit option assignments

### DIFF
--- a/Sources/Swift/DataCollection/SentryDataCollection+Options.swift
+++ b/Sources/Swift/DataCollection/SentryDataCollection+Options.swift
@@ -16,7 +16,11 @@ extension SentryDataCollection {
         /// Does **not** gate data explicitly set via `SentrySDK.setUser()`, which is always attached.
         ///
         /// Defaults to `true`.
-        public var userInfo: Bool
+        public var userInfo: Bool {
+            get { _userInfo.value }
+            set { _userInfo.value = newValue }
+        }
+        var _userInfo: SentryModifiable<Bool>
 
         /// Controls cookie collection. All cookie key names are always included; the SDK scrubs values
         /// for keys matching the sensitive denylist or custom allow/deny terms.
@@ -91,7 +95,7 @@ extension SentryDataCollection {
             stackFrameVariables: Bool = true,
             frameContextLines: UInt = 5
         ) {
-            self.userInfo = userInfo
+            self._userInfo = .init(userInfo)
             self.cookies = cookies
             self.httpHeaders = httpHeaders
             self.httpBodies = httpBodies
@@ -101,5 +105,11 @@ extension SentryDataCollection {
             self.stackFrameVariables = stackFrameVariables
             self.frameContextLines = frameContextLines
         }
+    }
+}
+
+extension SentryDataCollection.Options: SentryRecursiveModifiable {
+    mutating func markRecursivelyAsModified() {
+        _userInfo.markAsModified()
     }
 }

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -247,7 +247,11 @@
     /// the user address. Due to backward compatibility concerns, Sentry sets sdk.settings.infer_ip to
     /// auto out of the box for Cocoa. If you want to stop Sentry from using the connections IP address,
     /// you have to enable Prevent Storing of IP Addresses in your project settings in Sentry.
-    @objc public var sendDefaultPii: Bool = false
+    @objc public var sendDefaultPii: Bool {
+        get { _sendDefaultPii.value }
+        set { _sendDefaultPii.value = newValue }
+    }
+    var _sendDefaultPii = SentryModifiable(false)
 
     /// When enabled, the SDK tracks performance for UIViewController subclasses and HTTP requests
     /// automatically. It also measures the app start and slow and frozen frames.
@@ -672,8 +676,12 @@
     }
 
     /// Options for experimental features that are subject to change.
-    @objc public var experimental = SentryExperimentalOptions()
-    
+    @objc public var experimental: SentryExperimentalOptions {
+        get { _experimental.value }
+        set { _experimental.setRecursivelyModifiedValue(newValue) }
+    }
+    var _experimental = SentryModifiable<SentryExperimentalOptions>(.init())
+
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
     
     // swiftlint:disable:next missing_docs

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -20,7 +20,11 @@ public final class SentryExperimentalOptions: NSObject {
     ///
     /// - Important: Replaces `sendDefaultPii` with granular per-category control.
     /// - SeeAlso: https://docs.sentry.io/platforms/apple/configuration/options/#dataCollection
-    public var dataCollection = SentryDataCollection.Options()
+    public var dataCollection: SentryDataCollection.Options {
+        get { _dataCollection.value }
+        set { _dataCollection.setRecursivelyModifiedValue(newValue) }
+    }
+    var _dataCollection = SentryModifiable<SentryDataCollection.Options>(.init())
 
     /**
      * When enabled, the SDK sends a standalone app start transaction instead of attaching app
@@ -30,5 +34,11 @@ public final class SentryExperimentalOptions: NSObject {
 
     // swiftlint:disable:next missing_docs
     @_spi(Private) public func validateOptions(_ options: [String: Any]?) {
+    }
+}
+
+extension SentryExperimentalOptions: SentryRecursiveModifiable {
+    func markRecursivelyAsModified() {
+        _dataCollection.markRecursivelyAsModified()
     }
 }

--- a/Sources/Swift/Utils/SentryModifiable.swift
+++ b/Sources/Swift/Utils/SentryModifiable.swift
@@ -1,9 +1,10 @@
 struct SentryModifiable<Value> {
     private var _value: Value
-    private(set) var isModified = false
+    private(set) var isModified: Bool
 
-    init(_ value: Value) {
+    init(_ value: Value, isModified: Bool = false) {
         self._value = value
+        self.isModified = isModified
     }
 
     var value: Value {

--- a/Sources/Swift/Utils/SentryModifiable.swift
+++ b/Sources/Swift/Utils/SentryModifiable.swift
@@ -1,0 +1,40 @@
+struct SentryModifiable<Value> {
+    private var _value: Value
+    private(set) var isModified = false
+
+    init(_ value: Value) {
+        self._value = value
+    }
+
+    var value: Value {
+        get { _value }
+        set {
+            _value = newValue
+            isModified = true
+        }
+    }
+
+    mutating func markAsModified() {
+        isModified = true
+    }
+}
+
+extension SentryModifiable where Value: SentryRecursiveModifiable {
+    mutating func setRecursivelyModifiedValue(_ newValue: Value) {
+        var newValue = newValue
+        newValue.markRecursivelyAsModified()
+        _value = newValue
+        isModified = true
+    }
+
+    mutating func markRecursivelyAsModified() {
+        _value.markRecursivelyAsModified()
+        isModified = true
+    }
+}
+
+extension SentryModifiable: Equatable where Value: Equatable {}
+
+protocol SentryRecursiveModifiable {
+    mutating func markRecursivelyAsModified()
+}

--- a/Tests/SentryTests/DataCollection/SentryDataCollectionOptionsTests.swift
+++ b/Tests/SentryTests/DataCollection/SentryDataCollectionOptionsTests.swift
@@ -68,6 +68,39 @@ class SentryDataCollectionOptionsTests: XCTestCase {
         XCTAssertFalse(options.experimental.dataCollection.userInfo)
     }
 
+    // MARK: - Modification Tracking
+
+    func testInit_withoutArguments_shouldNotMarkUserInfoAsModified() {
+        // -- Arrange --
+        let options = SentryDataCollection.Options()
+
+        // -- Assert --
+        XCTAssertFalse(options._userInfo.isModified)
+    }
+
+    func testUserInfo_whenSet_shouldMarkAsModified() {
+        // -- Arrange --
+        var options = SentryDataCollection.Options()
+
+        // -- Act --
+        options.userInfo = false
+
+        // -- Assert --
+        XCTAssertTrue(options._userInfo.isModified)
+    }
+
+    func testDataCollection_whenSet_shouldMarkDataCollectionAndUserInfoAsModified() {
+        // -- Arrange --
+        let experimental = SentryExperimentalOptions()
+
+        // -- Act --
+        experimental.dataCollection = SentryDataCollection.Options()
+
+        // -- Assert --
+        XCTAssertTrue(experimental._dataCollection.isModified)
+        XCTAssertTrue(experimental.dataCollection._userInfo.isModified)
+    }
+
     // MARK: - Equatable
 
     func testEquatable_defaultInstances_shouldBeEqual() {

--- a/Tests/SentryTests/Swift/OptionsTests.swift
+++ b/Tests/SentryTests/Swift/OptionsTests.swift
@@ -1,0 +1,29 @@
+@testable import Sentry
+import XCTest
+
+class OptionsTests: XCTestCase {
+
+    func testSendDefaultPii_whenSet_shouldMarkAsModified() {
+        // -- Arrange --
+        let sut = Options()
+
+        // -- Act --
+        sut.sendDefaultPii = true
+
+        // -- Assert --
+        XCTAssertTrue(sut._sendDefaultPii.isModified)
+    }
+
+    func testExperimental_whenSet_shouldMarkExperimentalDataCollectionAndUserInfoAsModified() {
+        // -- Arrange --
+        let sut = Options()
+
+        // -- Act --
+        sut.experimental = SentryExperimentalOptions()
+
+        // -- Assert --
+        XCTAssertTrue(sut._experimental.isModified)
+        XCTAssertTrue(sut.experimental._dataCollection.isModified)
+        XCTAssertTrue(sut.experimental.dataCollection._userInfo.isModified)
+    }
+}

--- a/Tests/SentryTests/Swift/SentryExperimentalOptionsTests.swift
+++ b/Tests/SentryTests/Swift/SentryExperimentalOptionsTests.swift
@@ -1,0 +1,17 @@
+@testable import Sentry
+import XCTest
+
+class SentryExperimentalOptionsTests: XCTestCase {
+
+    func testMarkRecursivelyAsModified_shouldMarkDataCollectionAndUserInfoAsModified() {
+        // -- Arrange --
+        let sut = SentryExperimentalOptions()
+
+        // -- Act --
+        sut.markRecursivelyAsModified()
+
+        // -- Assert --
+        XCTAssertTrue(sut._dataCollection.isModified)
+        XCTAssertTrue(sut.dataCollection._userInfo.isModified)
+    }
+}

--- a/Tests/SentryTests/Swift/Tools/SentryModifiableTests.swift
+++ b/Tests/SentryTests/Swift/Tools/SentryModifiableTests.swift
@@ -28,6 +28,15 @@ class SentryModifiableTests: XCTestCase {
         XCTAssertTrue(sut.isModified)
     }
 
+    func testInit_whenModifiedStateIsProvided_shouldUseModifiedState() {
+        // -- Arrange --
+        let sut = SentryModifiable(false, isModified: true)
+
+        // -- Assert --
+        XCTAssertFalse(sut.value)
+        XCTAssertTrue(sut.isModified)
+    }
+
     func testSetRecursivelyModifiedValue_whenSet_shouldMarkValueAndDescendantsAsModified() {
         // -- Arrange --
         var sut = SentryModifiable(TestRecursiveModifiable())

--- a/Tests/SentryTests/Swift/Tools/SentryModifiableTests.swift
+++ b/Tests/SentryTests/Swift/Tools/SentryModifiableTests.swift
@@ -1,0 +1,62 @@
+@testable import Sentry
+import XCTest
+
+class SentryModifiableTests: XCTestCase {
+
+    func testValue_whenSet_shouldMarkAsModified() {
+        // -- Arrange --
+        var sut = SentryModifiable(false)
+
+        // -- Act --
+        sut.value = true
+
+        // -- Assert --
+        XCTAssertTrue(sut.value)
+        XCTAssertTrue(sut.isModified)
+    }
+
+    func testValue_whenResetToOriginalValue_shouldRemainModified() {
+        // -- Arrange --
+        var sut = SentryModifiable(false)
+        sut.value = true
+
+        // -- Act --
+        sut.value = false
+
+        // -- Assert --
+        XCTAssertFalse(sut.value)
+        XCTAssertTrue(sut.isModified)
+    }
+
+    func testSetRecursivelyModifiedValue_whenSet_shouldMarkValueAndDescendantsAsModified() {
+        // -- Arrange --
+        var sut = SentryModifiable(TestRecursiveModifiable())
+
+        // -- Act --
+        sut.setRecursivelyModifiedValue(TestRecursiveModifiable())
+
+        // -- Assert --
+        XCTAssertTrue(sut.isModified)
+        XCTAssertTrue(sut.value.child.isModified)
+    }
+
+    func testMarkRecursivelyAsModified_shouldMarkValueAndDescendantsAsModified() {
+        // -- Arrange --
+        var sut = SentryModifiable(TestRecursiveModifiable())
+
+        // -- Act --
+        sut.markRecursivelyAsModified()
+
+        // -- Assert --
+        XCTAssertTrue(sut.isModified)
+        XCTAssertTrue(sut.value.child.isModified)
+    }
+
+    private struct TestRecursiveModifiable: SentryRecursiveModifiable {
+        var child = SentryModifiable(false)
+
+        mutating func markRecursivelyAsModified() {
+            child.markAsModified()
+        }
+    }
+}

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -24803,7 +24803,6 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvg",
                 "moduleName": "Sentry",
@@ -24831,11 +24830,11 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvs",
                 "moduleName": "Sentry",
                 "name": "Set",
+                "objc_name": "setExperimental:",
                 "printedName": "Set()",
                 "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setExperimental:"
               }
@@ -24850,11 +24849,9 @@
             ],
             "declAttributes": [
               "Final",
-              "HasStorage",
               "ObjC"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvp",
             "moduleName": "Sentry",
@@ -26628,7 +26625,6 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvg",
                 "moduleName": "Sentry",
@@ -26656,11 +26652,11 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvs",
                 "moduleName": "Sentry",
                 "name": "Set",
+                "objc_name": "setSendDefaultPii:",
                 "printedName": "Set()",
                 "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setSendDefaultPii:"
               }
@@ -26675,11 +26671,9 @@
             ],
             "declAttributes": [
               "Final",
-              "HasStorage",
               "ObjC"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvp",
             "moduleName": "Sentry",
@@ -38312,7 +38306,6 @@
                       }
                     ],
                     "declKind": "Accessor",
-                    "implicit": true,
                     "kind": "Accessor",
                     "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvg",
                     "moduleName": "Sentry",
@@ -38336,7 +38329,6 @@
                       }
                     ],
                     "declKind": "Accessor",
-                    "implicit": true,
                     "kind": "Accessor",
                     "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvs",
                     "moduleName": "Sentry",
@@ -38353,11 +38345,7 @@
                     "usr": "s:Sb"
                   }
                 ],
-                "declAttributes": [
-                  "HasStorage"
-                ],
                 "declKind": "Var",
-                "hasStorage": true,
                 "kind": "Var",
                 "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvp",
                 "moduleName": "Sentry",
@@ -39333,7 +39321,6 @@
                   "Final"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvg",
                 "moduleName": "Sentry",
@@ -39360,7 +39347,6 @@
                   "Final"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvs",
                 "moduleName": "Sentry",
@@ -39378,11 +39364,9 @@
               }
             ],
             "declAttributes": [
-              "Final",
-              "HasStorage"
+              "Final"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvp",
             "moduleName": "Sentry",

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -24803,7 +24803,6 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvg",
                 "moduleName": "Sentry",
@@ -24831,11 +24830,11 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvs",
                 "moduleName": "Sentry",
                 "name": "Set",
+                "objc_name": "setExperimental:",
                 "printedName": "Set()",
                 "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setExperimental:"
               }
@@ -24850,11 +24849,9 @@
             ],
             "declAttributes": [
               "Final",
-              "HasStorage",
               "ObjC"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry7OptionsC12experimentalAA0a12ExperimentalB0Cvp",
             "moduleName": "Sentry",
@@ -26447,7 +26444,6 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvg",
                 "moduleName": "Sentry",
@@ -26475,11 +26471,11 @@
                   "ObjC"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvs",
                 "moduleName": "Sentry",
                 "name": "Set",
+                "objc_name": "setSendDefaultPii:",
                 "printedName": "Set()",
                 "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setSendDefaultPii:"
               }
@@ -26494,11 +26490,9 @@
             ],
             "declAttributes": [
               "Final",
-              "HasStorage",
               "ObjC"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry7OptionsC14sendDefaultPiiSbvp",
             "moduleName": "Sentry",
@@ -38131,7 +38125,6 @@
                       }
                     ],
                     "declKind": "Accessor",
-                    "implicit": true,
                     "kind": "Accessor",
                     "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvg",
                     "moduleName": "Sentry",
@@ -38155,7 +38148,6 @@
                       }
                     ],
                     "declKind": "Accessor",
-                    "implicit": true,
                     "kind": "Accessor",
                     "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvs",
                     "moduleName": "Sentry",
@@ -38172,11 +38164,7 @@
                     "usr": "s:Sb"
                   }
                 ],
-                "declAttributes": [
-                  "HasStorage"
-                ],
                 "declKind": "Var",
-                "hasStorage": true,
                 "kind": "Var",
                 "mangledName": "$s6Sentry0A14DataCollectionO7OptionsV8userInfoSbvp",
                 "moduleName": "Sentry",
@@ -39152,7 +39140,6 @@
                   "Final"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvg",
                 "moduleName": "Sentry",
@@ -39179,7 +39166,6 @@
                   "Final"
                 ],
                 "declKind": "Accessor",
-                "implicit": true,
                 "kind": "Accessor",
                 "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvs",
                 "moduleName": "Sentry",
@@ -39197,11 +39183,9 @@
               }
             ],
             "declAttributes": [
-              "Final",
-              "HasStorage"
+              "Final"
             ],
             "declKind": "Var",
-            "hasStorage": true,
             "kind": "Var",
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC14dataCollectionAA0a4DataE0O0C0Vvp",
             "moduleName": "Sentry",


### PR DESCRIPTION
## :scroll: Description

Add internal modification tracking for `sendDefaultPii` and the experimental data-collection hierarchy. Assigning `experimental` or `dataCollection` propagates explicit state to tracked descendants, and restoring a value to its default does not erase that state.

## :bulb: Motivation and Context

The forthcoming data-collection resolver needs to distinguish a value that merely has its default from one the user explicitly configured. Because data collection is currently experimental, an untouched experimental tree must not enable IP inference even though individual data-collection fields have defaults such as `userInfo: true`.

This tracking will let the resolver consume the values and modification flags for `sendDefaultPii` and `userInfo`, including configuration applied through `experimental` or `dataCollection` assignment. It establishes the precedence foundation without changing data-collection behavior in this PR.

Furthermore we do not want to use `

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- `make build-ios`
- `make test-ios ONLY_TESTING=SentryTests/SentryModifiableTests,SentryTests/SentryDataCollectionOptionsTests,SentryTests/SentryExperimentalOptionsTests,SentryTests/OptionsTests`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog