### PR TITLE
fix: normalize build numbers

### DIFF
--- a/Sources/SentryDistribution/Updater.swift
+++ b/Sources/SentryDistribution/Updater.swift
@@ -94,7 +94,7 @@ public final class Updater: Sendable {
       components.queryItems?.append(URLQueryItem(name: "build_version", value: shortVersionString))
     }
     if let bundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
-      components.queryItems?.append(URLQueryItem(name: "build_number", value: bundleVersion))
+      components.queryItems?.append(URLQueryItem(name: "build_number", value: normalizeBuildNumber(bundleVersion)))
     }
       if let installGroups = params.installGroupsOverride {
         for group in installGroups {
@@ -113,6 +113,33 @@ public final class Updater: Sendable {
     session.perform(request, decode: UpdateCheckResponse.self) { result in
       completion(result)
     }
+  }
+
+  private func normalizeBuildNumber(_ buildNumber: String) -> String {
+    let components = buildNumber.split(separator: ".", omittingEmptySubsequences: false)
+    guard (2...3).contains(components.count),
+          components.allSatisfy({ component in
+            !component.isEmpty && component.allSatisfy(\.isNumber)
+          }) else {
+      return buildNumber
+    }
+
+    // Sentry stores each version component in a six-digit base-1,000,000 slot.
+    let componentBase: UInt64 = 1_000_000
+    let numericComponents = components.compactMap { UInt64($0) }
+    guard numericComponents.count == components.count,
+          numericComponents.allSatisfy({ $0 < componentBase }) else {
+      return buildNumber
+    }
+
+    let paddedComponents = numericComponents + Array(
+      repeating: 0,
+      count: 3 - numericComponents.count)
+    let normalizedBuildNumber = paddedComponents.reduce(UInt64(0)) { result, component in
+      result * componentBase + component
+    }
+
+    return String(normalizedBuildNumber)
   }
 
   // MARK: - Private


### PR DESCRIPTION
## :scroll: Description

Added a normalizeBuildNumber() method that converts dotted version strings into Sentry's base-1,000,000 format:

- Each component occupies a 6-digit slot (values 0-999,999)
- Supports 2-3 component versions (e.g., "1.2" or "1.2.3")
- Pads to 3 components with zeros if needed
- Falls back to the original string for invalid formats (non-numeric, out of range, wrong component count)

Examples:
- "1.2" → "1002000000000"
- "1.2.3" → "1002003000000"
- "999999.999999.999999" → "999999999999999999"
- "1.2.beta" → "1.2.beta" (unchanged, invalid format)

## :bulb: Motivation and Context

The SentryDistribution.Updater was sending raw build numbers (e.g., "1.2.3") to Sentry's distribution API, but Sentry stores build numbers in a normalized base-1,000,000 format. This mismatch caused update checks to fail or return incorrect results    

when comparing build numbers.

For example:
- Client sends: "1.2.3"
- Sentry expects: "1002003000000"

Without normalization, the server can't properly compare versions to determine if an update is available.


## :green_heart: How did you test it?

- Manual verification: build numbers are correctly normalized before being sent in API requests