### PR TITLE
test(kscrash): expand crash E2E migration coverage

### DIFF
--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
@@ -52,6 +52,11 @@ extension SentryKSCrash {
                 return nil
             }
 
+            // KSCRASH_TODO: Preserve SentryCrashIntegration's macOS AppKit NSException forwarding.
+            // SentryUncaughtNSExceptions currently routes reportException:/_crashOnException:
+            // through SentryNSExceptionCaptureHelper to SentryCrashSwift. Replace that direct
+            // dependency with an active-backend facade and supply KSCrash's uncaughtExceptionHandler.
+            // The reporter-neutral macOS CrashE2E ns-exception scenario is the acceptance test.
             SentrySDKInternal.crashReporterInstalled = true
             if installer.crashedLastLaunch {
                 SentrySDKInternal.fatalDetected = true

--- a/TestSamples/CrashE2E/App/Sources/CrashE2ECrashTriggers.swift
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2ECrashTriggers.swift
@@ -24,8 +24,9 @@ enum CrashE2ECrashTriggers {
             CrashE2ERuntime.closeAndRestartSDK()
             SentrySDK.crash()
             abortBecauseScenarioReturned(scenario)
-        case .nsException, .cppExceptionV1, .cppExceptionV2, .swiftAsyncCPPExceptionV2Off,
-             .swiftAsyncCPPExceptionV2On, .unityCxaThrow, .objcObject, .idle, .drain,
+        case .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On, .unityCxaThrow,
+             .objcObject, .objcObjectAfterCaughtCPP, .idle, .drain,
              .managedRuntimePreSDKSignal:
             triggerExceptionScenario(scenario)
         }
@@ -40,6 +41,9 @@ enum CrashE2ECrashTriggers {
                 userInfo: ["scenario": scenario.rawValue]
             ).raise()
             abortBecauseScenarioReturned(scenario)
+        case .nsExceptionSubclass:
+            CrashE2ETriggerNSExceptionSubclass()
+            abortBecauseScenarioReturned(scenario)
         case .cppExceptionV1, .cppExceptionV2:
             CrashE2ETriggerCPPException()
             abortBecauseScenarioReturned(scenario)
@@ -51,8 +55,13 @@ enum CrashE2ECrashTriggers {
         case .objcObject:
             // This is a modern C++ monitor scenario. The arbitrary Objective-C object throw is
             // expected to be reported by the C++ monitor, but the migration-sensitive contract is
-            // for the V2/KSCrash path, not SentryCrash's legacy V1 fallback behavior.
+            // for the throw-site-swapping path, not SentryCrash's weaker option-off report shape.
             CrashE2ETriggerObjCObjectException()
+            abortBecauseScenarioReturned(scenario)
+        case .objcObjectAfterCaughtCPP:
+            // A caught C++ throw first populates the throw-site cursor. The later fatal arbitrary
+            // Objective-C object must replace that cursor rather than report the stale C++ stack.
+            CrashE2ETriggerObjCObjectAfterCaughtCPPException()
             abortBecauseScenarioReturned(scenario)
         case .idle, .drain, .managedRuntimePreSDKSignal:
             abortBecauseScenarioReturned(scenario)

--- a/TestSamples/CrashE2E/App/Sources/CrashE2EObjCBridge.h
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2EObjCBridge.h
@@ -9,9 +9,11 @@ extern "C" {
 void CrashE2EInstallFakeManagedRuntimeSignalHandler(const char *markerPath);
 NSString *_Nullable CrashE2ELoadDynamicBinaryImage(const char *path, int slot);
 void CrashE2ETriggerDynamicBinaryImageCrash(void);
+void CrashE2ETriggerNSExceptionSubclass(void);
 void CrashE2ETriggerCPPException(void);
 void CrashE2ETriggerUnitySentryCxaThrow(void);
 void CrashE2ETriggerObjCObjectException(void);
+void CrashE2ETriggerObjCObjectAfterCaughtCPPException(void);
 
 #ifdef __cplusplus
 }

--- a/TestSamples/CrashE2E/App/Sources/CrashE2EObjCBridge.mm
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2EObjCBridge.mm
@@ -12,6 +12,12 @@
 #include <typeinfo>
 #include <unistd.h>
 
+@interface CrashE2ENSExceptionSubclass : NSException
+@end
+
+@implementation CrashE2ENSExceptionSubclass
+@end
+
 @interface CrashE2EThrownObject : NSObject
 @end
 
@@ -126,7 +132,13 @@ CrashE2EFakeManagedRuntimeSignalHandler(int signal, siginfo_t *info, void *conte
 
     // The intended chain is managed runtime -> SentryCrash/KSCrash -> system. This fake handler
     // stands in for .NET/Mono after SentryCrash's preload constructor has installed the early
-    // signal handler. Recoverable managed faults are intentionally out of scope: with the correct
+    // signal handler.
+    //
+    // KSCRASH_TODO: Sentry+KSCrash still compiles that SentryCrash constructor, so a green marker
+    // currently proves only that the fake handler ran, not that a KSCrash-owned preloader/plugin
+    // established the intended order. Rectify this when managed-runtime handling moves to KSCrash.
+    //
+    // Recoverable managed faults are intentionally out of scope: with the correct
     // order, the managed runtime handles them without ever calling Sentry. This handler forwards
     // only to smoke-test the unrecoverable path where the runtime delegates to its previous
     // handler. Resetting to the default action before forwarding keeps Sentry's final re-raise from
@@ -178,6 +190,16 @@ CrashE2EInstallFakeManagedRuntimeSignalHandler(const char *markerPath)
 }
 
 extern "C" void
+CrashE2ETriggerNSExceptionSubclass(void)
+{
+    [[CrashE2ENSExceptionSubclass exceptionWithName:@"CrashE2ENSExceptionSubclass"
+                                             reason:@"Crash E2E uncaught NSException subclass"
+                                           userInfo:@ { @"scenario" : @"ns-exception-subclass" }]
+        raise];
+    abort();
+}
+
+extern "C" void
 CrashE2ETriggerCPPException(void)
 {
     throw std::runtime_error("CrashE2ECPPException");
@@ -217,4 +239,24 @@ extern "C" void
 CrashE2ETriggerObjCObjectException(void)
 {
     @throw [[CrashE2EThrownObject alloc] init];
+}
+
+__attribute__((noinline, disable_tail_calls)) static void
+CrashE2EThrowCaughtCPPException(void)
+{
+    throw std::runtime_error("CrashE2ECaughtCPPException");
+}
+
+extern "C" __attribute__((noinline, disable_tail_calls)) void
+CrashE2ETriggerObjCObjectAfterCaughtCPPException(void)
+{
+    try {
+        CrashE2EThrowCaughtCPPException();
+    } catch (const std::runtime_error &) {
+        // Intentionally handled so its captured throw-site cursor becomes stale state that the
+        // later fatal Objective-C object throw must replace.
+    }
+
+    @
+    throw [[CrashE2EThrownObject alloc] init];
 }

--- a/TestSamples/CrashE2E/App/Sources/CrashE2ERuntime.swift
+++ b/TestSamples/CrashE2E/App/Sources/CrashE2ERuntime.swift
@@ -7,10 +7,12 @@ enum CrashE2EScenario: String {
     case drain
     case signal
     case nsException = "ns-exception"
+    case nsExceptionSubclass = "ns-exception-subclass"
     case cppExceptionV1 = "cpp-exception-v1"
     case cppExceptionV2 = "cpp-exception-v2"
     case unityCxaThrow = "unity-cxa-throw"
     case objcObject = "objc-object"
+    case objcObjectAfterCaughtCPP = "objc-object-after-caught-cpp"
     case binaryImages = "binary-images"
     case ignoredSignal = "ignored-signal"
     case managedRuntimeSignalChain = "managed-runtime-signal-chain"
@@ -86,9 +88,10 @@ enum CrashE2ERuntime {
             scheduleExitIfRequested(defaultDelay: 3.0)
         case .managedRuntimePreSDKSignal:
             abortBecausePreSDKScenarioReturned()
-        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .ignoredSignal, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
-             .managedRuntimeReinitSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+        case .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages, .ignoredSignal,
+             .managedRuntimeSignalChain, .managedRuntimeClosedSignal, .managedRuntimeReinitSignal,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             NSLog("CrashE2E - will trigger scenario: \(configuration.scenario.rawValue)")
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 CrashE2ECrashTriggers.trigger(configuration.scenario)
@@ -106,9 +109,10 @@ enum CrashE2ERuntime {
             sleepThenExit(configuration.exitAfterSeconds ?? 3.0)
         case .managedRuntimePreSDKSignal:
             abortBecausePreSDKScenarioReturned()
-        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .ignoredSignal, .managedRuntimeSignalChain, .managedRuntimeClosedSignal,
-             .managedRuntimeReinitSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+        case .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages, .ignoredSignal,
+             .managedRuntimeSignalChain, .managedRuntimeClosedSignal, .managedRuntimeReinitSignal,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             NSLog("CrashE2E - will trigger scenario synchronously: \(configuration.scenario.rawValue)")
             Thread.sleep(forTimeInterval: 0.5)
             CrashE2ECrashTriggers.trigger(configuration.scenario)
@@ -134,12 +138,13 @@ enum CrashE2ERuntime {
             #endif
             options.maxCacheItems = 100
 
-            // Keep cpp-exception-v1 and unity-cxa-throw in the current SentryCrash V1/fallback
-            // context. V1 is being sunset and is not a KSCrash parity target, but Unity's current
-            // native shim does not enable Sentry Cocoa's C++ V2 option, so the V1-context Unity
-            // scenario remains a temporary compatibility/counterexample check for the old backend.
+            // Keep cpp-exception-v1 in the public option-off configuration for both reporters.
+            // KSCrash has no "V1" implementation, but its standard terminate monitor must preserve
+            // uncaught C++ reporting when throw-site swapping is disabled. Unity's current native
+            // shim also does not enable Sentry Cocoa's C++ V2 option.
             if configuration.scenario == .cppExceptionV2
                 || configuration.scenario == .objcObject
+                || configuration.scenario == .objcObjectAfterCaughtCPP
                 || configuration.scenario == .swiftAsyncCPPExceptionV2Off
                 || configuration.scenario == .swiftAsyncCPPExceptionV2On {
                 options.experimental.enableUnhandledCPPExceptionsV2 = true
@@ -173,9 +178,10 @@ enum CrashE2ERuntime {
         switch configuration.scenario {
         case .managedRuntimeSignalChain, .managedRuntimeClosedSignal, .managedRuntimeReinitSignal:
             installFakeManagedRuntimeHandler()
-        case .idle, .drain, .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow,
-             .objcObject, .binaryImages, .ignoredSignal, .managedRuntimePreSDKSignal,
-             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+        case .idle, .drain, .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1,
+             .cppExceptionV2, .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages,
+             .ignoredSignal, .managedRuntimePreSDKSignal, .swiftAsyncCPPExceptionV2Off,
+             .swiftAsyncCPPExceptionV2On:
             return
         }
     }

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/Config.swift
@@ -82,10 +82,12 @@ enum Reporter: String, CaseIterable {
 enum Scenario: String, CaseIterable {
     case signal
     case nsException = "ns-exception"
+    case nsExceptionSubclass = "ns-exception-subclass"
     case cppExceptionV1 = "cpp-exception-v1"
     case cppExceptionV2 = "cpp-exception-v2"
     case unityCxaThrow = "unity-cxa-throw"
     case objcObject = "objc-object"
+    case objcObjectAfterCaughtCPP = "objc-object-after-caught-cpp"
     case binaryImages = "binary-images"
     case ignoredSignal = "ignored-signal"
     case managedRuntimeSignalChain = "managed-runtime-signal-chain"
@@ -98,8 +100,9 @@ enum Scenario: String, CaseIterable {
     static let defaultScenarios: [Scenario] = [
         .signal,
         .nsException,
-        // Current-backend-only counterexample. Drop/deactivate when running against KSCrash;
-        // V1 is sunsetting and is not a KSCrash parity target.
+        .nsExceptionSubclass,
+        // Keep the public option-off path reporter-neutral. KSCrash should continue reporting an
+        // uncaught C++ exception without throw-site swapping even though it has no "V1" backend.
         .cppExceptionV1,
         .cppExceptionV2,
         // Current Sentry Unity does not enable C++ V2, so this exercises the named-symbol
@@ -108,6 +111,7 @@ enum Scenario: String, CaseIterable {
         // Runs with C++ V2 enabled and strict modern-backend assertions. Current SentryCrash is
         // expected to fail this scenario; use --keep-going to continue the default run.
         .objcObject,
+        .objcObjectAfterCaughtCPP,
         .binaryImages,
         .ignoredSignal,
         .managedRuntimeSignalChain,
@@ -123,8 +127,9 @@ enum Scenario: String, CaseIterable {
         case .managedRuntimeSignalChain, .managedRuntimePreSDKSignal, .managedRuntimeClosedSignal,
              .managedRuntimeReinitSignal:
             return true
-        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .ignoredSignal, .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
+        case .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages, .ignoredSignal,
+             .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             return false
         }
     }
@@ -133,8 +138,9 @@ enum Scenario: String, CaseIterable {
         switch self {
         case .ignoredSignal:
             return false
-        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .managedRuntimeSignalChain, .managedRuntimePreSDKSignal,
+        case .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages,
+             .managedRuntimeSignalChain, .managedRuntimePreSDKSignal,
              .managedRuntimeClosedSignal, .managedRuntimeReinitSignal,
              .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             return true
@@ -145,8 +151,9 @@ enum Scenario: String, CaseIterable {
         switch self {
         case .managedRuntimePreSDKSignal, .managedRuntimeClosedSignal, .ignoredSignal:
             return false
-        case .signal, .nsException, .cppExceptionV1, .cppExceptionV2, .unityCxaThrow, .objcObject,
-             .binaryImages, .managedRuntimeSignalChain, .managedRuntimeReinitSignal,
+        case .signal, .nsException, .nsExceptionSubclass, .cppExceptionV1, .cppExceptionV2,
+             .unityCxaThrow, .objcObject, .objcObjectAfterCaughtCPP, .binaryImages,
+             .managedRuntimeSignalChain, .managedRuntimeReinitSignal,
              .swiftAsyncCPPExceptionV2Off, .swiftAsyncCPPExceptionV2On:
             return true
         }

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/CrashE2ERunner.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/CrashE2ERunner.swift
@@ -60,6 +60,10 @@ final class CrashE2ERunner {
             try buildVariant(derivedDataPath: config.derivedDataPath, label: "default", extraBuildSettings: [])
         }
         if shouldBuildManagedRuntimeVariant {
+            // KSCRASH_TODO: Sentry+KSCrash still compiles the SentryCrash recording sources, so
+            // this define activates SentryCrash's constructor-based signal preloader even when the
+            // selected integration is KSCrash. Replace it with the KSCrash-owned managed-runtime
+            // integration path before treating these scenarios as KSCrash handler-order coverage.
             try buildVariant(
                 derivedDataPath: config.managedRuntimeDerivedDataPath,
                 label: "managed runtime",

--- a/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
+++ b/TestSamples/CrashE2E/Runner/Sources/CrashE2ERunner/EventAssertions.swift
@@ -45,19 +45,20 @@ enum EventAssertions {
             // actual exception/main thread from threads.values, especially on iOS. The Unity smoke
             // intentionally runs in the same V1/fallback context because Sentry Unity does not
             // enable Sentry Cocoa's C++ V2 option today. Keep this escape hatch limited to these
-            // V1-context scenarios; V1 is being sunset and KSCrash should not preserve this report
-            // shape as parity behavior.
+            // option-off scenarios. The reporting behavior remains a contract for both reporters,
+            // even though KSCrash does not have a separate "V1" implementation.
             try assert(exceptionThreadID != nil,
                        "Expected exception thread id for \(platform)/\(scenario.rawValue)")
             try assert(!threadValues.isEmpty, "Expected threads for \(platform)/\(scenario.rawValue)")
         case .cppExceptionV2, .swiftAsyncCPPExceptionV2Off,
-             .swiftAsyncCPPExceptionV2On, .objcObject:
+             .swiftAsyncCPPExceptionV2On, .objcObject, .objcObjectAfterCaughtCPP:
             try assert(exceptionThreadID != nil,
                        "Expected exception thread id for \(platform)/\(scenario.rawValue)")
             try assertCrashedThread(threadValues, expectedThreadID: exceptionThreadID,
                                     platform: platform, scenario: scenario)
         case .signal, .binaryImages, .managedRuntimeSignalChain, .managedRuntimePreSDKSignal,
-             .managedRuntimeClosedSignal, .managedRuntimeReinitSignal, .nsException:
+             .managedRuntimeClosedSignal, .managedRuntimeReinitSignal, .nsException,
+             .nsExceptionSubclass:
             try assertCrashedThread(threadValues, expectedThreadID: exceptionThreadID,
                                     platform: platform, scenario: scenario)
         case .ignoredSignal:
@@ -101,18 +102,23 @@ enum EventAssertions {
         switch scenario {
         case .signal, .binaryImages, .managedRuntimeSignalChain, .managedRuntimePreSDKSignal,
              .managedRuntimeClosedSignal, .managedRuntimeReinitSignal:
-            let exceptionType = string(firstException["type"])
-            let signalName = string(dictionary(dictionary(mechanism["meta"])["signal"])["name"])
-            try assert(exceptionType == "EXC_BAD_ACCESS" || signalName == "SIGSEGV",
-                       "Expected signal/mach exception for \(platform)/\(scenario.rawValue)")
-            if scenario == .binaryImages {
-                try assertBinaryImageScenario(debugImages, platform: platform, cacheRoot: cacheRoot)
-            }
+            try assertSignalScenario(
+                scenario, firstException: firstException,
+                mechanism: mechanism,
+                debugImages: debugImages,
+                platform: platform,
+                cacheRoot: cacheRoot
+            )
 
         case .nsException:
-            try assert(string(firstException["type"]) == "CrashE2ENSException",
-                       "Expected NSException type for \(platform)/ns-exception")
-            try assertNSExceptionUserInfo(eventContext: eventContext, platform: platform)
+            try assertNSException(firstException, eventContext: eventContext,
+                                  expectedType: "CrashE2ENSException", platform: platform,
+                                  scenario: scenario)
+
+        case .nsExceptionSubclass:
+            try assertNSException(firstException, eventContext: eventContext,
+                                  expectedType: "CrashE2ENSExceptionSubclass", platform: platform,
+                                  scenario: scenario)
 
         case .cppExceptionV1, .cppExceptionV2, .swiftAsyncCPPExceptionV2Off:
             try assertCPPException(firstException, mechanism: mechanism, platform: platform,
@@ -128,17 +134,53 @@ enum EventAssertions {
                                    scenario: scenario, expectedValue: "CrashE2EUnitySentryCxaThrowException")
 
         case .objcObject:
-            try assertObjCObjectThrow(firstException, mechanism: mechanism, platform: platform)
+            try assertObjCObjectThrow(
+                firstException,
+                mechanism: mechanism,
+                platform: platform,
+                scenario: scenario
+            )
+
+        case .objcObjectAfterCaughtCPP:
+            try assertObjCObjectThrow(
+                firstException,
+                mechanism: mechanism,
+                platform: platform,
+                scenario: scenario
+            )
+            try assertFreshObjCObjectThrowFrames(
+                firstException,
+                platform: platform,
+                scenario: scenario
+            )
 
         case .ignoredSignal:
             return
         }
     }
 
-    private static func assertNSExceptionUserInfo(eventContext: [String: Any], platform: String) throws {
+    private static func assertSignalScenario(_ scenario: Scenario,
+                                             firstException: [String: Any],
+                                             mechanism: [String: Any],
+                                             debugImages: [[String: Any]], platform: String,
+                                             cacheRoot: URL) throws {
+        let exceptionType = string(firstException["type"])
+        let signalName = string(dictionary(dictionary(mechanism["meta"])["signal"])["name"])
+        try assert(exceptionType == "EXC_BAD_ACCESS" || signalName == "SIGSEGV",
+                   "Expected signal/mach exception for \(platform)/\(scenario.rawValue)")
+        if scenario == .binaryImages {
+            try assertBinaryImageScenario(debugImages, platform: platform, cacheRoot: cacheRoot)
+        }
+    }
+
+    private static func assertNSException(_ firstException: [String: Any],
+                                          eventContext: [String: Any], expectedType: String,
+                                          platform: String, scenario: Scenario) throws {
+        try assert(string(firstException["type"]) == expectedType,
+                   "Expected NSException type for \(platform)/\(scenario.rawValue)")
         let userInfoContext = dictionary(eventContext["user info"])
-        try assert(string(userInfoContext["scenario"]) == "ns-exception",
-                   "Expected NSException userInfo scenario for \(platform)/ns-exception")
+        try assert(string(userInfoContext["scenario"]) == scenario.rawValue,
+                   "Expected NSException userInfo scenario for \(platform)/\(scenario.rawValue)")
     }
 
     private static func assertBinaryImageScenario(_ debugImages: [[String: Any]], platform: String,
@@ -214,14 +256,29 @@ enum EventAssertions {
     }
 
     private static func assertObjCObjectThrow(_ firstException: [String: Any], mechanism: [String: Any],
-                                              platform: String) throws {
+                                              platform: String, scenario: Scenario) throws {
         try assert(string(firstException["type"]) == "C++ Exception",
-                   "Expected Objective-C object throw to be reported by C++ monitor for \(platform)/objc-object")
+                   "Expected Objective-C object throw to be reported by C++ monitor for \(platform)/\(scenario.rawValue)")
         try assert(string(mechanism["type"]) == "cpp_exception",
-                   "Expected C++ exception mechanism for \(platform)/objc-object")
+                   "Expected C++ exception mechanism for \(platform)/\(scenario.rawValue)")
         let value = string(firstException["value"]) ?? ""
         try assert(value.contains("CrashE2EThrownObject"),
-                   "Expected thrown Objective-C object class in value for \(platform)/objc-object")
+                   "Expected thrown Objective-C object class in value for \(platform)/\(scenario.rawValue)")
+    }
+
+    private static func assertFreshObjCObjectThrowFrames(_ firstException: [String: Any],
+                                                         platform: String,
+                                                         scenario: Scenario) throws {
+        let frames = valuesArray(firstException["stacktrace"], key: "frames")
+        let appFrames = frames.filter { string($0["package"])?.contains("CrashE2E-") == true }
+        try assert(!appFrames.isEmpty,
+                   "Expected Objective-C throw-site app frames for \(platform)/\(scenario.rawValue)")
+
+        let symbols = try symbolicatedFrameNames(appFrames)
+        try assert(symbols.contains { $0.contains("CrashE2ETriggerObjCObjectAfterCaughtCPPException") },
+                   "Expected current Objective-C throw site for \(platform)/\(scenario.rawValue): \(symbols)")
+        try assert(!symbols.contains { $0.contains("CrashE2EThrowCaughtCPPException") },
+                   "Expected stale caught C++ throw site to be absent for \(platform)/\(scenario.rawValue): \(symbols)")
     }
 
     private static func assertCPPException(_ firstException: [String: Any], mechanism: [String: Any],


### PR DESCRIPTION
## :scroll: Description

- keeps C++ option-off coverage reporter-neutral
- adds _`NSException` subclass_ and _stale ObjC throw-site_ scenarios
- document managed-runtime and macOS AppKit `NSException` migration TODOs

## :bulb: Motivation and Context

Builds on top of #8515 where the first KSCrash matrix was unexpectedly successful. This is a start in separating valid compatibility from misleading coverage without making the scenario matrix reporter-aware (because I want to share scenario code between KSCrash and SentryCrash as long as possible rather than start with scenario adaptations right away just to become green).

The motivation for the specific changes:

Keeping the C++ option-off scenario for both reporters after confirming that KSCrash legitimately handles it through its standard terminate monitor while running the E2E tests against #8515. Add NSException-subclass and stale ObjC throw-site scenarios to exercise the specific fixes already included in KSCrash 2.6 after our upstream (the latter is not fixed in v9).

Document in code where green results are not yet sufficient: managed-runtime tests still activate SentryCrash's `dylib` constructor, and macOS AppKit NSException forwarding remains coupled to `SentryCrash`. Record both as migration TODOs and retain the existing macOS NSException failure as acceptance coverage.

This does not yet fix managed-runtime ordering, AppKit forwarding, or the other known parity failures (fixing them right away is also not the goal, because we want to be able to record maintained `SentryCrash` behavior _before_ the `KSCrash` integration supports it). However, it establishes more discriminating E2E coverage for those subsequent migration steps.

## :green_heart: How did you test it?

This is a test PR, so the test is the test for the test.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
