### PR TITLE
fix: Propagate manually bound transaction trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix trace propagation for manually instrumented transactions when automatic performance tracing is disabled (#8522)
+
 ## 9.23.0
 
 ### Features

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -233,14 +233,27 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 
 - (void)addTraceWithoutTransactionToTask:(NSURLSessionTask *)sessionTask
 {
-    SentryPropagationContext *propagationContext
-        = SentrySDKInternal.currentHub.scope.propagationContext;
+    SentryScope *scope = SentrySDKInternal.currentHub.scope;
+    id<SentrySpan> _Nullable span = scope.span;
+    SentryTracer *tracer = [SentryTracer getTracer:span];
 
+    if (span != nil && tracer != nil) {
+        [SentryTracePropagation
+                   addBaggageHeader:SENTRY_UNWRAP_NULLABLE(
+                                        SentryBaggage, [[tracer traceContext] toBaggage])
+                        traceHeader:SENTRY_UNWRAP_NULLABLE(SentryTraceHeader, [span toTraceHeader])
+               propagateTraceparent:SentrySDKInternal.options.enablePropagateTraceparent
+            tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
+                          toRequest:sessionTask];
+        return;
+    }
+
+    SentryPropagationContext *propagationContext = scope.propagationContext;
     SentryTraceContext *traceContext =
         [[SentryTraceContext alloc] initWithTraceId:propagationContext.traceId
                                             options:SENTRY_UNWRAP_NULLABLE(SentryOptions,
                                                         SentrySDKInternal.currentHub.client.options)
-                                           replayId:SentrySDKInternal.currentHub.scope.replayId];
+                                           replayId:scope.replayId];
 
     [SentryTracePropagation addBaggageHeader:[traceContext toBaggage]
                                  traceHeader:[propagationContext traceHeader]

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1317,6 +1317,23 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
     }
 
+    func testTraceHeader_whenNetworkTrackingDisabledAndTransactionBoundToScope_shouldUseTransactionTraceId() throws {
+        // -- Arrange --
+        let sut = fixture.getSut()
+        sut.disable()
+        sut.enableNetworkBreadcrumbs()
+        let task = createDataTask()
+        let transaction = try XCTUnwrap(startTransaction() as? SentryTracer)
+
+        // -- Act --
+        sut.urlSessionTaskResume(task)
+
+        // -- Assert --
+        let traceHeader = try XCTUnwrap(task.currentRequest?.value(forHTTPHeaderField: "sentry-trace"))
+        let propagatedTraceId = traceHeader.components(separatedBy: "-").first
+        XCTAssertEqual(propagatedTraceId, transaction.traceId.sentryIdString)
+    }
+
     func testDontOverrideTraceHeader() {
         let sut = fixture.getSut()
         let task = createDataTask {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1395,12 +1395,11 @@ class SentryNetworkTrackerTests: XCTestCase {
         sut.disable()
 
         let task = createDataTask()
-        _ = try XCTUnwrap(startTransaction() as? SentryTracer)
+        let transaction = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
-        let expectedTraceHeader = SentrySDKInternal.currentHub().scope.propagationContext.traceHeader.value()
-        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, replayId: nil)
-        let expectedBaggageHeader = traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
+        let expectedTraceHeader = transaction.toTraceHeader().value()
+        let expectedBaggageHeader = transaction.traceContext?.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", expectedBaggageHeader)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
     }


### PR DESCRIPTION
## 📜 Description

Use the transaction or span bound to the current scope when adding distributed tracing headers while automatic network span creation is disabled. The existing propagation context remains the fallback when no usable span is bound.

The regression coverage reproduces the mismatched trace IDs and verifies both the manual-transaction path and the no-transaction fallback.

## 💡 Motivation and Context

When `enableAutoPerformanceTracing` was disabled, URL session interception propagated `scope.propagationContext` even when a manually started transaction was bound to `scope.span`. Because those contexts have independent trace IDs, backend transactions could not connect to the manually instrumented Cocoa transaction.

Fixes getsentry/sentry-cocoa#7856

## 💚 How did you test it?

* `make format`
* `make analyze`
* `make build-ios FOR_AGENTS=true`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryNetworkTrackerTests`

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).