### PR TITLE
build: disable arm64e slices in Xcode for KSCrash enabled builds

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,8 @@ excluded:
   # Exclude auto-generated files from sample app builds
   - "**/Build/Intermediates.noindex/iOS-Swift.build/**/DerivedSources/**"
   - "**/Build/Intermediates.noindex/iOS-SwiftClip.build/**/DerivedSources/**"
+  - "**/worktree/**"
+  - "**/worktrees/**"
 
 only_rules:
   - class_delegate_protocol

--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,42 @@ build-xcframework-sentryobjc-dynamic:
 	./scripts/validate-xcframework.sh --xcframework "SentryObjC-Dynamic.xcframework"
 	./scripts/compress-xcframework.sh --xcframework "SentryObjC-Dynamic.xcframework"
 
+## Build Sentry+KSCrash Dynamic XCFramework
+#
+# Builds the Sentry+KSCrash target as a dynamic xcframework. Overrides the
+# arm64e xcconfig restriction for tvOS, watchOS, and Mac Catalyst, which exists
+# only to work around an Xcode UI bug that does not affect xcodebuild.
+#
+# SDKS is a comma-separated list of SDK names (default: all).
+#
+# Examples:
+#   make build-xcframework-kscrash-dynamic
+#   make build-xcframework-kscrash-dynamic SDKS=iphoneos
+.PHONY: build-xcframework-kscrash-dynamic
+build-xcframework-kscrash-dynamic:
+	@echo "--> Creating Sentry+KSCrash-Dynamic xcframework (SDKs: $(SDKS))"
+	./scripts/build-xcframework-kscrash.sh --suffix "-Dynamic" --sdks "$(SDKS)"
+	./scripts/validate-xcframework.sh --xcframework "Sentry+KSCrash-Dynamic.xcframework"
+	./scripts/compress-xcframework.sh --xcframework "Sentry+KSCrash-Dynamic.xcframework"
+
+## Build Sentry+KSCrash Static XCFramework
+#
+# Builds the Sentry+KSCrash target as a static xcframework. Overrides the
+# arm64e xcconfig restriction for tvOS, watchOS, and Mac Catalyst, which exists
+# only to work around an Xcode UI bug that does not affect xcodebuild.
+#
+# SDKS is a comma-separated list of SDK names (default: all).
+#
+# Examples:
+#   make build-xcframework-kscrash-static
+#   make build-xcframework-kscrash-static SDKS=iphoneos
+.PHONY: build-xcframework-kscrash-static
+build-xcframework-kscrash-static:
+	@echo "--> Creating Sentry+KSCrash Static xcframework (SDKs: $(SDKS))"
+	./scripts/build-xcframework-kscrash.sh --mach-o-type "staticlib" --sdks "$(SDKS)"
+	./scripts/validate-xcframework.sh --xcframework "Sentry+KSCrash.xcframework"
+	./scripts/compress-xcframework.sh --xcframework "Sentry+KSCrash.xcframework"
+
 # ============================================================================
 # SAMPLE APPS
 # ============================================================================

--- a/Sentry.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Sentry.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -4,5 +4,7 @@
 <dict>
 	<key>PreviewsEnabled</key>
 	<false/>
+	<key>iOSPackagesShouldBuildARM64e</key>
+	<true/>
 </dict>
 </plist>

--- a/Sources/Configuration/SentryKSCrash.xcconfig
+++ b/Sources/Configuration/SentryKSCrash.xcconfig
@@ -16,6 +16,11 @@ EXCLUDED_SOURCE_FILE_NAMES =
 // can find SentryProfilingConditionals.h (a public header not under include/).
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/Sources/Sentry/Public
 
+// Dynamic framework — keeps Sentry+KSCrash consistent with the rest of the SDK xcframework
+// builds. Declared here rather than as a global xcodebuild command-line override so it does
+// NOT propagate to KSCrash SPM package sub-targets (which have their own product types).
+MACH_O_TYPE = mh_dylib
+
 // There is a 'bug' in Xcode that doesn't build arm64e slices for SPM depedendencies
 // regardless of the Xcode settings. This can somewhat be worked around
 // by setting iOSPackagesShouldBuildARM64e to true in the workspace settings

--- a/Sources/Configuration/SentryKSCrash.xcconfig
+++ b/Sources/Configuration/SentryKSCrash.xcconfig
@@ -25,6 +25,7 @@ MACH_O_TYPE = mh_dylib
 // regardless of the Xcode settings. This can somewhat be worked around
 // by setting iOSPackagesShouldBuildARM64e to true in the workspace settings
 // however that only applies to iOS, macOS, and visionOS
+// see https://github.com/getsentry/sentry-cocoa/pull/8426 for more context
 ARCHS[sdk=appletvos*] = $(ARCHS_STANDARD)
 ARCHS[sdk=watchos*] = $(ARCHS_STANDARD)
 ARCHS[sdk=maccatalyst*] = $(ARCHS_STANDARD)

--- a/Sources/Configuration/SentryKSCrash.xcconfig
+++ b/Sources/Configuration/SentryKSCrash.xcconfig
@@ -16,6 +16,14 @@ EXCLUDED_SOURCE_FILE_NAMES =
 // can find SentryProfilingConditionals.h (a public header not under include/).
 HEADER_SEARCH_PATHS = $(inherited) $(SRCROOT)/Sources/Sentry/Public
 
+// There is a 'bug' in Xcode that doesn't build arm64e slices for SPM depedendencies
+// regardless of the Xcode settings. This can somewhat be worked around
+// by setting iOSPackagesShouldBuildARM64e to true in the workspace settings
+// however that only applies to iOS, macOS, and visionOS
+ARCHS[sdk=appletvos*] = $(ARCHS_STANDARD)
+ARCHS[sdk=watchos*] = $(ARCHS_STANDARD)
+ARCHS[sdk=maccatalyst*] = $(ARCHS_STANDARD)
+
 // Both this target and the base Sentry target share PRODUCT_MODULE_NAME=Sentry. Xcode's
 // explicit module scanner can't tell them apart and emits a spurious missing-dependency
 // warning. Disabling explicit modules for this target silences it without affecting correctness.

--- a/scripts/assemble-xcframework.sh
+++ b/scripts/assemble-xcframework.sh
@@ -8,7 +8,7 @@ source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
 usage() {
     cat <<EOF
-Usage: $(basename "$0") <scheme> <suffix> <configuration_suffix> <sdks> <xcarchive_path_template>
+Usage: $(basename "$0") <scheme> <suffix> <configuration_suffix> <sdks> <xcarchive_path_template> [product_name]
 
 Assembles an XCFramework from per-SDK xcarchive slices.
 
@@ -18,16 +18,19 @@ ARGUMENTS:
     configuration_suffix        Suffix for the product name inside archives (can be empty)
     sdks                        Comma-separated list of SDKs (e.g., iphoneos,macosx)
     xcarchive_path_template     Path template with SDK_NAME placeholder(s)
+    product_name                Framework name on disk inside xcarchives when it differs
+                                from the scheme name (default: scheme)
 
 EXAMPLES:
     $(basename "$0") Sentry "" "" "iphoneos,macosx" "/path/to/SDK_NAME.xcarchive"
+    $(basename "$0") "Sentry+KSCrash" "-Dynamic" "" "iphoneos,macosx" "/path/to/SDK_NAME.xcarchive" "Sentry"
 
 EOF
     exit 1
 }
 
 if [ $# -lt 5 ]; then
-    log_error "Expected 5 arguments, got $#"
+    log_error "Expected at least 5 arguments, got $#"
     usage
 fi
 
@@ -35,6 +38,7 @@ scheme="$1"
 suffix="$2"
 configuration_suffix="$3"
 IFS=',' read -r -a sdks <<< "$4"
+product_name="${6:-$scheme}"
 
 log_info "Assembling XCFramework:"
 log_info "  Scheme:               $scheme"
@@ -42,6 +46,9 @@ log_info "  Suffix:               ${suffix:-(none)}"
 log_info "  Configuration suffix: ${configuration_suffix:-(none)}"
 log_info "  SDKs:                 ${sdks[*]}"
 log_info "  Archive template:     $5"
+if [[ "$product_name" != "$scheme" ]]; then
+    log_info "  Product name:         $product_name"
+fi
 
 # on ci, the xcarchives live in paths like the following:
 #   /path/to/.../xcframework-slices/xcframework-sentry-swiftui-slice-maccatalyst/Library/Frameworks/SentrySwiftUI.framework
@@ -56,9 +63,9 @@ xcarchive_path_template="${5}" # may contain any number of instances of the temp
 xcodebuild_cmd="xcodebuild -create-xcframework"
 
 if [ -z "$configuration_suffix" ]; then
-    resolved_product_name="$scheme"
+    resolved_product_name="$product_name"
 else
-    resolved_product_name="$scheme$configuration_suffix"
+    resolved_product_name="$product_name$configuration_suffix"
 fi
 
 framework_filename="$resolved_product_name.framework"

--- a/scripts/build-xcframework-kscrash.sh
+++ b/scripts/build-xcframework-kscrash.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Builds all slices for a Sentry+KSCrash XCFramework variant and assembles
+# the final xcframework.
+#
+# Orchestrates per-SDK slice builds (sequentially) then assembles the final
+# xcframework. For CI, each slice runs as a separate parallel job; this script
+# is the local equivalent that runs them in sequence.
+#
+# The Sentry+KSCrash xcconfig disables arm64e on tvOS, watchOS, and Mac
+# Catalyst to work around an Xcode UI bug where the IDE does not propagate
+# ARCHS into SPM package builds.
+#
+# However, even for the SDKs where xcconfig already includes arm64e (iOS,
+# macOS, visionOS), xcconfig ARCHS settings also do NOT propagate to SPM
+# sub-targets — only command-line build setting overrides do. Without the
+# override, SPM packages (KSCrash) build arm64 only, producing a
+# symbol-inconsistent fat binary that fails validation.
+#
+# Therefore this script passes ARCHS explicitly on the command line for every
+# arm64e-capable device SDK, ensuring SPM sub-targets also build arm64e.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+SUFFIX=""
+MACH_O_TYPE="inherit"
+SDKS=""
+
+# The Sentry+KSCrash target uses PRODUCT_NAME = Sentry (via xcconfig), so the
+# framework on disk is always named Sentry.framework regardless of the scheme.
+SCHEME="Sentry+KSCrash"
+PRODUCT_NAME="Sentry"
+
+# KSCrash builds use the ReleaseV10 configuration.
+CONFIGURATION_SUFFIX="V10"
+
+# All device SDKs that include arm64e in the xcframework slice. ARCHS must be
+# passed on the command line (not via xcconfig) so that SPM sub-targets inherit
+# the arch list and produce symbol-consistent fat binaries.
+ARM64E_DEVICE_SDKS=( iphoneos macosx maccatalyst appletvos watchos xros )
+
+usage() {
+    log_notice "Usage: $0 [options]"
+    log_notice "  --suffix <suffix>      Output xcframework name suffix (default: empty)"
+    log_notice "  --mach-o-type <type>   staticlib for a static build; omit for dynamic (default: inherit from xcconfig)"
+    log_notice "  --sdks <list>          Comma-separated SDKs or AllSDKs (default: all)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --suffix)       SUFFIX="$2";      shift 2 ;;
+        --mach-o-type)  MACH_O_TYPE="$2"; shift 2 ;;
+        --sdks)         SDKS="$2";        shift 2 ;;
+        -h|--help)      usage ;;
+        *)              log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+if [ -z "$SDKS" ] || [ "$SDKS" = "AllSDKs" ]; then
+    sdks=( iphoneos iphonesimulator macosx maccatalyst appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+else
+    IFS=',' read -r -a sdks <<< "$SDKS"
+fi
+
+for sdk in "${sdks[@]}"; do
+    extra_build_settings=()
+
+    for arm64e_sdk in "${ARM64E_DEVICE_SDKS[@]}"; do
+        if [[ "$sdk" == "$arm64e_sdk" ]]; then
+            # Pass ARCHS on the command line so it propagates to SPM sub-targets
+            # (KSCrash packages), ensuring arm64e symbols are present in all
+            # architectures of the fat binary.
+            extra_build_settings+=( "ARCHS=\$(ARCHS_STANDARD) arm64e" )
+            break
+        fi
+    done
+
+    "$SCRIPT_DIR/build-xcframework-slice.sh" \
+        "$sdk" \
+        "$SCHEME" \
+        "$SUFFIX" \
+        "$MACH_O_TYPE" \
+        "$CONFIGURATION_SUFFIX" \
+        "$PRODUCT_NAME" \
+        "${extra_build_settings[@]+"${extra_build_settings[@]}"}"
+done
+
+xcframework_sdks="$(IFS=,; echo "${sdks[*]}")"
+"$SCRIPT_DIR/assemble-xcframework.sh" \
+    "$SCHEME" \
+    "$SUFFIX" \
+    "" \
+    "$xcframework_sdks" \
+    "$(pwd)/XCFrameworkBuildPath/archive/$SCHEME$SUFFIX/SDK_NAME.xcarchive" \
+    "$PRODUCT_NAME"

--- a/scripts/build-xcframework-slice.sh
+++ b/scripts/build-xcframework-slice.sh
@@ -10,7 +10,7 @@ source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
 usage() {
     cat <<EOF
-Usage: $(basename "$0") <sdk> <scheme> [suffix] [mach_o_type] [configuration_suffix]
+Usage: $(basename "$0") <sdk> <scheme> [suffix] [mach_o_type] [configuration_suffix] [product_name] [extra_build_settings...]
 
 Build a single SDK slice to be packaged into an XCFramework.
 
@@ -20,10 +20,13 @@ ARGUMENTS:
     suffix                  Output name suffix, e.g. '-Dynamic' (default: empty)
     mach_o_type             Mach-O type: mh_dylib or staticlib (default: mh_dylib)
     configuration_suffix    Build configuration suffix (default: empty)
+    product_name            Framework product name on disk (default: scheme+configuration_suffix)
+    extra_build_settings    Additional xcodebuild KEY=VALUE overrides (default: none)
 
 EXAMPLES:
     $(basename "$0") iphoneos Sentry "-Dynamic" mh_dylib
     $(basename "$0") macosx Sentry "" staticlib
+    $(basename "$0") appletvos "Sentry+KSCrash" "" mh_dylib "" "Sentry" "ARCHS=\$(ARCHS_STANDARD) arm64e"
 
 EOF
     exit 1
@@ -43,6 +46,8 @@ scheme="$2"
 suffix="${3:-}"
 MACH_O_TYPE="${4-mh_dylib}"
 configuration_suffix="${5-}"
+product_name="${6:-$scheme$configuration_suffix}"
+extra_build_settings=("${@:7}")
 
 log_info "Building XCFramework slice:"
 log_info "  SDK:                  $sdk"
@@ -50,18 +55,30 @@ log_info "  Scheme:               $scheme"
 log_info "  Suffix:               ${suffix:-(none)}"
 log_info "  Mach-O type:          $MACH_O_TYPE"
 log_info "  Configuration suffix: ${configuration_suffix:-(none)}"
+log_info "  Product name:         $product_name"
+if [[ ${#extra_build_settings[@]} -gt 0 ]]; then
+    log_info "  Extra build settings: ${extra_build_settings[*]}"
+fi
 
 resolved_configuration="Release$configuration_suffix"
-resolved_product_name="$scheme$configuration_suffix.framework"
+resolved_product_name="$product_name.framework"
 OTHER_LDFLAGS=""
 
 log_info "  Configuration:        $resolved_configuration"
-log_info "  Product name:         $resolved_product_name"
+log_info "  Resolved product:     $resolved_product_name"
 
 GCC_GENERATE_DEBUGGING_SYMBOLS="YES"
 if [ "$MACH_O_TYPE" = "staticlib" ]; then
     #For static framework we disabled symbols because they are not distributed in the framework causing warnings.
     GCC_GENERATE_DEBUGGING_SYMBOLS="NO"
+fi
+
+# When MACH_O_TYPE is 'inherit', the target's xcconfig controls the product type
+# and we must NOT pass MACH_O_TYPE on the command line, as that would propagate
+# to every sub-target in the build (including SPM package targets) and break their link.
+mach_o_type_override=()
+if [ "$MACH_O_TYPE" != "inherit" ]; then
+    mach_o_type_override=( MACH_O_TYPE="$MACH_O_TYPE" )
 fi
 
 rm -rf XCFrameworkBuildPath/DerivedData
@@ -90,11 +107,12 @@ if [ "$sdk" = "maccatalyst" ]; then
         CODE_SIGNING_REQUIRED=NO
         SKIP_INSTALL=NO
         CODE_SIGN_IDENTITY=
-        MACH_O_TYPE="$MACH_O_TYPE"
+        "${mach_o_type_override[@]+${mach_o_type_override[@]}}"
         SUPPORTS_MACCATALYST=YES
         ENABLE_CODE_COVERAGE=NO
         GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS"
         OTHER_LDFLAGS="$OTHER_LDFLAGS"
+        "${extra_build_settings[@]+${extra_build_settings[@]}}"
     )
     set -o pipefail && NSUnbufferedIO=YES xcodebuild "${maccatalyst_args[@]}" 2>&1 | tee "${slice_id}.maccatalyst.log" | xcbeautify --preserve-unbeautified
     end_group
@@ -133,10 +151,11 @@ else
         CODE_SIGNING_REQUIRED=NO
         SKIP_INSTALL=NO
         CODE_SIGN_IDENTITY=
-        MACH_O_TYPE="$MACH_O_TYPE"
+        "${mach_o_type_override[@]+${mach_o_type_override[@]}}"
         ENABLE_CODE_COVERAGE=NO
         GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS"
         OTHER_LDFLAGS="$OTHER_LDFLAGS"
+        "${extra_build_settings[@]+${extra_build_settings[@]}}"
     )
 
     archive_args=(


### PR DESCRIPTION
## 📜 Description

This change disables arm64e slices for targets other than iOS, visionOS, & macOS of KSCrash enabled builds *only for the [Xcode.app](<http://Xcode.app>) builds*. `xcodebuild` can still produce these slices.

## 💡 Motivation and Context

There is an Xcode bug (FB23764103) where Xcode will not pass on the `ARCHS` setting from the target to an SPM dependency. This means that when building for non-standard architectures (i.e. arm64e) the SPM dependency would not be instructed to build an arm64e slice, meaning linking would fail (arm64e binaries cannot call into an arm64 framework).

There is one singular reference to a workaround from Apple - when the EU forced them to open up the abilities of alternative browser engines they published this page: [Creating browser extensions in Xcode](<https://developer.apple.com/documentation/browserenginekit/creating-browser-extensions-in-xcode>) which states:

> If your Xcode workspace includes Swift Packages as dependencies for your targets, use workspace settings to build the packages using the arm64e instruction set. In Terminal, run these commands:

```
% plutil -create xml1 MyWorkspace.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
% plutil -insert iOSPackagesShouldBuildARM64e -bool YES MyWorkspace.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
```

This is the **only** reference Apple ever makes about this setting. When enabling it - it does indeed enable SPM to build arm64e slices. It also does this for visionOS & macOS, but not tvOS or watchOS. The change in this PR is to disable arm64e builds for tvOS & watchOS by default (so that devs building in [Xcode.app](<http://Xcode.app>) aren't blocked by spurious errors) and overridden in the build scripts since `xcodebuild` is unaffected by this bug.

### TL;DR - Context

In [Xcode.app](<http://Xcode.app>) - arm64e is disabled for tvOS & watchOS<br>With `xcodebuild` you can override these and there's an included build script to build in the way we would expect to distribute.

## 💚 How did you test it?

* Build all platforms in [Xcode.app](<http://Xcode.app>) -> all built
* Build universal xcframework -> all slices & platforms built
* Ran tests locally<br>\~ CI on this PR

#skip-changelog

Closes getsentry/sentry-cocoa#8427