### PR TITLE
ci: add Craft target to release to sentry-apple-binaries

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,6 +3,12 @@ changelogPolicy: auto
 preReleaseCommand: bash ./scripts/bump.sh
 targets:
   - name: github
+    excludeNames: /\.tgz$/
+  - name: commit-on-git-repository
+    archive: /^sentry-apple-binaries\.tgz$/
+    repositoryUrl: https://github.com/getsentry/sentry-apple-binaries
+    branch: main
+    createTag: true
   # The canonical name 'cocoapods:sentry-cocoa' is a historical artifact from when
   # the SDK was distributed via CocoaPods. Changing it requires manual surgery in
   # the sentry-release-registry repo, so we keep it as-is.

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -439,6 +439,12 @@ run_version_bump_util_for_prs: &run_version_bump_util_for_prs
   - "Sources/Configuration/Versioning.xcconfig"
   - "Sources/Configuration/SentrySwiftUI.xcconfig"
 
+run_apple_binaries_archive_for_prs: &run_apple_binaries_archive_for_prs
+  - ".github/workflows/apple-binaries-archive.yml"
+  - ".github/file-filters.yml"
+  - "scripts/create-apple-binaries-archive.sh"
+  - "distribution/**"
+
 run_ui_tests_for_prs: &run_ui_tests_for_prs
   - "Sources/**"
   - "Tests/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -433,6 +433,7 @@ run_version_bump_util_for_prs: &run_version_bump_util_for_prs
   # Project files with version info
   - "Package*.swift"
   - "3rd-party-integrations/**/Package.swift"
+  - "distribution/**/Package.swift"
 
   # Configuration files
   - "Sources/Configuration/SDK.xcconfig"

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v8.x
 
   pull_request:
 

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -85,7 +85,7 @@ jobs:
         files-changed,
         test-apple-binaries-archive,
       ]
-    name: Test Apple Binaries Archive
+    name: Test Apple Binaries Archive - Required Check
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -1,0 +1,96 @@
+name: Test Apple Binaries Archive
+
+on:
+  push:
+    branches:
+      - main
+      - v8.x
+
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_for_prs: ${{ steps.changes.outputs.run_apple_binaries_archive_for_prs }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  test-apple-binaries-archive:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_for_prs == 'true'
+    needs: files-changed
+    name: Test Apple Binaries Archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create fake xcframeworks
+        run: |
+          mkdir -p XCFrameworkBuildPath
+          echo "<FAKE STATIC ZIP>" > XCFrameworkBuildPath/Sentry.xcframework.zip
+          echo "<FAKE DYNAMIC ZIP>" > XCFrameworkBuildPath/Sentry-Dynamic.xcframework.zip
+          echo "<FAKE SENTRYOBJC DYNAMIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Dynamic.xcframework.zip
+          echo "<FAKE SENTRYOBJC STATIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Static.xcframework.zip
+
+      - name: Create archive
+        run: |
+          ./scripts/create-apple-binaries-archive.sh \
+            --version "99.0.0" \
+            --xcframework-dir XCFrameworkBuildPath \
+            --output-dir XCFrameworkBuildPath
+
+      - name: Verify archive contents
+        run: |
+          mkdir -p /tmp/apple-binaries-verify
+          tar -xzf XCFrameworkBuildPath/sentry-apple-binaries.tgz -C /tmp/apple-binaries-verify
+
+          # Verify all expected files exist
+          test -f /tmp/apple-binaries-verify/Package.swift
+          test -f /tmp/apple-binaries-verify/.gitignore
+          test -f /tmp/apple-binaries-verify/Sources/SentryCppHelper/SentryCppHelper.swift
+
+          # Verify version was stamped
+          grep -q "releases/download/99.0.0/" /tmp/apple-binaries-verify/Package.swift
+
+          # Verify checksums were updated (should match the fake zips)
+          EXPECTED_STATIC=$(sha256sum XCFrameworkBuildPath/Sentry.xcframework.zip | awk '{print $1}')
+          EXPECTED_OBJC_DYN=$(sha256sum XCFrameworkBuildPath/SentryObjC-Dynamic.xcframework.zip | awk '{print $1}')
+
+          grep -q "checksum: \"${EXPECTED_STATIC}\" //Sentry-Static" /tmp/apple-binaries-verify/Package.swift
+          grep -q "checksum: \"${EXPECTED_OBJC_DYN}\" //SentryObjC-Dynamic" /tmp/apple-binaries-verify/Package.swift
+
+          # Verify no extra files leaked into the archive
+          FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)
+          if [ "$FILE_COUNT" -ne 3 ]; then
+            echo "Expected 3 files in archive but found $FILE_COUNT"
+            find /tmp/apple-binaries-verify -type f
+            exit 1
+          fi
+
+          echo "Apple-binaries archive verified successfully"
+
+  apple-binaries-archive-required-check:
+    needs:
+      [
+        files-changed,
+        test-apple-binaries-archive,
+      ]
+    name: Test Apple Binaries Archive
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Apple binaries archive test failed." && exit 1

--- a/.github/workflows/release-upload-xcframework.yml
+++ b/.github/workflows/release-upload-xcframework.yml
@@ -44,3 +44,4 @@ jobs:
           overwrite: true
           path: |
             ${{github.workspace}}/XCFrameworkBuildPath/*.zip
+            ${{github.workspace}}/XCFrameworkBuildPath/*.tgz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,6 +508,14 @@ jobs:
           merge-multiple: true
           path: XCFrameworkBuildPath/
 
+      - name: Create apple-binaries archive
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          ./scripts/create-apple-binaries-archive.sh \
+            --version "${{ github.event.inputs.version }}" \
+            --xcframework-dir XCFrameworkBuildPath \
+            --output-dir XCFrameworkBuildPath
+
       - name: Archive XCFrameworks for Craft
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -516,6 +524,7 @@ jobs:
           overwrite: true
           path: |
             ${{github.workspace}}/XCFrameworkBuildPath/*.zip
+            ${{github.workspace}}/XCFrameworkBuildPath/*.tgz
 
       # update-package-sha.sh uses this env variable to update Package.swift.
       # During release Craft calls bump.sh that uses update-package-sha.sh.

--- a/Utils/VersionBump/main.swift
+++ b/Utils/VersionBump/main.swift
@@ -41,6 +41,7 @@ let files = [
     "./Package@swift-6.1.swift",
     "./Package@swift-6.2.swift",
     "./Sources/Sentry/SentryMeta.m",
+    "./distribution/apple-binaries/Package.swift",
     "./3rd-party-integrations/SentrySwiftLog/Package.swift",
     "./3rd-party-integrations/SentrySwiftyBeaver/Package.swift",
     "./3rd-party-integrations/SentryCocoaLumberjack/Package.swift",
@@ -193,7 +194,9 @@ func verifyRestrictedFile(_ file: String, expectedVersion: String) throws {
 }
 
 func getRegexString(for file: String) throws -> String {
-    if file.hasPrefix("./Package") && file.hasSuffix(".swift") {
+    if file.hasPrefix("./distribution/") && file.hasSuffix("/Package.swift") {
+        return "https:\\/\\/github\\.com\\/getsentry\\/sentry-cocoa\\/releases\\/download\\/(?<version>[a-zA-z0-9\\.\\-]+)\\/Sentry"
+    } else if file.hasPrefix("./Package") && file.hasSuffix(".swift") {
         return "https:\\/\\/github\\.com\\/getsentry\\/sentry-cocoa\\/releases\\/download\\/(?<version>[a-zA-z0-9\\.\\-]+)\\/Sentry"
     } else if file.hasPrefix("./3rd-party-integrations/") && file.hasSuffix("/Package.swift") {
         return "\\.package\\(url:\\s\"https:\\/\\/github\\.com\\/getsentry\\/sentry-cocoa\",\\sfrom:\\s\"(?<version>[a-zA-z0-9\\.\\-]+)\""

--- a/distribution/apple-binaries/.gitignore
+++ b/distribution/apple-binaries/.gitignore
@@ -1,0 +1,37 @@
+# Mac OS X
+.DS_Store
+tmp
+
+# Xcode
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+.idea
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+
+# Swift Package Manager
+.build/
+.swiftpm
+Packages

--- a/distribution/apple-binaries/Package.swift
+++ b/distribution/apple-binaries/Package.swift
@@ -1,0 +1,45 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "Sentry",
+    platforms: [.iOS(.v15), .macOS(.v10_14), .tvOS(.v15), .watchOS(.v8), .visionOS(.v1)],
+    products: [
+        .library(name: "Sentry-Static", targets: ["Sentry-Static", "SentryCppHelper"]),
+        .library(name: "Sentry-Dynamic", targets: ["Sentry-Dynamic"]),
+        .library(name: "SentryObjC-Dynamic", targets: ["SentryObjC-Dynamic"]),
+        .library(name: "SentryObjC-Static", targets: ["SentryObjC-Static"])
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(
+            name: "Sentry-Static",
+            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.23.0/Sentry.xcframework.zip",
+            checksum: "e16f1fb6333f572e980be28d2a9e1ea20a08c2c91b7901d612ff6cee2af697cf" //Sentry-Static
+        ),
+        .binaryTarget(
+            name: "Sentry-Dynamic",
+            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.23.0/Sentry-Dynamic.xcframework.zip",
+            checksum: "0693709291e8713c189b3c2407cc87885aca57819d3356710ea04e9076dfdd26" //Sentry-Dynamic
+        ),
+        .binaryTarget(
+            name: "SentryObjC-Dynamic",
+            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.23.0/SentryObjC-Dynamic.xcframework.zip",
+            checksum: "23faa002b65d60185fa3a157c0febc2be27ff5b1f69d02718fb1a0843e295680" //SentryObjC-Dynamic
+        ),
+        .binaryTarget(
+            name: "SentryObjC-Static",
+            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.23.0/SentryObjC-Static.xcframework.zip",
+            checksum: "85f70dbfef220f347934ce660b955f094065cc0b0bf555b93eb57205efcc9121" //SentryObjC-Static
+        ),
+        .target(
+            name: "SentryCppHelper",
+            path: "Sources/SentryCppHelper",
+            linkerSettings: [
+                .linkedLibrary("c++")
+            ]
+        )
+    ],
+    swiftLanguageModes: [.v5],
+    cxxLanguageStandard: .cxx14
+)

--- a/distribution/apple-binaries/Sources/SentryCppHelper/SentryCppHelper.swift
+++ b/distribution/apple-binaries/Sources/SentryCppHelper/SentryCppHelper.swift
@@ -1,0 +1,1 @@
+// No content needed, we just need this empty file

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+VERSION=""
+OUTPUT_DIR=""
+XCFRAMEWORK_DIR="XCFrameworkBuildPath"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Create a .tgz archive for the sentry-apple-binaries distribution repo.
+Copies the binary Package.swift template, stamps in the release version
+and xcframework checksums, and tars the result alongside the SentryCppHelper
+source and .gitignore.
+
+OPTIONS:
+    --version <ver>             Release version, e.g. 9.24.0 (required)
+    --xcframework-dir <path>    Directory containing *.xcframework.zip files
+                                (default: XCFrameworkBuildPath)
+    --output-dir <path>         Directory to write the archive to (default: repo root)
+    -h, --help                  Show this help message
+
+EXAMPLES:
+    $(basename "$0") --version 9.24.0
+    $(basename "$0") --version 9.24.0 --output-dir XCFrameworkBuildPath
+
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)         VERSION="$2";         shift 2 ;;
+        --xcframework-dir) XCFRAMEWORK_DIR="$2"; shift 2 ;;
+        --output-dir)      OUTPUT_DIR="$2";      shift 2 ;;
+        -h|--help)         usage ;;
+        *)                 log_error "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    log_error "--version is required"
+    usage
+fi
+
+REPO_ROOT="$SCRIPT_DIR/.."
+DIST_DIR="$REPO_ROOT/distribution/apple-binaries"
+
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR="$REPO_ROOT"
+fi
+
+if [ ! -f "$DIST_DIR/Package.swift" ]; then
+    log_error "distribution/apple-binaries/Package.swift not found"
+    exit 1
+fi
+
+ZIPS_AND_MARKERS=(
+    "Sentry.xcframework.zip|Sentry-Static"
+    "Sentry-Dynamic.xcframework.zip|Sentry-Dynamic"
+    "SentryObjC-Dynamic.xcframework.zip|SentryObjC-Dynamic"
+    "SentryObjC-Static.xcframework.zip|SentryObjC-Static"
+)
+
+ARCHIVE_NAME="sentry-apple-binaries.tgz"
+ARCHIVE_PATH="$OUTPUT_DIR/$ARCHIVE_NAME"
+
+begin_group "Create $ARCHIVE_NAME"
+
+STAGING_DIR=$(mktemp -d)
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
+cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
+mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
+cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
+
+log_info "Stamping version $VERSION into Package.swift"
+sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
+rm -f "$STAGING_DIR/Package.swift.bak"
+
+log_info "Updating checksums from $XCFRAMEWORK_DIR"
+for entry in "${ZIPS_AND_MARKERS[@]}"; do
+    zip="${entry%%|*}"
+    marker="${entry##*|}"
+    zip_path="${XCFRAMEWORK_DIR}/${zip}"
+    if [ ! -f "$zip_path" ]; then
+        log_error "Missing ${marker}: ${zip_path} not found"
+        exit 1
+    fi
+    checksum=$(shasum -a 256 "$zip_path" | awk '{print $1}')
+    sed -i.bak "s/checksum: \".*\" \/\/${marker}/checksum: \"${checksum}\" \/\/${marker}/" "$STAGING_DIR/Package.swift"
+    rm -f "$STAGING_DIR/Package.swift.bak"
+    log_info "  ${marker}: ${checksum}"
+done
+
+tar -czf "$ARCHIVE_PATH" \
+    -C "$STAGING_DIR" \
+    Package.swift \
+    Sources/SentryCppHelper/SentryCppHelper.swift \
+    .gitignore
+
+log_info "Created $ARCHIVE_PATH"
+log_info "Contents:"
+tar -tzf "$ARCHIVE_PATH"
+
+end_group

--- a/scripts/update-package-sha.sh
+++ b/scripts/update-package-sha.sh
@@ -10,7 +10,11 @@ if [ -z "$GITHUB_RUN_ID" ]; then
   exit 1
 fi
 
-PACKAGE_FILES=$(find . -maxdepth 1 -name "Package.swift" -o -name "Package@swift-*.swift" | sort)
+PACKAGE_FILES=$(find . -maxdepth 1 \( -name "Package.swift" -o -name "Package@swift-*.swift" \) | sort)
+DIST_PACKAGE="./distribution/apple-binaries/Package.swift"
+if [ -f "$DIST_PACKAGE" ]; then
+    PACKAGE_FILES="$PACKAGE_FILES"$'\n'"$DIST_PACKAGE"
+fi
 
 if [ -z "$PACKAGE_FILES" ]; then
     log_error "No Package.swift or Package@swift-*.swift files found"

--- a/scripts/verify-package-sha.sh
+++ b/scripts/verify-package-sha.sh
@@ -186,7 +186,36 @@ for package_file in $PACKAGE_FILES; do
     log_info "✓ All checksums verified in $package_file"
 done
 
+DIST_PACKAGE="./distribution/apple-binaries/Package.swift"
+if [ -f "$DIST_PACKAGE" ]; then
+    log_info "Verifying checksums in $DIST_PACKAGE"
 
+    UPDATED_PACKAGE_SHA=$(grep "checksum.*Sentry-Static" "$DIST_PACKAGE" | cut -d '"' -f 2)
+    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_STATIC_CHECKSUM" ]; then
+        log_error "Expected static checksum to be $EXPECTED_STATIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
+        exit 1
+    fi
+
+    UPDATED_PACKAGE_SHA=$(grep "checksum.*Sentry-Dynamic" "$DIST_PACKAGE" | cut -d '"' -f 2)
+    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_DYNAMIC_CHECKSUM" ]; then
+        log_error "Expected dynamic checksum to be $EXPECTED_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
+        exit 1
+    fi
+
+    UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Dynamic" "$DIST_PACKAGE" | cut -d '"' -f 2)
+    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM" ]; then
+        log_error "Expected SentryObjC-Dynamic checksum to be $EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
+        exit 1
+    fi
+
+    UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Static" "$DIST_PACKAGE" | cut -d '"' -f 2)
+    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_STATIC_CHECKSUM" ]; then
+        log_error "Expected SentryObjC-Static checksum to be $EXPECTED_SENTRYOBJC_STATIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
+        exit 1
+    fi
+
+    log_info "✓ All checksums verified in $DIST_PACKAGE"
+fi
 
 log_info "Verify last-release-runid"
 LAST_RELEASE_RUNID=$(cat .github/last-release-runid)


### PR DESCRIPTION
## Summary

- Configure Craft's `commit-on-git-repository` target so each sentry-cocoa release automatically pushes an updated binary `Package.swift` to `getsentry/sentry-apple-binaries` and tags it
- Add `distribution/apple-binaries/` with the binary Package.swift template, `.gitignore`, and `SentryCppHelper` stub
- Add `scripts/create-apple-binaries-archive.sh` that stamps version + checksums and produces a `.tgz` for Craft
- Extend `update-package-sha.sh`, `verify-package-sha.sh`, and `VersionBump` to keep the distribution Package.swift in sync
- Add a dedicated CI workflow (`apple-binaries-archive.yml`) to test archive creation on PRs

Closes #8479

#skip-changelog

## How it works

During a release (`workflow_dispatch`):
1. XCFrameworks are built and downloaded to `XCFrameworkBuildPath/`
2. `create-apple-binaries-archive.sh` copies the binary Package.swift template, stamps the release version into URLs, computes checksums from the xcframework zips, and creates `sentry-apple-binaries.tgz`
3. The `.tgz` is uploaded alongside xcframework zips as a workflow artifact
4. Craft's `github` target creates the release (excluding `.tgz` via `excludeNames`)
5. Craft's `commit-on-git-repository` target unpacks the `.tgz` and force-pushes to `getsentry/sentry-apple-binaries` with a version tag

## Test plan

- [ ] `version-bump-util` CI passes (VersionBump + update-package-sha changes)
- [ ] `apple-binaries-archive` CI passes (new workflow)
- [ ] Verify archive script produces correct Package.swift with version + checksums
- [ ] Dry-run a release to confirm Craft discovers the `.tgz` artifact