### PR TITLE
fix(data-collection): resolve IP inference from data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Session Replay now correctly reads the response `Content-Type` for HTTP/2 and HTTP/3, so it captures HTTP response bodies as it was supposed to (when body capturing is enabled via `options.sessionReplay.networkCaptureBodies`) (#8390)
 - Log the actual request error instead of `(null)` when a Spotlight request fails (#8401)
-- Resolve IP inference from experimental `dataCollection.userInfo`, with `sendDefaultPii` retained as a compatibility bridge (#8421)
+- Resolve IP inference from experimental `dataCollection.userInfo`, with `sendDefaultPii` retained as a compatibility bridge (#8422)
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Session Replay now correctly reads the response `Content-Type` for HTTP/2 and HTTP/3, so it captures HTTP response bodies as it was supposed to (when body capturing is enabled via `options.sessionReplay.networkCaptureBodies`) (#8390)
 - Log the actual request error instead of `(null)` when a Spotlight request fails (#8401)
+- Resolve IP inference from experimental `dataCollection.userInfo`, with `sendDefaultPii` retained as a compatibility bridge (#8421)
 
 ## Features
 

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -4,6 +4,12 @@
 #import "SentrySDK+Private.h"
 #import "SentrySwift.h"
 
+@interface SentryOptions (DataCollection)
+
+@property (nonatomic, readonly) BOOL resolvedAutoInferIP;
+
+@end
+
 @implementation SentryDependencyContainerSwiftHelper
 
 #if SENTRY_HAS_UIKIT
@@ -50,9 +56,9 @@
     return [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:options];
 }
 
-+ (BOOL)sendDefaultPii:(SentryOptions *)options
++ (BOOL)autoInferIP:(SentryOptions *)options
 {
-    return options.sendDefaultPii;
+    return options.resolvedAutoInferIP;
 }
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSObject *_Nullable)beforeSendLog:(NSObject *)beforeSendLog options:(SentryOptionsObjC *)options;
 + (BOOL)enableLogs:(SentryOptionsObjC *)options;
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptionsObjC *)options;
-+ (BOOL)sendDefaultPii:(SentryOptionsObjC *)options;
++ (BOOL)autoInferIP:(SentryOptionsObjC *)options;
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block;

--- a/Sources/Swift/DataCollection/DataCollectionResolver.swift
+++ b/Sources/Swift/DataCollection/DataCollectionResolver.swift
@@ -1,0 +1,22 @@
+/// Resolves automatic user information collection for Data Collection spec v0.6.0.
+///
+/// See https://develop.sentry.dev/sdk/foundations/client/data-collection/.
+/// While `dataCollection` remains experimental in Cocoa, an untouched configuration
+/// does not enable collection. Explicit `userInfo` takes precedence over the legacy
+/// `sendDefaultPii` bridge.
+struct DataCollectionResolver {
+    static func resolveAutoInferIP(
+        sendDefaultPii: SentryModifiable<Bool>,
+        userInfo: SentryModifiable<Bool>
+    ) -> Bool {
+        if userInfo.isModified {
+            return userInfo.value
+        }
+
+        if sendDefaultPii.isModified {
+            return sendDefaultPii.value
+        }
+
+        return false
+    }
+}

--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -12,9 +12,9 @@ struct SentrySdkInfo {
     static func global() -> Self {
         if let options = SentrySDKInternal.currentHub().getClient()?.getOptions() {
             let enabledFeatures = SentryDependencyContainerSwiftHelper.enabledFeatures(options)
-            return Self(withEnabledFeatures: enabledFeatures, sendDefaultPii: SentryDependencyContainerSwiftHelper.sendDefaultPii(options))
+            return Self(withEnabledFeatures: enabledFeatures, autoInferIP: SentryDependencyContainerSwiftHelper.autoInferIP(options))
         }
-        return Self(withEnabledFeatures: [], sendDefaultPii: false)
+        return Self(withEnabledFeatures: [], autoInferIP: false)
     }
     
     /**
@@ -59,10 +59,10 @@ struct SentrySdkInfo {
     
     init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
-        self.init(withEnabledFeatures: features, sendDefaultPii: options?.sendDefaultPii ?? false)
+        self.init(withEnabledFeatures: features, autoInferIP: options?.resolvedAutoInferIP ?? false)
     }
 
-    init(withEnabledFeatures features: [String], sendDefaultPii: Bool) {
+    init(withEnabledFeatures features: [String], autoInferIP: Bool) {
         let integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()
         var packages = SentryExtraPackages.getPackages()
         let sdkPackage = SentrySdkPackage.global()
@@ -75,7 +75,7 @@ struct SentrySdkInfo {
             integrations: integrations,
             features: features,
             packages: Array(packages),
-            settings: SentrySDKSettings(sendDefaultPii: sendDefaultPii))
+            settings: SentrySDKSettings(autoInferIP: autoInferIP))
     }
     
     init(name: String?, version: String?, integrations: [String]?, features: [String]?, packages: [[String: String]]?, settings: SentrySDKSettings) {

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -242,11 +242,9 @@
 
     /// When enabled, the SDK sends personal identifiable along with events.
     /// @note The default is @c false.
-    /// @discussion When the user of an event doesn't contain an IP address, and this flag is @c true, the
-    /// SDK sets sdk.settings.infer_ip to auto to instruct the server to use the connection IP address as
-    /// the user address. Due to backward compatibility concerns, Sentry sets sdk.settings.infer_ip to
-    /// auto out of the box for Cocoa. If you want to stop Sentry from using the connections IP address,
-    /// you have to enable Prevent Storing of IP Addresses in your project settings in Sentry.
+    /// @discussion While data collection remains experimental, this provides a backwards-compatible
+    /// fallback for automatic user information, including connection IP inference. Explicit
+    /// ``SentryDataCollection/Options/userInfo`` configuration takes precedence.
     @objc public var sendDefaultPii: Bool {
         get { _sendDefaultPii.value }
         set { _sendDefaultPii.value = newValue }
@@ -681,6 +679,13 @@
         set { _experimental.setRecursivelyModifiedValue(newValue) }
     }
     var _experimental = SentryModifiable<SentryExperimentalOptions>(.init())
+
+    @objc var resolvedAutoInferIP: Bool {
+        DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: _sendDefaultPii,
+            userInfo: _experimental.value._dataCollection.value._userInfo
+        )
+    }
 
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
     

--- a/Sources/Swift/Protocol/SentrySDKSettings.swift
+++ b/Sources/Swift/Protocol/SentrySDKSettings.swift
@@ -8,8 +8,8 @@ struct SentrySDKSettings {
         autoInferIP = false
     }
 
-    init(sendDefaultPii: Bool) {
-        autoInferIP = sendDefaultPii
+    init(autoInferIP: Bool) {
+        self.autoInferIP = autoInferIP
     }
     
     init(dict: NSDictionary) {

--- a/Tests/SentryTests/DataCollection/DataCollectionResolverTests.swift
+++ b/Tests/SentryTests/DataCollection/DataCollectionResolverTests.swift
@@ -1,0 +1,50 @@
+@_spi(Private) @testable import Sentry
+import XCTest
+
+final class DataCollectionResolverTests: XCTestCase {
+
+    func testResolveAutoInferIP_whenNoOptionIsModified_shouldReturnFalse() {
+        let result = DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: SentryModifiable(false),
+            userInfo: SentryModifiable(true)
+        )
+
+        XCTAssertFalse(result)
+    }
+
+    func testResolveAutoInferIP_whenSendDefaultPiiIsExplicitlyEnabled_shouldReturnTrue() {
+        let result = DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: SentryModifiable(true, isModified: true),
+            userInfo: SentryModifiable(true)
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    func testResolveAutoInferIP_whenSendDefaultPiiIsExplicitlyDisabled_shouldReturnFalse() {
+        let result = DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: SentryModifiable(false, isModified: true),
+            userInfo: SentryModifiable(true)
+        )
+
+        XCTAssertFalse(result)
+    }
+
+    func testResolveAutoInferIP_whenUserInfoIsExplicitlyEnabled_shouldReturnTrue() {
+        let result = DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: SentryModifiable(false),
+            userInfo: SentryModifiable(true, isModified: true)
+        )
+
+        XCTAssertTrue(result)
+    }
+
+    func testResolveAutoInferIP_whenUserInfoIsExplicitlyDisabled_shouldReturnFalse() {
+        let result = DataCollectionResolver.resolveAutoInferIP(
+            sendDefaultPii: SentryModifiable(true, isModified: true),
+            userInfo: SentryModifiable(false, isModified: true)
+        )
+
+        XCTAssertFalse(result)
+    }
+}

--- a/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySDKSettingsTests.swift
@@ -82,19 +82,19 @@ class SentrySDKSettingsTests: XCTestCase {
     }
     
     func testSerialize_WhenAutoInferIPIsSetDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings(sendDefaultPii: true)
-        
+        let settings = SentrySDKSettings(autoInferIP: true)
+
         let serialized = settings.serialize()
-        
+
         XCTAssertNotNil(serialized)
         XCTAssertEqual(serialized["infer_ip"] as? String, "auto")
     }
-    
+
     func testSerialize_WhenAutoInferIPIsSetToFalseDirectly_ReturnsCorrectDictionary() {
-        let settings = SentrySDKSettings(sendDefaultPii: false)
-        
+        let settings = SentrySDKSettings(autoInferIP: false)
+
         let serialized = settings.serialize()
-        
+
         XCTAssertNotNil(serialized)
         XCTAssertEqual(serialized["infer_ip"] as? String, "never")
     }
@@ -108,11 +108,11 @@ class SentrySDKSettingsTests: XCTestCase {
         XCTAssertFalse(settings.autoInferIP)
         
         // Test setting to true
-        settings = SentrySDKSettings(sendDefaultPii: true)
+        settings = SentrySDKSettings(autoInferIP: true)
         XCTAssertTrue(settings.autoInferIP)
-        
+
         // Test setting to false
-        settings = SentrySDKSettings(sendDefaultPii: false)
+        settings = SentrySDKSettings(autoInferIP: false)
         XCTAssertFalse(settings.autoInferIP)
     }
     

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -171,7 +171,7 @@ class SentrySdkInfoTests: XCTestCase {
     
     func testInitWithDict_SdkInfo() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings(sendDefaultPii: true)
+        let settings = SentrySDKSettings(autoInferIP: true)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,
@@ -291,7 +291,7 @@ class SentrySdkInfoTests: XCTestCase {
 
     func testInitWithDict_WrongTypesInArrays() {
         let version = "10.3.1"
-        let settings = SentrySDKSettings(sendDefaultPii: false)
+        let settings = SentrySDKSettings(autoInferIP: false)
         let expected = SentrySdkInfo(
             name: sdkName,
             version: version,
@@ -367,6 +367,68 @@ class SentrySdkInfoTests: XCTestCase {
         XCTAssertEqual(actual.packages.count, 2)
         XCTAssertTrue(actual.packages.contains(extraPackage))
         XCTAssertTrue(actual.packages.contains(["name": "cocoapods:getsentry/\(SentryMeta.sdkName)", "version": SentryMeta.versionString]))
+    }
+
+    func testInitWithOptions_whenDataCollectionIsUntouched_shouldNeverInferIP() {
+        let sdkInfo = SentrySdkInfo(withOptions: Options())
+
+        XCTAssertFalse(sdkInfo.settings.autoInferIP)
+    }
+
+    func testInitWithOptions_whenSendDefaultPiiIsEnabled_shouldAutoInferIP() {
+        let options = Options()
+        options.sendDefaultPii = true
+
+        let sdkInfo = SentrySdkInfo(withOptions: options)
+
+        XCTAssertTrue(sdkInfo.settings.autoInferIP)
+    }
+
+    func testInitWithOptions_whenUserInfoIsEnabled_shouldAutoInferIP() {
+        let options = Options()
+        options.experimental.dataCollection.userInfo = true
+
+        let sdkInfo = SentrySdkInfo(withOptions: options)
+
+        XCTAssertTrue(sdkInfo.settings.autoInferIP)
+    }
+
+    func testInitWithOptions_whenUserInfoIsDisabled_shouldNeverInferIP() {
+        let options = Options()
+        options.sendDefaultPii = true
+        options.experimental.dataCollection.userInfo = false
+
+        let sdkInfo = SentrySdkInfo(withOptions: options)
+
+        XCTAssertFalse(sdkInfo.settings.autoInferIP)
+    }
+
+    func testInitWithOptions_whenDataCollectionIsAssigned_shouldAutoInferIP() {
+        let options = Options()
+        options.experimental.dataCollection = .init()
+
+        let sdkInfo = SentrySdkInfo(withOptions: options)
+
+        XCTAssertTrue(sdkInfo.settings.autoInferIP)
+    }
+
+    func testInitWithOptions_whenExperimentalOptionsAreAssigned_shouldAutoInferIP() {
+        let options = Options()
+        options.experimental = SentryExperimentalOptions()
+
+        let sdkInfo = SentrySdkInfo(withOptions: options)
+
+        XCTAssertTrue(sdkInfo.settings.autoInferIP)
+    }
+
+    func testGlobal_whenUserInfoIsEnabled_shouldAutoInferIP() {
+        let options = Options()
+        options.experimental.dataCollection.userInfo = true
+        SentrySDK.start(options: options)
+
+        let sdkInfo = SentrySdkInfo.global()
+
+        XCTAssertTrue(sdkInfo.settings.autoInferIP)
     }
 
     func testSerializationIncludesSettings() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2235,17 +2235,47 @@ final class SentryClientTests: XCTestCase {
         XCTAssertEqual(fixture.user.email, actual.user?.email)
     }
     
+    func testDataCollectionUserInfoUntouched_GivenNoIP_sdkIPIsNever() throws {
+        fixture.getSut().capture(message: "any")
+
+        let actual = try lastSentEvent()
+        let settings = try sdkSettings(from: actual)
+
+        XCTAssertEqual(settings["infer_ip"] as? String, "never")
+    }
+
     func testSendDefaultPiiEnabled_GivenNoIP_sdkIPIsAuto() throws {
         fixture.getSut(configureOptions: { options in
             options.sendDefaultPii = true
         }).capture(message: "any")
-        
+
         let actual = try lastSentEvent()
-        XCTAssertNotNil(actual.sdk)
-        let sdk = try XCTUnwrap(actual.sdk)
-        XCTAssertNotNil(sdk["settings"])
-        let settings = try XCTUnwrap(sdk["settings"] as? [String: Any])
+        let settings = try sdkSettings(from: actual)
+
         XCTAssertEqual(settings["infer_ip"] as? String, "auto")
+    }
+
+    func testDataCollectionUserInfoEnabled_GivenNoIP_sdkIPIsAuto() throws {
+        fixture.getSut(configureOptions: { options in
+            options.experimental.dataCollection.userInfo = true
+        }).capture(message: "any")
+
+        let actual = try lastSentEvent()
+        let settings = try sdkSettings(from: actual)
+
+        XCTAssertEqual(settings["infer_ip"] as? String, "auto")
+    }
+
+    func testDataCollectionUserInfoDisabled_GivenNoIP_sdkIPIsNever() throws {
+        fixture.getSut(configureOptions: { options in
+            options.sendDefaultPii = true
+            options.experimental.dataCollection.userInfo = false
+        }).capture(message: "any")
+
+        let actual = try lastSentEvent()
+        let settings = try sdkSettings(from: actual)
+
+        XCTAssertEqual(settings["infer_ip"] as? String, "never")
     }
     
     func testSendDefaultPiiEnabled_GivenIP_IPAddressNotChanged() throws {
@@ -3038,6 +3068,11 @@ private extension SentryClientTests {
         let lastSentEventArguments = try XCTUnwrap(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
         XCTAssertEqual([TestData.dataAttachment], lastSentEventArguments.attachments)
         return lastSentEventArguments.event
+    }
+
+    private func sdkSettings(from event: Event) throws -> [String: Any] {
+        let sdk = try XCTUnwrap(event.sdk)
+        return try XCTUnwrap(sdk["settings"] as? [String: Any])
     }
 
     private func assertFeatureFlags(on event: Event) throws {


### PR DESCRIPTION
## :scroll: Description

Resolve `sdk.settings.infer_ip` from experimental `dataCollection.userInfo`. A pure resolver consumes the tracked legacy and data-collection values, then the resolved value flows through SDK-info serialization for both direct Swift options and the Objective-C global-options path.

## :bulb: Motivation and Context

`dataCollection.userInfo` is the granular replacement for the legacy `sendDefaultPii` setting. While data collection remains experimental in Cocoa, an untouched experimental tree must not opt in to IP inference. Explicit `userInfo` overrides `sendDefaultPii`, while an explicit legacy value remains a compatibility bridge when `userInfo` is untouched.

As soon as the options are moved out of experimental state, we will align with the latest specifications, allowing us to continously merge changes until then.

This stacks on #8420, which supplies the recursive explicit-assignment tracking required to distinguish an untouched default from a configured default. The generated API manifests are retained here by request, even though they describe the parent PR's public stored-to-computed property changes.

Fixes #8246

## :green_heart: How did you test it?

- `make format`
- `make test-ios ONLY_TESTING=SentryTests/DataCollectionResolverTests,SentryTests/SentrySdkInfoTests,SentryTests/SentrySDKSettingsTests,SentryTests/SentryClientTests,SentryTests/SentryDataCollectionOptionsTests,SentryTests/SentryExperimentalOptionsTests,SentryTests/OptionsTests,SentryTests/SentryModifiableTests`
- `make analyze`
- `make build-ios`
- `make generate-public-api`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
