### PR TITLE
ci: add xcodegen version to CI diagnostics

### DIFF
--- a/scripts/ci-diagnostics.sh
+++ b/scripts/ci-diagnostics.sh
@@ -86,6 +86,14 @@ if command -v system_profiler >/dev/null 2>&1; then
 fi
 end_group
 
+begin_group "XcodeGen version"
+if command -v xcodegen >/dev/null 2>&1; then
+  xcodegen --version || true
+else
+  log_warning "xcodegen not found in PATH"
+fi
+end_group
+
 begin_group "Disk space"
 df -h || true
 end_group


### PR DESCRIPTION
## Summary
- Adds `xcodegen --version` output to the CI diagnostics script so XcodeGen version drift is visible in failure logs

#skip-changelog

Closes #8477