### PR TITLE
ref: Add Swift synchronized helper

### DIFF
--- a/Sources/Swift/Concurrency/Synchronized.swift
+++ b/Sources/Swift/Concurrency/Synchronized.swift
@@ -1,0 +1,51 @@
+/// Executes a closure while holding an Objective‑C runtime lock on the given object,
+/// providing a simple, scoped critical section for synchronizing access to shared state.
+///
+/// This helper mirrors the behavior of `@synchronized` in Objective‑C by calling
+/// `objc_sync_enter(_:)` before running `operation` and guaranteeing a matching
+/// `objc_sync_exit(_:)` via `defer`, even if the closure throws or early‑returns.
+/// Use it to prevent data races when multiple threads or tasks may access or mutate
+/// resources protected by the same lock object.
+///
+/// Important:
+/// - The lock is associated with the identity of `object` (its pointer), not its value.
+///   All callers that need to synchronize must pass the exact same object instance.
+/// - Avoid locking on highly shared or public objects (e.g., `self` of a widely
+///   accessible singleton, or class objects) to reduce the risk of deadlocks.
+/// - Keep the critical section as short as possible. Do not perform long‑running work
+///   or call out to unknown code while holding the lock.
+/// - This function is not `async` and does not suspend. If used from concurrent Swift
+///   tasks, ensure all tasks use the same synchronization strategy to avoid priority
+///   inversions or deadlocks.
+///
+/// Thread safety:
+/// - Multiple threads calling this function with the same `object` will serialize
+///   execution of their `operation` closures.
+/// - Calls that use different lock objects proceed independently.
+///
+/// - Parameters:
+///   - object: The object whose associated monitor will be used to guard the critical section.
+///             All threads that need mutual exclusion must pass the same object instance.
+///   - operation: A closure to execute while holding the lock.
+/// - Returns: The value returned by `operation`.
+///
+/// Example:
+/// ```swift
+/// final class Counter {
+///     private var value = 0
+///     private let lock = NSObject()
+///
+///     func increment() {
+///         synchronized(lock) { value += 1 }
+///     }
+///
+///     var current: Int {
+///         synchronized(lock) { value }
+///     }
+/// }
+/// ```
+func synchronized<T>(_ object: AnyObject, operation: () throws -> T) rethrows -> T {
+    objc_sync_enter(object)
+    defer { objc_sync_exit(object) }
+    return try operation()
+}

--- a/Tests/SentryTests/Swift/Concurrency/SynchronizedTests.swift
+++ b/Tests/SentryTests/Swift/Concurrency/SynchronizedTests.swift
@@ -1,0 +1,120 @@
+@testable import Sentry
+import XCTest
+
+final class SynchronizedTests: XCTestCase {
+
+    func testSynchronized_whenOperationReturnsValue_shouldReturnValue() {
+        // -- Arrange --
+        let object = SynchronizedObject()
+
+        // -- Act --
+        let result = synchronized(object) {
+            object.value = 42
+            return object.value
+        }
+
+        // -- Assert --
+        XCTAssertEqual(result, 42)
+    }
+
+    func testSynchronized_whenCalledConcurrentlyWithSameObject_shouldSerializeOperations() {
+        // -- Arrange --
+        let object = SynchronizedObject()
+
+        // -- Act --
+        testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 1_000) { _ in
+            synchronized(object) {
+                object.value += 1
+            }
+        }
+
+        // -- Assert --
+        XCTAssertEqual(object.value, 10_010)
+    }
+
+    func testSynchronized_whenCalledRecursivelyWithSameObject_shouldExecuteNestedOperation() {
+        // -- Arrange --
+        let object = SynchronizedObject()
+
+        // -- Act --
+        let result = synchronized(object) {
+            object.value += 1
+            return synchronized(object) {
+                object.value += 1
+                return object.value
+            }
+        }
+
+        // -- Assert --
+        XCTAssertEqual(result, 2)
+    }
+
+    func testSynchronized_whenOperationThrows_shouldPropagateErrorAndReleaseLock() {
+        // -- Arrange --
+        let object = SynchronizedObject()
+        let expectedError = TestError.operationFailed
+        let lockAcquiredFromAnotherThread = expectation(description: "Lock acquired from another thread")
+
+        // -- Act --
+        XCTAssertThrowsError(try synchronized(object) {
+            throw expectedError
+        }) { error in
+            XCTAssertEqual(error as? TestError, expectedError)
+        }
+
+        DispatchQueue.global().async {
+            synchronized(object) {
+                object.value += 1
+                lockAcquiredFromAnotherThread.fulfill()
+            }
+        }
+
+        // -- Assert --
+        wait(for: [lockAcquiredFromAnotherThread], timeout: 1)
+        XCTAssertEqual(object.value, 1)
+    }
+
+    func testSynchronized_whenCalledWithDifferentObjects_shouldExecuteIndependently() {
+        // -- Arrange --
+        let firstObject = SynchronizedObject()
+        let secondObject = SynchronizedObject()
+        let releaseFirstOperation = DispatchSemaphore(value: 0)
+        let firstOperationEntered = expectation(description: "First operation entered")
+        let firstOperationFinished = expectation(description: "First operation finished")
+        let secondOperationEntered = expectation(description: "Second operation entered")
+
+        DispatchQueue.global().async {
+            synchronized(firstObject) {
+                firstObject.value += 1
+                firstOperationEntered.fulfill()
+                releaseFirstOperation.wait()
+            }
+            firstOperationFinished.fulfill()
+        }
+        wait(for: [firstOperationEntered], timeout: 1)
+
+        // -- Act --
+        DispatchQueue.global().async {
+            synchronized(secondObject) {
+                secondObject.value += 1
+                secondOperationEntered.fulfill()
+            }
+        }
+
+        // -- Assert --
+        wait(for: [secondOperationEntered], timeout: 1)
+        XCTAssertEqual(secondObject.value, 1)
+        releaseFirstOperation.signal()
+        wait(for: [firstOperationFinished], timeout: 1)
+        XCTAssertEqual(firstObject.value, 1)
+    }
+
+    private enum TestError: Error {
+        case operationFailed
+    }
+}
+
+@objcMembers
+private final class SynchronizedObject: NSObject {
+    var value = 0
+}


### PR DESCRIPTION
## :scroll: Description

Adds an internal Swift `synchronized` helper backed by the Objective-C runtime's `objc_sync_enter` and `objc_sync_exit`. It preserves `@synchronized` behavior for return values, recursive locking, thrown errors, and object-identity-based synchronization.

The unit tests cover concurrent mutation of the synchronized object, recursive access, error propagation and lock release, and independent access through different objects.

## :bulb: Motivation and Context

This helper is introduced as an Objective-C replacement for `@synchronized` during Objective-C to Swift conversions. It lets converted code retain the existing runtime locking semantics without introducing a different synchronization strategy as part of the conversion.

<details>
<summary>Why not an Objective-C wrapper that calls <code>@synchronized</code> directly?</summary>

An ObjC wrapper was considered, but it provides no additional safety and loses ergonomics:

- **This helper already _is_ `@synchronized`.** Clang lowers `@synchronized(obj) { ... }` to exactly `objc_sync_enter(obj)` / `objc_sync_exit(obj)` with a cleanup handler — the same two public, stable runtime calls this helper makes, with `defer` playing the role of the cleanup. There is no hidden behavior in `@synchronized` that a wrapper would capture and this implementation misses.
- **The one theoretical difference doesn't apply.** `@synchronized` unlocks via `@finally` if an `NSException` propagates through the block. In a wrapper, the block would be a Swift closure, and an `NSException` unwinding through Swift frames is undefined behavior regardless — so the wrapper buys no safety there.
- **An ObjC function can't be generic.** Returning a value through the wrapper would require a `__block` result variable or a Swift generic shim around the ObjC call — and that shim is Swift code needing tests again, defeating the purpose.
- **It adds a reverse dependency.** New ObjC code the Swift layer depends on works against the ongoing ObjC→Swift conversion and would block a future pure-Swift target.

</details>

Extracted from #8502 

#skip-changelog

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- `make build-ios FOR_AGENTS=true`
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SynchronizedTests`

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

