### PR TITLE
build: reduce output for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,12 @@ search_issues  → check for new/regressed issues
 - **YAML tasks** — always use `yq`; do not shell out to `node` or `python` for YAML parsing
 - **GitHub** — prefer `gh` CLI over web scraping when interacting with GitHub.com
 
+## Agent Build and Test Output
+
+- Use `FOR_AGENTS=true` with SDK platform `make build-*` and `make test-*` targets to reduce terminal output.
+- Example: `make build-ios FOR_AGENTS=true` or `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests`.
+- If reduced output does not explain a failure, inspect the updated `raw-*-output.log` files in the repository root for complete diagnostics before retrying or changing code.
+
 ## Verification Loop
 
 Run before every commit. Stop at the first failure and fix before proceeding.
@@ -115,10 +121,10 @@ make format
 make analyze
 
 # 3. Build (at minimum iOS; ideally all platforms)
-make build-ios
+make build-ios FOR_AGENTS=true
 
 # 4. Test (targeted — see Tests/AGENTS.md for ONLY_TESTING usage)
-make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests
+make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests
 
 # 5. If the public API surface changed (Swift/ObjC public headers, @objc/public symbols)
 make generate-public-api  # regenerates sdk_api.json; commit any diff
@@ -133,15 +139,17 @@ make test-sample-iOS-Swift-ui  # if UI behavior changed
 
 ### Platform Decision Tree
 
-| Change scope                                                 | Build                                                                                                                | Test                                         |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| Feature code (no `#if os`)                                   | `make build-ios`                                                                                                     | `make test-ios`                              |
-| Platform-specific (`#if os(macOS)`)                          | Build that platform (e.g., `make build-macos`)                                                                       | Test that platform (e.g., `make test-macos`) |
-| Public API / core (`SentryHub`, `SentryClient`, `SentrySDK`) | `make build-ios` + `make build-macos`                                                                                | `make test-ios` (broad impact)               |
-| `SentryCrash` / C code                                       | `make build-ios` + `make build-macos`                                                                                | `make test-ios`                              |
-| `SentrySwiftUI`                                              | `make build-ios`                                                                                                     | `make test-ios`                              |
-| Build system / `Package.swift`                               | All platforms                                                                                                        | `make test`                                  |
-| Cross-platform concern                                       | All platforms (`make build-ios`, `make build-macos`, `make build-tvos`, `make build-watchos`, `make build-visionos`) | `make test`                                  |
+| Change scope                                                 | Build                                                                                                                                                                                                | Test                                                           |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Change scope                                                 | Build                                                                                                                                                                                                | Test                                                           |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------                                                                 | -------------------------------------------------------------- |
+| Feature code (no `#if os`)                                   | `make build-ios FOR_AGENTS=true`                                                                                                                                                                     | `make test-ios FOR_AGENTS=true`                                |
+| Platform-specific (`#if os(macOS)`)                          | Build that platform (e.g., `make build-macos FOR_AGENTS=true`)                                                                                                                                       | Test that platform (e.g., `make test-macos FOR_AGENTS=true`)   |
+| Public API / core (`SentryHub`, `SentryClient`, `SentrySDK`) | `make build-ios FOR_AGENTS=true` + `make build-macos FOR_AGENTS=true`                                                                                                                                | `make test-ios FOR_AGENTS=true` (broad impact)                 |
+| `SentryCrash` / C code                                       | `make build-ios FOR_AGENTS=true` + `make build-macos FOR_AGENTS=true`                                                                                                                                | `make test-ios FOR_AGENTS=true`                                |
+| `SentrySwiftUI`                                              | `make build-ios FOR_AGENTS=true`                                                                                                                                                                     | `make test-ios FOR_AGENTS=true`                                |
+| Build system / `Package.swift`                               | All platforms                                                                                                                                                                                        | `make test FOR_AGENTS=true`                                    |
+| Cross-platform concern                                       | All platforms (`make build-ios FOR_AGENTS=true`, `make build-macos FOR_AGENTS=true`, `make build-tvos FOR_AGENTS=true`, `make build-watchos FOR_AGENTS=true`, `make build-visionos FOR_AGENTS=true`) | `make test FOR_AGENTS=true`                                    |
 
 Ensure no new issues from: static analysis, thread/address/UB sanitizers, or cross-platform dependants (React Native, Flutter, .NET, Unity).
 
@@ -184,7 +192,7 @@ Non-changelog types require `#skip-changelog` in PR description. Breaking change
 
 ## CLI
 
-See `make help` and the Makefile for commands and documentation. Key targets: `make format`, `make analyze`, `make build-ios`, `make test-ios`, `make build-xcframework-dynamic`.
+See `make help` and the Makefile for commands and documentation. Key targets: `make format`, `make analyze`, `make build-ios FOR_AGENTS=true`, `make test-ios FOR_AGENTS=true`, `make build-xcframework-dynamic`.
 
 ## Shell Scripts
 

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ WATCHOS_DEVICE_NAME ?= Apple Watch SE 3 (44mm)
 # Current git reference name
 GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)
 
+# Reduce build and test output for agents while retaining raw xcodebuild logs.
+FOR_AGENTS ?= false
+export FOR_AGENTS
+XCBEAUTIFY_OUTPUT_FLAGS = $(if $(filter true,$(FOR_AGENTS)),--quieter --disable-logging,--preserve-unbeautified)
+
 # ============================================================================
 # SETUP
 # ============================================================================
@@ -201,7 +206,7 @@ build-watchos:
 		-scheme $(XCODE_SCHEME) \
 		-destination 'platform=watchOS Simulator,OS=$(WATCHOS_SIMULATOR_OS),name=$(WATCHOS_DEVICE_NAME)' \
 		-configuration Debug \
-		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | tee raw-build-output.log | xcbeautify $(XCBEAUTIFY_OUTPUT_FLAGS)
 
 ## Build all platforms with SDK_V10 flag
 #
@@ -293,7 +298,7 @@ build-watchos-v10:
 		-scheme SentryV10 \
 		-destination 'platform=watchOS Simulator,OS=$(WATCHOS_SIMULATOR_OS),name=$(WATCHOS_DEVICE_NAME)' \
 		-configuration DebugV10 \
-		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | tee raw-build-output.log | xcbeautify $(XCBEAUTIFY_OUTPUT_FLAGS)
 
 ## Build all platforms with ENABLE_KSCRASH and SDK_V10 flags
 #
@@ -385,7 +390,7 @@ build-watchos-v10-with-kscrash:
 		-scheme Sentry+KSCrash \
 		-destination 'platform=watchOS Simulator,OS=$(WATCHOS_SIMULATOR_OS),name=$(WATCHOS_DEVICE_NAME)' \
 		-configuration DebugV10 \
-		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | tee raw-build-output.log | xcbeautify $(XCBEAUTIFY_OUTPUT_FLAGS)
 ## Build XCFramework validation sample
 #
 # Builds the XCFramework validation sample project to verify XCFramework integration.

--- a/Samples/AGENTS.md
+++ b/Samples/AGENTS.md
@@ -45,18 +45,19 @@ For each sample app, you can:
 
 ## Commands
 
-| Command                         | Description                                            |
-| ------------------------------- | ------------------------------------------------------ |
-| **Generate (Project Creation)** |                                                        |
-| `make xcode-ci`                 | Regenerate all Xcode projects                          |
-| `make xcode-ci-<name>`          | Regenerate specific project (e.g., `xcode-ci-SPM`)     |
-| **Build**                       |                                                        |
-| `make build-samples`            | Build all sample apps                                  |
-| `make build-sample-<name>`      | Build specific sample (e.g., `build-sample-iOS-Swift`) |
-| **Test (UI Tests)**             |                                                        |
-| `make test-samples-ui`          | Run all sample UI tests                                |
-| `make test-sample-<name>-ui`    | Run specific sample UI tests (e.g., `iOS-Swift-ui`)    |
-| `make test-ui-critical`         | Run critical UI test suites for validation             |
+| Command                         | Description                                                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Generate (Project Creation)** |                                                                                                                                   |
+| `make xcode-ci`                 | Regenerate all Xcode projects                                                                                                     |
+| `make xcode-ci-<name>`          | Regenerate specific project (e.g., `xcode-ci-SPM`)                                                                                |
+| **Build**                       |                                                                                                                                   |
+| `make build-samples`            | Build all sample apps                                                                                                             |
+| `make build-sample-<name>`      | Build specific sample (e.g., `build-sample-iOS-Swift`)                                                                            |
+| `make <target> FOR_AGENTS=true` | Reduce output for supported SDK platform build/test targets. Inspect `raw-*-output.log` only when reduced output is inconclusive. |
+| **Test (UI Tests)**             |                                                                                                                                   |
+| `make test-samples-ui`          | Run all sample UI tests                                                                                                           |
+| `make test-sample-<name>-ui`    | Run specific sample UI tests (e.g., `iOS-Swift-ui`)                                                                               |
+| `make test-ui-critical`         | Run critical UI test suites for validation                                                                                        |
 
 ## Samples with UI Tests
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -4144,7 +4144,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint lint --quiet\nfi\n";
 		};
 		D480390A2F19316E00FA1619 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4163,7 +4163,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint lint --quiet\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -4,22 +4,22 @@
 
 ## Running Tests
 
-Test classes follow naming pattern `<SourceFile>Tests`. Default to iOS (fastest).
+Test classes follow naming pattern `<SourceFile>Tests`. Default to iOS (fastest). Use `FOR_AGENTS=true` to reduce platform test output. If reduced output does not explain a failure, inspect updated `raw-*-output.log` files in the repository root.
 
 ```bash
-make test-ios                                                  # all iOS tests
-make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests  # single class
-make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests,SentryTests/SentryHubTests  # multiple
-make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests/testFlush_WhenNoInternet  # single method
-make test                                                      # all platforms
+make test-ios FOR_AGENTS=true                                                  # all iOS tests
+make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests  # single class
+make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests,SentryTests/SentryHubTests  # multiple
+make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests/testFlush_WhenNoInternet  # single method
+make test FOR_AGENTS=true                                                      # all platforms
 make test-ui-critical                                          # important UI tests
 ```
 
 **Scope assessment:**
 
-- Specific feature → run related test classes
-- Core SDK (`SentryHub`, `SentryClient`, `SentrySDK`) → `make test-ios`
-- Multiple areas or unsure → `make test-ios` or `make test`
+- Specific feature → run related test classes with `FOR_AGENTS=true`
+- Core SDK (`SentryHub`, `SentryClient`, `SentrySDK`) → `make test-ios FOR_AGENTS=true`
+- Multiple areas or unsure → `make test-ios FOR_AGENTS=true` or `make test FOR_AGENTS=true`
 
 ### Test Server
 
@@ -49,8 +49,8 @@ SPM does not support mixed ObjC/Swift sources in one target. Two test targets ex
 
 - Do **not** create test targets that depend on `SentryHeaders` for implementations — it is header-only (see [`develop-docs/SENTRY-OBJC.md`](../develop-docs/SENTRY-OBJC.md))
 - Both targets are in the `SentryObjCTests` scheme and `SentryObjC_Base.xctestplan`
-- Run via: `make test-macos TEST_SCHEME=SentryObjCTests`
-- Targeted class: `make test-macos TEST_SCHEME=SentryObjCTests ONLY_TESTING=SentryObjCTests/SentryObjCOptionsTests`
+- Run via: `make test-macos FOR_AGENTS=true TEST_SCHEME=SentryObjCTests`
+- Targeted class: `make test-macos FOR_AGENTS=true TEST_SCHEME=SentryObjCTests ONLY_TESTING=SentryObjCTests/SentryObjCOptionsTests`
 
 ## Naming Convention
 

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 # Disable SC1091 because it won't work with pre-commit
 # shellcheck source=./scripts/ci-utils.sh disable=SC1091
@@ -27,6 +27,7 @@ ONLY_TESTING=""
 WORKSPACE="Sentry.xcworkspace"
 SDK=""
 RAW_DESTINATION=""
+FOR_AGENTS="${FOR_AGENTS:-false}"
 
 usage() {
     cat <<EOF
@@ -226,6 +227,14 @@ case $COMMAND in
     ;;
 esac
 
+format_output() {
+    if [ "$FOR_AGENTS" = true ]; then
+        xcbeautify --quieter --disable-logging
+    else
+        xcbeautify "$@"
+    fi
+}
+
 if [ $RUN_BUILD == true ]; then
     log_info "Running xcodebuild build"
 
@@ -242,7 +251,7 @@ if [ $RUN_BUILD == true ]; then
         "${BUILD_ARGS[@]}" \
         build 2>&1 |
         tee raw-build-output.log |
-        xcbeautify --preserve-unbeautified
+        format_output --preserve-unbeautified
 fi
 
 TEST_PLAN_ARGS=()
@@ -281,7 +290,7 @@ if [ $RUN_BUILD_FOR_TESTING == true ]; then
         "${BFT_ARGS[@]}" \
         build-for-testing 2>&1 |
         tee raw-build-for-testing-output.log |
-        xcbeautify --preserve-unbeautified
+        format_output --preserve-unbeautified
 fi
 
 if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
@@ -307,7 +316,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
         "${TWB_ARGS[@]}" \
         test-without-building 2>&1 |
         tee raw-test-output.log |
-        xcbeautify --report junit
+        format_output --report junit
 fi
 
 log_info "Finished xcodebuild"


### PR DESCRIPTION
Add `FOR_AGENTS=true` for SDK platform build and test targets to reduce terminal output while retaining complete raw `xcodebuild` logs.

This keeps normal developer output unchanged, removes shell trace noise, and makes Xcode SwiftLint build phases quiet. The agent instructions now use the compact mode and direct agents to inspect raw logs only when reduced output is inconclusive.

The raw logs preserve full diagnostics without requiring another build or test run.

Validated with `make format`, `make analyze`, `make build-ios`, and `make test-ios ONLY_TESTING=SentryTests/SentryHttpTransportTests`.

The goal of these changes are reducing amount of input tokens used by agents.

#skip-changelog

Closes getsentry/sentry-cocoa#8425