### PR TITLE
fix: Persist environment in crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Add a depth limit to view hierarchy serialization to prevent a stack overflow crash on deeply nested view hierarchies (#8292)
+- Persist the configured environment in crash reports so later app launches don't overwrite it (#5260)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Add a depth limit to view hierarchy serialization to prevent a stack overflow crash on deeply nested view hierarchies (#8292)
-- Persist the configured environment in crash reports so later app launches don't overwrite it (#5260)
+- Persist the configured environment in crash reports so later app launches don't overwrite it (#8511)
 
 ### Improvements
 

--- a/Sources/Swift/Integrations/SentryCrash/SentryCrashIntegration.swift
+++ b/Sources/Swift/Integrations/SentryCrash/SentryCrashIntegration.swift
@@ -225,14 +225,17 @@ final class SentryCrashIntegration<Dependencies: CrashIntegrationProvider>: NSOb
 
             var userInfo = outerScope.serialize()
 
-            // SentryCrashReportConverter.convertReportToEvent needs the release name and
-            // the dist of the SentryOptions in the UserInfo. When SentryCrash records a
-            // crash it writes the UserInfo into SentryCrashField_User of the report.
-            // SentryCrashReportConverter.initWithReport loads the contents of
-            // SentryCrashField_User into self.userContext and convertReportToEvent can map
-            // the release name and dist to the SentryEvent. Fixes GH-581
+            // SentryCrashReportConverter.convertReportToEvent needs the release name, dist, and
+            // environment of the SentryOptions in the UserInfo. When SentryCrash records a crash it
+            // writes the UserInfo into SentryCrashField_User of the report.
+            // SentryCrashReportConverter.initWithReport loads the contents of SentryCrashField_User
+            // into self.userContext and convertReportToEvent can map the release name, dist, and
+            // environment to the SentryEvent. Fixes GH-581 and GH-5260.
             userInfo["release"] = options.releaseName
             userInfo["dist"] = options.dist
+            if userInfo["environment"] == nil {
+                userInfo["environment"] = options.environment
+            }
 
             // Crashes don't use the attributes field, we remove them to avoid uploading them
             // unnecessarily.

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -120,6 +120,21 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         assertUserInfoField(userInfo: userInfo, key: "dist", expected: dist)
     }
 
+    func testConfigureScope_whenEnvironmentSetInOptions_shouldPassEnvironmentToSentryCrash() throws {
+        try XCTSkipIf(SentryTestSetup.isKSCrashEnabled, "Skipping SentryCrash test while in KSCrash mode")
+
+        let environment = "production"
+        SentrySDK.start { options in
+            options.dsn = SentryCrashIntegrationTests.dsnAsString
+            options.environment = environment
+            options.removeAllIntegrations()
+            options.enableCrashHandler = true
+        }
+
+        let userInfo = try XCTUnwrap(SentryDependencyContainer.sharedInstance().crashReporter.userInfo)
+        assertUserInfoField(userInfo: userInfo, key: "environment", expected: environment)
+    }
+
     func testContext_IsPassedToSentryCrash() throws {
         try XCTSkipIf(SentryTestSetup.isKSCrashEnabled, "Skipping SentryCrash test while in KSCrash mode")
 


### PR DESCRIPTION
## :scroll: Description

Persist the configured environment with SentryCrash metadata when the active scope does not already provide one. Crash report conversion can then retain the environment from the crashing app launch instead of using the environment from a later launch.

An explicitly configured scope environment keeps precedence over the options default.

## :bulb: Motivation and Context

Crash reports persist release and distribution metadata, but did not persist `Options.environment`. If another build processed the report later, the crash could be assigned that build's environment.

Fixes #5260

## :green_heart: How did you test it?

- Added a regression test that failed because `environment` was absent from SentryCrash metadata and passes with the fix.
- Verified options environment fallback and explicit scope environment precedence on macOS.
- Ran formatting and static analysis.
- Built the SDK for iOS and macOS.

The full `SentryCrashIntegrationTests` class still has an unrelated order-dependent failure in `testUncaughtExceptions_Enabled_ButSwizzlingDisabled`. That test passes independently.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
