### PR TITLE
ci: simplify benchmarking to main-only, drop mid-range device

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -88,31 +88,6 @@ run_api_stability_for_prs: &run_api_stability_for_prs
   # Build configuration
   - "Makefile"
 
-# Benchmarks always run on main, but on PRs they only run when benchmarking-related files change.
-# We intentionally exclude Sources/**, Tests/**, and other broad patterns here because benchmarks
-# are expensive (SauceLabs devices) and slow down PR CI. SDK source changes are covered by the
-# benchmarks running on every push to main.
-run_benchmarking_for_prs: &run_benchmarking_for_prs # GH Actions
-  - ".github/workflows/benchmarking.yml"
-  - ".github/file-filters.yml"
-
-  # Scripts & actions
-  - "scripts/ci-select-xcode.sh"
-  - "scripts/ci-utils.sh"
-  - ".github/actions/saucelabs-run/**"
-  - ".github/actions/setup-xcode/**"
-
-  # Benchmarking test target and implementation
-  - "Samples/iOS-Swift/iOS-Benchmarking/**"
-  - "Samples/iOS-Swift/iOS-Benchmarking.xcconfig"
-  - "Samples/iOS-Swift/iOS-Swift/Profiling/BenchmarkingViewController.swift"
-  - "Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.h"
-  - "Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.mm"
-  - "Samples/iOS-Swift/iOS-Swift.yml"
-  - "Samples/SentrySampleShared/SentrySampleUITestShared/**"
-  - ".sauce/benchmarking-config.yml"
-  - "Plans/iOS-Benchmarking_Base.xctestplan"
-
 run_lint_clang_formatting_for_prs: &run_lint_clang_formatting_for_prs
   - "**/*.h"
   - "**/*.hpp"

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -4,15 +4,36 @@ on:
     branches:
       - main
 
-# Never cancel benchmarks on main to ensure complete performance baselines
-# for every commit, which are critical for regression detection.
+  pull_request:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    outputs:
+      benchmarking_changed: ${{ steps.changes.outputs.benchmarking_changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          token: ${{ github.token }}
+          filters: |
+            benchmarking_changed:
+              - '.github/workflows/benchmarking.yml'
+              - '.sauce/benchmarking-config.yml'
+
   build-benchmark-test-target:
     name: Build App and Test Runner
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.files-changed.outputs.benchmarking_changed == 'true'
+    needs: files-changed
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
@@ -69,8 +90,11 @@ jobs:
 
   run-ui-tests-with-sauce:
     name: Run Benchmarks ${{matrix.suite}}
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.files-changed.outputs.benchmarking_changed == 'true'
     runs-on: ubuntu-latest
-    needs: build-benchmark-test-target
+    needs: [files-changed, build-benchmark-test-target]
     strategy:
       fail-fast: false
       matrix:
@@ -100,11 +124,6 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
           TEST_ID: ${{ steps.run-benchmarks-in-sauce-lab.outputs.test_id }}
         with:
-          # Retry Logic: This step only runs when the benchmark test has failed.
-          # We determine if the failure was due to SauceLabs infrastructure issues
-          # (which can be fixed by retrying) or legitimate test failures (which cannot).
-          # SauceLabs internal errors frequently cause CI failures that can be resolved
-          # by re-running the test.
           script: |
             const { execSync } = require('child_process');
             const testId = process.env.TEST_ID;
@@ -133,7 +152,6 @@ jobs:
 
       - name: Run Benchmarks in SauceLab - Retry 1
         id: run-benchmarks-in-sauce-lab-retry-1
-        # Note: We need to use always() here, because the previous run step might be marked as failed.
         if: ${{ always() && steps.should-retry-test.outputs.RETRY_TEST == 'true' }}
         uses: ./.github/actions/saucelabs-run
         with:
@@ -149,7 +167,7 @@ jobs:
         if: failure()
 
   benchmarking-required-check:
-    needs: [build-benchmark-test-target, run-ui-tests-with-sauce]
+    needs: [files-changed, build-benchmark-test-target, run-ui-tests-with-sauce]
     name: Benchmarking
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -4,36 +4,13 @@ on:
     branches:
       - main
 
-  pull_request:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
-  files-changed:
-    name: Detect File Changes
-    runs-on: ubuntu-latest
-    outputs:
-      benchmarking_changed: ${{ steps.changes.outputs.benchmarking_changed }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Get changed files
-        id: changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        with:
-          token: ${{ github.token }}
-          filters: |
-            benchmarking_changed:
-              - '.github/workflows/benchmarking.yml'
-              - '.sauce/benchmarking-config.yml'
-
   build-benchmark-test-target:
     name: Build App and Test Runner
-    if: >-
-      github.event_name != 'pull_request' ||
-      needs.files-changed.outputs.benchmarking_changed == 'true'
-    needs: files-changed
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
@@ -90,11 +67,8 @@ jobs:
 
   run-ui-tests-with-sauce:
     name: Run Benchmarks ${{matrix.suite}}
-    if: >-
-      github.event_name != 'pull_request' ||
-      needs.files-changed.outputs.benchmarking_changed == 'true'
     runs-on: ubuntu-latest
-    needs: [files-changed, build-benchmark-test-target]
+    needs: build-benchmark-test-target
     strategy:
       fail-fast: false
       matrix:
@@ -165,14 +139,3 @@ jobs:
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics
         if: failure()
-
-  benchmarking-required-check:
-    needs: [files-changed, build-benchmark-test-target, run-ui-tests-with-sauce]
-    name: Benchmarking
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for failures
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: |
-          echo "One of the benchmark jobs has failed." && exit 1

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -3,71 +3,16 @@ on:
   push:
     branches:
       - main
-      - v8.x
 
-  pull_request:
-
-# Concurrency configuration:
-# - We use workflow-specific concurrency groups to prevent multiple benchmark runs on the same code,
-#   as benchmarks are extremely resource-intensive and require dedicated device time on SauceLabs.
-# - For pull requests, we cancel in-progress runs when new commits are pushed to avoid wasting
-#   expensive external testing resources and provide timely performance feedback.
-# - For main branch pushes, we never cancel benchmarks to ensure we have complete performance
-#   baselines for every main branch commit, which are critical for performance regression detection.
+# Never cancel benchmarks on main to ensure complete performance baselines
+# for every commit, which are critical for regression detection.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
-  files-changed:
-    name: Detect File Changes
-    runs-on: ubuntu-latest
-    outputs:
-      run_benchmarking_for_prs: ${{ steps.changes.outputs.run_benchmarking_for_prs }}
-      is_dependabot: ${{ github.actor == 'dependabot[bot]' }}
-      is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Get changed files
-        id: changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
-  skip-benchmarking-for-non-contributors:
-    name: Skip Benchmarking for Non-Contributors
-    runs-on: ubuntu-latest
-    needs: files-changed
-    # Skip for non-contributors or fork PRs, but not for dependabot (handled in build-benchmark-test-target)
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
-      (
-        !contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) ||
-        needs.files-changed.outputs.is_fork == 'true'
-      ) &&
-      needs.files-changed.outputs.is_dependabot == 'false'
-    steps:
-      - name: Skip Benchmarking for Non-Contributors
-        run: |
-          echo "Skipping benchmarking for non-contributors"
-          exit 0
-
   build-benchmark-test-target:
     name: Build App and Test Runner
-    # Run for PRs with related changes (including dependabot) or non-PR events.
-    if: |
-      github.event_name != 'pull_request' || (
-        needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
-        needs.files-changed.outputs.is_fork != 'true' && (
-          contains(
-          fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'),
-          github.event.pull_request.author_association
-        ) ||
-        needs.files-changed.outputs.is_dependabot == 'true')
-      )
-    needs: files-changed
     runs-on: macos-26
     steps:
       - name: Warm CoreSimulator
@@ -85,24 +30,16 @@ jobs:
       - run: make init-ci-build
       - run: make xcode-ci
       - name: Install Sentry CLI
-        if: needs.files-changed.outputs.is_dependabot != 'true'
         run: brew install getsentry/tools/sentry-cli
-
-      # When running the workflows for dependabot PRs, we need to skip code signing, because the code signing secrets are not available for dependabot PRs.
-      # We still want to run as much of the full workflow as possible, to verify the behaviour.
       - name: Build iOS-Swift for tests
-        run: |
-          bundle exec fastlane build_ios_swift_for_tests \
-            skip_codesigning:${{ needs.files-changed.outputs.is_dependabot == 'true' }}
+        run: bundle exec fastlane build_ios_swift_for_tests
         env:
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Build iOS benchmark test
-        run: |
-          bundle exec fastlane build_ios_benchmark_test \
-            skip_codesigning:${{ needs.files-changed.outputs.is_dependabot == 'true' }}
+        run: bundle exec fastlane build_ios_benchmark_test
         env:
           FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
@@ -110,7 +47,6 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
 
       - name: Upload dSYMs
-        if: needs.files-changed.outputs.is_dependabot != 'true'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
@@ -120,7 +56,6 @@ jobs:
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
 
       - name: Upload Built Apps for SauceLabs
-        if: needs.files-changed.outputs.is_dependabot != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-apps
@@ -134,19 +69,12 @@ jobs:
 
   run-ui-tests-with-sauce:
     name: Run Benchmarks ${{matrix.suite}}
-    # Run the job only for PRs with related changes (excluding dependabot) or non-PR events.
-    if: |
-      github.event_name != 'pull_request' || (
-        needs.files-changed.outputs.run_benchmarking_for_prs == 'true' &&
-        needs.files-changed.outputs.is_dependabot == 'false' &&
-        needs.files-changed.outputs.is_fork != 'true'
-      )
     runs-on: ubuntu-latest
-    needs: [files-changed, build-benchmark-test-target]
+    needs: build-benchmark-test-target
     strategy:
       fail-fast: false
       matrix:
-        suite: ["High-end device", "Mid-range device", "Low-end device"]
+        suite: ["High-end device", "Low-end device"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -165,7 +93,6 @@ jobs:
 
       - name: Should Retry Test
         id: should-retry-test
-        # Note: We need to use always() here, because the previous run step might be marked as failed.
         if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -222,20 +149,11 @@ jobs:
         if: failure()
 
   benchmarking-required-check:
-    needs:
-      [
-        files-changed,
-        build-benchmark-test-target,
-        run-ui-tests-with-sauce,
-        skip-benchmarking-for-non-contributors,
-      ]
+    needs: [build-benchmark-test-target, run-ui-tests-with-sauce]
     name: Benchmarking
-    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()
     runs-on: ubuntu-latest
     steps:
-      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
-      # Skipped jobs are not considered failures.
       - name: Check for failures
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -19,4 +19,4 @@ suites:
   - name: "Low-end device"
     devices:
       - name: "iPhone SE 2022"
-        platformVersion: "16"
+        platformVersion: "18"

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -16,10 +16,6 @@ suites:
     devices:
       - name: "iPad Pro 11 2024"
         platformVersion: "17"
-  - name: "Mid-range device"
-    devices:
-      - name: "iPhone 13 Mini"
-        platformVersion: "17"
   - name: "Low-end device"
     devices:
       - name: "iPhone SE 2022"

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -19,4 +19,4 @@ suites:
   - name: "Low-end device"
     devices:
       - name: "iPhone SE 2022"
-        platformVersion: "15"
+        platformVersion: "16"


### PR DESCRIPTION
## Summary

* Remove PR trigger — benchmarks now only run on pushes to `main`
* Remove all PR-related conditional logic (file change detection, contributor/fork/dependabot checks)
* Remove mid-range device (iPhone 13 Mini) from the SauceLabs matrix, keeping high-end (iPad Pro 11 2024) and low-end (iPhone SE 2022) only

#skip-changelog

Closes getsentry/sentry-cocoa#8542