### PR TITLE
ci: always run brew update and guard xcodegen version

### DIFF
--- a/.github/actions/cache-homebrew/action.yml
+++ b/.github/actions/cache-homebrew/action.yml
@@ -1,7 +1,8 @@
 name: "Cache Homebrew or Update"
 description: >-
-  Caches Homebrew downloads and installed formulae. The cache key rotates
-  daily so formulae stay reasonably fresh without downloading on every run.
+  Caches Homebrew downloads and always runs brew update. The runner image's
+  baked-in core tap resolves formula versions, so brew update must run even
+  on cache hit; the cache only avoids re-downloading bottles.
 runs:
   using: "composite"
   steps:
@@ -20,7 +21,9 @@ runs:
         # Add here any relevant lockfiles
         key: homebrew-${{ runner.os }}-${{ runner.arch }}-${{ steps.day.outputs.day }}-${{ hashFiles('scripts/.clang-format-version', 'scripts/.swiftlint-version', 'scripts/.xcodegen-version', '.ruby-version', 'Brewfile*') }}
 
+    # The formula versions come from the runner image's homebrew/core tap,
+    # not from the cached paths, so skipping this on cache hit installs
+    # outdated formulae (e.g. XcodeGen without package-traits support).
     - name: Update Homebrew formulae
-      if: steps.cache.outputs.cache-hit != 'true' || github.run_attempt > 1
       shell: bash
       run: brew update

--- a/Makefile
+++ b/Makefile
@@ -638,6 +638,7 @@ build-sample-macOS-SwiftUI-SPM:
 # Builds the macOS CLI sample that uses SentrySPM without UIKit/AppKit linkage.
 .PHONY: build-sample-macOS-CLI-Xcode
 build-sample-macOS-CLI-Xcode:
+	./scripts/check-xcodegen-version.sh
 	xcodegen --spec Samples/macOS-CLI-Xcode/macOS-CLI-Xcode.yml
 	set -o pipefail && xcodebuild \
 		-project "Samples/macOS-CLI-Xcode/macOS-CLI-Xcode.xcodeproj" \
@@ -1708,6 +1709,7 @@ xcode-ci-iOS15-SwiftUI: xcode-ci-SentrySampleShared
 
 .PHONY: xcode-ci-macOS-CLI-Xcode
 xcode-ci-macOS-CLI-Xcode:
+	./scripts/check-xcodegen-version.sh
 	xcodegen --spec Samples/macOS-CLI-Xcode/macOS-CLI-Xcode.yml
 
 .PHONY: xcode-ci-macOS-Swift

--- a/Samples/macOS-CLI-Xcode/macOS-CLI-Xcode.yml
+++ b/Samples/macOS-CLI-Xcode/macOS-CLI-Xcode.yml
@@ -3,11 +3,10 @@
 # macOS command-line tool using SentrySPM with NoUIFramework trait.
 # Verifies that the SDK can be used without linking AppKit or UIKit.
 #
-# LIMITATION: XcodeGen does not yet support Swift package traits (enabledTraits on
-# XCSwiftPackageProductDependency). As of Xcode 26.4 Beta, traits can be set from the
-# Xcode UI when adding a package dependency. We keep the .xcodeproj in version control
-# with the NoUIFramework trait applied and use a Makefile post-step when regenerating
-# via xcodegen until XcodeGen adds support. See: https://github.com/yonaskolb/XcodeGen/issues/1585
+# NOTE: The `traits` key requires XcodeGen 2.46.0+ (see scripts/.xcodegen-version).
+# Older versions silently ignore it, producing a project that links AppKit and
+# fails the linkage check. Makefile targets guard against this via
+# scripts/check-xcodegen-version.sh.
 
 name: macOS-CLI-Xcode
 createIntermediateGroups: true

--- a/scripts/check-xcodegen-version.sh
+++ b/scripts/check-xcodegen-version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Verifies the installed XcodeGen matches scripts/.xcodegen-version.
+# Older versions silently drop unsupported spec keys (e.g. package traits),
+# producing broken projects, so fail fast before generating.
+
+# Source CI utilities for proper logging
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+EXPECTED_VERSION="$(cat "$SCRIPT_DIR/.xcodegen-version")"
+INSTALLED_VERSION="$(xcodegen --version | awk -F ': ' '{print $2}')"
+
+if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+    log_error "XcodeGen version mismatch: installed $INSTALLED_VERSION, expected $EXPECTED_VERSION. In CI this usually means stale Homebrew formula metadata; locally run 'make init' to update."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Always run `brew update` in the `cache-homebrew` action. Formula versions resolve from the runner image's baked-in `homebrew/core` tap, not the cached paths, so skipping the update on cache hit installs outdated formulae — e.g. XcodeGen 2.45.4, which silently drops the `traits` key and makes the `macOS CLI (NoUIFramework)` job fail with an AppKit linkage error (#8490 and others).
- Add `scripts/check-xcodegen-version.sh` to the CLI sample Makefile targets so a version mismatch fails fast with a clear message instead.

#skip-changelog