### PR TITLE
fix(data-collection): Omit disabled failed headers

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -21,4 +21,5 @@
 
 ### Fixes
 
+- Omit failed-request headers when `options.dataCollection.httpHeaders` is disabled (#8562)
 - Normalize profiling CPU usage to 0–100 percent (#8323)

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -370,7 +370,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
                 headers,
                 options: options.dataCollection
             )
-            if !sanitizedHeaders.headers.isEmpty {
+            if options.dataCollection.httpHeaders.request != .off {
                 request.headers = sanitizedHeaders.headers
             }
             request.cookies = sanitizedHeaders.cookies
@@ -397,7 +397,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             responseHeaders,
             options: options.dataCollection
         )
-        if !sanitizedHeaders.headers.isEmpty {
+        if options.dataCollection.httpHeaders.response != .off {
             responseContext["headers"] = sanitizedHeaders.headers
         }
         responseContext["cookies"] = sanitizedHeaders.cookies

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -370,7 +370,9 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
                 headers,
                 options: options.dataCollection
             )
-            request.headers = sanitizedHeaders.headers
+            if !sanitizedHeaders.headers.isEmpty {
+                request.headers = sanitizedHeaders.headers
+            }
             request.cookies = sanitizedHeaders.cookies
             #else
             request.headers = HTTPHeaderSanitizer.sanitizeHeaders(headers)
@@ -390,12 +392,14 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             result[key] = value
         }
         // swiftlint:enable avoid_all_header_fields
-        #if SDK_V10
+#if SDK_V10
         let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeResponseHeaders(
             responseHeaders,
             options: options.dataCollection
         )
-        responseContext["headers"] = sanitizedHeaders.headers
+        if !sanitizedHeaders.headers.isEmpty {
+            responseContext["headers"] = sanitizedHeaders.headers
+        }
         responseContext["cookies"] = sanitizedHeaders.cookies
         #else
         responseContext["headers"] = HTTPHeaderSanitizer.sanitizeHeaders(responseHeaders)

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -392,7 +392,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             result[key] = value
         }
         // swiftlint:enable avoid_all_header_fields
-#if SDK_V10
+        #if SDK_V10
         let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeResponseHeaders(
             responseHeaders,
             options: options.dataCollection

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1643,6 +1643,27 @@ class SentryNetworkTrackerTests: XCTestCase {
 #endif // SDK_V10
     }
 
+    func testCaptureHTTPClientErrorRequest_whenHeaderNamePartiallyMatchesSensitiveTerm_shouldFilterValue() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        // -- Arrange --
+        let task = createDataTask { request in
+            var request = request
+            request.allHTTPHeaderFields = ["X-Auth-Token": "secret-token"]
+            return request
+        }
+        task.setResponse(try createResponse(code: 500))
+
+        // -- Act --
+        fixture.getSut().urlSessionTask(task, setState: .completed)
+
+        // -- Assert --
+        let request = try XCTUnwrap(fixture.hub.capturedErrorEvents.first?.request)
+        XCTAssertEqual(request.headers, ["X-Auth-Token": "[Filtered]"])
+#endif // SDK_V10
+    }
+
     func testCaptureHTTPClientErrorResponse() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
@@ -1747,7 +1768,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         // -- Assert --
         let request = try XCTUnwrap(fixture.hub.capturedErrorEvents.first?.request)
 #if SDK_V10
-        XCTAssertEqual(request.headers, [:])
+        XCTAssertNil(request.headers)
         XCTAssertEqual(request.cookies, ["theme": "dark", "session": "[Filtered]"])
 #else
         XCTAssertEqual(request.headers, ["Content-Type": "application/json"])
@@ -1778,7 +1799,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         // -- Assert --
         let response = try XCTUnwrap(fixture.hub.capturedErrorEvents.first?.context?["response"])
 #if SDK_V10
-        XCTAssertEqual(response["headers"] as? [String: String], [:])
+        XCTAssertNil(response["headers"])
         XCTAssertEqual(response["cookies"] as? [String: String], ["theme": "dark"])
 #else
         XCTAssertEqual(response["headers"] as? [String: String], ["Content-Type": "application/json"])

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1707,6 +1707,36 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(response["headers"] as? [String: String], [:])
     }
 
+    func testCaptureHTTPClientError_whenOnlyCookiesArePresentAndHeaderCollectionIsEnabled_shouldIncludeEmptyHeaders() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        // -- Arrange --
+        let task = createDataTask { request in
+            var request = request
+            request.allHTTPHeaderFields = ["Cookie": "theme=dark"]
+            return request
+        }
+        task.setResponse(try XCTUnwrap(HTTPURLResponse(
+            url: SentryNetworkTrackerTests.fullUrl,
+            statusCode: 500,
+            httpVersion: "1.1",
+            headerFields: ["Set-Cookie": "locale=en; HttpOnly"]
+        )))
+
+        // -- Act --
+        fixture.getSut().urlSessionTask(task, setState: .completed)
+
+        // -- Assert --
+        let event = try XCTUnwrap(fixture.hub.capturedErrorEvents.first)
+        XCTAssertEqual(event.request?.headers, [:])
+        XCTAssertEqual(event.request?.cookies, ["theme": "dark"])
+        let response = try XCTUnwrap(event.context?["response"])
+        XCTAssertEqual(response["headers"] as? [String: String], [:])
+        XCTAssertEqual(response["cookies"] as? [String: String], ["locale": "en"])
+#endif // SDK_V10
+    }
+
     func testCaptureHTTPClientErrorResponse_noSecurityHeader() throws {
         let sut = fixture.getSut()
         let task = createDataTask()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2236,6 +2236,30 @@ final class SentryClientTests: XCTestCase {
 #endif
     }
 
+    func testCapture_whenRequestHeadersAreExplicitAndCollectionIsOff_shouldNotFilterHeaders() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        // -- Arrange --
+        let event = Event()
+        let request = SentryRequest()
+        request.headers = ["Authorization": "Bearer user-provided-token"]
+        event.request = request
+        let sut = fixture.getSut { options in
+            options.dataCollection.httpHeaders = .init(request: .off, response: .off)
+        }
+
+        // -- Act --
+        sut.capture(event: event)
+
+        // -- Assert --
+        let capturedEvent = try lastSentEvent()
+        XCTAssertEqual(capturedEvent.request?.headers, [
+            "Authorization": "Bearer user-provided-token"
+        ])
+#endif // SDK_V10
+    }
+
     func testInstallationIdNotSetWhenUserIsSetWithoutId() throws {
         let scope = fixture.scope
         scope.setUser(fixture.user)


### PR DESCRIPTION
## 📜 Description

Failed-request instrumentation now omits request and response header fields when the corresponding V10 `dataCollection.httpHeaders` direction is `.off`, rather than attaching an empty dictionary.

The regression coverage also verifies partial sensitive-name filtering with `X-Auth-Token` and confirms that headers explicitly supplied on an event are not modified by this automatic-instrumentation gate.

## 💡 Motivation and Context

This completes the failed-request header behavior required by the data-collection specification while preserving the cookie collection handled independently by the stacked base.

Fixes getsentry/sentry-cocoa#8553

## 💚 How did you test it?

* `make format`
* `make analyze`
* `make build-ios-v10 FOR_AGENTS=true`
* `make test-ios-v10 FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryNetworkTrackerTests,SentryTests/SentryClientTests/testCapture_whenRequestHeadersAreExplicitAndCollectionIsOff_shouldNotFilterHeaders`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryNetworkTrackerTests`

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

#skip-changelog