### PR TITLE
test: skip SPM resolution in UI test lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,8 @@ platform :ios do
       device: device,
       address_sanitizer: address_sanitizer,
       app_identifier: app_identifier,
-      ensure_devices_found: true
+      ensure_devices_found: true,
+      skip_package_dependencies_resolution: true # See SKIP_SPM_RESOLUTION_NOTE
     )
   end
 


### PR DESCRIPTION
The UI test lane intermittently fails during `xcodebuild -resolvePackageDependencies` when GitHub/DNS is briefly unavailable, because `run_ui_tests` resolves the release binary targets in `Package.swift` over the network on every run.

The sample UI test schemes embed the locally built framework (via `make xcode-ci`) and don't consume those release artifacts, so resolution is unnecessary here. Skip it, matching the build/release lanes (see `SKIP_SPM_RESOLUTION_NOTE`).

Example failure: [https://github.com/getsentry/sentry-cocoa/actions/runs/29433544695/job/87342167607](<https://github.com/getsentry/sentry-cocoa/actions/runs/29433544695/job/87342167607>)

#skip-changelog

Closes getsentry/sentry-cocoa#8440