### PR TITLE
feat(ci): Add label 'autocreated' to create-issue-for-unreferenced-pr.yml

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-pr.yml
+++ b/.github/workflows/create-issue-for-unreferenced-pr.yml
@@ -114,7 +114,10 @@ jobs:
               repo: context.repo.repo,
               title: issueTitle,
               body: issueBody,
-              assignees: [prAuthor]
+              assignees: [prAuthor],
+              labels: [
+                'autocreated'
+              ]
             });
 
             const issueID = newIssue.data.number;


### PR DESCRIPTION
The workflow will now assign the label `autocreated` to created issues, allowing us to do further automations based on the label.

#skip-changelog

Closes getsentry/sentry-cocoa#8474