### PR TITLE
test: Configure sample data collection

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -36,6 +36,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
     var featureFlags: [any SentrySDKOverride] {
         switch self {
         case .special: return SentrySDKOverrides.Special.allCases
+        case .dataCollection: return SentrySDKOverrides.DataCollection.allCases
         case .events: return SentrySDKOverrides.Events.allCases
         case .performance: return SentrySDKOverrides.Performance.allCases
         case .appStart: return SentrySDKOverrides.AppStart.allCases
@@ -75,6 +76,25 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case dsn               = "--io.sentry.special.dsn"
     }
     case special = "Special"
+
+    public enum DataCollection: String, SentrySDKOverride {
+        case disableUserInfo = "--io.sentry.data-collection.disable-user-info"
+        case cookiesMode = "--io.sentry.data-collection.cookies.mode"
+        case cookiesTerms = "--io.sentry.data-collection.cookies.terms"
+        case httpRequestHeadersMode = "--io.sentry.data-collection.http-headers.request.mode"
+        case httpRequestHeadersTerms = "--io.sentry.data-collection.http-headers.request.terms"
+        case httpResponseHeadersMode = "--io.sentry.data-collection.http-headers.response.mode"
+        case httpResponseHeadersTerms = "--io.sentry.data-collection.http-headers.response.terms"
+        case httpBodies = "--io.sentry.data-collection.http-bodies"
+        case urlQueryParamsMode = "--io.sentry.data-collection.url-query-params.mode"
+        case urlQueryParamsTerms = "--io.sentry.data-collection.url-query-params.terms"
+        case disableGraphQLDocument = "--io.sentry.data-collection.graphql.disable-document"
+        case disableGraphQLVariables = "--io.sentry.data-collection.graphql.disable-variables"
+        case disableDatabaseQueryParams = "--io.sentry.data-collection.database.disable-query-params"
+        case disableStackFrameVariables = "--io.sentry.data-collection.disable-stack-frame-variables"
+        case frameContextLines = "--io.sentry.data-collection.frame-context-lines"
+    }
+    case dataCollection = "Data Collection"
 
     public enum Events: String, SentrySDKOverride {
         case sampleRate       = "--io.sentry.events.sample-rate"
@@ -370,6 +390,20 @@ extension SentrySDKOverrides.Special {
     }
 }
 
+extension SentrySDKOverrides.DataCollection {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableUserInfo, .disableGraphQLDocument, .disableGraphQLVariables,
+             .disableDatabaseQueryParams, .disableStackFrameVariables:
+            return .boolean
+        case .cookiesMode, .cookiesTerms, .httpRequestHeadersMode, .httpRequestHeadersTerms,
+             .httpResponseHeadersMode, .httpResponseHeadersTerms, .httpBodies,
+             .urlQueryParamsMode, .urlQueryParamsTerms, .frameContextLines:
+            return .string
+        }
+    }
+}
+
 extension SentrySDKOverrides.Events {
     public var overrideType: OverrideType {
         switch self {
@@ -624,6 +658,10 @@ extension SentrySDKOverrides.Special {
             return true
         }
     }
+}
+
+extension SentrySDKOverrides.DataCollection {
+    public var ignoresDisableEverything: Bool { return false }
 }
 
 extension SentrySDKOverrides.Events {

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -51,8 +51,81 @@ public struct SentrySDKWrapper {
 #endif // os(iOS) || os(tvOS) || os(visionOS))
     }
 
+    public func configureDataCollection(_ options: Options) {
+#if SDK_V10
+        options.dataCollection.userInfo = !SentrySDKOverrides.DataCollection.disableUserInfo.boolValue
+        options.dataCollection.cookies = dataCollectionBehavior(
+            mode: SentrySDKOverrides.DataCollection.cookiesMode.stringValue,
+            terms: SentrySDKOverrides.DataCollection.cookiesTerms.stringValue
+        )
+        options.dataCollection.httpHeaders.request = dataCollectionBehavior(
+            mode: SentrySDKOverrides.DataCollection.httpRequestHeadersMode.stringValue,
+            terms: SentrySDKOverrides.DataCollection.httpRequestHeadersTerms.stringValue
+        )
+        options.dataCollection.httpHeaders.response = dataCollectionBehavior(
+            mode: SentrySDKOverrides.DataCollection.httpResponseHeadersMode.stringValue,
+            terms: SentrySDKOverrides.DataCollection.httpResponseHeadersTerms.stringValue
+        )
+        if SentrySDKOverrides.Special.disableEverything.boolValue {
+            options.dataCollection.httpBodies = []
+        } else if let httpBodies = SentrySDKOverrides.DataCollection.httpBodies.stringValue {
+            options.dataCollection.httpBodies = dataCollectionHttpBodies(commaSeparatedValues(httpBodies))
+        }
+        options.dataCollection.urlQueryParams = dataCollectionBehavior(
+            mode: SentrySDKOverrides.DataCollection.urlQueryParamsMode.stringValue,
+            terms: SentrySDKOverrides.DataCollection.urlQueryParamsTerms.stringValue
+        )
+        options.dataCollection.graphql.document = !SentrySDKOverrides.DataCollection.disableGraphQLDocument.boolValue
+        options.dataCollection.graphql.variables = !SentrySDKOverrides.DataCollection.disableGraphQLVariables.boolValue
+        options.dataCollection.database.queryParams = !SentrySDKOverrides.DataCollection.disableDatabaseQueryParams.boolValue
+        options.dataCollection.stackFrameVariables = !SentrySDKOverrides.DataCollection.disableStackFrameVariables.boolValue
+        if SentrySDKOverrides.Special.disableEverything.boolValue {
+            options.dataCollection.frameContextLines = 0
+        } else if let frameContextLines = SentrySDKOverrides.DataCollection.frameContextLines.stringValue,
+                  let value = UInt(frameContextLines) {
+            options.dataCollection.frameContextLines = value
+        }
+#endif // SDK_V10
+    }
+
+#if SDK_V10
+    private func dataCollectionBehavior(
+        mode: String?,
+        terms: String?
+    ) -> SentryDataCollection.KeyValueCollectionBehavior {
+        guard !SentrySDKOverrides.Special.disableEverything.boolValue else { return .off }
+        let values = commaSeparatedValues(terms)
+        switch mode {
+        case "off": return .off
+        case "allowList": return .allowList(terms: values)
+        case "denyList", nil: return .denyList(terms: values)
+        default: return .denyList()
+        }
+    }
+
+    private func dataCollectionHttpBodies(_ values: [String]) -> SentryDataCollection.HttpBodyType {
+        values.reduce(into: []) { result, value in
+            switch value {
+            case "incomingRequest": result.insert(.incomingRequest)
+            case "outgoingRequest": result.insert(.outgoingRequest)
+            case "incomingResponse": result.insert(.incomingResponse)
+            case "outgoingResponse": result.insert(.outgoingResponse)
+            default: break
+            }
+        }
+    }
+
+    private func commaSeparatedValues(_ value: String?) -> [String] {
+        value?
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+    }
+#endif // SDK_V10
+
     func configureSentryOptions(options: Options) {
         options.dsn = dsn
+        configureDataCollection(options)
         if let sampleRate = SentrySDKOverrides.Events.sampleRate.floatValue {
             options.sampleRate = NSNumber(value: sampleRate)
         }
@@ -413,9 +486,11 @@ extension SentrySDKWrapper {
     func configureFeedback(config: SentryUserFeedbackConfiguration) {
         let shouldConfigureDeprecatedWidget = SentrySDKOverrides.Feedback.disableAutoInject.boolValue
         guard !args.contains(SentrySDKOverrides.Feedback.allDefaults.rawValue) else {
+#if !SDK_V10
             if shouldConfigureDeprecatedWidget {
                 config.configureWidget = configureFeedbackWidget(config:)
             }
+#endif // !SDK_V10
             configureHooks(config: config)
             return
         }
@@ -423,16 +498,20 @@ extension SentrySDKWrapper {
         config.animations = !SentrySDKOverrides.Feedback.noAnimations.boolValue
         config.useShakeGesture = !SentrySDKOverrides.Feedback.noShakeGesture.boolValue
         config.showFormForScreenshots = !SentrySDKOverrides.Feedback.noScreenshots.boolValue
+#if !SDK_V10
         if shouldConfigureDeprecatedWidget {
             config.configureWidget = configureFeedbackWidget(config:)
         }
+#endif // !SDK_V10
         config.configureForm = configureFeedbackForm(config:)
         config.configureTheme = configureFeedbackTheme(config:)
         configureHooks(config: config)
 
+#if !SDK_V10
         if SentrySDKOverrides.Feedback.useCustomFeedbackButton.boolValue {
             config.customButton = feedbackButton
         }
+#endif // !SDK_V10
     }
 
     func configureHooks(config: SentryUserFeedbackConfiguration) {
@@ -577,5 +656,14 @@ extension SentrySDKWrapper {
     }
 }
 #endif // !os(tvOS) && !os(watchOS) && !os(visionOS)
+
+#if SDK_V10
+@objcMembers public final class SentrySampleDataCollectionConfiguration: NSObject {
+    @objc(configureWithOptions:)
+    public static func configure(options: Options) {
+        SentrySDKWrapper.shared.configureDataCollection(options)
+    }
+}
+#endif // SDK_V10
 
 // swiftlint:enable file_length function_body_length

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -9,6 +9,13 @@ schemeTemplates:
         "--io.sentry.special.wipe-data": false
         "--io.sentry.special.disable-debug-mode": false
 
+        # data collection
+        "--io.sentry.data-collection.disable-user-info": false
+        "--io.sentry.data-collection.graphql.disable-document": false
+        "--io.sentry.data-collection.graphql.disable-variables": false
+        "--io.sentry.data-collection.database.disable-query-params": false
+        "--io.sentry.data-collection.disable-stack-frame-variables": false
+
         # events
         "--io.sentry.events.reject-all": false
         "--io.sentry.events.attach-all-threads": false
@@ -125,6 +132,38 @@ schemeTemplates:
       environmentVariables:
         # special
         - variable: "--io.sentry.special.dsn"
+          value:
+          isEnabled: false
+
+        # data collection
+        - variable: "--io.sentry.data-collection.cookies.mode"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.cookies.terms"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.http-headers.request.mode"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.http-headers.request.terms"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.http-headers.response.mode"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.http-headers.response.terms"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.http-bodies"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.url-query-params.mode"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.url-query-params.terms"
+          value:
+          isEnabled: false
+        - variable: "--io.sentry.data-collection.frame-context-lines"
           value:
           isEnabled: false
 

--- a/Samples/iOS-ObjectiveC/App/Sources/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/App/Sources/AppDelegate.m
@@ -16,6 +16,9 @@
         options.debug = YES;
         options.attachScreenshot = YES;
         options.attachViewHierarchy = YES;
+#if SDK_V10
+        [SentrySampleDataCollectionConfiguration configureWithOptions:options];
+#endif // SDK_V10
 
         if (env[@"--io.sentry.tracesSamplerValue"] != nil) {
             options.tracesSampler = ^(SentrySamplingContext *_Nonnull samplingContext) {

--- a/Samples/iOS-Swift/ActionExtension/Sources/ActionViewController.swift
+++ b/Samples/iOS-Swift/ActionExtension/Sources/ActionViewController.swift
@@ -27,6 +27,7 @@ class ActionViewController: UIViewController {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-Swift/IntentExtension/Sources/IntentHandler.swift
+++ b/Samples/iOS-Swift/IntentExtension/Sources/IntentHandler.swift
@@ -26,6 +26,7 @@ class IntentHandler: INExtension, INSendMessageIntentHandling {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-Swift/NotificationServiceExtension/Sources/NotificationService.swift
+++ b/Samples/iOS-Swift/NotificationServiceExtension/Sources/NotificationService.swift
@@ -44,6 +44,7 @@ class NotificationService: UNNotificationServiceExtension {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-Swift/ShareExtension/Sources/ShareViewController.swift
+++ b/Samples/iOS-Swift/ShareExtension/Sources/ShareViewController.swift
@@ -27,6 +27,7 @@ class ShareViewController: SLComposeServiceViewController {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-SwiftUI-Widgets/App/Sources/MainApp.swift
+++ b/Samples/iOS-SwiftUI-Widgets/App/Sources/MainApp.swift
@@ -12,6 +12,7 @@ struct MainApp: App {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-SwiftUI-Widgets/LiveActivity/Sources/LiveActivityWidget.swift
+++ b/Samples/iOS-SwiftUI-Widgets/LiveActivity/Sources/LiveActivityWidget.swift
@@ -16,6 +16,7 @@ struct LiveActivityWidget: Widget {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
             options.enableAppHangTracking = true
         }
     }

--- a/Samples/iOS-SwiftUI-Widgets/WidgetExtension/Sources/SampleWidget.swift
+++ b/Samples/iOS-SwiftUI-Widgets/WidgetExtension/Sources/SampleWidget.swift
@@ -74,6 +74,7 @@ private struct Provider: AppIntentTimelineProvider {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
 
             // App Hang Tracking must be enabled, but should not be installed
             options.enableAppHangTracking = true

--- a/Samples/iOS-SwiftUI-Widgets/WidgetExtension/Sources/SampleWidgetControl.swift
+++ b/Samples/iOS-SwiftUI-Widgets/WidgetExtension/Sources/SampleWidgetControl.swift
@@ -18,6 +18,7 @@ struct SampleWidgetControl: ControlWidget {
         SentrySDK.start { options in
             options.dsn = SentrySDKWrapper.defaultDSN
             options.debug = true
+            SentrySDKWrapper.shared.configureDataCollection(options)
             options.enableAppHangTracking = true
         }
     }


### PR DESCRIPTION
## 📜 Description

Add runtime overrides for every `SentryDataCollection.Options` value, including key-value modes and terms, HTTP body directions, GraphQL, database, stack frame variables, and frame context lines.

The shared initializer applies these overrides across the sample apps. Independent SDK initialization paths in the iOS extensions, widgets, and Objective-C sample now use the same configuration.

## 💡 Motivation and Context

Issue getsentry/sentry-cocoa#8255 requires the sample apps to exercise the granular `dataCollection` configuration instead of relying on a commented snippet. Runtime overrides make each value available to integration tests through the existing launch argument, environment variable, and in-app override system.

Fixes getsentry/sentry-cocoa#8255

## 💚 How did you test it?

* `make format`
* `make analyze`
* `make build-sample-iOS-Swift`
* `make build-sample-iOS-ObjectiveC`
* `make build-sample-iOS-SwiftUI-Widgets`
* Built `SentrySampleShared` for the iOS Simulator with `SDK_V10`
* Built `macOS-Swift` with `SDK_V10`
* Confirmed the generated Objective-C header exports `configureWithOptions:`

Full iOS V10 sample builds remain blocked by existing references to APIs already removed under `SDK_V10`, including the deprecated feedback widget and legacy `SentrySDK` Objective-C surface.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes. No sample override unit-test target exists.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

#skip-changelog