### PR TITLE
chore: prohibit direct associated object access

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -137,3 +137,13 @@ custom_rules:
     match_kinds:
       - identifier
     severity: error
+  avoid_direct_associated_object_access:
+    name: "Avoid direct associated object access"
+    message: "Use AssociatedObjectAccessor instead of calling the Objective-C associated object APIs directly."
+    regex: "objc_(get|set)AssociatedObject"
+    match_kinds:
+      - identifier
+    severity: error
+    excluded:
+      - "./Sources/Swift/Core/Helper/AssociatedObjectAccessor.swift"
+      - "./Tests/.*\\.swift"


### PR DESCRIPTION
## :scroll: Description

Adds an error-level SwiftLint custom rule that prohibits direct `objc_getAssociatedObject` and `objc_setAssociatedObject` calls in production Swift code. The typed accessor implementation and test files are excluded.

## :bulb: Motivation and Context

Centralizing associated-object access prevents new call sites from bypassing typed keys, conversion handling, and invalid-value reporting.

This PR intentionally targets `main` independently from the implementation stack. It is expected to fail while existing production direct calls remain. Those violations are removed by #8505 and #8507, so this PR becomes mergeable after both are merged.

## :green_heart: How did you test it?

- `swiftlint --strict --quiet` on top of #8505 and #8507

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
