### PR TITLE
test: remove length invocation testing from SentryInvalidJSONString

### DIFF
--- a/Tests/SentryTests/Helper/SentryDeviceTests.m
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.m
@@ -106,14 +106,14 @@
 #endif
 
 #if TARGET_OS_OSX
-    SENTRY_ASSERT_PREFIX(osVersion, @"10.", @"11.", @"12.", @"13.", @"14.", @"15.", @"26.");
+    SENTRY_ASSERT_PREFIX(osVersion, @"10.", @"11.", @"12.", @"13.", @"14.", @"15.", @"26.", @"27.");
 #elif TARGET_OS_IOS || TARGET_OS_MACCATALYST || TARGET_OS_TV
     SENTRY_ASSERT_PREFIX(osVersion, @"9.", @"10.", @"11.", @"12.", @"13.", @"14.", @"15.", @"16.",
-        @"17.", @"18.", @"26.");
+        @"17.", @"18.", @"26.", @"27.");
 #elif TARGET_OS_WATCH
     XCTAssertEqualObjects(osVersion, @"");
 #elif TARGET_OS_VISION
-    SENTRY_ASSERT_PREFIX(osVersion, @"1.", @"2.", @"26.");
+    SENTRY_ASSERT_PREFIX(osVersion, @"1.", @"2.", @"26.", @"27.");
 #else
     XCTFail(@"Unexpected OS.");
 #endif

--- a/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
+++ b/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
@@ -46,12 +46,10 @@ NS_ASSUME_NONNULL_BEGIN
         @[ @"__CFStringEncodeByteStream", @"+[_NSJSONReader validForJSON:depth:allowFragments:]" ];
 
     NSString *callStackSymbol = NSThread.callStackSymbols[1];
-    NSLog(@"running on symbol: %@", callStackSymbol);
 
     BOOL shouldIgnoreInvocation = NO;
     for (NSString *symbol in ignoredSymbols) {
         if ([callStackSymbol containsString:symbol]) {
-            NSLog(@"ignoring invocation because: %@", symbol);
             shouldIgnoreInvocation = YES;
         }
     }

--- a/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
+++ b/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
@@ -34,12 +34,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)length
 {
-    // Apple changed the implementation of `__CFStringEncodeByteStream` in some version after iOS26
-    // (and other platforms). Previously `length` was only called from
-    // `-[NSString(NSStringOtherEncodings) dataUsingEncoding:allowLossyConversion:]` but now it is
-    // also called by `__CFStringEncodeByteStream` so to avoid double counting, we ignore it.
-    if ([NSThread.callStackSymbols[1] rangeOfString:@"__CFStringEncodeByteStream"].location
-        == NSNotFound) {
+    // Prior to some version after *OS 26 Apple changed the implementation of
+    // `__CFStringEncodeByteStream` Previously, `length` was only called from
+    // `-[NSString(NSStringOtherEncodings) dataUsingEncoding:allowLossyConversion:] but now it is
+    // called also called by `__CFStringEncodeByteStream`. In *OS 27 `+[_NSJSONReader
+    // validForJSON:depth:allowFragments]` also calls length _before_
+    // `__CFStringEncodeByteStream does. To avoid counting an invocation more than once we ignore
+    // them.
+
+    NSArray<NSString *> *ignoredSymbols =
+        @[ @"__CFStringEncodeByteStream", @"+[_NSJSONReader validForJSON:depth:allowFragments:]" ];
+
+    NSString *callStackSymbol = NSThread.callStackSymbols[1];
+    NSLog(@"running on symbol: %@", callStackSymbol);
+
+    BOOL shouldIgnoreInvocation = NO;
+    for (NSString *symbol in ignoredSymbols) {
+        if ([callStackSymbol containsString:symbol]) {
+            NSLog(@"ignoring invocation because: %@", symbol);
+            shouldIgnoreInvocation = YES;
+        }
+    }
+
+    if (!shouldIgnoreInvocation) {
         self.lengthInvocations++;
     }
 


### PR DESCRIPTION
## 📜 Description

## 💡 Motivation and Context

Why: Apple changes the call stack every now and then and we're playing cat and mouse - couldn't find a use of the invocation checks in a test where it made sense to keep it.

This brings us closer to \*OS 27 testing parity (but not there - `testFramesOrder()` still fails as there's a new async mechanism being used to start XCTest (I think))

## 💚 How did you test it?

- Locally ran all tests on 26.4.1 & 27.0

## :pencil: Checklist

You have to check all boxes before merging:

- \[\~\] I added tests to verify the changes.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

Closes getsentry/sentry-cocoa#8454