### PR TITLE
test: add testDispatchSourceWrapper_Repeats to flaky test plan

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -40,6 +40,7 @@
         "SentryCrashReportStore_Tests\/testDeleteAllReports",
         "SentryCrashReportStore_Tests\/testPruneReports",
         "SentryCrashReportStore_Tests\/testStoresLoadsMultipleReports",
+        "SentryDispatchSourceWrapperTests\/testDispatchSourceWrapper_Repeats()",
         "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
         "SentryHttpTransportTests\/testFlush_WhenNoInternet_BlocksAndFinishes()",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -23,6 +23,7 @@
         "SentryCrashReportStore_Tests\/testCrashReportCount1",
         "SentryCrashReportStore_Tests\/testDeleteAllReports",
         "SentryCrashReportStore_Tests\/testPruneReports",
+        "SentryDispatchSourceWrapperTests\/testDispatchSourceWrapper_Repeats()",
         "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
         "SentryOnDemandReplayTests\/testAddFrameIsThreadSafe()",


### PR DESCRIPTION
Move `testDispatchSourceWrapper_Repeats` into the flaky test plan. It intermittently fails on CI when host scheduling jitter pushes timer intervals outside the tolerance.

- Skip in `Sentry_Base.xctestplan`
- Add to `Sentry_Flaky.xctestplan` (retries on failure)

Example failure: https://github.com/getsentry/sentry-cocoa/actions/runs/29411675476/job/87340011371

#skip-changelog