### PR TITLE
fix(replay)!: Filter captured network headers

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -24,5 +24,6 @@
 
 ### Fixes
 
+- Filter sensitive values from selected Session Replay network headers and cookies (#8566)
 - Omit failed-request headers when `options.dataCollection.httpHeaders` is disabled (#8562)
 - Normalize profiling CPU usage to 0–100 percent (#8323)

--- a/Sources/Swift/Core/Tools/HTTPHeaderSanitizer.swift
+++ b/Sources/Swift/Core/Tools/HTTPHeaderSanitizer.swift
@@ -44,7 +44,7 @@ enum HTTPHeaderSanitizer {
         )
     }
 
-    private static func sanitizeHeaders(
+    static func sanitizeHeaders(
         _ headers: [String: String],
         headerBehavior: SentryDataCollection.KeyValueCollectionBehavior,
         cookieBehavior: SentryDataCollection.KeyValueCollectionBehavior

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+extension SentryReplayNetworkDetails {
+    /// Sets request details from raw body data.
+    @objc
+    public func setRequest(
+        size: NSNumber?,
+        bodyData: Data?,
+        contentType: String?,
+        allHeaders: [String: Any]?,
+        configuredHeaders: [String]?
+    ) {
+        let headers = Self.extractHeaders(from: allHeaders, matching: configuredHeaders)
+#if SDK_V10
+        let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeHeaders(
+            headers,
+            headerBehavior: .denyList(),
+            cookieBehavior: .denyList()
+        )
+        self.request = Detail(
+            size: size,
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
+            headers: sanitizedHeaders.headers,
+            cookies: sanitizedHeaders.cookies
+        )
+#else
+        self.request = Detail(
+            size: size,
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
+            headers: headers
+        )
+#endif // SDK_V10
+    }
+
+
+    /// Sets response details from raw body data.
+    @objc
+    public func setResponse(
+        statusCode: Int,
+        size: NSNumber?,
+        bodyData: Data?,
+        contentType: String?,
+        allHeaders: [String: Any]?,
+        configuredHeaders: [String]?
+    ) {
+        self.statusCode = NSNumber(value: statusCode)
+        let headers = Self.extractHeaders(from: allHeaders, matching: configuredHeaders)
+#if SDK_V10
+        let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeHeaders(
+            headers,
+            headerBehavior: .denyList(),
+            cookieBehavior: .denyList()
+        )
+        self.response = Detail(
+            size: size,
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
+            headers: sanitizedHeaders.headers,
+            cookies: sanitizedHeaders.cookies
+        )
+#else
+        self.response = Detail(
+            size: size,
+            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
+            headers: headers
+        )
+#endif // SDK_V10
+    }
+
+
+    static func extractHeaders(
+        from sourceHeaders: [String: Any]?,
+        matching configuredHeaders: [String]?
+    ) -> [String: String] {
+        guard let sourceHeaders, let configuredHeaders else { return [:] }
+
+        var extracted = [String: String]()
+        for configured in configuredHeaders {
+            let lowered = configured.lowercased()
+            for (key, value) in sourceHeaders where key.lowercased() == lowered {
+                extracted[key] = (value as? String) ?? "\(value)"
+                break
+            }
+        }
+        return extracted
+    }
+
+
+    /// Serializes to dictionary for inclusion in breadcrumb data.
+    @objc public func serialize() -> [String: Any] {
+        var result = [String: Any]()
+        if let method { result["method"] = method }
+        if let statusCode { result["statusCode"] = statusCode }
+        if let requestBodySize { result["requestBodySize"] = requestBodySize }
+        if let responseBodySize { result["responseBodySize"] = responseBodySize }
+        if let request { result["request"] = request.serialize() }
+        if let response { result["response"] = response.serialize() }
+        return result
+    }
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
@@ -32,7 +32,6 @@ extension SentryReplayNetworkDetails {
 #endif // SDK_V10
     }
 
-
     /// Sets response details from raw body data.
     @objc
     public func setResponse(
@@ -66,7 +65,6 @@ extension SentryReplayNetworkDetails {
 #endif // SDK_V10
     }
 
-
     static func extractHeaders(
         from sourceHeaders: [String: Any]?,
         matching configuredHeaders: [String]?
@@ -83,7 +81,6 @@ extension SentryReplayNetworkDetails {
         }
         return extracted
     }
-
 
     /// Serializes to dictionary for inclusion in breadcrumb data.
     @objc public func serialize() -> [String: Any] {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
@@ -12,11 +12,7 @@ extension SentryReplayNetworkDetails {
     ) {
         let headers = Self.extractHeaders(from: allHeaders, matching: configuredHeaders)
 #if SDK_V10
-        let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeHeaders(
-            headers,
-            headerBehavior: .denyList(),
-            cookieBehavior: .denyList()
-        )
+        let sanitizedHeaders = Self.sanitizeHeaders(headers)
         self.request = Detail(
             size: size,
             body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
@@ -45,11 +41,7 @@ extension SentryReplayNetworkDetails {
         self.statusCode = NSNumber(value: statusCode)
         let headers = Self.extractHeaders(from: allHeaders, matching: configuredHeaders)
 #if SDK_V10
-        let sanitizedHeaders = HTTPHeaderSanitizer.sanitizeHeaders(
-            headers,
-            headerBehavior: .denyList(),
-            cookieBehavior: .denyList()
-        )
+        let sanitizedHeaders = Self.sanitizeHeaders(headers)
         self.response = Detail(
             size: size,
             body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
@@ -64,6 +56,32 @@ extension SentryReplayNetworkDetails {
         )
 #endif // SDK_V10
     }
+
+#if SDK_V10
+    /// Applies the built-in sensitive denylist to headers Session Replay is about to capture.
+    ///
+    /// Session Replay deliberately does **not** read the header and cookie behaviors from
+    /// `SentryOptions.dataCollection`. Per the data collection spec, Replay is not gated by
+    /// `dataCollection` (or its predecessor `sendDefaultPii`): it is a privacy-sensitive feature with
+    /// its own opt-in privacy model — masking everything by default — which is the opposite of the
+    /// `dataCollection` opt-out model. Wiring the two together would flip privacy-sensitive defaults
+    /// for existing Replay users and blur which layer controls masking. Which headers Replay captures
+    /// therefore stays controlled exclusively by `networkRequestHeaders` and `networkResponseHeaders`.
+    ///
+    /// The denylist is still applied on top of that user selection, because sensitive values must
+    /// never be sent in plaintext through automatic instrumentation, regardless of which layer
+    /// selected the header. Using `.denyList()` without extra terms keeps the user's explicit
+    /// selection intact while scrubbing values whose names match the built-in sensitive terms.
+    ///
+    /// See https://develop.sentry.dev/sdk/foundations/client/data-collection/#session-replay
+    private static func sanitizeHeaders(_ headers: [String: String]) -> HTTPHeaderSanitizer.SanitizedHeaders {
+        HTTPHeaderSanitizer.sanitizeHeaders(
+            headers,
+            headerBehavior: .denyList(),
+            cookieBehavior: .denyList()
+        )
+    }
+#endif // SDK_V10
 
     static func extractHeaders(
         from sourceHeaders: [String: Any]?,

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails+Capture.swift
@@ -103,12 +103,12 @@ extension SentryReplayNetworkDetails {
     /// Serializes to dictionary for inclusion in breadcrumb data.
     @objc public func serialize() -> [String: Any] {
         var result = [String: Any]()
-        if let method { result["method"] = method }
-        if let statusCode { result["statusCode"] = statusCode }
-        if let requestBodySize { result["requestBodySize"] = requestBodySize }
-        if let responseBodySize { result["responseBodySize"] = responseBodySize }
-        if let request { result["request"] = request.serialize() }
-        if let response { result["response"] = response.serialize() }
+        result["method"] = method
+        result["statusCode"] = statusCode
+        result["requestBodySize"] = requestBodySize
+        result["responseBodySize"] = responseBodySize
+        result["request"] = request?.serialize()
+        result["response"] = response?.serialize()
         return result
     }
 }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -256,12 +256,18 @@ enum NetworkBodyWarning: String {
         let size: NSNumber?
         let body: Body?
         let headers: [String: String]
+#if SDK_V10
+        let cookies: [String: String]
+#endif // SDK_V10
 
         func serialize() -> [String: Any] {
             var result = [String: Any]()
             if let size { result["size"] = size }
             if let body { result["body"] = body.serialize() }
             if !headers.isEmpty { result["headers"] = headers }
+#if SDK_V10
+            if !cookies.isEmpty { result["cookies"] = cookies }
+#endif // SDK_V10
             return result
         }
     }
@@ -280,9 +286,9 @@ enum NetworkBodyWarning: String {
     // MARK: - Properties
 
     private(set) var method: String?
-    private(set) var statusCode: NSNumber?
-    private(set) var request: Detail?
-    private(set) var response: Detail?
+    var statusCode: NSNumber?
+    var request: Detail?
+    var response: Detail?
 
     /// Request body size in bytes, derived from request details.
     var requestBodySize: NSNumber? { request?.size }
@@ -297,89 +303,6 @@ enum NetworkBodyWarning: String {
     public init(method: String?) {
         self.method = method
         super.init()
-    }
-
-    // MARK: - ObjC Setters
-
-    /// Sets request details from raw body data.
-    ///
-    /// Parses the body data based on content type (JSON, form-urlencoded, text)
-    /// and applies size limits and truncation warnings automatically.
-    ///
-    /// - Parameters:
-    ///   - size: Request body size in bytes, or nil if unknown.
-    ///   - bodyData: Raw body bytes, or nil if body capture is disabled or unavailable.
-    ///   - contentType: MIME content type for body parsing (e.g. "application/json").
-    ///   - allHeaders: All headers from the request (e.g. from `NSURLRequest.allHTTPHeaderFields`).
-    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
-    @objc
-    public func setRequest(size: NSNumber?, bodyData: Data?, contentType: String?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
-        self.request = Detail(
-            size: size,
-            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
-            headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
-        )
-    }
-
-    /// Sets response details from raw body data.
-    ///
-    /// Parses the body data based on content type (JSON, form-urlencoded, text)
-    /// and applies size limits and truncation warnings automatically.
-    ///
-    /// - Parameters:
-    ///   - statusCode: HTTP status code.
-    ///   - size: Response body size in bytes, or nil if unknown.
-    ///   - bodyData: Raw body bytes, or nil if body capture is disabled or unavailable.
-    ///   - contentType: MIME content type for body parsing (e.g. "application/json").
-    ///   - allHeaders: All headers from the response (e.g. from `NSHTTPURLResponse.allHeaderFields`).
-    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
-    @objc
-    public func setResponse(statusCode: Int, size: NSNumber?, bodyData: Data?, contentType: String?, allHeaders: [String: Any]?, configuredHeaders: [String]?) {
-        self.statusCode = NSNumber(value: statusCode)
-        self.response = Detail(
-            size: size,
-            body: bodyData.flatMap { Body(data: $0, contentType: contentType) },
-            headers: SentryReplayNetworkDetails.extractHeaders(from: allHeaders, matching: configuredHeaders)
-        )
-    }
-
-    // MARK: - Header Extraction
-
-    /// Extracts headers from a source dictionary using case-insensitive matching.
-    /// Preserves the original casing of the header key as seen in the source.
-    ///
-    /// - Parameters:
-    ///   - sourceHeaders: All available headers (e.g. from `NSURLRequest` or `NSHTTPURLResponse`).
-    ///   - configuredHeaders: Header names to extract, matched case-insensitively.
-    /// - Returns: Dictionary containing matched headers with original key casing preserved.
-    static func extractHeaders(from sourceHeaders: [String: Any]?, matching configuredHeaders: [String]?) -> [String: String] {
-        guard let sourceHeaders, let configuredHeaders else { return [:] }
-
-        var extracted = [String: String]()
-        for configured in configuredHeaders {
-            let lowered = configured.lowercased()
-            for (key, value) in sourceHeaders {
-                if key.lowercased() == lowered {
-                    extracted[key] = (value as? String) ?? "\(value)"
-                    break
-                }
-            }
-        }
-        return extracted
-    }
-
-    // MARK: - Serialization
-
-    /// Serializes to dictionary for inclusion in breadcrumb data.
-    @objc public func serialize() -> [String: Any] {
-        var result = [String: Any]()
-        if let method { result["method"] = method }
-        if let statusCode { result["statusCode"] = statusCode }
-        if let requestBodySize { result["requestBodySize"] = requestBodySize }
-        if let responseBodySize { result["responseBodySize"] = responseBodySize }
-        if let request { result["request"] = request.serialize() }
-        if let response { result["response"] = response.serialize() }
-        return result
     }
 
     public override var description: String {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -262,8 +262,8 @@ enum NetworkBodyWarning: String {
 
         func serialize() -> [String: Any] {
             var result = [String: Any]()
-            if let size { result["size"] = size }
-            if let body { result["body"] = body.serialize() }
+            result["size"] = size
+            result["body"] = body?.serialize()
             if !headers.isEmpty { result["headers"] = headers }
 #if SDK_V10
             if !cookies.isEmpty { result["cookies"] = cookies }

--- a/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
@@ -162,6 +162,10 @@ extension SentryReplayBreadcrumbConverter {
         if let headers = sourceData["headers"] as? [String: String], !headers.isEmpty {
             result["headers"] = headers
         }
+
+        if let cookies = sourceData["cookies"] as? [String: String], !cookies.isEmpty {
+            result["cookies"] = cookies
+        }
         
         return result.isEmpty ? nil : result
     }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -295,6 +295,31 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData.count, 0, "No keys should be present when details is empty")
     }
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
+    func testHttpBreadcrumb_whenV10NetworkDetailsContainCookies_shouldIncludeCookies() throws {
+#if !SDK_V10
+        throw XCTSkip("Test only runs with SDK_V10")
+#else
+        // -- Act --
+        let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
+            details.setRequest(
+                size: nil,
+                bodyData: nil,
+                contentType: nil,
+                allHeaders: ["Cookie": "theme=dark; session=secret"],
+                configuredHeaders: ["Cookie"]
+            )
+        }
+
+        // -- Assert --
+        let request = try XCTUnwrap(payloadData["request"] as? [String: Any])
+        XCTAssertEqual(request["cookies"] as? [String: String], [
+            "session": "[Filtered]",
+            "theme": "dark"
+        ])
+#endif // SDK_V10
+    }
+
     // MARK: - Helpers
 
     /// Creates an HTTP breadcrumb with a `SentryReplayNetworkDetails` attached,

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsBodyTests.swift
@@ -27,7 +27,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     func testInit_whenV10JSONHasSensitiveTopLevelKeys_shouldFilterTheirValues() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Arrange --
         let bodyData = try JSONSerialization.data(withJSONObject: [
@@ -49,7 +49,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     func testInit_whenV10JSONHasNestedSensitiveKeys_shouldNotFilterNestedValues() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Arrange --
         let bodyData = try JSONSerialization.data(withJSONObject: [
@@ -264,7 +264,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     func testInit_whenV10FormHasSensitiveKeys_shouldFilterTheirValues() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Act --
         let body = try XCTUnwrap(Body(
@@ -293,7 +293,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     func testInit_whenV10FormHasDuplicateSensitiveKeys_shouldFilterEveryValue() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Act --
         let body = try XCTUnwrap(Body(
@@ -399,7 +399,7 @@ class SentryReplayNetworkDetailsBodyTests: XCTestCase {
 
     func testInit_whenV10BodyIsNotKeyValueStructure_shouldFilterEntireBody() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         let bodies: [(Data, String?)] = [
             (Data("{ invalid json }".utf8), "application/json"),

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
@@ -47,11 +47,6 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
         let result = details.serialize()
 
         // -- Assert --
-#if SDK_V10
-        let expectedAuthorization = "[Filtered]"
-#else
-        let expectedAuthorization = "Bearer token"
-#endif
         let expectedJSON = """
         {
             "method": "PUT",
@@ -61,7 +56,7 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
             "request": {
                 "size": 100,
                 "headers": {
-                    "Authorization": "\(expectedAuthorization)",
+                    "Authorization": "\(SentryTestSetup.isV10 ? "[Filtered]" : "Bearer token")",
                     "Content-Type": "application/json"
                 },
                 "body": {
@@ -91,7 +86,7 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
 
     func testSerialize_whenReplaySelectsSensitiveRequestHeaders_shouldFilterValues() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Arrange --
         let details = SentryReplayNetworkDetails(method: "GET")
@@ -124,7 +119,7 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
 
     func testSerialize_whenReplaySelectsCookie_shouldFilterSensitiveValues() throws {
 #if !SDK_V10
-        throw XCTSkip("Test skipped for SDK_V10")
+        throw XCTSkip("Test only runs with SDK_V10")
 #else
         // -- Arrange --
         let details = SentryReplayNetworkDetails(method: "GET")

--- a/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryReplayNetworkDetailsIntegrationTests.swift
@@ -47,6 +47,11 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
         let result = details.serialize()
 
         // -- Assert --
+#if SDK_V10
+        let expectedAuthorization = "[Filtered]"
+#else
+        let expectedAuthorization = "Bearer token"
+#endif
         let expectedJSON = """
         {
             "method": "PUT",
@@ -56,7 +61,7 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
             "request": {
                 "size": 100,
                 "headers": {
-                    "Authorization": "Bearer token",
+                    "Authorization": "\(expectedAuthorization)",
                     "Content-Type": "application/json"
                 },
                 "body": {
@@ -82,6 +87,66 @@ class SentryReplayNetworkDetailsIntegrationTests: XCTestCase {
         """
 
         assertJSONEqual(result, expectedJSON: expectedJSON)
+    }
+
+    func testSerialize_whenReplaySelectsSensitiveRequestHeaders_shouldFilterValues() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        // -- Arrange --
+        let details = SentryReplayNetworkDetails(method: "GET")
+        details.setRequest(
+            size: nil,
+            bodyData: nil,
+            contentType: nil,
+            allHeaders: [
+                "Authorization": "Bearer secret",
+                "X-Auth-Token": "secret-token",
+                "X-API-Key": "api-key",
+                "X-Request-Id": "request-id"
+            ],
+            configuredHeaders: ["Authorization", "X-Auth-Token", "X-API-Key", "X-Request-Id"]
+        )
+
+        // -- Act --
+        let result = details.serialize()
+
+        // -- Assert --
+        let request = try XCTUnwrap(result["request"] as? [String: Any])
+        XCTAssertEqual(request["headers"] as? [String: String], [
+            "Authorization": "[Filtered]",
+            "X-API-Key": "[Filtered]",
+            "X-Auth-Token": "[Filtered]",
+            "X-Request-Id": "request-id"
+        ])
+#endif
+    }
+
+    func testSerialize_whenReplaySelectsCookie_shouldFilterSensitiveValues() throws {
+#if !SDK_V10
+        throw XCTSkip("Test skipped for SDK_V10")
+#else
+        // -- Arrange --
+        let details = SentryReplayNetworkDetails(method: "GET")
+        details.setRequest(
+            size: nil,
+            bodyData: nil,
+            contentType: nil,
+            allHeaders: ["Cookie": "theme=dark; session=secret"],
+            configuredHeaders: ["Cookie"]
+        )
+
+        // -- Act --
+        let result = details.serialize()
+
+        // -- Assert --
+        let request = try XCTUnwrap(result["request"] as? [String: Any])
+        XCTAssertNil(request["headers"])
+        XCTAssertEqual(request["cookies"] as? [String: String], [
+            "session": "[Filtered]",
+            "theme": "dark"
+        ])
+#endif
     }
 
     func testSerialize_withPartialData_shouldOnlyIncludeSetFields() {

--- a/Tests/SentryTests/SentryTestSetup.swift
+++ b/Tests/SentryTests/SentryTestSetup.swift
@@ -1,6 +1,14 @@
 // This currently exists because we needed to duplicate the test target to link the Sentry+KSCrash variant
 // Once SentryCrash is removed, we should also remove this.
 enum SentryTestSetup {
+    static var isV10: Bool {
+        #if SDK_V10
+        true
+        #else
+        false
+        #endif
+    }
+
     static var isKSCrashEnabled: Bool {
         #if ENABLE_KSCRASH
         true


### PR DESCRIPTION
## :scroll: Description

Session Replay network headers continue to be selected exclusively through `networkRequestHeaders` and `networkResponseHeaders`. In V10, selected headers and parsed cookies are passed through the built-in sensitive denylist before Replay serializes them.

Request and response selections remain independent. Sensitive names are matched case-insensitively and by substring. Parsed cookies are emitted separately, and malformed cookie values use the whole-value `"[Filtered]"` fallback. Non-V10 behavior remains unchanged.

## :bulb: Motivation and Context

Replay must remain independent of global `dataCollection`, consistent with its opt-in privacy model. This change ensures that sensitive values cannot be exposed in plaintext when users explicitly select Replay network headers.

Closes #8554

## :green_heart: How did you test it?

- `make test-ios-v10 FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryReplayNetworkDetailsIntegrationTests`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
