### PR TITLE
impr: Reduce slight overhead during SDK start (#8494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Reduce slight overhead during SDK start by skipping an unnecessary main thread dispatch when there's no work to do (#8494)
+
 ### Breaking Changes
 
 - Only expose `experimental.dataCollection` APIs in SDK V10 (#8435)

--- a/Sources/Swift/Core/Integrations/Performance/SentrySubClassFinder.swift
+++ b/Sources/Swift/Core/Integrations/Performance/SentrySubClassFinder.swift
@@ -84,6 +84,11 @@ class SentrySubClassFinder: NSObject {
 
             free(classes)
 
+            if classesToSwizzle.isEmpty {
+                SentrySDKLog.debug("No UIViewController subclasses to swizzle in image: \(imageName).")
+                return
+            }
+
             self.dispatchQueue.dispatchAsyncOnMainQueueIfNotMainThread {
                 for className in classesToSwizzle {
                     if let cls = NSClassFromString(className) {

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -126,10 +126,6 @@ class SentrySubClassFinderTests: XCTestCase {
         }.count
 
         XCTAssertEqual(expected.count, count)
-
-        // When there are no classes to swizzle, we early exit and must not dispatch
-        // to the main queue. Otherwise, we dispatch exactly once.
-        XCTAssertEqual(fixture.dispatchQueue.blockOnMainInvocations.count, expected.isEmpty ? 0 : 1)
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -15,6 +15,7 @@ class SentrySubClassFinderTests: XCTestCase {
             return result
         }()
         let imageName: String
+        let dispatchQueue = TestSentryDispatchQueueWrapper()
         let testClassesNames = [NSStringFromClass(FirstViewController.self),
                                 NSStringFromClass(SecondViewController.self),
                                 NSStringFromClass(ViewControllerNumberThree.self),
@@ -29,7 +30,7 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         func getSut(swizzleClassNameExcludes: Set<String> = []) -> SentrySubClassFinder {
-            return SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper, swizzleClassNameExcludes: swizzleClassNameExcludes)
+            return SentrySubClassFinder(dispatchQueue: dispatchQueue, objcRuntimeWrapper: runtimeWrapper, swizzleClassNameExcludes: swizzleClassNameExcludes)
         }
     }
     
@@ -51,6 +52,20 @@ class SentrySubClassFinderTests: XCTestCase {
     func testActOnSubclassesOfViewController_NoViewController() {
         fixture.runtimeWrapper.classesNames = { _ in [] }
         assertActOnSubclassesOfViewController(expected: [])
+    }
+
+    func testActOnSubclassesOfViewController_NoViewController_DoesNotDispatchToMainQueue() {
+        // Arrange
+        fixture.runtimeWrapper.classesNames = { _ in [] }
+        let sut = fixture.getSut()
+
+        // Act
+        sut.actOnSubclassesOfViewController(inImage: fixture.imageName) { _ in
+            XCTFail("Block must not be called when there are no subclasses to swizzle.")
+        }
+
+        // Assert
+        XCTAssertEqual(fixture.dispatchQueue.blockOnMainInvocations.count, 0)
     }
     
     func testActOnSubclassesOfViewController_IgnoreFakeViewController() {
@@ -103,14 +118,18 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         wait(for: [expect], timeout: 1)
-        
+
         let count = actual.filter { element in
             return expected.contains { ex in
                 return element == ex
             }
         }.count
-        
+
         XCTAssertEqual(expected.count, count)
+
+        // When there are no classes to swizzle, we early exit and must not dispatch
+        // to the main queue. Otherwise, we dispatch exactly once.
+        XCTAssertEqual(fixture.dispatchQueue.blockOnMainInvocations.count, expected.isEmpty ? 0 : 1)
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

`SentrySubClassFinder.actOnSubclassesOfViewController` always dispatched back to the main thread after scanning an image, even when no view controller subclasses were found. This adds an early exit so we skip that unnecessary main thread dispatch when there's no work to do.

## :bulb: Motivation and Context

Reduce slight overhead during SDK start.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
