### PR TITLE
fix(replay): stop touch tracker when session replay is paused

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -1,840 +1,846 @@
 // swiftlint:disable file_length missing_docs
 import Foundation
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-@_implementationOnly import _SentryPrivate
-import UIKit
+    @_implementationOnly import _SentryPrivate
+    import UIKit
 
-/// Tracks full-session segment boundaries while video rendering happens asynchronously.
-///
-/// Callers must mutate this only while holding `SentrySessionReplay.lock`.
-///
-/// Normal flow: a segment due at `5s` returns `0...5s`, marks `5s` as pending, and
-/// advances the next segment start only after that video is produced.
-///
-/// Pause/resume while rendering: if `0...5s` is rendering, pause happens at `6s`,
-/// and resume happens at `7s` before rendering finishes, keep `6s` as the pause tail
-/// and `7s` as the later resume start. When `0...5s` finishes, callers first render
-/// `5...6s`, then restart future segments at `7s`.
-private struct SessionSegmentState {
-    private(set) var sessionStart: Date?
-    private var segmentStart: Date?
-    private var pendingSegmentEnd: Date?
-    private var pendingPauseEnd: Date?
-    private var pendingResumeStart: Date?
+    /// Tracks full-session segment boundaries while video rendering happens asynchronously.
+    ///
+    /// Callers must mutate this only while holding `SentrySessionReplay.lock`.
+    ///
+    /// Normal flow: a segment due at `5s` returns `0...5s`, marks `5s` as pending, and
+    /// advances the next segment start only after that video is produced.
+    ///
+    /// Pause/resume while rendering: if `0...5s` is rendering, pause happens at `6s`,
+    /// and resume happens at `7s` before rendering finishes, keep `6s` as the pause tail
+    /// and `7s` as the later resume start. When `0...5s` finishes, callers first render
+    /// `5...6s`, then restart future segments at `7s`.
+    private struct SessionSegmentState {
+        private(set) var sessionStart: Date?
+        private var segmentStart: Date?
+        private var pendingSegmentEnd: Date?
+        private var pendingPauseEnd: Date?
+        private var pendingResumeStart: Date?
 
-    mutating func reset() {
-        segmentStart = nil
-        pendingSegmentEnd = nil
-        pendingPauseEnd = nil
-        pendingResumeStart = nil
-    }
-
-    mutating func start(at date: Date?) {
-        sessionStart = date
-        segmentStart = date
-    }
-
-    mutating func setSegmentStart(_ date: Date?) {
-        segmentStart = date
-    }
-
-    mutating func queuePendingPauseIfNeeded(at date: Date) -> Bool {
-        guard pendingSegmentEnd != nil else { return false }
-        pendingPauseEnd = date
-        pendingResumeStart = nil
-        return true
-    }
-
-    mutating func resumeSession(at date: Date) {
-        if pendingPauseEnd != nil {
-            pendingResumeStart = date
-        } else {
-            segmentStart = date
-        }
-    }
-
-    mutating func nextSegmentIfDue(at date: Date, duration: TimeInterval) -> DateInterval? {
-        guard pendingSegmentEnd == nil else { return nil }
-        if segmentStart == nil {
-            segmentStart = date
-        }
-
-        guard let start = segmentStart, date.timeIntervalSince(start) >= duration else { return nil }
-
-        let end = start.addingTimeInterval(duration)
-        pendingSegmentEnd = end
-        return DateInterval(start: start, end: end)
-    }
-
-    mutating func finishPendingSegment(_ end: Date) -> (pauseSegmentEnd: Date?, resumeSegmentStart: Date?) {
-        if pendingSegmentEnd == end {
+        mutating func reset() {
+            segmentStart = nil
             pendingSegmentEnd = nil
+            pendingPauseEnd = nil
+            pendingResumeStart = nil
         }
 
-        let pauseSegmentEnd = pendingPauseEnd
-        pendingPauseEnd = nil
-        let resumeSegmentStart = pendingResumeStart
-        pendingResumeStart = nil
-        return (pauseSegmentEnd, resumeSegmentStart)
-    }
-
-    func segmentStartForPauseSegment(endingAt date: Date, duration: TimeInterval) -> Date {
-        let fallbackStart = date.addingTimeInterval(-duration)
-        return segmentStart ?? max(sessionStart ?? fallbackStart, fallbackStart)
-    }
-
-    mutating func advanceSegmentStart(to end: Date) {
-        segmentStart = max(segmentStart ?? end, end)
-    }
-}
-
-// swiftlint:disable type_body_length
-@objcMembers
-@_spi(Private) public class SentrySessionReplay: NSObject {
-    public private(set) var isFullSession: Bool {
-        get { state.withLock { $0.isFullSession } }
-        set { state.withLock { $0.isFullSession = newValue } }
-    }
-    var isSessionPaused: Bool {
-        state.withLock { $0.isSessionPaused }
-    }
-    public private(set) var sessionReplayId: SentryId?
-
-    private var urlToCache: URL?
-    private var rootView: UIView?
-    /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
-    private var lastScreenshotAt: Date?
-    /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
-    private var nextScreenshotAt: Date?
-    private var imageCollection: [UIImage] = []
-    private weak var delegate: SentrySessionReplayDelegate?
-    private var replayType = SentryReplayType.buffer
-
-    /// State shared between the main thread and background queues, guarded by `lock`.
-    ///
-    /// Contains segment bookkeeping (`segmentState`, `currentSegmentId`), capture scheduler state
-    /// (`captureSchedulerToken`, `captureSchedulerGeneration`, `nextCaptureActivityCheckAt`) and the
-    /// `isFullSession`, `processingScreenshot`, `isSessionPaused` and `reachedMaximumDuration` flags.
-    ///
-    /// Capture pacing state (`lastScreenshotAt`, `nextScreenshotAt`, `adaptiveScreenshotInterval`,
-    /// `deferredScreenshotStart`) is not guarded by this lock; it is main-thread confined and only
-    /// mutated from the run-loop capture scheduler callbacks, blocks dispatched to the main
-    /// thread, and `start`.
-    private struct State {
-        var isFullSession = false
-        var processingScreenshot = false
-        var isSessionPaused = false
-        var reachedMaximumDuration = false
-        var segmentState = SessionSegmentState()
-        var currentSegmentId = 0
-        var captureSchedulerToken: NSObject?
-        /// Invalidates resume starts queued before a later pause.
-        /// Example: reachability resumes off-main, then the app backgrounds before the main-queue
-        /// start runs. Without this, the stale start can mark capture as running after pause, so the
-        /// next foreground resume may skip restarting the scheduler.
-        var captureSchedulerGeneration = 0
-        var nextCaptureActivityCheckAt: Date?
-    }
-
-    private let state = SentryMutex(State())
-
-    private let replayOptions: SentryReplayOptions
-    private let replayMaker: SentryReplayVideoMaker
-    private let dateProvider: SentryCurrentDateProvider
-    private let touchTracker: SentryTouchTracker?
-    private let captureScheduler: SentrySessionReplayRunLoopCaptureScheduler
-    /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
-    private var adaptiveScreenshotInterval: TimeInterval = 0
-    /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
-    private var deferredScreenshotStart: Date?
-    public var replayTags: [String: Any]?
-
-    var isRunning: Bool {
-        state.withLock {
-            $0.captureSchedulerToken != nil
-        }
-    }
-
-    public var screenshotProvider: SentryViewScreenshotProvider
-    public var breadcrumbConverter: SentryReplayBreadcrumbConverter
-
-    public init(
-        replayOptions: SentryReplayOptions,
-        replayFolderPath: URL,
-        screenshotProvider: SentryViewScreenshotProvider,
-        replayMaker: SentryReplayVideoMaker,
-        breadcrumbConverter: SentryReplayBreadcrumbConverter,
-        touchTracker: SentryTouchTracker?,
-        dateProvider: SentryCurrentDateProvider,
-        delegate: SentrySessionReplayDelegate,
-        captureScheduler: SentrySessionReplayRunLoopCaptureScheduler
-    ) {
-        self.replayOptions = replayOptions
-        self.dateProvider = dateProvider
-        self.delegate = delegate
-        self.screenshotProvider = screenshotProvider
-        self.urlToCache = replayFolderPath
-        self.replayMaker = replayMaker
-        self.breadcrumbConverter = breadcrumbConverter
-        self.touchTracker = touchTracker
-        self.captureScheduler = captureScheduler
-    }
-
-    deinit {
-        stopCaptureScheduler()
-    }
-
-    public func start(rootView: UIView?, fullSession: Bool) {
-        SentrySDKLog.debug("[Session Replay] Starting session replay with full session: \(fullSession)")
-        guard !isRunning else {
-            SentrySDKLog.debug("[Session Replay] Session replay is already running, not starting again")
-            return
+        mutating func start(at date: Date?) {
+            sessionStart = date
+            segmentStart = date
         }
 
-        self.rootView = rootView
-        let now = dateProvider.date()
-        resetCapturePacing(at: now)
-        startCaptureScheduler()
-        state.withLock {
-            $0.segmentState.reset()
-            $0.currentSegmentId = 0
+        mutating func setSegmentStart(_ date: Date?) {
+            segmentStart = date
         }
-        sessionReplayId = SentryId()
-        imageCollection = []
-        replayType = fullSession ? .session : .buffer
 
-        if fullSession {
-            startFullReplay(startedAt: lastScreenshotAt)
+        mutating func queuePendingPauseIfNeeded(at date: Date) -> Bool {
+            guard pendingSegmentEnd != nil else { return false }
+            pendingPauseEnd = date
+            pendingResumeStart = nil
+            return true
         }
-    }
 
-    private func startFullReplay(startedAt: Date?) {
-        SentrySDKLog.debug("[Session Replay] Starting full session replay")
-        state.withLock {
-            $0.segmentState.start(at: startedAt)
-            $0.isFullSession = true
-        }
-        guard let sessionReplayId = sessionReplayId else { return }
-        delegate?.sessionReplayStarted(replayId: sessionReplayId)
-    }
-
-    public func pauseSessionMode() {
-        SentrySDKLog.debug("[Session Replay] Pausing session mode")
-        let pauseDate = dateProvider.date()
-        state.withLock {
-            $0.isSessionPaused = true
-
-            if !queuePendingPauseSegmentIfNeeded(state: &$0, at: pauseDate) {
-                $0.segmentState.setSegmentStart(nil)
+        mutating func resumeSession(at date: Date) {
+            if pendingPauseEnd != nil {
+                pendingResumeStart = date
+            } else {
+                segmentStart = date
             }
         }
+
+        mutating func nextSegmentIfDue(at date: Date, duration: TimeInterval) -> DateInterval? {
+            guard pendingSegmentEnd == nil else { return nil }
+            if segmentStart == nil {
+                segmentStart = date
+            }
+
+            guard let start = segmentStart, date.timeIntervalSince(start) >= duration else { return nil }
+
+            let end = start.addingTimeInterval(duration)
+            pendingSegmentEnd = end
+            return DateInterval(start: start, end: end)
+        }
+
+        mutating func finishPendingSegment(_ end: Date) -> (pauseSegmentEnd: Date?, resumeSegmentStart: Date?) {
+            if pendingSegmentEnd == end {
+                pendingSegmentEnd = nil
+            }
+
+            let pauseSegmentEnd = pendingPauseEnd
+            pendingPauseEnd = nil
+            let resumeSegmentStart = pendingResumeStart
+            pendingResumeStart = nil
+            return (pauseSegmentEnd, resumeSegmentStart)
+        }
+
+        func segmentStartForPauseSegment(endingAt date: Date, duration: TimeInterval) -> Date {
+            let fallbackStart = date.addingTimeInterval(-duration)
+            return segmentStart ?? max(sessionStart ?? fallbackStart, fallbackStart)
+        }
+
+        mutating func advanceSegmentStart(to end: Date) {
+            segmentStart = max(segmentStart ?? end, end)
+        }
     }
 
-    public func pause() {
-        SentrySDKLog.debug("[Session Replay] Pausing session")
-        stopCaptureScheduler()
+    // swiftlint:disable type_body_length
+    @objcMembers
+    @_spi(Private) public class SentrySessionReplay: NSObject {
+        public private(set) var isFullSession: Bool {
+            get { state.withLock { $0.isFullSession } }
+            set { state.withLock { $0.isFullSession = newValue } }
+        }
 
-        let pauseDate = dateProvider.date()
-        let shouldPreparePauseSegment = state.withLock { (state: inout State) -> Bool in
+        var isSessionPaused: Bool {
+            state.withLock { $0.isSessionPaused }
+        }
+
+        public private(set) var sessionReplayId: SentryId?
+
+        private var urlToCache: URL?
+        private var rootView: UIView?
+        /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
+        private var lastScreenshotAt: Date?
+        /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
+        private var nextScreenshotAt: Date?
+        private var imageCollection: [UIImage] = []
+        private weak var delegate: SentrySessionReplayDelegate?
+        private var replayType = SentryReplayType.buffer
+
+        /// State shared between the main thread and background queues, guarded by `lock`.
+        ///
+        /// Contains segment bookkeeping (`segmentState`, `currentSegmentId`), capture scheduler state
+        /// (`captureSchedulerToken`, `captureSchedulerGeneration`, `nextCaptureActivityCheckAt`) and the
+        /// `isFullSession`, `processingScreenshot`, `isSessionPaused` and `reachedMaximumDuration` flags.
+        ///
+        /// Capture pacing state (`lastScreenshotAt`, `nextScreenshotAt`, `adaptiveScreenshotInterval`,
+        /// `deferredScreenshotStart`) is not guarded by this lock; it is main-thread confined and only
+        /// mutated from the run-loop capture scheduler callbacks, blocks dispatched to the main
+        /// thread, and `start`.
+        private struct State {
+            var isFullSession = false
+            var processingScreenshot = false
+            var isSessionPaused = false
+            var reachedMaximumDuration = false
+            var segmentState = SessionSegmentState()
+            var currentSegmentId = 0
+            var captureSchedulerToken: NSObject?
+            /// Invalidates resume starts queued before a later pause.
+            /// Example: reachability resumes off-main, then the app backgrounds before the main-queue
+            /// start runs. Without this, the stale start can mark capture as running after pause, so the
+            /// next foreground resume may skip restarting the scheduler.
+            var captureSchedulerGeneration = 0
+            var nextCaptureActivityCheckAt: Date?
+        }
+
+        private let state = SentryMutex(State())
+
+        private let replayOptions: SentryReplayOptions
+        private let replayMaker: SentryReplayVideoMaker
+        private let dateProvider: SentryCurrentDateProvider
+        private let touchTracker: SentryTouchTracker?
+        private let captureScheduler: SentrySessionReplayRunLoopCaptureScheduler
+        /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
+        private var adaptiveScreenshotInterval: TimeInterval = 0
+        /// Capture pacing state; main-thread confined and deliberately not guarded by `lock` (see its docs).
+        private var deferredScreenshotStart: Date?
+        public var replayTags: [String: Any]?
+
+        var isRunning: Bool {
+            state.withLock {
+                $0.captureSchedulerToken != nil
+            }
+        }
+
+        public var screenshotProvider: SentryViewScreenshotProvider
+        public var breadcrumbConverter: SentryReplayBreadcrumbConverter
+
+        public init(
+            replayOptions: SentryReplayOptions,
+            replayFolderPath: URL,
+            screenshotProvider: SentryViewScreenshotProvider,
+            replayMaker: SentryReplayVideoMaker,
+            breadcrumbConverter: SentryReplayBreadcrumbConverter,
+            touchTracker: SentryTouchTracker?,
+            dateProvider: SentryCurrentDateProvider,
+            delegate: SentrySessionReplayDelegate,
+            captureScheduler: SentrySessionReplayRunLoopCaptureScheduler
+        ) {
+            self.replayOptions = replayOptions
+            self.dateProvider = dateProvider
+            self.delegate = delegate
+            self.screenshotProvider = screenshotProvider
+            urlToCache = replayFolderPath
+            self.replayMaker = replayMaker
+            self.breadcrumbConverter = breadcrumbConverter
+            self.touchTracker = touchTracker
+            self.captureScheduler = captureScheduler
+        }
+
+        deinit {
+            stopCaptureScheduler()
+        }
+
+        public func start(rootView: UIView?, fullSession: Bool) {
+            SentrySDKLog.debug("[Session Replay] Starting session replay with full session: \(fullSession)")
+            guard !isRunning else {
+                SentrySDKLog.debug("[Session Replay] Session replay is already running, not starting again")
+                return
+            }
+
+            self.rootView = rootView
+            let now = dateProvider.date()
+            resetCapturePacing(at: now)
+            startCaptureScheduler()
+            state.withLock {
+                $0.segmentState.reset()
+                $0.currentSegmentId = 0
+            }
+            sessionReplayId = SentryId()
+            imageCollection = []
+            replayType = fullSession ? .session : .buffer
+
+            if fullSession {
+                startFullReplay(startedAt: lastScreenshotAt)
+            }
+        }
+
+        private func startFullReplay(startedAt: Date?) {
+            SentrySDKLog.debug("[Session Replay] Starting full session replay")
+            state.withLock {
+                $0.segmentState.start(at: startedAt)
+                $0.isFullSession = true
+            }
+            guard let sessionReplayId = sessionReplayId else { return }
+            delegate?.sessionReplayStarted(replayId: sessionReplayId)
+        }
+
+        public func pauseSessionMode() {
+            SentrySDKLog.debug("[Session Replay] Pausing session mode")
+            let pauseDate = dateProvider.date()
+            state.withLock {
+                $0.isSessionPaused = true
+
+                if !queuePendingPauseSegmentIfNeeded(state: &$0, at: pauseDate) {
+                    $0.segmentState.setSegmentStart(nil)
+                }
+            }
+        }
+
+        public func pause() {
+            SentrySDKLog.debug("[Session Replay] Pausing session")
+            stopCaptureScheduler()
+            touchTracker?.isEnabled = false
+
+            let pauseDate = dateProvider.date()
+            let shouldPreparePauseSegment = state.withLock { (state: inout State) -> Bool in
+                guard state.isFullSession else { return false }
+                guard !queuePendingPauseSegmentIfNeeded(state: &state, at: pauseDate) else { return false }
+                return true
+            }
+
+            if shouldPreparePauseSegment {
+                prepareSegmentUntil(date: pauseDate)
+            }
+        }
+
+        private func queuePendingPauseSegmentIfNeeded(state: inout State, at pauseDate: Date) -> Bool {
             guard state.isFullSession else { return false }
-            guard !queuePendingPauseSegmentIfNeeded(state: &state, at: pauseDate) else { return false }
-            return true
+            return state.segmentState.queuePendingPauseIfNeeded(at: pauseDate)
         }
 
-        if shouldPreparePauseSegment {
-            prepareSegmentUntil(date: pauseDate)
-        }
-    }
-
-    private func queuePendingPauseSegmentIfNeeded(state: inout State, at pauseDate: Date) -> Bool {
-        guard state.isFullSession else { return false }
-        return state.segmentState.queuePendingPauseIfNeeded(at: pauseDate)
-    }
-
-    public func resume() {
-        SentrySDKLog.debug("[Session Replay] Resuming session")
-        let resumeDate = dateProvider.date()
-        let schedulerGeneration = state.withLock { (state: inout State) -> Int? in
-            if state.isFullSession && state.isSessionPaused {
-                return nil
-            }
-
-            guard !state.reachedMaximumDuration else {
-                SentrySDKLog.warning("[Session Replay] Reached maximum duration, not resuming")
-                return nil
-            }
-            guard state.captureSchedulerToken == nil else {
-                SentrySDKLog.debug("[Session Replay] Session is already running, not resuming")
-                return nil
-            }
-
-            state.captureSchedulerGeneration += 1
-            if state.isFullSession {
-                state.segmentState.resumeSession(at: resumeDate)
-            } else {
-                state.segmentState.setSegmentStart(nil)
-            }
-            return state.captureSchedulerGeneration
-        }
-        guard let schedulerGeneration = schedulerGeneration else { return }
-
-        runOnMainThread { [weak self] in
-            guard let self = self else { return }
-
-            if self.startCaptureScheduler(expectedGeneration: schedulerGeneration) {
-                self.resetCapturePacing(at: self.dateProvider.date())
-            }
-        }
-    }
-
-    func resumeSessionMode(restartCaptureScheduler: Bool = true) {
-        SentrySDKLog.debug("[Session Replay] Resuming session mode")
-        let resumeDate = dateProvider.date()
-        state.withLock {
-            $0.isSessionPaused = false
-            if $0.isFullSession {
-                $0.segmentState.resumeSession(at: resumeDate)
-            }
-        }
-        guard restartCaptureScheduler else { return }
-        resume()
-    }
-
-    public func captureReplayFor(event: Event) {
-        SentrySDKLog.debug("[Session Replay] Capturing replay for event: \(event)")
-        guard isRunning else {
-            SentrySDKLog.debug("[Session Replay] Session replay is not running, not capturing replay")
-            return
-        }
-
-        if isFullSession {
-            SentrySDKLog.info("[Session Replay] Session replay is in full session mode, setting event context")
-            setEventContext(event: event)
-            return
-        }
-
-        guard (event.error != nil || event.exceptions?.isEmpty == false) && captureReplay(replayType: .buffer) else {
-            SentrySDKLog.debug("[Session Replay] Not capturing replay, reason: event is not an error or exceptions are empty")
-            return
-        }
-
-        setEventContext(event: event)
-    }
-
-    @discardableResult
-    public func captureReplay() -> Bool {
-        captureReplay(replayType: .buffer)
-    }
-
-    @discardableResult
-    func captureReplay(replayType: SentryReplayType) -> Bool {
-        guard isRunning else {
-            SentrySDKLog.debug("[Session Replay] Session replay is not running, not capturing replay")
-            return false
-        }
-        guard !isFullSession else {
-            SentrySDKLog.debug("[Session Replay] Session replay is full, not capturing replay")
-            return true
-        }
-
-        guard delegate?.sessionReplayShouldCaptureReplayForError() == true else {
-            SentrySDKLog.debug("[Session Replay] Not capturing replay, reason: delegate should not capture replay")
-            return false
-        }
-
-        // `lastScreenshotAt` is main-thread confined with the capture pacing state.
-        let startedAt = runOnMainThreadSync { lastScreenshotAt }
-        self.replayType = replayType
-        startFullReplay(startedAt: startedAt)
-        let replayStart = dateProvider.date().addingTimeInterval(-replayOptions.errorReplayDuration - (Double(replayOptions.frameRate) / 2.0))
-
-        createAndCaptureInBackground(startedAt: replayStart, endedAt: dateProvider.date(), replayType: replayType)
-        return true
-    }
-
-    private func setEventContext(event: Event) {
-        SentrySDKLog.debug("[Session Replay] Setting event context")
-        guard let sessionReplayId = sessionReplayId, event.type != "replay_video" else {
-            SentrySDKLog.debug("[Session Replay] Not setting event context, reason: session replay id is nil or event type is replay_video")
-            return
-        }
-
-        var context = event.context ?? [:]
-        context["replay"] = ["replay_id": sessionReplayId.sentryIdString]
-        event.context = context
-
-        var tags = ["replayId": sessionReplayId.sentryIdString]
-        if let eventTags = event.tags {
-            tags.merge(eventTags) { (_, new) in new }
-        }
-        event.tags = tags
-    }
-
-    /// Decides on each run-loop pass whether to capture a screenshot. Stages, in order:
-    /// 1. Skip captures while session mode is paused or once the maximum duration is reached.
-    /// 2. Skip while a previous screenshot is still being processed.
-    /// 3. Throttle view-hierarchy activity checks via `shouldCheckCaptureActivity`.
-    /// 4. Apply pacing: interaction captures use the base frame interval, idle captures the
-    ///    adaptive backoff interval.
-    /// 5. Defer captures while animations are running (up to a maximum deferral), then capture.
-    ///
-    /// Early exits after stage 1 still call `prepareFullSessionSegmentsIfNeeded` so session
-    /// segments are cut on time even when no screenshot is taken.
-    // swiftlint:disable function_body_length cyclomatic_complexity
-    private func captureFrameIfNeeded(isInteractiveRunLoopMode: Bool = false) {
-        guard isRunning else { return }
-
-        let now = dateProvider.date()
-        let fullSessionState = state.withLock { (isFullSession: $0.isFullSession, sessionStart: $0.segmentState.sessionStart) }
-
-        if fullSessionState.isFullSession && state.withLock({ $0.isSessionPaused }) {
-            return
-        }
-
-        if let sessionStart = fullSessionState.sessionStart,
-            fullSessionState.isFullSession,
-            now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration {
-            SentrySDKLog.debug("[Session Replay] Reached maximum duration, pausing session")
-            state.withLock { $0.reachedMaximumDuration = true }
-            pause()
-            delegate?.sessionReplayEnded()
-            return
-        }
-
-        guard !state.withLock({ $0.processingScreenshot }) else {
-            prepareFullSessionSegmentsIfNeeded(until: now)
-            return
-        }
-
-        guard shouldCheckCaptureActivity(at: now, isInteractiveRunLoopMode: isInteractiveRunLoopMode) else {
-            prepareFullSessionSegmentsIfNeeded(until: now)
-            return
-        }
-
-        let captureActivityReason = isInteractiveRunLoopMode
-            ? nil
-            : rootView.flatMap { SentrySessionReplayCaptureGuard.captureActivityReason(rootView: $0, options: replayOptions) }
-        let isInteractionCapture = isInteractiveRunLoopMode || captureActivityReason == .interaction
-
-        guard shouldCaptureScreenshot(at: now, usesAdaptiveBackoff: !isInteractionCapture) else {
-            let activityCheckInterval: TimeInterval
-            if let nextScreenshotAt = nextScreenshotAt {
-                activityCheckInterval = max(0, min(baseScreenshotInterval, nextScreenshotAt.timeIntervalSince(now)))
-            } else {
-                activityCheckInterval = baseScreenshotInterval
-            }
-            state.withLock { $0.nextCaptureActivityCheckAt = now.addingTimeInterval(activityCheckInterval) }
-            prepareFullSessionSegmentsIfNeeded(until: now)
-            return
-        }
-
-        let deferralDecision = screenshotDeferralDecision(
-            activityReason: isInteractionCapture ? nil : captureActivityReason,
-            at: now
-        )
-        if deferralDecision == .defer {
-            scheduleNextScreenshot(after: CapturePacing.captureDeferralInterval, from: now)
-            prepareFullSessionSegmentsIfNeeded(until: now)
-            return
-        }
-
-        guard takeScreenshot(timestamp: now, completion: { [weak self] captureDuration in
-            guard let self = self else { return }
-            self.runOnMainThread { [weak self] in
-                guard let self = self else { return }
-                defer { self.state.withLock { $0.processingScreenshot = false } }
-
-                if deferralDecision == .captureAfterDeferral {
-                    self.adaptiveScreenshotInterval = 0
-                } else if !isInteractionCapture {
-                    self.updateAdaptiveScreenshotInterval(captureDuration)
+        public func resume() {
+            SentrySDKLog.debug("[Session Replay] Resuming session")
+            let resumeDate = dateProvider.date()
+            let schedulerGeneration = state.withLock { (state: inout State) -> Int? in
+                if state.isFullSession, state.isSessionPaused {
+                    return nil
                 }
 
-                let finishedAt = self.dateProvider.date()
-                self.lastScreenshotAt = finishedAt
-                self.scheduleNextScreenshot(after: self.screenshotInterval(usesAdaptiveBackoff: !isInteractionCapture), from: finishedAt)
-
-                let shouldPrepareSegment = self.state.withLock { state in
-                    state.captureSchedulerToken != nil && !state.isSessionPaused && !state.reachedMaximumDuration
+                guard !state.reachedMaximumDuration else {
+                    SentrySDKLog.warning("[Session Replay] Reached maximum duration, not resuming")
+                    return nil
                 }
-                if shouldPrepareSegment {
-                    self.prepareFullSessionSegmentsIfNeeded(until: finishedAt)
+                guard state.captureSchedulerToken == nil else {
+                    SentrySDKLog.debug("[Session Replay] Session is already running, not resuming")
+                    return nil
                 }
-            }
-        }) else {
-            let finishedAt = dateProvider.date()
-            lastScreenshotAt = finishedAt
-            scheduleNextScreenshot(after: screenshotInterval(usesAdaptiveBackoff: !isInteractionCapture), from: finishedAt)
-            prepareFullSessionSegmentsIfNeeded(until: finishedAt)
-            return
-        }
-    }
-    // swiftlint:enable function_body_length cyclomatic_complexity
 
-    private var baseScreenshotInterval: TimeInterval {
-        1.0 / Double(replayOptions.frameRate)
-    }
-
-    private func resetCapturePacing(at date: Date) {
-        lastScreenshotAt = date
-        adaptiveScreenshotInterval = 0
-        deferredScreenshotStart = nil
-        scheduleNextScreenshot(after: screenshotInterval(), from: date)
-    }
-
-    private func screenshotInterval(usesAdaptiveBackoff: Bool = true) -> TimeInterval {
-        usesAdaptiveBackoff ? max(baseScreenshotInterval, adaptiveScreenshotInterval) : baseScreenshotInterval
-    }
-
-    private func shouldCaptureScreenshot(at date: Date, usesAdaptiveBackoff: Bool = true) -> Bool {
-        if !usesAdaptiveBackoff, let lastScreenshotAt = lastScreenshotAt {
-            return isDeadlineReached(lastScreenshotAt.addingTimeInterval(baseScreenshotInterval), at: date)
-        }
-
-        guard let nextScreenshotAt = nextScreenshotAt else { return true }
-        return isDeadlineReached(nextScreenshotAt, at: date)
-    }
-
-    /// Whether `date` is at or past `deadline`, within ``CapturePacing/screenshotIntervalTolerance``
-    /// to absorb run-loop scheduling jitter.
-    private func isDeadlineReached(_ deadline: Date, at date: Date) -> Bool {
-        date.timeIntervalSince(deadline) >= -CapturePacing.screenshotIntervalTolerance
-    }
-
-    private func scheduleNextScreenshot(after interval: TimeInterval, from date: Date) {
-        nextScreenshotAt = date.addingTimeInterval(interval)
-        state.withLock { state in
-            state.nextCaptureActivityCheckAt = date.addingTimeInterval(min(interval, baseScreenshotInterval))
-        }
-    }
-
-    private func shouldCheckCaptureActivity(at date: Date, isInteractiveRunLoopMode: Bool) -> Bool {
-        if isInteractiveRunLoopMode {
-            return shouldCaptureScreenshot(at: date, usesAdaptiveBackoff: false)
-        }
-
-        if shouldCaptureScreenshot(at: date) {
-            return true
-        }
-
-        let nextCaptureActivityCheckAt: Date? = state.withLock { state in
-            state.nextCaptureActivityCheckAt
-        }
-        guard let nextCaptureActivityCheckAt = nextCaptureActivityCheckAt else { return true }
-        return isDeadlineReached(nextCaptureActivityCheckAt, at: date)
-    }
-
-    @discardableResult
-    private func startCaptureScheduler(expectedGeneration: Int? = nil) -> Bool {
-        let token = NSObject()
-        let shouldInstallObserver = state.withLock { state in
-            if let expectedGeneration, state.captureSchedulerGeneration != expectedGeneration {
-                return false
-            }
-            guard state.captureSchedulerToken == nil else { return false }
-
-            if expectedGeneration == nil {
                 state.captureSchedulerGeneration += 1
+                if state.isFullSession {
+                    state.segmentState.resumeSession(at: resumeDate)
+                } else {
+                    state.segmentState.setSegmentStart(nil)
+                }
+                return state.captureSchedulerGeneration
             }
-            state.captureSchedulerToken = token
+            guard let schedulerGeneration = schedulerGeneration else { return }
+
+            runOnMainThread { [weak self] in
+                guard let self = self else { return }
+
+                if self.startCaptureScheduler(expectedGeneration: schedulerGeneration) {
+                    self.touchTracker?.isEnabled = true
+                    self.resetCapturePacing(at: self.dateProvider.date())
+                }
+            }
+        }
+
+        func resumeSessionMode(restartCaptureScheduler: Bool = true) {
+            SentrySDKLog.debug("[Session Replay] Resuming session mode")
+            let resumeDate = dateProvider.date()
+            state.withLock {
+                $0.isSessionPaused = false
+                if $0.isFullSession {
+                    $0.segmentState.resumeSession(at: resumeDate)
+                }
+            }
+            guard restartCaptureScheduler else { return }
+            resume()
+        }
+
+        public func captureReplayFor(event: Event) {
+            SentrySDKLog.debug("[Session Replay] Capturing replay for event: \(event)")
+            guard isRunning else {
+                SentrySDKLog.debug("[Session Replay] Session replay is not running, not capturing replay")
+                return
+            }
+
+            if isFullSession {
+                SentrySDKLog.info("[Session Replay] Session replay is in full session mode, setting event context")
+                setEventContext(event: event)
+                return
+            }
+
+            guard event.error != nil || event.exceptions?.isEmpty == false, captureReplay(replayType: .buffer) else {
+                SentrySDKLog.debug("[Session Replay] Not capturing replay, reason: event is not an error or exceptions are empty")
+                return
+            }
+
+            setEventContext(event: event)
+        }
+
+        @discardableResult
+        public func captureReplay() -> Bool {
+            captureReplay(replayType: .buffer)
+        }
+
+        @discardableResult
+        func captureReplay(replayType: SentryReplayType) -> Bool {
+            guard isRunning else {
+                SentrySDKLog.debug("[Session Replay] Session replay is not running, not capturing replay")
+                return false
+            }
+            guard !isFullSession else {
+                SentrySDKLog.debug("[Session Replay] Session replay is full, not capturing replay")
+                return true
+            }
+
+            guard delegate?.sessionReplayShouldCaptureReplayForError() == true else {
+                SentrySDKLog.debug("[Session Replay] Not capturing replay, reason: delegate should not capture replay")
+                return false
+            }
+
+            // `lastScreenshotAt` is main-thread confined with the capture pacing state.
+            let startedAt = runOnMainThreadSync { lastScreenshotAt }
+            self.replayType = replayType
+            startFullReplay(startedAt: startedAt)
+            let replayStart = dateProvider.date().addingTimeInterval(-replayOptions.errorReplayDuration - (Double(replayOptions.frameRate) / 2.0))
+
+            createAndCaptureInBackground(startedAt: replayStart, endedAt: dateProvider.date(), replayType: replayType)
             return true
         }
-        guard shouldInstallObserver else { return false }
 
-        captureScheduler.start(token: token) { [weak self] isInteractiveRunLoopMode in
-            self?.captureFrameIfNeeded(isInteractiveRunLoopMode: isInteractiveRunLoopMode)
+        private func setEventContext(event: Event) {
+            SentrySDKLog.debug("[Session Replay] Setting event context")
+            guard let sessionReplayId = sessionReplayId, event.type != "replay_video" else {
+                SentrySDKLog.debug("[Session Replay] Not setting event context, reason: session replay id is nil or event type is replay_video")
+                return
+            }
+
+            var context = event.context ?? [:]
+            context["replay"] = ["replay_id": sessionReplayId.sentryIdString]
+            event.context = context
+
+            var tags = ["replayId": sessionReplayId.sentryIdString]
+            if let eventTags = event.tags {
+                tags.merge(eventTags) { _, new in new }
+            }
+            event.tags = tags
         }
-        return true
-    }
 
-    private func stopCaptureScheduler() {
-        let token = state.withLock { (state: inout State) -> NSObject? in
-            state.captureSchedulerGeneration += 1
-            let token = state.captureSchedulerToken
-            state.captureSchedulerToken = nil
-            state.nextCaptureActivityCheckAt = nil
-            return token
+        /// Decides on each run-loop pass whether to capture a screenshot. Stages, in order:
+        /// 1. Skip captures while session mode is paused or once the maximum duration is reached.
+        /// 2. Skip while a previous screenshot is still being processed.
+        /// 3. Throttle view-hierarchy activity checks via `shouldCheckCaptureActivity`.
+        /// 4. Apply pacing: interaction captures use the base frame interval, idle captures the
+        ///    adaptive backoff interval.
+        /// 5. Defer captures while animations are running (up to a maximum deferral), then capture.
+        ///
+        /// Early exits after stage 1 still call `prepareFullSessionSegmentsIfNeeded` so session
+        /// segments are cut on time even when no screenshot is taken.
+        // swiftlint:disable function_body_length cyclomatic_complexity
+        private func captureFrameIfNeeded(isInteractiveRunLoopMode: Bool = false) {
+            guard isRunning else { return }
+
+            let now = dateProvider.date()
+            let fullSessionState = state.withLock { (isFullSession: $0.isFullSession, sessionStart: $0.segmentState.sessionStart) }
+
+            if fullSessionState.isFullSession && state.withLock({ $0.isSessionPaused }) {
+                return
+            }
+
+            if let sessionStart = fullSessionState.sessionStart,
+               fullSessionState.isFullSession,
+               now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration
+            {
+                SentrySDKLog.debug("[Session Replay] Reached maximum duration, pausing session")
+                state.withLock { $0.reachedMaximumDuration = true }
+                pause()
+                delegate?.sessionReplayEnded()
+                return
+            }
+
+            guard !state.withLock({ $0.processingScreenshot }) else {
+                prepareFullSessionSegmentsIfNeeded(until: now)
+                return
+            }
+
+            guard shouldCheckCaptureActivity(at: now, isInteractiveRunLoopMode: isInteractiveRunLoopMode) else {
+                prepareFullSessionSegmentsIfNeeded(until: now)
+                return
+            }
+
+            let captureActivityReason = isInteractiveRunLoopMode
+                ? nil
+                : rootView.flatMap { SentrySessionReplayCaptureGuard.captureActivityReason(rootView: $0, options: replayOptions) }
+            let isInteractionCapture = isInteractiveRunLoopMode || captureActivityReason == .interaction
+
+            guard shouldCaptureScreenshot(at: now, usesAdaptiveBackoff: !isInteractionCapture) else {
+                let activityCheckInterval: TimeInterval
+                if let nextScreenshotAt = nextScreenshotAt {
+                    activityCheckInterval = max(0, min(baseScreenshotInterval, nextScreenshotAt.timeIntervalSince(now)))
+                } else {
+                    activityCheckInterval = baseScreenshotInterval
+                }
+                state.withLock { $0.nextCaptureActivityCheckAt = now.addingTimeInterval(activityCheckInterval) }
+                prepareFullSessionSegmentsIfNeeded(until: now)
+                return
+            }
+
+            let deferralDecision = screenshotDeferralDecision(
+                activityReason: isInteractionCapture ? nil : captureActivityReason,
+                at: now
+            )
+            if deferralDecision == .defer {
+                scheduleNextScreenshot(after: CapturePacing.captureDeferralInterval, from: now)
+                prepareFullSessionSegmentsIfNeeded(until: now)
+                return
+            }
+
+            guard takeScreenshot(timestamp: now, completion: { [weak self] captureDuration in
+                guard let self = self else { return }
+                self.runOnMainThread { [weak self] in
+                    guard let self = self else { return }
+                    defer { self.state.withLock { $0.processingScreenshot = false } }
+
+                    if deferralDecision == .captureAfterDeferral {
+                        self.adaptiveScreenshotInterval = 0
+                    } else if !isInteractionCapture {
+                        self.updateAdaptiveScreenshotInterval(captureDuration)
+                    }
+
+                    let finishedAt = self.dateProvider.date()
+                    self.lastScreenshotAt = finishedAt
+                    self.scheduleNextScreenshot(after: self.screenshotInterval(usesAdaptiveBackoff: !isInteractionCapture), from: finishedAt)
+
+                    let shouldPrepareSegment = self.state.withLock { state in
+                        state.captureSchedulerToken != nil && !state.isSessionPaused && !state.reachedMaximumDuration
+                    }
+                    if shouldPrepareSegment {
+                        self.prepareFullSessionSegmentsIfNeeded(until: finishedAt)
+                    }
+                }
+            }) else {
+                let finishedAt = dateProvider.date()
+                lastScreenshotAt = finishedAt
+                scheduleNextScreenshot(after: screenshotInterval(usesAdaptiveBackoff: !isInteractionCapture), from: finishedAt)
+                prepareFullSessionSegmentsIfNeeded(until: finishedAt)
+                return
+            }
         }
 
-        guard let token = token else { return }
-        captureScheduler.stop(token: token)
-    }
+        // swiftlint:enable function_body_length cyclomatic_complexity
 
-    /// Tuning constants for the screenshot capture pacing and adaptive backoff policy.
-    private enum CapturePacing {
-        /// Interval to wait before re-evaluating a capture that was deferred due to ongoing animations.
-        static let captureDeferralInterval: TimeInterval = 0.25
-        /// Captures taking at least this long double the adaptive screenshot interval;
-        /// faster captures halve it again.
-        static let slowCaptureThreshold: TimeInterval = 0.05
-        /// Upper bound for the adaptive screenshot interval.
-        static let maximumAdaptiveCaptureInterval: TimeInterval = 5
-        /// Maximum time captures can be deferred due to animations before forcing a capture.
-        static let maximumAnimationCaptureDeferralInterval: TimeInterval = 1
-        /// Tolerance applied when comparing dates against capture deadlines, to absorb
-        /// run-loop scheduling jitter.
-        static let screenshotIntervalTolerance: TimeInterval = 0.001
-    }
+        private var baseScreenshotInterval: TimeInterval {
+            1.0 / Double(replayOptions.frameRate)
+        }
 
-    private enum ScreenshotDeferralDecision {
-        case none
-        case `defer`
-        case captureAfterDeferral
-    }
-
-    private func screenshotDeferralDecision(
-        activityReason: SentrySessionReplayCaptureGuard.CaptureActivityReason?,
-        at date: Date
-    ) -> ScreenshotDeferralDecision {
-        guard activityReason == .animation else {
+        private func resetCapturePacing(at date: Date) {
+            lastScreenshotAt = date
+            adaptiveScreenshotInterval = 0
             deferredScreenshotStart = nil
-            return .none
+            scheduleNextScreenshot(after: screenshotInterval(), from: date)
         }
 
-        guard let deferredScreenshotStart = deferredScreenshotStart else {
-            self.deferredScreenshotStart = date
-            return .defer
+        private func screenshotInterval(usesAdaptiveBackoff: Bool = true) -> TimeInterval {
+            usesAdaptiveBackoff ? max(baseScreenshotInterval, adaptiveScreenshotInterval) : baseScreenshotInterval
         }
 
-        let deferralDuration = date.timeIntervalSince(deferredScreenshotStart)
-        guard deferralDuration >= CapturePacing.maximumAnimationCaptureDeferralInterval else {
-            return .defer
+        private func shouldCaptureScreenshot(at date: Date, usesAdaptiveBackoff: Bool = true) -> Bool {
+            if !usesAdaptiveBackoff, let lastScreenshotAt = lastScreenshotAt {
+                return isDeadlineReached(lastScreenshotAt.addingTimeInterval(baseScreenshotInterval), at: date)
+            }
+
+            guard let nextScreenshotAt = nextScreenshotAt else { return true }
+            return isDeadlineReached(nextScreenshotAt, at: date)
         }
 
-        SentrySDKLog.debug("[Session Replay] Forcing screenshot after deferring for \(deferralDuration)s")
-        self.deferredScreenshotStart = nil
-        return .captureAfterDeferral
-    }
-
-    private func updateAdaptiveScreenshotInterval(_ captureDuration: TimeInterval) {
-        guard captureDuration > 0 else { return }
-
-        guard captureDuration >= CapturePacing.slowCaptureThreshold else {
-            guard adaptiveScreenshotInterval > 0 else { return }
-
-            let nextInterval = adaptiveScreenshotInterval / 2
-            adaptiveScreenshotInterval = nextInterval <= baseScreenshotInterval ? 0 : nextInterval
-            return
+        /// Whether `date` is at or past `deadline`, within ``CapturePacing/screenshotIntervalTolerance``
+        /// to absorb run-loop scheduling jitter.
+        private func isDeadlineReached(_ deadline: Date, at date: Date) -> Bool {
+            date.timeIntervalSince(deadline) >= -CapturePacing.screenshotIntervalTolerance
         }
 
-        let nextInterval = adaptiveScreenshotInterval > 0 ? adaptiveScreenshotInterval * 2 : baseScreenshotInterval * 2
-        adaptiveScreenshotInterval = min(nextInterval, CapturePacing.maximumAdaptiveCaptureInterval)
-        SentrySDKLog.debug("[Session Replay] Screenshot capture took \(captureDuration)s, backing off to \(adaptiveScreenshotInterval)s")
-    }
-
-    // swiftlint:disable:next cyclomatic_complexity
-    private func prepareFullSessionSegmentsIfNeeded(until date: Date) {
-        let sessionSegmentDuration = replayOptions.sessionSegmentDuration
-        guard sessionSegmentDuration > 0 else {
-            SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: session segment duration is not positive")
-            return
-        }
-
-        let segmentBounds: DateInterval? = state.withLock { state in
-            guard state.isFullSession else { return nil }
-            return state.segmentState.nextSegmentIfDue(at: date, duration: sessionSegmentDuration)
-        }
-        guard let segmentBounds = segmentBounds else { return }
-        let segmentEnd = segmentBounds.end
-
-        if !prepareSegment(from: segmentBounds.start, until: segmentEnd, completion: { [weak self] in
-            self?.finishPendingSegment(segmentEnd)
-        }) {
-            finishPendingSegment(segmentEnd)
-        }
-    }
-
-    private func finishPendingSegment(_ segmentEnd: Date) {
-        let pending = state.withLock { state in
-            state.segmentState.finishPendingSegment(segmentEnd)
-        }
-
-        if let pauseSegmentEnd = pending.pauseSegmentEnd {
-            prepareSegmentUntil(date: pauseSegmentEnd)
-        }
-
-        if let resumeSegmentStart = pending.resumeSegmentStart {
+        private func scheduleNextScreenshot(after interval: TimeInterval, from date: Date) {
+            nextScreenshotAt = date.addingTimeInterval(interval)
             state.withLock { state in
-                state.segmentState.setSegmentStart(resumeSegmentStart)
-            }
-        }
-    }
-
-    private func prepareSegmentUntil(date: Date) {
-        let segmentStart = state.withLock { state in
-            state.segmentState.segmentStartForPauseSegment(endingAt: date, duration: replayOptions.sessionSegmentDuration)
-        }
-        prepareSegment(from: segmentStart, until: date)
-    }
-
-    @discardableResult
-    private func prepareSegment(
-        from segmentStart: Date,
-        until date: Date,
-        completion: (() -> Void)? = nil
-    ) -> Bool {
-        SentrySDKLog.debug("[Session Replay] Preparing segment until date: \(date)")
-        guard date > segmentStart else {
-            SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: segment duration is empty")
-            return false
-        }
-
-        guard let pathToSegment = urlToCache?.appendingPathComponent("segments") else {
-            SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: could not create path to segments folder")
-            return false
-        }
-
-        let fileManager = FileManager.default
-        if !fileManager.fileExists(atPath: pathToSegment.path) {
-            do {
-                try fileManager.createDirectory(atPath: pathToSegment.path, withIntermediateDirectories: true, attributes: nil)
-                SentrySDKLog.debug("[Session Replay] Created segments folder at path: \(pathToSegment.path)")
-            } catch {
-                SentrySDKLog.debug("Can't create session replay segment folder. Error: \(error.localizedDescription)")
-                return false
+                state.nextCaptureActivityCheckAt = date.addingTimeInterval(min(interval, baseScreenshotInterval))
             }
         }
 
-        createAndCaptureInBackground(
-            startedAt: segmentStart,
-            endedAt: date,
-            replayType: replayType,
-            completion: completion
-        )
-        return true
-    }
-
-    private func createAndCaptureInBackground(
-        startedAt: Date,
-        endedAt: Date,
-        replayType: SentryReplayType,
-        completion: (() -> Void)? = nil
-    ) {
-        SentrySDKLog.debug("[Session Replay] Creating replay video started at date: \(startedAt), replayType: \(replayType)")
-        // Creating a video is computationally expensive, therefore perform it on a background queue.
-        self.replayMaker.createVideoInBackgroundWith(beginning: startedAt, end: endedAt) { [weak self] videos in
-            guard let self = self else { return }
-            SentrySDKLog.debug("[Session Replay] Created replay video with \(videos.count) segments")
-            for video in videos {
-                self.processNewlyAvailableSegment(videoInfo: video, replayType: replayType)
+        private func shouldCheckCaptureActivity(at date: Date, isInteractiveRunLoopMode: Bool) -> Bool {
+            if isInteractiveRunLoopMode {
+                return shouldCaptureScreenshot(at: date, usesAdaptiveBackoff: false)
             }
-            completion?()
-            SentrySDKLog.debug("[Session Replay] Finished processing replay video with \(videos.count) segments")
-        }
-    }
 
-    private func processNewlyAvailableSegment(videoInfo: SentryVideoInfo, replayType: SentryReplayType) {
-        SentrySDKLog.debug("[Session Replay] Processing new segment available for replayType: \(replayType), videoInfo: \(videoInfo)")
-        guard let sessionReplayId = sessionReplayId else {
-            SentrySDKLog.warning("[Session Replay] No session replay ID available, ignoring segment.")
-            return
-        }
-        let segmentId = state.withLock { (state: inout State) -> Int in
-            let segmentId = state.currentSegmentId
-            state.currentSegmentId += 1
-            return segmentId
-        }
-
-        captureSegment(segment: segmentId, video: videoInfo, replayId: sessionReplayId, replayType: replayType)
-        replayMaker.releaseFramesUntil(videoInfo.end)
-        state.withLock { state in
-            // Advance the segment start monotonically; never move it backwards.
-            state.segmentState.advanceSegmentStart(to: videoInfo.end)
-        }
-        SentrySDKLog.debug("[Session Replay] Processed segment, incrementing currentSegmentId to: \(segmentId + 1)")
-    }
-
-    private func captureSegment(segment: Int, video: SentryVideoInfo, replayId: SentryId, replayType: SentryReplayType) {
-        SentrySDKLog.debug("[Session Replay] Capturing segment: \(segment), replayId: \(replayId), replayType: \(replayType)")
-        let replayEvent = SentryReplayEvent(eventId: replayId, replayStartTimestamp: video.start, replayType: replayType, segmentId: segment)
-
-        replayEvent.sdk = self.replayOptions.sdkInfo
-        replayEvent.timestamp = video.end
-        replayEvent.urls = video.screens
-
-        let breadcrumbs = delegate?.breadcrumbsForSessionReplay() ?? []
-
-        var events = breadcrumbConverter.convert(breadcrumbs, from: video.start, until: video.end)
-        if let touchTracker = touchTracker {
-            SentrySDKLog.debug("[Session Replay] Adding touch tracker events")
-            events.append(contentsOf: touchTracker.replayEvents(from: video.start, until: video.end))
-            touchTracker.flushFinishedEvents()
-        }
-
-        if segment == 0 {
-            SentrySDKLog.debug("[Session Replay] Adding options event to segment 0")
-            if let customOptions = replayTags {
-                events.append(SentryRRWebOptionsEvent(timestamp: video.start, customOptions: customOptions))
-            } else {
-                events.append(SentryRRWebOptionsEvent(timestamp: video.start, options: self.replayOptions))
+            if shouldCaptureScreenshot(at: date) {
+                return true
             }
-        }
 
-        let recording = SentryReplayRecording(segmentId: segment, video: video, extraEvents: events)
-
-        delegate?.sessionReplayNewSegment(replayEvent: replayEvent, replayRecording: recording, videoUrl: video.path)
-
-        do {
-            try FileManager.default.removeItem(at: video.path)
-            SentrySDKLog.debug("[Session Replay] Deleted replay segment from disk")
-        } catch {
-            SentrySDKLog.debug("[Session Replay] Could not delete replay segment from disk: \(error)")
-        }
-    }
-
-    private func takeScreenshot(timestamp: Date, completion: @escaping (TimeInterval) -> Void) -> Bool {
-        guard let rootView = rootView else {
-            SentrySDKLog.debug("[Session Replay] Not taking screenshot, reason: root view is nil")
-            return false
-        }
-        SentrySDKLog.debug("[Session Replay] Taking screenshot of root view: \(rootView)")
-
-        let canProceed = state.withLock { (state: inout State) -> Bool in
-            guard !state.processingScreenshot else {
-                SentrySDKLog.debug("[Session Replay] Not taking screenshot, reason: processing screenshot")
-                return false
+            let nextCaptureActivityCheckAt: Date? = state.withLock { state in
+                state.nextCaptureActivityCheckAt
             }
-            state.processingScreenshot = true
+            guard let nextCaptureActivityCheckAt = nextCaptureActivityCheckAt else { return true }
+            return isDeadlineReached(nextCaptureActivityCheckAt, at: date)
+        }
+
+        @discardableResult
+        private func startCaptureScheduler(expectedGeneration: Int? = nil) -> Bool {
+            let token = NSObject()
+            let shouldInstallObserver = state.withLock { state in
+                if let expectedGeneration, state.captureSchedulerGeneration != expectedGeneration {
+                    return false
+                }
+                guard state.captureSchedulerToken == nil else { return false }
+
+                if expectedGeneration == nil {
+                    state.captureSchedulerGeneration += 1
+                }
+                state.captureSchedulerToken = token
+                return true
+            }
+            guard shouldInstallObserver else { return false }
+
+            captureScheduler.start(token: token) { [weak self] isInteractiveRunLoopMode in
+                self?.captureFrameIfNeeded(isInteractiveRunLoopMode: isInteractiveRunLoopMode)
+            }
             return true
         }
-        guard canProceed else { return false }
 
-        SentrySDKLog.debug("[Session Replay] Getting screenshot from screenshot provider")
-        let screenName = delegate?.currentScreenNameForSessionReplay()
-        let captureStart = dateProvider.systemTime()
-        screenshotProvider.image(view: rootView) { [weak self] screenshot in
-            guard let self = self else { return }
-
-            let captureEnd = self.dateProvider.systemTime()
-            let captureDuration = captureEnd >= captureStart
-                ? TimeInterval(captureEnd - captureStart) / TimeInterval(NSEC_PER_SEC)
-                : 0
-            SentrySDKLog.debug("[Session Replay] New frame available, for screen: \(screenName ?? "nil")")
-            self.state.withLock { _ in
-                self.replayMaker.addFrameAsync(timestamp: timestamp, maskedViewImage: screenshot, forScreen: screenName)
+        private func stopCaptureScheduler() {
+            let token = state.withLock { (state: inout State) -> NSObject? in
+                state.captureSchedulerGeneration += 1
+                let token = state.captureSchedulerToken
+                state.captureSchedulerToken = nil
+                state.nextCaptureActivityCheckAt = nil
+                return token
             }
-            completion(captureDuration)
-        }
-        return true
-    }
 
-    private func runOnMainThread(_ block: @escaping () -> Void) {
-        if Thread.isMainThread {
-            block()
-        } else {
-            DispatchQueue.main.async(execute: block)
+            guard let token = token else { return }
+            captureScheduler.stop(token: token)
         }
-    }
 
-    private func runOnMainThreadSync<T>(_ block: () -> T) -> T {
-        if Thread.isMainThread {
-            return block()
-        } else {
-            return DispatchQueue.main.sync(execute: block)
+        /// Tuning constants for the screenshot capture pacing and adaptive backoff policy.
+        private enum CapturePacing {
+            /// Interval to wait before re-evaluating a capture that was deferred due to ongoing animations.
+            static let captureDeferralInterval: TimeInterval = 0.25
+            /// Captures taking at least this long double the adaptive screenshot interval;
+            /// faster captures halve it again.
+            static let slowCaptureThreshold: TimeInterval = 0.05
+            /// Upper bound for the adaptive screenshot interval.
+            static let maximumAdaptiveCaptureInterval: TimeInterval = 5
+            /// Maximum time captures can be deferred due to animations before forcing a capture.
+            static let maximumAnimationCaptureDeferralInterval: TimeInterval = 1
+            /// Tolerance applied when comparing dates against capture deadlines, to absorb
+            /// run-loop scheduling jitter.
+            static let screenshotIntervalTolerance: TimeInterval = 0.001
+        }
+
+        private enum ScreenshotDeferralDecision {
+            case none
+            case `defer`
+            case captureAfterDeferral
+        }
+
+        private func screenshotDeferralDecision(
+            activityReason: SentrySessionReplayCaptureGuard.CaptureActivityReason?,
+            at date: Date
+        ) -> ScreenshotDeferralDecision {
+            guard activityReason == .animation else {
+                deferredScreenshotStart = nil
+                return .none
+            }
+
+            guard let deferredScreenshotStart = deferredScreenshotStart else {
+                deferredScreenshotStart = date
+                return .defer
+            }
+
+            let deferralDuration = date.timeIntervalSince(deferredScreenshotStart)
+            guard deferralDuration >= CapturePacing.maximumAnimationCaptureDeferralInterval else {
+                return .defer
+            }
+
+            SentrySDKLog.debug("[Session Replay] Forcing screenshot after deferring for \(deferralDuration)s")
+            self.deferredScreenshotStart = nil
+            return .captureAfterDeferral
+        }
+
+        private func updateAdaptiveScreenshotInterval(_ captureDuration: TimeInterval) {
+            guard captureDuration > 0 else { return }
+
+            guard captureDuration >= CapturePacing.slowCaptureThreshold else {
+                guard adaptiveScreenshotInterval > 0 else { return }
+
+                let nextInterval = adaptiveScreenshotInterval / 2
+                adaptiveScreenshotInterval = nextInterval <= baseScreenshotInterval ? 0 : nextInterval
+                return
+            }
+
+            let nextInterval = adaptiveScreenshotInterval > 0 ? adaptiveScreenshotInterval * 2 : baseScreenshotInterval * 2
+            adaptiveScreenshotInterval = min(nextInterval, CapturePacing.maximumAdaptiveCaptureInterval)
+            SentrySDKLog.debug("[Session Replay] Screenshot capture took \(captureDuration)s, backing off to \(adaptiveScreenshotInterval)s")
+        }
+
+        // swiftlint:disable:next cyclomatic_complexity
+        private func prepareFullSessionSegmentsIfNeeded(until date: Date) {
+            let sessionSegmentDuration = replayOptions.sessionSegmentDuration
+            guard sessionSegmentDuration > 0 else {
+                SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: session segment duration is not positive")
+                return
+            }
+
+            let segmentBounds: DateInterval? = state.withLock { state in
+                guard state.isFullSession else { return nil }
+                return state.segmentState.nextSegmentIfDue(at: date, duration: sessionSegmentDuration)
+            }
+            guard let segmentBounds = segmentBounds else { return }
+            let segmentEnd = segmentBounds.end
+
+            if !prepareSegment(from: segmentBounds.start, until: segmentEnd, completion: { [weak self] in
+                self?.finishPendingSegment(segmentEnd)
+            }) {
+                finishPendingSegment(segmentEnd)
+            }
+        }
+
+        private func finishPendingSegment(_ segmentEnd: Date) {
+            let pending = state.withLock { state in
+                state.segmentState.finishPendingSegment(segmentEnd)
+            }
+
+            if let pauseSegmentEnd = pending.pauseSegmentEnd {
+                prepareSegmentUntil(date: pauseSegmentEnd)
+            }
+
+            if let resumeSegmentStart = pending.resumeSegmentStart {
+                state.withLock { state in
+                    state.segmentState.setSegmentStart(resumeSegmentStart)
+                }
+            }
+        }
+
+        private func prepareSegmentUntil(date: Date) {
+            let segmentStart = state.withLock { state in
+                state.segmentState.segmentStartForPauseSegment(endingAt: date, duration: replayOptions.sessionSegmentDuration)
+            }
+            prepareSegment(from: segmentStart, until: date)
+        }
+
+        @discardableResult
+        private func prepareSegment(
+            from segmentStart: Date,
+            until date: Date,
+            completion: (() -> Void)? = nil
+        ) -> Bool {
+            SentrySDKLog.debug("[Session Replay] Preparing segment until date: \(date)")
+            guard date > segmentStart else {
+                SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: segment duration is empty")
+                return false
+            }
+
+            guard let pathToSegment = urlToCache?.appendingPathComponent("segments") else {
+                SentrySDKLog.debug("[Session Replay] Not preparing segment, reason: could not create path to segments folder")
+                return false
+            }
+
+            let fileManager = FileManager.default
+            if !fileManager.fileExists(atPath: pathToSegment.path) {
+                do {
+                    try fileManager.createDirectory(atPath: pathToSegment.path, withIntermediateDirectories: true, attributes: nil)
+                    SentrySDKLog.debug("[Session Replay] Created segments folder at path: \(pathToSegment.path)")
+                } catch {
+                    SentrySDKLog.debug("Can't create session replay segment folder. Error: \(error.localizedDescription)")
+                    return false
+                }
+            }
+
+            createAndCaptureInBackground(
+                startedAt: segmentStart,
+                endedAt: date,
+                replayType: replayType,
+                completion: completion
+            )
+            return true
+        }
+
+        private func createAndCaptureInBackground(
+            startedAt: Date,
+            endedAt: Date,
+            replayType: SentryReplayType,
+            completion: (() -> Void)? = nil
+        ) {
+            SentrySDKLog.debug("[Session Replay] Creating replay video started at date: \(startedAt), replayType: \(replayType)")
+            // Creating a video is computationally expensive, therefore perform it on a background queue.
+            replayMaker.createVideoInBackgroundWith(beginning: startedAt, end: endedAt) { [weak self] videos in
+                guard let self = self else { return }
+                SentrySDKLog.debug("[Session Replay] Created replay video with \(videos.count) segments")
+                for video in videos {
+                    self.processNewlyAvailableSegment(videoInfo: video, replayType: replayType)
+                }
+                completion?()
+                SentrySDKLog.debug("[Session Replay] Finished processing replay video with \(videos.count) segments")
+            }
+        }
+
+        private func processNewlyAvailableSegment(videoInfo: SentryVideoInfo, replayType: SentryReplayType) {
+            SentrySDKLog.debug("[Session Replay] Processing new segment available for replayType: \(replayType), videoInfo: \(videoInfo)")
+            guard let sessionReplayId = sessionReplayId else {
+                SentrySDKLog.warning("[Session Replay] No session replay ID available, ignoring segment.")
+                return
+            }
+            let segmentId = state.withLock { (state: inout State) -> Int in
+                let segmentId = state.currentSegmentId
+                state.currentSegmentId += 1
+                return segmentId
+            }
+
+            captureSegment(segment: segmentId, video: videoInfo, replayId: sessionReplayId, replayType: replayType)
+            replayMaker.releaseFramesUntil(videoInfo.end)
+            state.withLock { state in
+                // Advance the segment start monotonically; never move it backwards.
+                state.segmentState.advanceSegmentStart(to: videoInfo.end)
+            }
+            SentrySDKLog.debug("[Session Replay] Processed segment, incrementing currentSegmentId to: \(segmentId + 1)")
+        }
+
+        private func captureSegment(segment: Int, video: SentryVideoInfo, replayId: SentryId, replayType: SentryReplayType) {
+            SentrySDKLog.debug("[Session Replay] Capturing segment: \(segment), replayId: \(replayId), replayType: \(replayType)")
+            let replayEvent = SentryReplayEvent(eventId: replayId, replayStartTimestamp: video.start, replayType: replayType, segmentId: segment)
+
+            replayEvent.sdk = replayOptions.sdkInfo
+            replayEvent.timestamp = video.end
+            replayEvent.urls = video.screens
+
+            let breadcrumbs = delegate?.breadcrumbsForSessionReplay() ?? []
+
+            var events = breadcrumbConverter.convert(breadcrumbs, from: video.start, until: video.end)
+            if let touchTracker = touchTracker {
+                SentrySDKLog.debug("[Session Replay] Adding touch tracker events")
+                events.append(contentsOf: touchTracker.replayEvents(from: video.start, until: video.end))
+                touchTracker.flushFinishedEvents()
+            }
+
+            if segment == 0 {
+                SentrySDKLog.debug("[Session Replay] Adding options event to segment 0")
+                if let customOptions = replayTags {
+                    events.append(SentryRRWebOptionsEvent(timestamp: video.start, customOptions: customOptions))
+                } else {
+                    events.append(SentryRRWebOptionsEvent(timestamp: video.start, options: replayOptions))
+                }
+            }
+
+            let recording = SentryReplayRecording(segmentId: segment, video: video, extraEvents: events)
+
+            delegate?.sessionReplayNewSegment(replayEvent: replayEvent, replayRecording: recording, videoUrl: video.path)
+
+            do {
+                try FileManager.default.removeItem(at: video.path)
+                SentrySDKLog.debug("[Session Replay] Deleted replay segment from disk")
+            } catch {
+                SentrySDKLog.debug("[Session Replay] Could not delete replay segment from disk: \(error)")
+            }
+        }
+
+        private func takeScreenshot(timestamp: Date, completion: @escaping (TimeInterval) -> Void) -> Bool {
+            guard let rootView = rootView else {
+                SentrySDKLog.debug("[Session Replay] Not taking screenshot, reason: root view is nil")
+                return false
+            }
+            SentrySDKLog.debug("[Session Replay] Taking screenshot of root view: \(rootView)")
+
+            let canProceed = state.withLock { (state: inout State) -> Bool in
+                guard !state.processingScreenshot else {
+                    SentrySDKLog.debug("[Session Replay] Not taking screenshot, reason: processing screenshot")
+                    return false
+                }
+                state.processingScreenshot = true
+                return true
+            }
+            guard canProceed else { return false }
+
+            SentrySDKLog.debug("[Session Replay] Getting screenshot from screenshot provider")
+            let screenName = delegate?.currentScreenNameForSessionReplay()
+            let captureStart = dateProvider.systemTime()
+            screenshotProvider.image(view: rootView) { [weak self] screenshot in
+                guard let self = self else { return }
+
+                let captureEnd = self.dateProvider.systemTime()
+                let captureDuration = captureEnd >= captureStart
+                    ? TimeInterval(captureEnd - captureStart) / TimeInterval(NSEC_PER_SEC)
+                    : 0
+                SentrySDKLog.debug("[Session Replay] New frame available, for screen: \(screenName ?? "nil")")
+                self.state.withLock { _ in
+                    self.replayMaker.addFrameAsync(timestamp: timestamp, maskedViewImage: screenshot, forScreen: screenName)
+                }
+                completion(captureDuration)
+            }
+            return true
+        }
+
+        private func runOnMainThread(_ block: @escaping () -> Void) {
+            if Thread.isMainThread {
+                block()
+            } else {
+                DispatchQueue.main.async(execute: block)
+            }
+        }
+
+        private func runOnMainThreadSync<T>(_ block: () -> T) -> T {
+            if Thread.isMainThread {
+                return block()
+            } else {
+                return DispatchQueue.main.sync(execute: block)
+            }
         }
     }
-}
-// swiftlint:enable type_body_length
+    // swiftlint:enable type_body_length
 
 #endif
 // swiftlint:enable file_length missing_docs

--- a/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
@@ -1,225 +1,226 @@
 // swiftlint:disable missing_docs
 import Foundation
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-@_implementationOnly import _SentryPrivate
-import UIKit
+    @_implementationOnly import _SentryPrivate
+    import UIKit
 
-@objcMembers
-@_spi(Private) public class SentryTouchTracker: NSObject {
-    
-    private struct TouchEvent {
-        let x: CGFloat
-        let y: CGFloat
-        let timestamp: TimeInterval
-        let phase: TouchEventPhase
-        
-        var point: CGPoint {
-            CGPoint(x: x, y: y)
-        }
-    }
-    
-    private final class TouchInfo {
-        let id: Int
-        let identifier: ObjectIdentifier
-        
-        var startEvent: TouchEvent?
-        var endEvent: TouchEvent?
-        var moveEvents = [TouchEvent]()
-        
-        init(id: Int, identifier: ObjectIdentifier) {
-            self.id = id
-            self.identifier = identifier
-        }
-    }
-    
-    private struct ExtractedTouchData {
-        let identifier: ObjectIdentifier
-        let position: CGPoint
-        let phase: UITouch.Phase
-    }
-    
-    /**
-     * Active touches tracked by ObjectIdentifier for O(1) lookup performance.
-     * ObjectIdentifier can collide when UITouch memory is reused.
-     */
-    private var trackedTouches = [ObjectIdentifier: TouchInfo]()
-    
-    /**
-     * Touches that were replaced in trackedTouches due to ObjectIdentifier collision.
-     * Preserves events when UITouch memory is reused before flushFinishedEvents().
-     */
-    private var orphanedTouches = [TouchInfo]()
-    
-    private let dispatchQueue: SentryDispatchQueueWrapper
-    private var touchId = 1
-    private let dateProvider: SentryCurrentDateProvider
-    private let scale: CGAffineTransform
-    
-    public init(dateProvider: SentryCurrentDateProvider, scale: Float, dispatchQueue: SentryDispatchQueueWrapper) {
-        self.dateProvider = dateProvider
-        self.scale = CGAffineTransform(scaleX: CGFloat(scale), y: CGFloat(scale))
-        self.dispatchQueue = dispatchQueue
-    }
-    
-    public convenience init(dateProvider: SentryCurrentDateProvider, scale: Float) {
-        // SentryTouchTracker has it own dispatch queue instead of using the one
-        // from Dependency container to avoid the bottleneck of sharing the same
-        // queue with the rest of the SDK.
-        self.init(dateProvider: dateProvider, scale: scale, dispatchQueue: SentryDispatchQueueWrapper())
-    }
-    
-    public func trackTouchFrom(event: UIEvent) {
-        guard let touches = event.allTouches else { return }
-        let timestamp = event.timestamp
-        
-        // Extract touch data on the main thread before dispatching to background queue
-        // to avoid accessing UIKit objects from a background thread
-        let extractedTouches: [ExtractedTouchData] = touches.compactMap { touch in
-            guard touch.phase == .began || touch.phase == .ended || touch.phase == .moved || touch.phase == .cancelled else { return nil }
-            let position = touch.location(in: nil).applying(scale)
-            // There is no way to uniquely identify a touch, so we use the ObjectIdentifier of the UITouch instance.
-            // This is not a perfect solution, but it is the best we can do without holding references to UIKit objects.
-            return ExtractedTouchData(identifier: ObjectIdentifier(touch), position: position, phase: touch.phase)
-        }
-        
-        dispatchQueue.dispatchAsync { [self] in
-            for extractedTouch in extractedTouches {
-                processTouchEvent(extractedTouch, timestamp: timestamp)
+    @objcMembers
+    @_spi(Private) public class SentryTouchTracker: NSObject {
+        private struct TouchEvent {
+            let x: CGFloat
+            let y: CGFloat
+            let timestamp: TimeInterval
+            let phase: TouchEventPhase
+
+            var point: CGPoint {
+                CGPoint(x: x, y: y)
             }
         }
-    }
-    
-    private func processTouchEvent(_ extractedTouch: ExtractedTouchData, timestamp: TimeInterval) {
-        let info: TouchInfo
-        
-        if extractedTouch.phase == .began {
-            // Check for ObjectIdentifier collision - if touch already exists, orphan it
-            if let existingTouch = trackedTouches[extractedTouch.identifier] {
-                orphanedTouches.append(existingTouch)
+
+        private final class TouchInfo {
+            let id: Int
+            let identifier: ObjectIdentifier
+
+            var startEvent: TouchEvent?
+            var endEvent: TouchEvent?
+            var moveEvents = [TouchEvent]()
+
+            init(id: Int, identifier: ObjectIdentifier) {
+                self.id = id
+                self.identifier = identifier
             }
-            
-            // Create new TouchInfo for .began
-            info = TouchInfo(id: touchId++, identifier: extractedTouch.identifier)
-            trackedTouches[extractedTouch.identifier] = info
-        } else {
-            // O(1) dictionary lookup for non-.began phases
-            if let existingInfo = trackedTouches[extractedTouch.identifier] {
-                info = existingInfo
-            } else {
-                // Create new if not found (shouldn't happen, but handle gracefully)
+        }
+
+        private struct ExtractedTouchData {
+            let identifier: ObjectIdentifier
+            let position: CGPoint
+            let phase: UITouch.Phase
+        }
+
+        /**
+         * Active touches tracked by ObjectIdentifier for O(1) lookup performance.
+         * ObjectIdentifier can collide when UITouch memory is reused.
+         */
+        private var trackedTouches = [ObjectIdentifier: TouchInfo]()
+
+        /**
+         * Touches that were replaced in trackedTouches due to ObjectIdentifier collision.
+         * Preserves events when UITouch memory is reused before flushFinishedEvents().
+         */
+        private var orphanedTouches = [TouchInfo]()
+
+        private let dispatchQueue: SentryDispatchQueueWrapper
+        private var touchId = 1
+        private let dateProvider: SentryCurrentDateProvider
+        private let scale: CGAffineTransform
+        var isEnabled = true
+
+        public init(dateProvider: SentryCurrentDateProvider, scale: Float, dispatchQueue: SentryDispatchQueueWrapper) {
+            self.dateProvider = dateProvider
+            self.scale = CGAffineTransform(scaleX: CGFloat(scale), y: CGFloat(scale))
+            self.dispatchQueue = dispatchQueue
+        }
+
+        public convenience init(dateProvider: SentryCurrentDateProvider, scale: Float) {
+            // SentryTouchTracker has it own dispatch queue instead of using the one
+            // from Dependency container to avoid the bottleneck of sharing the same
+            // queue with the rest of the SDK.
+            self.init(dateProvider: dateProvider, scale: scale, dispatchQueue: SentryDispatchQueueWrapper())
+        }
+
+        public func trackTouchFrom(event: UIEvent) {
+            guard isEnabled else { return }
+            guard let touches = event.allTouches else { return }
+            let timestamp = event.timestamp
+
+            // Extract touch data on the main thread before dispatching to background queue
+            // to avoid accessing UIKit objects from a background thread
+            let extractedTouches: [ExtractedTouchData] = touches.compactMap { touch in
+                guard touch.phase == .began || touch.phase == .ended || touch.phase == .moved || touch.phase == .cancelled else { return nil }
+                let position = touch.location(in: nil).applying(scale)
+                // There is no way to uniquely identify a touch, so we use the ObjectIdentifier of the UITouch instance.
+                // This is not a perfect solution, but it is the best we can do without holding references to UIKit objects.
+                return ExtractedTouchData(identifier: ObjectIdentifier(touch), position: position, phase: touch.phase)
+            }
+
+            dispatchQueue.dispatchAsync { [self] in
+                for extractedTouch in extractedTouches {
+                    processTouchEvent(extractedTouch, timestamp: timestamp)
+                }
+            }
+        }
+
+        private func processTouchEvent(_ extractedTouch: ExtractedTouchData, timestamp: TimeInterval) {
+            let info: TouchInfo
+
+            if extractedTouch.phase == .began {
+                // Check for ObjectIdentifier collision - if touch already exists, orphan it
+                if let existingTouch = trackedTouches[extractedTouch.identifier] {
+                    orphanedTouches.append(existingTouch)
+                }
+
+                // Create new TouchInfo for .began
                 info = TouchInfo(id: touchId++, identifier: extractedTouch.identifier)
                 trackedTouches[extractedTouch.identifier] = info
+            } else {
+                // O(1) dictionary lookup for non-.began phases
+                if let existingInfo = trackedTouches[extractedTouch.identifier] {
+                    info = existingInfo
+                } else {
+                    // Create new if not found (shouldn't happen, but handle gracefully)
+                    info = TouchInfo(id: touchId++, identifier: extractedTouch.identifier)
+                    trackedTouches[extractedTouch.identifier] = info
+                }
             }
-        }
-        
-        let position = extractedTouch.position
-        let newEvent = TouchEvent(x: position.x, y: position.y, timestamp: timestamp, phase: extractedTouch.phase.toRRWebTouchPhase())
-        
-        switch extractedTouch.phase {
-        case .began:
-            info.startEvent = newEvent
-        case .ended, .cancelled:
-            info.endEvent = newEvent
-        case .moved:
-            // If the distance between two points is smaller than 10 points, we don't record the second movement.
-            // iOS event polling is fast and will capture any movement; we don't need this granularity for replay.
-            if let last = info.moveEvents.last, touchesDelta(last.point, position) < 10 { return }
-            info.moveEvents.append(newEvent)
-            self.debounceEvents(in: info)
-        default:
-            return
-        }
-    }
-    
-    private func touchesDelta(_ lastTouch: CGPoint, _ newTouch: CGPoint) -> CGFloat {
-        let dx = newTouch.x - lastTouch.x
-        let dy = newTouch.y - lastTouch.y
-        return sqrt(dx * dx + dy * dy)
-    }
-    
-    private func debounceEvents(in touchInfo: TouchInfo) {
-        guard touchInfo.moveEvents.count >= 3 else { return }
-        let subset = touchInfo.moveEvents.suffix(3)
-        if subset[subset.startIndex + 2].timestamp - subset[subset.startIndex + 1].timestamp > 0.5 {
-            // Don't debounce if the last two touches have at least a 500 millisecond difference to show this pause in the replay.
-            return
-        }
-        // If the last 3 touch points exist in a straight line, we don't need the middle point,
-        // because the representation in the replay with 2 or 3 points will be the same.
-        if arePointsCollinearSameDirection(subset[subset.startIndex].point, subset[subset.startIndex + 1].point, subset[subset.startIndex + 2].point) {
-            touchInfo.moveEvents.remove(at: touchInfo.moveEvents.count - 2)
-        }
-    }
-    
-    private func arePointsCollinearSameDirection(_ a: CGPoint, _ b: CGPoint, _ c: CGPoint) -> Bool {
-        // In the case some tweeking in the tolerances is required
-        // its possible to test this function in the following link: https://jsfiddle.net/dhiogorb/8owgh1pb/3/
-        var abAngle = atan2(b.x - a.x, b.y - a.y)
-        var bcAngle = atan2(c.x - b.x, c.y - b.y)
 
-        if abAngle * bcAngle < 0 { return false; }
+            let position = extractedTouch.position
+            let newEvent = TouchEvent(x: position.x, y: position.y, timestamp: timestamp, phase: extractedTouch.phase.toRRWebTouchPhase())
 
-        abAngle += .pi
-        bcAngle += .pi
-
-        return abs(abAngle - bcAngle) < 0.05 || abs(abAngle - (2 * .pi - bcAngle)) < 0.05
-    }
-    
-    func flushFinishedEvents() {
-        SentrySDKLog.debug("[Session Replay] Flushing finished events")
-        dispatchQueue.dispatchSync { [self] in
-            trackedTouches = trackedTouches.filter { $0.value.endEvent == nil }
-            orphanedTouches = orphanedTouches.filter { $0.endEvent == nil }
-        }
-    }
-    
-    func replayEvents(from: Date, until: Date) -> [SentryRRWebEvent] {
-        let uptime = dateProvider.systemUptime()
-        let now = dateProvider.date()
-        let startTimeInterval = uptime - now.timeIntervalSince(from)
-        let endTimeInterval = uptime - now.timeIntervalSince(until)
-        
-        var result = [SentryRRWebEvent]()
-        
-        var touches = [TouchInfo]()
-        dispatchQueue.dispatchSync { [self] in
-            // Include both active and orphaned touches to preserve all events
-            touches = Array(trackedTouches.values) + orphanedTouches
-        }
-        
-        for info in touches {
-            if let infoStart = info.startEvent, infoStart.timestamp >= startTimeInterval && infoStart.timestamp <= endTimeInterval {
-                result.append(RRWebTouchEvent(timestamp: now.addingTimeInterval(infoStart.timestamp - uptime), touchId: info.id, x: Float(infoStart.x), y: Float(infoStart.y), phase: .start))
-            }
-            
-            let moveEvents: [TouchPosition] = info.moveEvents.compactMap { movement in
-                movement.timestamp >= startTimeInterval && movement.timestamp <= endTimeInterval
-                    ? TouchPosition(x: Float(movement.x), y: Float(movement.y), timestamp: now.addingTimeInterval(movement.timestamp - uptime))
-                    : nil
-            }
-            
-            if let lastMovement = moveEvents.last {
-                result.append(RRWebMoveEvent(timestamp: lastMovement.timestamp, touchId: info.id, positions: moveEvents))
-            }
-            
-            if let infoEnd = info.endEvent, infoEnd.timestamp >= startTimeInterval && infoEnd.timestamp <= endTimeInterval {
-                result.append(RRWebTouchEvent(timestamp: now.addingTimeInterval(infoEnd.timestamp - uptime), touchId: info.id, x: Float(infoEnd.x), y: Float(infoEnd.y), phase: .end))
+            switch extractedTouch.phase {
+            case .began:
+                info.startEvent = newEvent
+            case .ended, .cancelled:
+                info.endEvent = newEvent
+            case .moved:
+                // If the distance between two points is smaller than 10 points, we don't record the second movement.
+                // iOS event polling is fast and will capture any movement; we don't need this granularity for replay.
+                if let last = info.moveEvents.last, touchesDelta(last.point, position) < 10 { return }
+                info.moveEvents.append(newEvent)
+                debounceEvents(in: info)
+            default:
+                return
             }
         }
 
-        return result.sorted { $0.timestamp.compare($1.timestamp) == .orderedAscending }
-    }
-}
+        private func touchesDelta(_ lastTouch: CGPoint, _ newTouch: CGPoint) -> CGFloat {
+            let dx = newTouch.x - lastTouch.x
+            let dy = newTouch.y - lastTouch.y
+            return sqrt(dx * dx + dy * dy)
+        }
 
-private extension UITouch.Phase {
-    func toRRWebTouchPhase() -> TouchEventPhase {
-        switch self {
+        private func debounceEvents(in touchInfo: TouchInfo) {
+            guard touchInfo.moveEvents.count >= 3 else { return }
+            let subset = touchInfo.moveEvents.suffix(3)
+            if subset[subset.startIndex + 2].timestamp - subset[subset.startIndex + 1].timestamp > 0.5 {
+                // Don't debounce if the last two touches have at least a 500 millisecond difference to show this pause in the replay.
+                return
+            }
+            // If the last 3 touch points exist in a straight line, we don't need the middle point,
+            // because the representation in the replay with 2 or 3 points will be the same.
+            if arePointsCollinearSameDirection(subset[subset.startIndex].point, subset[subset.startIndex + 1].point, subset[subset.startIndex + 2].point) {
+                touchInfo.moveEvents.remove(at: touchInfo.moveEvents.count - 2)
+            }
+        }
+
+        private func arePointsCollinearSameDirection(_ a: CGPoint, _ b: CGPoint, _ c: CGPoint) -> Bool {
+            // In the case some tweeking in the tolerances is required
+            // its possible to test this function in the following link: https://jsfiddle.net/dhiogorb/8owgh1pb/3/
+            var abAngle = atan2(b.x - a.x, b.y - a.y)
+            var bcAngle = atan2(c.x - b.x, c.y - b.y)
+
+            if abAngle * bcAngle < 0 { return false }
+
+            abAngle += .pi
+            bcAngle += .pi
+
+            return abs(abAngle - bcAngle) < 0.05 || abs(abAngle - (2 * .pi - bcAngle)) < 0.05
+        }
+
+        func flushFinishedEvents() {
+            SentrySDKLog.debug("[Session Replay] Flushing finished events")
+            dispatchQueue.dispatchSync { [self] in
+                trackedTouches = trackedTouches.filter { $0.value.endEvent == nil }
+                orphanedTouches = orphanedTouches.filter { $0.endEvent == nil }
+            }
+        }
+
+        func replayEvents(from: Date, until: Date) -> [SentryRRWebEvent] {
+            let uptime = dateProvider.systemUptime()
+            let now = dateProvider.date()
+            let startTimeInterval = uptime - now.timeIntervalSince(from)
+            let endTimeInterval = uptime - now.timeIntervalSince(until)
+
+            var result = [SentryRRWebEvent]()
+
+            var touches = [TouchInfo]()
+            dispatchQueue.dispatchSync { [self] in
+                // Include both active and orphaned touches to preserve all events
+                touches = Array(trackedTouches.values) + orphanedTouches
+            }
+
+            for info in touches {
+                if let infoStart = info.startEvent, infoStart.timestamp >= startTimeInterval, infoStart.timestamp <= endTimeInterval {
+                    result.append(RRWebTouchEvent(timestamp: now.addingTimeInterval(infoStart.timestamp - uptime), touchId: info.id, x: Float(infoStart.x), y: Float(infoStart.y), phase: .start))
+                }
+
+                let moveEvents: [TouchPosition] = info.moveEvents.compactMap { movement in
+                    movement.timestamp >= startTimeInterval && movement.timestamp <= endTimeInterval
+                        ? TouchPosition(x: Float(movement.x), y: Float(movement.y), timestamp: now.addingTimeInterval(movement.timestamp - uptime))
+                        : nil
+                }
+
+                if let lastMovement = moveEvents.last {
+                    result.append(RRWebMoveEvent(timestamp: lastMovement.timestamp, touchId: info.id, positions: moveEvents))
+                }
+
+                if let infoEnd = info.endEvent, infoEnd.timestamp >= startTimeInterval, infoEnd.timestamp <= endTimeInterval {
+                    result.append(RRWebTouchEvent(timestamp: now.addingTimeInterval(infoEnd.timestamp - uptime), touchId: info.id, x: Float(infoEnd.x), y: Float(infoEnd.y), phase: .end))
+                }
+            }
+
+            return result.sorted { $0.timestamp.compare($1.timestamp) == .orderedAscending }
+        }
+    }
+
+    private extension UITouch.Phase {
+        func toRRWebTouchPhase() -> TouchEventPhase {
+            switch self {
             case .began: return .start
             case .ended, .cancelled: return .end
             default: return .unknown
+            }
         }
     }
-}
 
 #endif
 // swiftlint:enable missing_docs

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -1,513 +1,550 @@
 #if os(iOS)
 
-@_spi(Private) import SentryTestUtils
-@_spi(Private) @testable import Sentry
-import XCTest
+    @_spi(Private) import SentryTestUtils
+    @_spi(Private) @testable import Sentry
+    import XCTest
 
-class SentryTouchTrackerTests: XCTestCase {
-        
-    private class MockUIEvent: UIEvent {
-        var mockTouches = Set<UITouch>()
-        private var _timestamp: TimeInterval = 0
-        
-        override var timestamp: TimeInterval {
-            get {
-                _timestamp
-            }
-            set {
-                _timestamp = newValue
-            }
-        }
-        
-        override var allTouches: Set<UITouch>? {
-            return mockTouches
-        }
-        
-        func addTouch(_ touch: UITouch) {
-            mockTouches.insert(touch)
-        }
-        
-        init(timestamp: TimeInterval = 0) {
-            _timestamp = timestamp
-        }
-    }
+    class SentryTouchTrackerTests: XCTestCase {
+        private class MockUIEvent: UIEvent {
+            var mockTouches = Set<UITouch>()
+            private var _timestamp: TimeInterval = 0
 
-    private class MockUITouch: UITouch {
-        private var _phase: UITouch.Phase
-        var location: CGPoint
-        
-        init(phase: UITouch.Phase, location: CGPoint) {
-            _phase = phase
-            self.location = location
-            super.init()
-        }
-        
-        override var phase: UITouch.Phase {
-            get { _phase }
-            set { _phase = newValue }
-        }
-        
-        override func location(in view: UIView?) -> CGPoint {
-            return location
-        }
-    }
-    
-    private var dateprovider = TestCurrentDateProvider()
-    
-    override func setUp() {
-        super.setUp()
-        dateprovider.advance(by: 5)
-        dateprovider.setSystemUptime(5)
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
-    
-    private var referenceDate = Date(timeIntervalSinceReferenceDate: 0)
-    
-    private func getSut(dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper()) -> SentryTouchTracker {
-        return SentryTouchTracker(dateProvider: dateprovider, scale: 1, dispatchQueue: dispatchQueue)
-    }
-    
-    func testTrackTouchFromEvent() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 3)
-        let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
-        event.addTouch(touch)
-        
-        sut.trackTouchFrom(event: event)
-        touch.phase = .ended
-        event.timestamp = 4
-        
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result.first?.timestamp, referenceDate.addingTimeInterval(3))
-        XCTAssertEqual(result.first?.type, .touch)
-    }
-    
-    func testTrackTouchBegan() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 3)
-        event.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100)))
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        
-        XCTAssertEqual(data?["x"] as? Float, 100)
-        XCTAssertEqual(data?["y"] as? Float, 100)
-        XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.start.rawValue)
-        XCTAssertEqual(data?["pointerId"] as? Int, 1)
-        XCTAssertEqual(data?["pointerType"] as? Int, 2)
-        XCTAssertEqual(data?["source"] as? Int, 2)
-    }
-    
-    func testTrackTouchEnded() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 3)
-        event.addTouch(MockUITouch(phase: .ended, location: CGPoint(x: 100, y: 100)))
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        
-        XCTAssertEqual(data?["x"] as? Float, 100)
-        XCTAssertEqual(data?["y"] as? Float, 100)
-        XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.end.rawValue)
-        XCTAssertEqual(data?["pointerId"] as? Int, 1)
-        XCTAssertEqual(data?["pointerType"] as? Int, 2)
-        XCTAssertEqual(data?["source"] as? Int, 2)
-    }
-    
-    func testTrackTouchCanceled() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 3)
-        event.addTouch(MockUITouch(phase: .cancelled, location: CGPoint(x: 100, y: 100)))
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        
-        XCTAssertEqual(data?["x"] as? Float, 100)
-        XCTAssertEqual(data?["y"] as? Float, 100)
-        XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.end.rawValue)
-        XCTAssertEqual(data?["pointerId"] as? Int, 1)
-        XCTAssertEqual(data?["pointerType"] as? Int, 2)
-        XCTAssertEqual(data?["source"] as? Int, 2)
-    }
-    
-    func testTrackTouchEventKeepSameIdAccrossEvents() throws {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 3)
-        let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
-        let secondTouch = MockUITouch(phase: .began, location: CGPoint(x: 50, y: 50))
-        event.addTouch(touch)
-        event.addTouch(secondTouch)
-        sut.trackTouchFrom(event: event)
-        touch.phase = .ended
-        secondTouch.phase = .ended
-        event.timestamp = 4
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let firstEventFirstTouch = try XCTUnwrap(result.first).data
-        let firstEventSecondTouch = try XCTUnwrap(result.element(at: 1)).data
-        let secondEventFirstTouch = try XCTUnwrap(result.element(at: 2)).data
-        let secondEventSecondTouch = try XCTUnwrap(result.element(at: 3)).data
-        
-        XCTAssertEqual(firstEventFirstTouch?["pointerId"] as? Int, secondEventFirstTouch?["pointerId"] as? Int)
-        XCTAssertEqual(firstEventSecondTouch?["pointerId"] as? Int, secondEventSecondTouch?["pointerId"] as? Int)
-        XCTAssertNotEqual(firstEventFirstTouch?["pointerId"] as? Int, firstEventSecondTouch?["pointerId"] as? Int)
-    }
-    
-    func testTrackTouchMoved() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 3
-        touch.location = CGPoint(x: 50, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        let firstPosition = positions?.first
-        let secondPosition = positions?.last
-        
-        XCTAssertEqual(data?["pointerId"] as? Int, 1)
-        XCTAssertEqual(data?["source"] as? Int, 6)
-        XCTAssertEqual(positions?.count, 2)
-        
-        XCTAssertEqual(firstPosition?["x"] as? Float, 10)
-        XCTAssertEqual(firstPosition?["y"] as? Float, 10)
-        XCTAssertEqual(firstPosition?["timeOffset"] as? Int, -1_000)
-        
-        XCTAssertEqual(secondPosition?["x"] as? Float, 50)
-        XCTAssertEqual(secondPosition?["y"] as? Float, 50)
-        XCTAssertEqual(secondPosition?["timeOffset"] as? Int, 0)
-    }
-    
-    func testTrackTouchMoveIgnoreSmallMovement() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 3
-        touch.location = CGPoint(x: 10, y: 9)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        
-        XCTAssertEqual(positions?.count, 1)
-    }
-    
-    func testTrackTouchMoveDebounceStraightLines() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.1
-        touch.location = CGPoint(x: 10, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.2
-        touch.location = CGPoint(x: 10, y: 90)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        
-        XCTAssertEqual(positions?.count, 2)
-    }
-    
-    func testTrackTouchMoveDontDebounceStraightLinesChangeOfDirection() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.1
-        touch.location = CGPoint(x: 10, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.2
-        touch.location = CGPoint(x: 10, y: 30)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        
-        XCTAssertEqual(positions?.count, 3)
-    }
-    
-    func testTrackTouchMoveDontDebounceCurve() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.1
-        touch.location = CGPoint(x: 10, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.2
-        touch.location = CGPoint(x: 50, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        
-        XCTAssertEqual(positions?.count, 3)
-    }
-    
-    func testTrackTouchMoveDontDebouncePauses() {
-        let sut = getSut()
-        let event = MockUIEvent(timestamp: 2)
-        let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
-        event.addTouch(touch)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 2.6
-        touch.location = CGPoint(x: 10, y: 50)
-        sut.trackTouchFrom(event: event)
-        
-        event.timestamp = 3.2
-        touch.location = CGPoint(x: 10, y: 90)
-        sut.trackTouchFrom(event: event)
-        
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let data = result.first?.data
-        let positions = data?["positions"] as? [[String: Any]]
-        
-        XCTAssertEqual(positions?.count, 3)
-    }
-    
-    func testAddingReadingFlushing_DoesNotCrash() {
-        // Arrange
-        let iterations = 100
-
-        let sut = getSut(dispatchQueue: SentryDispatchQueueWrapper())
-        
-        let addExp = expectation(description: "add")
-        addExp.expectedFulfillmentCount = iterations
-        let removeExp = expectation(description: "remove")
-        removeExp.expectedFulfillmentCount = iterations
-        let readExp = expectation(description: "read")
-        readExp.expectedFulfillmentCount = iterations
-
-        let dispatchQueue = DispatchQueue(label: "sentry.test.queue", attributes: [.concurrent, .initiallyInactive])
-
-        // Act
-        for i in 0..<iterations {
-            dispatchQueue.async {
-                let event = MockUIEvent(timestamp: Double(i))
-                let touch = MockUITouch(phase: .ended, location: CGPoint(x: 100, y: 100))
-                event.addTouch(touch)
-                sut.trackTouchFrom(event: event)
-
-                addExp.fulfill()
+            override var timestamp: TimeInterval {
+                get {
+                    _timestamp
+                }
+                set {
+                    _timestamp = newValue
+                }
             }
 
-            dispatchQueue.async {
-                sut.flushFinishedEvents()
-                removeExp.fulfill()
+            override var allTouches: Set<UITouch>? {
+                return mockTouches
             }
 
-            dispatchQueue.async {
-                _ = sut.replayEvents(from: self.referenceDate, until: self.referenceDate.addingTimeInterval(10_000.0))
-                readExp.fulfill()
+            func addTouch(_ touch: UITouch) {
+                mockTouches.insert(touch)
+            }
+
+            init(timestamp: TimeInterval = 0) {
+                _timestamp = timestamp
             }
         }
 
-        dispatchQueue.activate()
+        private class MockUITouch: UITouch {
+            private var _phase: UITouch.Phase
+            var location: CGPoint
 
-        // Assert
-        wait(for: [addExp, removeExp, readExp], timeout: 5)
+            init(phase: UITouch.Phase, location: CGPoint) {
+                _phase = phase
+                self.location = location
+                super.init()
+            }
+
+            override var phase: UITouch.Phase {
+                get { _phase }
+                set { _phase = newValue }
+            }
+
+            override func location(in _: UIView?) -> CGPoint {
+                return location
+            }
+        }
+
+        private var dateprovider = TestCurrentDateProvider()
+
+        override func setUp() {
+            super.setUp()
+            dateprovider.advance(by: 5)
+            dateprovider.setSystemUptime(5)
+        }
+
+        override func tearDown() {
+            super.tearDown()
+        }
+
+        private var referenceDate = Date(timeIntervalSinceReferenceDate: 0)
+
+        private func getSut(dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper()) -> SentryTouchTracker {
+            return SentryTouchTracker(dateProvider: dateprovider, scale: 1, dispatchQueue: dispatchQueue)
+        }
+
+        func testTrackTouchFromEvent() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 3)
+            let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
+            event.addTouch(touch)
+
+            sut.trackTouchFrom(event: event)
+            touch.phase = .ended
+            event.timestamp = 4
+
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+
+            XCTAssertEqual(result.count, 2)
+            XCTAssertEqual(result.first?.timestamp, referenceDate.addingTimeInterval(3))
+            XCTAssertEqual(result.first?.type, .touch)
+        }
+
+        func testTrackTouchBegan() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 3)
+            event.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100)))
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+
+            XCTAssertEqual(data?["x"] as? Float, 100)
+            XCTAssertEqual(data?["y"] as? Float, 100)
+            XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.start.rawValue)
+            XCTAssertEqual(data?["pointerId"] as? Int, 1)
+            XCTAssertEqual(data?["pointerType"] as? Int, 2)
+            XCTAssertEqual(data?["source"] as? Int, 2)
+        }
+
+        func testTrackTouchEnded() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 3)
+            event.addTouch(MockUITouch(phase: .ended, location: CGPoint(x: 100, y: 100)))
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+
+            XCTAssertEqual(data?["x"] as? Float, 100)
+            XCTAssertEqual(data?["y"] as? Float, 100)
+            XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.end.rawValue)
+            XCTAssertEqual(data?["pointerId"] as? Int, 1)
+            XCTAssertEqual(data?["pointerType"] as? Int, 2)
+            XCTAssertEqual(data?["source"] as? Int, 2)
+        }
+
+        func testTrackTouchCanceled() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 3)
+            event.addTouch(MockUITouch(phase: .cancelled, location: CGPoint(x: 100, y: 100)))
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+
+            XCTAssertEqual(data?["x"] as? Float, 100)
+            XCTAssertEqual(data?["y"] as? Float, 100)
+            XCTAssertEqual(data?["type"] as? Int, TouchEventPhase.end.rawValue)
+            XCTAssertEqual(data?["pointerId"] as? Int, 1)
+            XCTAssertEqual(data?["pointerType"] as? Int, 2)
+            XCTAssertEqual(data?["source"] as? Int, 2)
+        }
+
+        func testTrackTouchEventKeepSameIdAccrossEvents() throws {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 3)
+            let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
+            let secondTouch = MockUITouch(phase: .began, location: CGPoint(x: 50, y: 50))
+            event.addTouch(touch)
+            event.addTouch(secondTouch)
+            sut.trackTouchFrom(event: event)
+            touch.phase = .ended
+            secondTouch.phase = .ended
+            event.timestamp = 4
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let firstEventFirstTouch = try XCTUnwrap(result.first).data
+            let firstEventSecondTouch = try XCTUnwrap(result.element(at: 1)).data
+            let secondEventFirstTouch = try XCTUnwrap(result.element(at: 2)).data
+            let secondEventSecondTouch = try XCTUnwrap(result.element(at: 3)).data
+
+            XCTAssertEqual(firstEventFirstTouch?["pointerId"] as? Int, secondEventFirstTouch?["pointerId"] as? Int)
+            XCTAssertEqual(firstEventSecondTouch?["pointerId"] as? Int, secondEventSecondTouch?["pointerId"] as? Int)
+            XCTAssertNotEqual(firstEventFirstTouch?["pointerId"] as? Int, firstEventSecondTouch?["pointerId"] as? Int)
+        }
+
+        func testTrackTouchMoved() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 3
+            touch.location = CGPoint(x: 50, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+            let firstPosition = positions?.first
+            let secondPosition = positions?.last
+
+            XCTAssertEqual(data?["pointerId"] as? Int, 1)
+            XCTAssertEqual(data?["source"] as? Int, 6)
+            XCTAssertEqual(positions?.count, 2)
+
+            XCTAssertEqual(firstPosition?["x"] as? Float, 10)
+            XCTAssertEqual(firstPosition?["y"] as? Float, 10)
+            XCTAssertEqual(firstPosition?["timeOffset"] as? Int, -1000)
+
+            XCTAssertEqual(secondPosition?["x"] as? Float, 50)
+            XCTAssertEqual(secondPosition?["y"] as? Float, 50)
+            XCTAssertEqual(secondPosition?["timeOffset"] as? Int, 0)
+        }
+
+        func testTrackTouchMoveIgnoreSmallMovement() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 3
+            touch.location = CGPoint(x: 10, y: 9)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+
+            XCTAssertEqual(positions?.count, 1)
+        }
+
+        func testTrackTouchMoveDebounceStraightLines() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.1
+            touch.location = CGPoint(x: 10, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.2
+            touch.location = CGPoint(x: 10, y: 90)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+
+            XCTAssertEqual(positions?.count, 2)
+        }
+
+        func testTrackTouchMoveDontDebounceStraightLinesChangeOfDirection() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.1
+            touch.location = CGPoint(x: 10, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.2
+            touch.location = CGPoint(x: 10, y: 30)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+
+            XCTAssertEqual(positions?.count, 3)
+        }
+
+        func testTrackTouchMoveDontDebounceCurve() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.1
+            touch.location = CGPoint(x: 10, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.2
+            touch.location = CGPoint(x: 50, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+
+            XCTAssertEqual(positions?.count, 3)
+        }
+
+        func testTrackTouchMoveDontDebouncePauses() {
+            let sut = getSut()
+            let event = MockUIEvent(timestamp: 2)
+            let touch = MockUITouch(phase: .moved, location: CGPoint(x: 10, y: 10))
+            event.addTouch(touch)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 2.6
+            touch.location = CGPoint(x: 10, y: 50)
+            sut.trackTouchFrom(event: event)
+
+            event.timestamp = 3.2
+            touch.location = CGPoint(x: 10, y: 90)
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            let data = result.first?.data
+            let positions = data?["positions"] as? [[String: Any]]
+
+            XCTAssertEqual(positions?.count, 3)
+        }
+
+        func testAddingReadingFlushing_DoesNotCrash() {
+            // Arrange
+            let iterations = 100
+
+            let sut = getSut(dispatchQueue: SentryDispatchQueueWrapper())
+
+            let addExp = expectation(description: "add")
+            addExp.expectedFulfillmentCount = iterations
+            let removeExp = expectation(description: "remove")
+            removeExp.expectedFulfillmentCount = iterations
+            let readExp = expectation(description: "read")
+            readExp.expectedFulfillmentCount = iterations
+
+            let dispatchQueue = DispatchQueue(label: "sentry.test.queue", attributes: [.concurrent, .initiallyInactive])
+
+            // Act
+            for i in 0 ..< iterations {
+                dispatchQueue.async {
+                    let event = MockUIEvent(timestamp: Double(i))
+                    let touch = MockUITouch(phase: .ended, location: CGPoint(x: 100, y: 100))
+                    event.addTouch(touch)
+                    sut.trackTouchFrom(event: event)
+
+                    addExp.fulfill()
+                }
+
+                dispatchQueue.async {
+                    sut.flushFinishedEvents()
+                    removeExp.fulfill()
+                }
+
+                dispatchQueue.async {
+                    _ = sut.replayEvents(from: self.referenceDate, until: self.referenceDate.addingTimeInterval(10000.0))
+                    readExp.fulfill()
+                }
+            }
+
+            dispatchQueue.activate()
+
+            // Assert
+            wait(for: [addExp, removeExp, readExp], timeout: 5)
+        }
+
+        func testObjectIdentifierCollision_NewTouchGetsNewId() {
+            // Arrange
+            // This test simulates ObjectIdentifier collision when UITouch memory is reused.
+            // When iOS reuses memory for a new UITouch at the same address as a previous touch,
+            // the ObjectIdentifier will be the same, but it's actually a different touch gesture.
+            let sut = getSut()
+            let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
+
+            // Act - First touch lifecycle (began -> moved -> ended)
+            let event1 = MockUIEvent(timestamp: 1)
+            event1.addTouch(touch)
+            sut.trackTouchFrom(event: event1)
+
+            touch.phase = .moved
+            touch.location = CGPoint(x: 150, y: 150)
+            let event2 = MockUIEvent(timestamp: 2)
+            event2.addTouch(touch)
+            sut.trackTouchFrom(event: event2)
+
+            touch.phase = .ended
+            touch.location = CGPoint(x: 200, y: 200)
+            let event3 = MockUIEvent(timestamp: 3)
+            event3.addTouch(touch)
+            sut.trackTouchFrom(event: event3)
+
+            // Get events from first touch before they're overwritten
+            let firstTouchEvents = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
+
+            // In real-world usage, flushFinishedEvents would be called periodically
+            // This removes finished touches from trackedTouches
+            sut.flushFinishedEvents()
+
+            // Simulate memory reuse: same UITouch object starts a NEW touch gesture
+            // In reality this would be a new UITouch at the same memory address,
+            // but for testing we can use the same object with .began phase at a different location
+            touch.phase = .began
+            touch.location = CGPoint(x: 50, y: 50) // Different location - this is a NEW touch
+            let event4 = MockUIEvent(timestamp: 4)
+            event4.addTouch(touch)
+            sut.trackTouchFrom(event: event4)
+
+            touch.phase = .ended
+            touch.location = CGPoint(x: 75, y: 75)
+            let event5 = MockUIEvent(timestamp: 5)
+            event5.addTouch(touch)
+            sut.trackTouchFrom(event: event5)
+
+            // Get second touch events
+            let secondTouchEvents = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
+
+            // Assert - First touch (captured before flush)
+            XCTAssertEqual(firstTouchEvents.count, 3, "First touch should have 3 events: start, move, end")
+
+            let firstTouchStart = firstTouchEvents[0].data
+            let firstTouchPointerId = firstTouchStart?["pointerId"] as? Int
+            XCTAssertEqual(firstTouchStart?["x"] as? Float, 100)
+            XCTAssertEqual(firstTouchStart?["y"] as? Float, 100)
+            XCTAssertEqual(firstTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
+            XCTAssertEqual(firstTouchPointerId, 1, "First touch should have pointer ID 1")
+
+            let firstTouchMove = firstTouchEvents[1].data
+            XCTAssertEqual(firstTouchMove?["pointerId"] as? Int, firstTouchPointerId)
+
+            let firstTouchEnd = firstTouchEvents[2].data
+            XCTAssertEqual(firstTouchEnd?["x"] as? Float, 200)
+            XCTAssertEqual(firstTouchEnd?["y"] as? Float, 200)
+            XCTAssertEqual(firstTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
+            XCTAssertEqual(firstTouchEnd?["pointerId"] as? Int, firstTouchPointerId)
+
+            // Assert - Second touch (after collision)
+            XCTAssertEqual(secondTouchEvents.count, 2, "Second touch should have 2 events: start, end")
+
+            let secondTouchStart = secondTouchEvents[0].data
+            let secondTouchPointerId = secondTouchStart?["pointerId"] as? Int
+            XCTAssertEqual(secondTouchStart?["x"] as? Float, 50)
+            XCTAssertEqual(secondTouchStart?["y"] as? Float, 50)
+            XCTAssertEqual(secondTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
+            XCTAssertEqual(secondTouchPointerId, 2, "Second touch should have pointer ID 2")
+
+            let secondTouchEnd = secondTouchEvents[1].data
+            XCTAssertEqual(secondTouchEnd?["x"] as? Float, 75)
+            XCTAssertEqual(secondTouchEnd?["y"] as? Float, 75)
+            XCTAssertEqual(secondTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
+            XCTAssertEqual(secondTouchEnd?["pointerId"] as? Int, secondTouchPointerId)
+
+            // Critical assertion: The two touches should have DIFFERENT pointer IDs
+            XCTAssertNotEqual(firstTouchPointerId, secondTouchPointerId,
+                              "Memory-reused touch should get a new pointer ID, not inherit the old one")
+        }
+
+        func testObjectIdentifierCollision_WithoutFlush_DoesNotOrphanEvents() {
+            // Arrange
+            // This test covers the case where a collision happens BEFORE flushFinishedEvents()
+            // The old touch's events should still be accessible, not orphaned
+            let sut = getSut()
+            let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
+
+            // Act - First touch begins but doesn't end
+            let event1 = MockUIEvent(timestamp: 1)
+            event1.addTouch(touch)
+            sut.trackTouchFrom(event: event1)
+
+            touch.phase = .moved
+            touch.location = CGPoint(x: 150, y: 150)
+            let event2 = MockUIEvent(timestamp: 2)
+            event2.addTouch(touch)
+            sut.trackTouchFrom(event: event2)
+
+            // Collision happens BEFORE first touch ends and BEFORE flush
+            // Same ObjectIdentifier starts a NEW touch
+            touch.phase = .began
+            touch.location = CGPoint(x: 50, y: 50)
+            let event3 = MockUIEvent(timestamp: 3)
+            event3.addTouch(touch)
+            sut.trackTouchFrom(event: event3)
+
+            touch.phase = .ended
+            touch.location = CGPoint(x: 75, y: 75)
+            let event4 = MockUIEvent(timestamp: 4)
+            event4.addTouch(touch)
+            sut.trackTouchFrom(event: event4)
+
+            // Assert
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
+
+            // We should have events from BOTH touches, even though the first didn't end:
+            // - Touch 1 start at (100, 100)
+            // - Touch 1 move at (150, 150)
+            // - Touch 2 start at (50, 50)  <- collision without flush
+            // - Touch 2 end at (75, 75)
+            //
+            // The first touch's events should NOT be orphaned/lost
+
+            XCTAssertEqual(result.count, 4, "Should have 4 events: both touches' events should be preserved")
+
+            // First touch events (incomplete, no end)
+            let firstTouchStart = result[0].data
+            let firstTouchPointerId = firstTouchStart?["pointerId"] as? Int
+            XCTAssertEqual(firstTouchStart?["x"] as? Float, 100)
+            XCTAssertEqual(firstTouchStart?["y"] as? Float, 100)
+            XCTAssertEqual(firstTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
+
+            let firstTouchMove = result[1].data
+            XCTAssertEqual(firstTouchMove?["pointerId"] as? Int, firstTouchPointerId)
+            let positions = firstTouchMove?["positions"] as? [[String: Any]]
+            XCTAssertEqual(positions?.first?["x"] as? Float, 150)
+            XCTAssertEqual(positions?.first?["y"] as? Float, 150)
+
+            // Second touch events (after collision)
+            let secondTouchStart = result[2].data
+            let secondTouchPointerId = secondTouchStart?["pointerId"] as? Int
+            XCTAssertEqual(secondTouchStart?["x"] as? Float, 50)
+            XCTAssertEqual(secondTouchStart?["y"] as? Float, 50)
+            XCTAssertEqual(secondTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
+
+            let secondTouchEnd = result[3].data
+            XCTAssertEqual(secondTouchEnd?["x"] as? Float, 75)
+            XCTAssertEqual(secondTouchEnd?["y"] as? Float, 75)
+            XCTAssertEqual(secondTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
+            XCTAssertEqual(secondTouchEnd?["pointerId"] as? Int, secondTouchPointerId)
+
+            // Critical assertion: Different IDs and NO orphaned events
+            XCTAssertNotEqual(firstTouchPointerId, secondTouchPointerId,
+                              "Touches should have different IDs")
+            XCTAssertNotNil(firstTouchPointerId, "First touch events should not be orphaned")
+        }
+
+        func testIsEnabledFalse_DropsAllTouches() {
+            let sut = getSut()
+            sut.isEnabled = false
+
+            let event = MockUIEvent(timestamp: 1)
+            event.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 10, y: 10)))
+            sut.trackTouchFrom(event: event)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            XCTAssertTrue(result.isEmpty, "No touch events should be recorded when isEnabled is false")
+        }
+
+        func testIsEnabledToggle_OnlyRecordsTouchesWhileEnabled() {
+            let sut = getSut()
+
+            let began = MockUIEvent(timestamp: 1)
+            began.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 10, y: 10)))
+            sut.trackTouchFrom(event: began)
+
+            sut.isEnabled = false
+            let whilePaused = MockUIEvent(timestamp: 2)
+            whilePaused.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 20, y: 20)))
+            sut.trackTouchFrom(event: whilePaused)
+
+            sut.isEnabled = true
+            let afterResume = MockUIEvent(timestamp: 3)
+            afterResume.addTouch(MockUITouch(phase: .began, location: CGPoint(x: 30, y: 30)))
+            sut.trackTouchFrom(event: afterResume)
+
+            let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
+            // Only the touch at t=1 and t=3 should appear; the paused touch at t=2 must be absent.
+            let timestamps = result.map { $0.timestamp }
+            XCTAssertTrue(timestamps.contains(referenceDate.addingTimeInterval(1)))
+            XCTAssertFalse(timestamps.contains(referenceDate.addingTimeInterval(2)),
+                           "Touch recorded while disabled must not appear in replay events")
+            XCTAssertTrue(timestamps.contains(referenceDate.addingTimeInterval(3)))
+        }
     }
-    
-    func testObjectIdentifierCollision_NewTouchGetsNewId() {
-        // Arrange
-        // This test simulates ObjectIdentifier collision when UITouch memory is reused.
-        // When iOS reuses memory for a new UITouch at the same address as a previous touch,
-        // the ObjectIdentifier will be the same, but it's actually a different touch gesture.
-        let sut = getSut()
-        let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
-        
-        // Act - First touch lifecycle (began -> moved -> ended)
-        let event1 = MockUIEvent(timestamp: 1)
-        event1.addTouch(touch)
-        sut.trackTouchFrom(event: event1)
-        
-        touch.phase = .moved
-        touch.location = CGPoint(x: 150, y: 150)
-        let event2 = MockUIEvent(timestamp: 2)
-        event2.addTouch(touch)
-        sut.trackTouchFrom(event: event2)
-        
-        touch.phase = .ended
-        touch.location = CGPoint(x: 200, y: 200)
-        let event3 = MockUIEvent(timestamp: 3)
-        event3.addTouch(touch)
-        sut.trackTouchFrom(event: event3)
-        
-        // Get events from first touch before they're overwritten
-        let firstTouchEvents = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
-        
-        // In real-world usage, flushFinishedEvents would be called periodically
-        // This removes finished touches from trackedTouches
-        sut.flushFinishedEvents()
-        
-        // Simulate memory reuse: same UITouch object starts a NEW touch gesture
-        // In reality this would be a new UITouch at the same memory address,
-        // but for testing we can use the same object with .began phase at a different location
-        touch.phase = .began
-        touch.location = CGPoint(x: 50, y: 50)  // Different location - this is a NEW touch
-        let event4 = MockUIEvent(timestamp: 4)
-        event4.addTouch(touch)
-        sut.trackTouchFrom(event: event4)
-        
-        touch.phase = .ended
-        touch.location = CGPoint(x: 75, y: 75)
-        let event5 = MockUIEvent(timestamp: 5)
-        event5.addTouch(touch)
-        sut.trackTouchFrom(event: event5)
-        
-        // Get second touch events
-        let secondTouchEvents = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
-        
-        // Assert - First touch (captured before flush)
-        XCTAssertEqual(firstTouchEvents.count, 3, "First touch should have 3 events: start, move, end")
-        
-        let firstTouchStart = firstTouchEvents[0].data
-        let firstTouchPointerId = firstTouchStart?["pointerId"] as? Int
-        XCTAssertEqual(firstTouchStart?["x"] as? Float, 100)
-        XCTAssertEqual(firstTouchStart?["y"] as? Float, 100)
-        XCTAssertEqual(firstTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
-        XCTAssertEqual(firstTouchPointerId, 1, "First touch should have pointer ID 1")
-        
-        let firstTouchMove = firstTouchEvents[1].data
-        XCTAssertEqual(firstTouchMove?["pointerId"] as? Int, firstTouchPointerId)
-        
-        let firstTouchEnd = firstTouchEvents[2].data
-        XCTAssertEqual(firstTouchEnd?["x"] as? Float, 200)
-        XCTAssertEqual(firstTouchEnd?["y"] as? Float, 200)
-        XCTAssertEqual(firstTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
-        XCTAssertEqual(firstTouchEnd?["pointerId"] as? Int, firstTouchPointerId)
-        
-        // Assert - Second touch (after collision)
-        XCTAssertEqual(secondTouchEvents.count, 2, "Second touch should have 2 events: start, end")
-        
-        let secondTouchStart = secondTouchEvents[0].data
-        let secondTouchPointerId = secondTouchStart?["pointerId"] as? Int
-        XCTAssertEqual(secondTouchStart?["x"] as? Float, 50)
-        XCTAssertEqual(secondTouchStart?["y"] as? Float, 50)
-        XCTAssertEqual(secondTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
-        XCTAssertEqual(secondTouchPointerId, 2, "Second touch should have pointer ID 2")
-        
-        let secondTouchEnd = secondTouchEvents[1].data
-        XCTAssertEqual(secondTouchEnd?["x"] as? Float, 75)
-        XCTAssertEqual(secondTouchEnd?["y"] as? Float, 75)
-        XCTAssertEqual(secondTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
-        XCTAssertEqual(secondTouchEnd?["pointerId"] as? Int, secondTouchPointerId)
-        
-        // Critical assertion: The two touches should have DIFFERENT pointer IDs
-        XCTAssertNotEqual(firstTouchPointerId, secondTouchPointerId,
-                         "Memory-reused touch should get a new pointer ID, not inherit the old one")
-    }
-    
-    func testObjectIdentifierCollision_WithoutFlush_DoesNotOrphanEvents() {
-        // Arrange
-        // This test covers the case where a collision happens BEFORE flushFinishedEvents()
-        // The old touch's events should still be accessible, not orphaned
-        let sut = getSut()
-        let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
-        
-        // Act - First touch begins but doesn't end
-        let event1 = MockUIEvent(timestamp: 1)
-        event1.addTouch(touch)
-        sut.trackTouchFrom(event: event1)
-        
-        touch.phase = .moved
-        touch.location = CGPoint(x: 150, y: 150)
-        let event2 = MockUIEvent(timestamp: 2)
-        event2.addTouch(touch)
-        sut.trackTouchFrom(event: event2)
-        
-        // Collision happens BEFORE first touch ends and BEFORE flush
-        // Same ObjectIdentifier starts a NEW touch
-        touch.phase = .began
-        touch.location = CGPoint(x: 50, y: 50)
-        let event3 = MockUIEvent(timestamp: 3)
-        event3.addTouch(touch)
-        sut.trackTouchFrom(event: event3)
-        
-        touch.phase = .ended
-        touch.location = CGPoint(x: 75, y: 75)
-        let event4 = MockUIEvent(timestamp: 4)
-        event4.addTouch(touch)
-        sut.trackTouchFrom(event: event4)
-        
-        // Assert
-        let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(10))
-        
-        // We should have events from BOTH touches, even though the first didn't end:
-        // - Touch 1 start at (100, 100)
-        // - Touch 1 move at (150, 150)
-        // - Touch 2 start at (50, 50)  <- collision without flush
-        // - Touch 2 end at (75, 75)
-        //
-        // The first touch's events should NOT be orphaned/lost
-        
-        XCTAssertEqual(result.count, 4, "Should have 4 events: both touches' events should be preserved")
-        
-        // First touch events (incomplete, no end)
-        let firstTouchStart = result[0].data
-        let firstTouchPointerId = firstTouchStart?["pointerId"] as? Int
-        XCTAssertEqual(firstTouchStart?["x"] as? Float, 100)
-        XCTAssertEqual(firstTouchStart?["y"] as? Float, 100)
-        XCTAssertEqual(firstTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
-        
-        let firstTouchMove = result[1].data
-        XCTAssertEqual(firstTouchMove?["pointerId"] as? Int, firstTouchPointerId)
-        let positions = firstTouchMove?["positions"] as? [[String: Any]]
-        XCTAssertEqual(positions?.first?["x"] as? Float, 150)
-        XCTAssertEqual(positions?.first?["y"] as? Float, 150)
-        
-        // Second touch events (after collision)
-        let secondTouchStart = result[2].data
-        let secondTouchPointerId = secondTouchStart?["pointerId"] as? Int
-        XCTAssertEqual(secondTouchStart?["x"] as? Float, 50)
-        XCTAssertEqual(secondTouchStart?["y"] as? Float, 50)
-        XCTAssertEqual(secondTouchStart?["type"] as? Int, TouchEventPhase.start.rawValue)
-        
-        let secondTouchEnd = result[3].data
-        XCTAssertEqual(secondTouchEnd?["x"] as? Float, 75)
-        XCTAssertEqual(secondTouchEnd?["y"] as? Float, 75)
-        XCTAssertEqual(secondTouchEnd?["type"] as? Int, TouchEventPhase.end.rawValue)
-        XCTAssertEqual(secondTouchEnd?["pointerId"] as? Int, secondTouchPointerId)
-        
-        // Critical assertion: Different IDs and NO orphaned events
-        XCTAssertNotEqual(firstTouchPointerId, secondTouchPointerId,
-                         "Touches should have different IDs")
-        XCTAssertNotNil(firstTouchPointerId, "First touch events should not be orphaned")
-    }
-}
 #endif


### PR DESCRIPTION
Fixes getsentry/sentry-cocoa#8409.

## Problem

`SentrySDK.replay.pause()` stops the capture scheduler (no new screenshots) but the touch tracker swizzle keeps firing unconditionally. `SentryTouchTracker.trackTouchFrom` is called on every `sendEvent:` regardless of replay pause state, so touches continue to buffer and appear in replay segments produced during or after the pause (e.g. triggered by an error capture).

## Fix

* Add `isEnabled: Bool = true` to `SentryTouchTracker`, checked at the top of `trackTouchFrom`. No thread lock needed — reads/writes happen on the main thread (swizzle always calls on main; `pause()`/`resume()` are called on main).
* `SentrySessionReplay.pause()` sets `touchTracker?.isEnabled = false` immediately after `stopCaptureScheduler()`.
* `SentrySessionReplay.resume()` restores `touchTracker?.isEnabled = true` only inside the `startCaptureScheduler(expectedGeneration:)` success branch, so stale or racing resume calls that don't actually restart capture don't re-enable tracking early.

## Tests

Two new tests in `SentryTouchTrackerTests`:

* `testIsEnabledFalse_DropsAllTouches` — verify zero events recorded when `isEnabled = false`
* `testIsEnabledToggle_OnlyRecordsTouchesWhileEnabled` — verify only touches recorded before disable and after re-enable appear; touch during disabled window is absent

#skip-changelog