### PR TITLE
ci: continue on microphone permission error

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -145,6 +145,7 @@ jobs:
         if: ${{ inputs.build_with_make }}
 
       - name: Add Microphone permissions
+        continue-on-error: true
         uses: ./.github/actions/add-microphone-permissions
 
       - name: Download XCFramework


### PR DESCRIPTION
Started to see flakiness when unlocking the `TCC.db` in runs like this: https://github.com/getsentry/sentry-cocoa/actions/runs/29488932451/job/87590110461

Allows these kind of errors to be ignored and continue running UI tests.

#skip-changelog

Closes #8450