### PR TITLE
chore: Fix changelog for 9.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ## Unreleased
 
+### Features
+
+- Mark opt in option `swiftAsyncStacktraces` as stable (#8373)
+- Add `dataCollection` option under `experimental` for configuring data scrubbing behavior (#8369)
+- Add scope API to clear feature flags (#8364)
+
 ### Fixes
 
 - Session Replay now correctly reads the response `Content-Type` for HTTP/2 and HTTP/3, so it captures HTTP response bodies as it was supposed to (when body capturing is enabled via `options.sessionReplay.networkCaptureBodies`) (#8390)
 - Log the actual request error instead of `(null)` when a Spotlight request fails (#8401)
 - Decoding dictionary to Options sets value of key `"dsn"` to property `dsn` instead of `nil` (#8393)
 
-## Features
-
-- Mark opt in option `swiftAsyncStacktraces` as stable (#8373)
-- Add `dataCollection` option under `experimental` for configuring data scrubbing behavior (#8369)
-- Add scope API to clear feature flags (#8364)
-
-## Improvements
+### Improvements
 
 - Remove `enableReplayNetworkDetailsCapturing` experimental flag; network detail capture is now enabled automatically when `networkDetailAllowUrls` is non-empty (#8396)
 


### PR DESCRIPTION
Fix headings and move features to the top.

#skip-changelog

Closes getsentry/sentry-cocoa#8430