### PR TITLE
chore: track missing experimental features in telemetry

### DIFF
--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -59,14 +59,14 @@ import Foundation
             features.append("watchdogTerminationsV2")
         }
 
-#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
         if options.attachViewHierarchy {
             features.append("viewHierarchy")
         }
         if options.screenshot.enableFastViewRendering {
             features.append("screenshotFastViewRendering")
         }
-#endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+#endif // (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
 
         return features
     }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -55,6 +55,18 @@ import Foundation
         if options.experimental.enableStandaloneAppStartTracing {
             features.append("standaloneAppStartTracing")
         }
+        if options.experimental.enableWatchdogTerminationsV2 {
+            features.append("watchdogTerminationsV2")
+        }
+
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+        if options.attachViewHierarchy {
+            features.append("viewHierarchy")
+        }
+        if options.screenshot.enableFastViewRendering {
+            features.append("screenshotFastViewRendering")
+        }
+#endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
         return features
     }

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -232,4 +232,98 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         // -- Assert --
         XCTAssertFalse(features.contains("standaloneAppStartTracing"))
     }
+
+    func testEnableWatchdogTerminationsV2_isEnabled_shouldAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableWatchdogTerminationsV2 = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertTrue(features.contains("watchdogTerminationsV2"))
+    }
+
+    func testEnableWatchdogTerminationsV2_isDisabled_shouldNotAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableWatchdogTerminationsV2 = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("watchdogTerminationsV2"))
+    }
+
+    func testAttachViewHierarchy_isEnabled_shouldAddFeature() throws {
+#if os(iOS)
+        // -- Arrange --
+        let options = Options()
+
+        options.attachViewHierarchy = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertTrue(features.contains("viewHierarchy"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
+    }
+
+    func testAttachViewHierarchy_isDisabled_shouldNotAddFeature() throws {
+#if os(iOS)
+        // -- Arrange --
+        let options = Options()
+
+        options.attachViewHierarchy = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("viewHierarchy"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
+    }
+
+    func testScreenshotFastViewRendering_isEnabled_shouldAddFeature() throws {
+#if os(iOS)
+        // -- Arrange --
+        let options = Options()
+
+        options.screenshot.enableFastViewRendering = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertTrue(features.contains("screenshotFastViewRendering"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
+    }
+
+    func testScreenshotFastViewRendering_isDisabled_shouldNotAddFeature() throws {
+#if os(iOS)
+        // -- Arrange --
+        let options = Options()
+
+        options.screenshot.enableFastViewRendering = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("screenshotFastViewRendering"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
+    }
 }


### PR DESCRIPTION
## Summary

Checked options marked as experimental not being tracked

* Add telemetry tracking for three experimental features that were missing from `SentryEnabledFeaturesBuilder`:
  * `watchdogTerminationsV2` (`experimental.enableWatchdogTerminationsV2`)
  * `viewHierarchy` (`attachViewHierarchy`)
  * `screenshotFastViewRendering` (`screenshot.enableFastViewRendering`)
* Add tests for each new tracked feature (enabled + disabled)

## Test plan

- [X] `make build-ios FOR_AGENTS=true` passes
- [X] `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryEnabledFeaturesBuilderTests` — all 23 tests pass

#skip-changelog

Closes getsentry/sentry-cocoa#8564