### PR TITLE
docs: Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,11 @@
 
 - Add a depth limit to view hierarchy serialization to prevent a stack overflow crash on deeply nested view hierarchies (#8292)
 - Persist the configured environment in crash reports so later app launches don't overwrite it (#8511)
+- Only expose `experimental.dataCollection` APIs in SDK V10 (#8435)
 
 ### Improvements
 
 - Reduce slight overhead during SDK start by skipping an unnecessary main thread dispatch when there's no work to do (#8494)
-
-### Breaking Changes
-
-- Only expose `experimental.dataCollection` APIs in SDK V10 (#8435)
 
 ## 9.22.0
 


### PR DESCRIPTION
The experimental data collection API has been introduced in the previous release v9.22.0, and immediately removed afterwards. It's also not used anywhere yet, so while it can be considered a breaking change, it should not have any impact.

#skip-changelog

Closes #8513