### PR TITLE
docs: add relay protocol-conformance audit docs

### DIFF
--- a/develop-docs/AGENTS.md
+++ b/develop-docs/AGENTS.md
@@ -20,6 +20,7 @@ Internal developer documentation for SDK maintainers.
 | `VIEW_MASKING_STRATEGIES.md` | View masking for screenshots/session replay                                 |
 | `OBJC-LOAD-AND-LINKING.md`   | ObjC `+load` behavior across distribution formats                           |
 | `Fishhook-Explanation.md`    | Fishhook Mach-O symbol rebinding mechanism                                  |
+| `audits/`                    | Recurring agent-driven protocol-conformance audits (see `audits/README.md`) |
 
 ## Conventions
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -10,6 +10,7 @@ This is a collection of documents that can help you develop for the SentrySDK.
 - RELEASE.md: our release processes and best practices
 - OBJC-LOAD-AND-LINKING.md: how Objective-C +load interacts with build configurations and distribution formats
 - SDK_HISTORY.md: historical context and FAQ for the SDK
+- audits/: recurring agent-driven protocol-conformance audits (e.g. Cocoa ↔ Relay)
 - [Language Trends Report](https://getsentry.github.io/sentry-cocoa/language-trends.html): interactive chart of the repository's language breakdown over time, updated on every merge to main via GitHub Pages
 
 ## GitHub Pages

--- a/develop-docs/audits/README.md
+++ b/develop-docs/audits/README.md
@@ -1,0 +1,26 @@
+# Protocol Conformance Audits
+
+Recurring, agent-driven audits that diff this SDK's wire protocol against an external source of truth. Each audit target gets its own folder with the same file shape, so the convention can be copied to other SDK repos (sentry-java, sentry-react-native, …).
+
+| Folder   | Compares against                                      | Status  |
+| -------- | ----------------------------------------------------- | ------- |
+| `relay/` | [getsentry/relay](https://github.com/getsentry/relay) | active  |
+| —        | develop-docs SDK spec (develop.sentry.dev/sdk)        | planned |
+
+## Folder shape (per audit target)
+
+| File                | Purpose                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| `AUDIT.md`          | The audit procedure: how to run, classify, and report                    |
+| `SURFACE_MAP.md`    | What to diff: SDK files ↔ external source ↔ spec pages, per area         |
+| `FINDINGS.md`       | Deterministic findings registry: open / accepted (ignore list) / fixed   |
+| `REPORT_FORMAT.md`  | Slack delta + threaded report templates, one-click GitHub issue links    |
+| `VALIDATION.md`     | Self-test: pinned pre-fix commit the audit MUST flag, pass/fail criteria |
+| `ROUTINE_PROMPT.md` | The exact scheduler prompt (source of truth for the claude.ai routine)   |
+
+## Principles
+
+- **Read-only** — the audit never edits SDK code, opens PRs, or files issues. Its only output is a report.
+- **Low noise** — only NEW findings make noise; a quiet week is a single ✅ line. Everything already triaged lives in `FINDINGS.md` and is counted, not repeated.
+- **Deterministic IDs** — findings get stable IDs (`RELAY-###`) assigned only via committed PRs to `FINDINGS.md`. The registry is the memory; the audit matches against it, humans maintain it.
+- **Validated** — each audit has a pinned historical commit containing a real, serious bug it must detect (see `VALIDATION.md`). Re-run validation whenever the procedure or surface map changes materially.

--- a/develop-docs/audits/relay/AUDIT.md
+++ b/develop-docs/audits/relay/AUDIT.md
@@ -1,0 +1,61 @@
+# Cocoa ↔ Relay Protocol Conformance Audit
+
+Audits the Sentry Cocoa SDK for **protocol-conformance drift** against **Relay** ([getsentry/relay](https://github.com/getsentry/relay)) — anywhere a string or wire format the SDK must match Relay exactly could silently drop, mis-route, or miscount data.
+
+**Why this exists:** bug [#8322](https://github.com/getsentry/sentry-cocoa/issues/8322) (fixed in [#8324](https://github.com/getsentry/sentry-cocoa/pull/8324)) came from reading the `X-Sentry-Rate-Limits` response header with a _case-sensitive_ lookup — which silently fails over HTTP/2/HTTP/3 (headers are lowercased on the wire), causing the SDK to rate-limit **all** categories and drop telemetry. That is one instance of a general shape: **the SDK hard-codes many strings and wire formats that must match Relay exactly, and a mismatch fails silently.** This audit hunts for that whole class, repeatably.
+
+**This audit is READ-ONLY.** It never edits SDK code, opens PRs, files issues, or modifies `FINDINGS.md`. Its only output is a report (Slack post or printed).
+
+## When to run
+
+- Weekly on a schedule (see `ROUTINE_PROMPT.md`).
+- On demand before/after a networking or protocol change.
+- After Relay adds a `DataCategory` / `ItemType` / discard reason, to check whether Cocoa needs to learn it.
+- In validation mode against the pinned pre-fix commit (see `VALIDATION.md`) whenever this procedure or `SURFACE_MAP.md` changes materially.
+
+## Inputs
+
+- A **sentry-cocoa checkout** on current `main` (or the pinned SHA in validation mode). Record `git rev-parse --short HEAD` and `date +%Y-%m-%d` via shell — both stamp the report. Do not hardcode dates.
+- **This folder** (`develop-docs/audits/relay/`) read from the _current `main`_ checkout — in validation mode the audited worktree predates these files.
+- **Web access** to fetch Relay source (`raw.githubusercontent.com`) and develop-docs pages (`develop.sentry.dev`).
+- **Slack** (scheduled runs): post via the configured Slack connector / bot token per `REPORT_FORMAT.md`.
+
+## Procedure
+
+1. **Snapshot the target.** Ensure the checkout is current; record SHA + date.
+
+2. **Fan out the diff.** For **each area** in `SURFACE_MAP.md`, spawn a read-only subagent (run areas in parallel) with this contract:
+   - Fetch the listed develop-docs URL(s) and Relay source file(s).
+   - Read the listed Cocoa source files.
+   - Diff them against the area's "what to check" notes.
+   - Return structured findings, each: `{ area, severity (HIGH|MEDIUM|LOW), location (file + symbol), summary, spec_citation (URL or Relay file), failure_mode }`, plus a short list of what it verified **CONFORMANT**.
+   - Cite exact wire strings and symbols. Severity is about **silent blast radius**, not fix effort: a wire-string mismatch that silently drops data is HIGH even if the fix is one line.
+
+3. **Classify against the registry.** Load `FINDINGS.md`. Match each raw finding on its **fingerprint** — `area` + `file` + normalized one-line summary (line numbers drift; never match on them). Label:
+   - **NEW** — no matching entry. _The only classification that makes noise._ Assign provisional labels `NEW-1`, `NEW-2`, … (permanent `RELAY-###` IDs are assigned by a human when triaging into `FINDINGS.md`).
+   - **KNOWN** — matches an `open` or `accepted` entry. Counted in the delta, not re-detailed. For `accepted` entries, first check the entry's _ignore-scenario_ still holds — if it no longer does, escalate to **NEW**.
+   - **REGRESSION** — matches a `fixed` entry (the bug is back), or breaks an item on the conformant checklist. Report as **NEW / HIGH**, prefixed `REGRESSION`.
+   - **RESOLVED** — an `open` entry the run no longer reproduces. Report it (suggest flipping to `fixed`), but it is good news, not noise.
+
+4. **Assemble the report** per `REPORT_FORMAT.md`: a skimmable **delta** (counts + NEW/RESOLVED bullets; quiet week = one ✅ line), a **TLDR management summary** thread reply, and a **full agent-pickup report** thread reply. Stamp all with date + SHA.
+
+5. **Deliver.** Scheduled: post to Slack per `REPORT_FORMAT.md`; if the post fails, print everything and state loudly that the Slack post FAILED — never report success on a failed post. Interactive: print delta, then full report.
+
+6. **Never modify SDK code or `FINDINGS.md`.** Registry changes are human decisions via normal PRs (see `FINDINGS.md` header for the maintenance rules).
+
+## Output contract
+
+- The **delta** must be skimmable in 5 seconds: run header (date + SHA), one count line (`NEW n · RESOLVED n · known n · conformant ok/BROKEN`), then NEW/RESOLVED bullets. Quiet weeks are a single ✅ line.
+- The **TLDR** is for humans deciding whether to care: 2–4 plain sentences per NEW finding — what's broken, user impact, blast radius. No jargon, no file paths.
+- The **full report** is for the agent (or human) who picks the finding up cold: files + symbols, exact wire strings, spec/Relay citations, failure mode, suggested verification steps.
+- Prefer precise locations and exact wire strings over prose — this is a diff, not an essay.
+
+## Guardrails
+
+- **Read-only, always.** No `git commit`, no `gh pr`, no issue creation. Issue creation is a human click on the pre-filled link in the report.
+- **Relay paths move.** If a Relay source file 404s, search the repo for the symbol (`ItemType`, `DataCategory`, `ClientReport`) rather than trusting a stale path; note the moved path in the report so `SURFACE_MAP.md` can be updated by PR.
+- **Bounded cost:** one subagent per area, run in parallel; don't recurse into unrelated SDK subsystems (`SentryCrash/` and other non-protocol code are out of scope unless the surface map names a file there).
+
+## Portability
+
+The procedure above is SDK-agnostic; everything Cocoa-specific lives in `SURFACE_MAP.md` and `FINDINGS.md`. To adopt this audit in another SDK repo (sentry-java, sentry-react-native, …), copy this folder shape and rewrite those two files. Keep the ID namespace per target (`RELAY-###` here; a future develop-docs-spec audit uses `SPEC-###`) so registries never collide.

--- a/develop-docs/audits/relay/FINDINGS.md
+++ b/develop-docs/audits/relay/FINDINGS.md
@@ -1,0 +1,64 @@
+# Findings registry — Cocoa ↔ Relay
+
+The deterministic memory of the relay conformance audit (see `AUDIT.md`). Every triaged finding lives here with a stable ID. The audit **reads** this file to classify its raw findings; it never writes it. All changes to this file are normal, human-reviewed PRs.
+
+State verified on **2026-07-27** against `main` (post-#8324, post-#8390).
+
+## Rules
+
+- **IDs** are `RELAY-###`, sequential, never reused. Assigning an ID = merging a PR that adds the entry. `legacy` column preserves the IDs from the pre-repo baseline (personal-agent-skills skill, 2026-07-14).
+- **Fingerprint** = `area + file + normalized one-line summary`. The audit matches on fingerprints; line numbers are hints only (they drift).
+- **Statuses:**
+  - `open` — confirmed real, awaiting a fix. Reported weekly as KNOWN (counted, not re-detailed).
+  - `accepted` — triaged won't-fix or false positive. **This is the ignore list.** Every `accepted` entry MUST state an _ignore-scenario_: the precise conditions under which it stays ignored. If an audit run finds the scenario no longer holds, the finding escalates to NEW.
+  - `fixed` — resolved; kept as a tombstone with the fixing PR. If the audit reproduces a `fixed` finding, that is a **REGRESSION** (NEW / HIGH).
+- **Maintenance:** finding fixed in the SDK → flip to `fixed` (never delete — the tombstone is the regression detector). New finding triaged → append with the next free ID. Won't-fix → `accepted` + ignore-scenario.
+
+## Open findings
+
+| ID        | Legacy | Sev    | Area                | Location                                                                  | Summary                                                                                                                                                                                                                 |
+| --------- | ------ | ------ | ------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RELAY-004 | F3     | MEDIUM | headers (§1)        | `Sources/Sentry/SentryTracePropagation.m` (`addBaggageHeader`)            | Incoming-baggage read via `allHTTPHeaderFields[SENTRY_BAGGAGE_HEADER]` subscript — case-sensitive; inconsistent with the `valueForHTTPHeaderField:` reads later in the same file.                                       |
+| RELAY-005 | G1     | HIGH   | prevention (§1)     | `.github/workflows/`, `Makefile` (`lint`)                                 | ObjC banned-pattern linter (`check-objc-banned-pattern.sh`, rule `avoid_all_header_fields`) runs in `make lint` / pre-commit but **no CI workflow runs it** — only `swiftlint --strict` runs in CI.                     |
+| RELAY-006 | G2     | MEDIUM | prevention (§1)     | `Makefile` (`AVOID_ALL_HEADER_FIELDS` pattern), `.swiftlint.yml`          | Banned pattern is `allHeaderFields`, which does not match `allHTTPHeaderFields` — so RELAY-004-shaped bugs slip through the linter.                                                                                     |
+| RELAY-007 | G3     | LOW    | prevention (§1)     | `Tests/.swiftlint.yml`                                                    | `parent_config:` doesn't merge parent `custom_rules`; `avoid_all_header_fields` not applied to test code.                                                                                                               |
+| RELAY-008 | A      | MEDIUM | DSC (§7)            | `Sources/Sentry/SentryTraceContext.m` + `SentryClient.m` (error path)     | Error-only / no-transaction traces emit a DSC with no `sample_rand`/`sample_rate`/`sampled` (propagation context never seeds `sample_rand`) → Relay must synthesize one; a later transaction in the trace can disagree. |
+| RELAY-009 | B      | MEDIUM | DSC (§7, §10)       | `Sources/Sentry/SentryTraceContext.m` (`baggageHttpHeader` serialization) | `sample_rand`/`sample_rate` serialized with `%f` (6-decimal rounding) — can flip Relay's `sample_rand < sample_rate ⟺ sampled` re-derivation at the boundary.                                                           |
+| RELAY-017 | L2     | LOW    | client reports (§5) | `Sources/Swift/Networking/SentryDiscardReason.swift` (headerdoc)          | Stale develop-docs link: `/sdk/client-reports/` → moved to `/sdk/telemetry/client-reports/`.                                                                                                                            |
+
+## Accepted findings (the ignore list)
+
+| ID        | Legacy | Sev | Area                 | Location                                                                      | Summary + ignore-scenario                                                                                                                                                                                                                         |
+| --------- | ------ | --- | -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| RELAY-010 | C      | LOW | sampling (§10)       | `Sources/Sentry/SentrySampling.m` (`random <= rate`)                          | Spec invariant is strict `<`; Cocoa uses `<=`. **Ignore while:** the only effect is a measure-zero boundary case of a uniform double — negligible in practice.                                                                                    |
+| RELAY-011 | 2b     | LOW | data categories (§3) | `Sources/Swift/Networking/SentryDataCategory.swift`                           | Enum raw values diverge from Relay's `DataCategory` discriminants. **Ignore while:** numeric indices never appear on the wire (wire uses names only). If any index is ever serialized → NEW / HIGH.                                               |
+| RELAY-012 | 2c     | LOW | data categories (§3) | `Sources/Swift/Networking/SentryDataCategory.swift` + `RateLimitParser.swift` | Unknown rate-limit category names map to `.unknown` and are silently ignored (e.g. non-UI `profile_chunk`). **Ignore while:** Cocoa recognizes every category it emits items for; re-alarm when Relay adds a category matching a Cocoa item type. |
+| RELAY-013 | 2e     | LOW | data categories (§3) | `Sources/Swift/Networking/SentryDataCategory+EnvelopeItemType.swift`          | `log` items map only to `log_item`, never `log_byte`, so a `log_byte`-only limit isn't enforced pre-send. **Ignore while:** byte quotas remain a Relay-side concern and other SDKs behave the same.                                               |
+| RELAY-014 | D      | LOW | sessions (§9)        | `Sources/Swift/SentrySession.swift` (`_sequence`)                             | `seq` starts at 1 rather than 0/UNIX-ms. **Ignore while:** Relay only requires monotonicity and forces `seq=0` on init server-side.                                                                                                               |
+| RELAY-015 | E      | LOW | sessions (§9)        | `Sources/Swift/SentrySession.swift` (`serialize`)                             | `attrs` omitted when release AND environment are both nil, though `attrs.release` is spec-required. **Ignore while:** release is always supplied in practice by `SentryOptions`.                                                                  |
+| RELAY-016 | L1     | LOW | client reports (§5)  | `Sources/Sentry/SentryDiscardReasonMapper.m`                                  | `network_error` / `queue_overflow` reason constants defined but no call site records them (dead code). **Ignore while:** both strings remain spec-valid; this is unused code, not a wire mismatch.                                                |
+
+## Fixed findings (tombstones — reproducing any of these is a REGRESSION, NEW / HIGH)
+
+| ID        | Legacy | Area                 | Location                                                             | Summary                                                                                                                                                                                     | Fixed by                                                                                                                            |
+| --------- | ------ | -------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| RELAY-001 | —      | rate limits (§1, §2) | `Sources/Swift/Networking/DefaultRateLimits.swift` (`update`)        | `X-Sentry-Rate-Limits` / `Retry-After` read via case-sensitive `allHeaderFields[...]` subscript → nil over HTTP/2/3 → 429 fallback rate-limited **all** categories (silent telemetry loss). | [#8324](https://github.com/getsentry/sentry-cocoa/pull/8324) (issue [#8322](https://github.com/getsentry/sentry-cocoa/issues/8322)) |
+| RELAY-002 | F1     | headers (§1)         | `Sources/Sentry/SentryNetworkTracker.m` (response Content-Type read) | Response `Content-Type` read via case-sensitive `allHeaderFields[@"Content-Type"]` subscript. Now uses `SentryHTTPHeaderReader valueForHTTPHeaderFieldCaseInsensitive:`.                    | issue [#8388](https://github.com/getsentry/sentry-cocoa/issues/8388) (closed); verified fixed on `main` 2026-07-27                  |
+| RELAY-003 | F2     | headers (§1)         | `Sources/Sentry/SentryNetworkTracker.m` (request Content-Type read)  | Request `Content-Type` read via case-sensitive `allHTTPHeaderFields[...]` subscript. Now uses `NSURLRequest.valueForHTTPHeaderField:` (case-insensitive).                                   | verified fixed on `main` 2026-07-27                                                                                                 |
+
+> [!NOTE]
+> **RELAY-001 is the validation target** — see `VALIDATION.md`. A validation run against the pinned pre-fix commit MUST report it as a REGRESSION.
+
+## Conformant checklist (regression detectors)
+
+Verified CONFORMANT on 2026-07-14 (re-confirmed selectively 2026-07-27). If a run finds any of these **broken**, treat it as **NEW / HIGH**, prefixed `REGRESSION`:
+
+- **Envelope item types** — all emitted strings recognized by Relay `ItemType::from_str` with exact casing (`event, transaction, feedback, session, attachment, client_report, profile, profile_chunk, replay_video, log, trace_metric, statsd`); replay msgpack keys `replay_event`/`replay_recording`/`replay_video` match.
+- **Data-category names** — all wire names match Relay `name()`/`from_name` (`default, error, session, transaction, attachment, profile, profile_chunk_ui, replay, metric_bucket, span, feedback, log_item, log_byte, trace_metric` + `""` = all); wire uses names, never indices.
+- **Discard reasons** — all emitted strings in the develop-docs allowlist; `ratelimit_backoff` correctly spelled (not `rate_limit_backoff`).
+- **Client report** — item type `client_report`; payload `{timestamp, discarded_events:[{reason, category, quantity}]}`; Relay-reserved arrays (`rate_limited_events`/`filtered_events`/`filtered_sampling_events`) never populated; 429s not double-counted; rate-limit drops attributed to the correct category with `ratelimit_backoff`.
+- **Auth/request** — `X-Sentry-Auth` (`sentry_version=7`, `sentry_client`, `sentry_key`), `Content-Type: application/x-sentry-envelope`, `Content-Encoding: gzip`, `POST`, `/api/<project>/envelope/` path.
+- **Rate-limit parser** — strips spaces; empty categories → all; all-unknown-category limits ignored (not applied to `default`); `metric_bucket` namespaces handled; **header-name reads case-insensitive** (the #8324 fix / RELAY-001).
+- **DSC keys** — all baggage keys exactly named (`trace_id, public_key, release, environment, transaction, sample_rate, sample_rand, sampled, replay_id, org_id`); `sentry-sampled` = `true`/`false`. (Known gap on the no-transaction path = RELAY-008.)
+- **sentry-trace** — `traceid-spanid-sampled`, 32/16 hex, sampled `1`/`0`/omitted.
+- **Sessions** — field names + ISO-8601 timestamps + status enum (`ok/exited/crashed/abnormal`) + init/seq dedup + never-drop-init migration.

--- a/develop-docs/audits/relay/REPORT_FORMAT.md
+++ b/develop-docs/audits/relay/REPORT_FORMAT.md
@@ -1,0 +1,98 @@
+# Report format & Slack posting — Cocoa ↔ Relay
+
+Three outputs per run, posted as one Slack message plus threaded replies. Slack uses _mrkdwn_, not full Markdown — no tables, `*bold*` (single asterisks), `` `code` ``, `<url|label>` links, `•` bullets. Keep the delta short; put detail in the thread.
+
+## 1. Main message — delta
+
+Header + one count line + NEW/RESOLVED bullets. Quiet week = a single ✅ line. Skimmable in 5 seconds.
+
+```
+:shield: *Cocoa ↔ Relay conformance* — <DATE> · sentry-cocoa@<SHA>
+NEW <n>  ·  RESOLVED <n>  ·  known <n>  ·  conformant <OK|:rotating_light: BROKEN>
+
+:warning: *NEW*
+• [NEW-1 | <SEVERITY>] <area> — <file (symbol)> — <one-line summary>
+• …
+
+:white_check_mark: *RESOLVED* (suggest flipping to `fixed` in FINDINGS.md)
+• <RELAY-###> <area> — <summary>
+
+:thread: TLDR + full report in thread.
+```
+
+Quiet week:
+
+```
+:shield: *Cocoa ↔ Relay conformance* — <DATE> · sentry-cocoa@<SHA>
+:white_check_mark: No new conformance drift. (known <n> · conformant OK)
+```
+
+- A regression (matched `fixed` tombstone or broken conformant-checklist item) is a NEW bullet prefixed `:rotating_light: REGRESSION`, always HIGH.
+- Validation runs (see `VALIDATION.md`) prefix the header with `:test_tube: VALIDATION RUN —` and end with `VALIDATION PASSED` / `VALIDATION FAILED`.
+- NEW findings use provisional labels `NEW-1`, `NEW-2`, … — permanent `RELAY-###` IDs are assigned by the human who triages them into `FINDINGS.md`.
+
+## 2. Thread reply 1 — TLDR (management summary)
+
+For humans deciding whether to care. Per NEW finding, 2–4 plain sentences: what is broken, what the user-visible impact is, how big the blast radius is. No file paths, no jargon.
+
+```
+:memo: *TLDR*
+
+*NEW-1 — <plain-English title>*
+<What's wrong, in one sentence.> <What data is lost/mis-routed and for whom.> <Why it fails silently / how it would be noticed.>
+```
+
+## 3. Thread reply 2 — full report (agent-pickup context)
+
+The standalone snapshot: everything an agent (or human) needs to pick a finding up cold. Grouped NEW → RESOLVED → KNOWN (counts only for KNOWN unless something changed), ending with the conformant-checklist result. Per NEW finding:
+
+```
+*NEW-1 · <SEVERITY> · <area>*
+Location: <file> (<symbol/method>)
+Wire strings: <the exact literal(s) involved>
+Spec: <develop-docs URL and/or Relay source file + symbol>
+Failure mode: <what silently goes wrong, end to end>
+Verify: <1–3 concrete steps to confirm (e.g. which test to write, which header to send)>
+Create issue: <pre-filled link, see below>
+```
+
+If the thread reply exceeds Slack's ~3000-char practical limit, split into multiple replies or upload `report.md` as a file in the thread.
+
+## One-click GitHub issue links
+
+Each NEW finding gets a pre-filled issue URL so triage is a single click:
+
+```
+https://github.com/getsentry/sentry-cocoa/issues/new?title=<urlencoded title>&body=<urlencoded body>&labels=Relay-Conformance
+```
+
+- **Title:** `<area>: <one-line summary>`
+- **Body:** the finding's full-report block (location, wire strings, spec citation, failure mode, verify steps) plus a line `Found by the weekly Relay conformance audit (<DATE>, sentry-cocoa@<SHA>). Triage: assign the next RELAY-### ID in develop-docs/audits/relay/FINDINGS.md.`
+- Keep the URL under ~8000 chars; if the body is too long, trim to location + failure mode + a pointer to the Slack thread.
+
+## Posting recipes
+
+### Via claude.ai Slack connector (current setup)
+
+Post the delta as the main message, capture its `message_ts`, then post replies 1 and 2 with `thread_ts` set to it. Verify each response is ok; if the connector is unavailable or a post fails, print the full delta + TLDR + report to the run output and state clearly that the Slack post FAILED — do not report success.
+
+### Via bot token (future GitHub Actions migration)
+
+Requires `SLACK_BOT_TOKEN` (scope `chat:write`) and `SLACK_CHANNEL_ID`. Threading needs the Web API — an incoming webhook cannot reply in-thread.
+
+````bash
+TS=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H 'Content-type: application/json; charset=utf-8' \
+  --data "$(jq -n --arg c "$SLACK_CHANNEL_ID" --arg t "$DELTA_TEXT" '{channel:$c, text:$t}')" \
+  | jq -r 'if .ok then .ts else ("ERR:"+.error) end')
+[ "${TS#ERR:}" = "$TS" ] || { echo "Slack post failed: $TS"; exit 1; }
+
+curl -sS -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H 'Content-type: application/json; charset=utf-8' \
+  --data "$(jq -n --arg c "$SLACK_CHANNEL_ID" --arg ts "$TS" \
+            --rawfile body full-report.md '{channel:$c, thread_ts:$ts, text:("```\n"+$body+"\n```")}')"
+````
+
+For a long report, upload it as a file in the thread instead: `files.getUploadURLExternal` → PUT the bytes → `files.completeUploadExternal` with `channel_id` + `thread_ts` (the old `files.upload` is deprecated). Always check `.ok` and log `.error` — a silent Slack outage must not look like "no drift."

--- a/develop-docs/audits/relay/ROUTINE_PROMPT.md
+++ b/develop-docs/audits/relay/ROUTINE_PROMPT.md
@@ -1,0 +1,43 @@
+# Scheduled routine prompt — Cocoa ↔ Relay audit
+
+Source of truth for the claude.ai routine that runs the weekly audit. When this file changes, update the routine to match (and re-run `VALIDATION.md`).
+
+## Configuration
+
+- **Schedule:** weekly, e.g. cron `0 7 * * 3` UTC (Wednesdays ~09:00 Europe/Vienna during CEST; cron is fixed UTC, so CET winter = 08:00).
+- **Sources (auto-checked-out):** `getsentry/sentry-cocoa` (`main`).
+- **Connectors:** Slack (personal account for now; bot token when this migrates to GitHub Actions — see `REPORT_FORMAT.md`).
+- **Target channel:** `#team-sdk-apple`.
+
+## Weekly prompt
+
+```
+You are running the weekly Sentry Cocoa ↔ Relay protocol-conformance audit. READ-ONLY: never modify SDK code, commit, open PRs, or file issues. Your only external action is posting the report to Slack.
+
+The sentry-cocoa repo (getsentry/sentry-cocoa) is checked out for you on main.
+
+1. Make sure main is current (git pull); record the short commit SHA (git rev-parse --short HEAD) and today's date (date +%Y-%m-%d) via shell — do not hardcode the date.
+2. Open develop-docs/audits/relay/AUDIT.md and follow it exactly. Its companion files are in the same folder: SURFACE_MAP.md (what to diff), FINDINGS.md (registry to classify against), REPORT_FORMAT.md (output templates).
+3. For each area in SURFACE_MAP.md, spawn a read-only subagent (parallel where available) to diff the mapped Cocoa files against the develop-docs page(s) and Relay source (fetch via raw.githubusercontent.com). Collect structured findings (area, severity, file + symbol, exact wire strings, spec citation, failure mode).
+4. Classify each finding NEW / KNOWN / RESOLVED / REGRESSION against FINDINGS.md per AUDIT.md. Only NEW and REGRESSION make noise. Check accepted entries' ignore-scenarios before counting them as KNOWN.
+5. Build the three outputs per REPORT_FORMAT.md — delta, TLDR, full agent-pickup report with pre-filled GitHub-issue links — stamped with the date + SHA.
+6. Post to Slack #team-sdk-apple: the delta as the main message, then the TLDR and the full report as threaded replies. Verify each Slack response is ok; if the Slack connector is unavailable or a post fails, print everything to your output and state clearly that the Slack post FAILED — do not report success.
+```
+
+## Validation prompt (manual trigger)
+
+```
+You are running a VALIDATION of the Sentry Cocoa ↔ Relay conformance audit — a self-test of the audit, not a real drift report. READ-ONLY except for creating/removing a temporary git worktree.
+
+The sentry-cocoa repo (getsentry/sentry-cocoa) is checked out for you on main.
+
+1. Open develop-docs/audits/relay/VALIDATION.md and follow it exactly: create a worktree at the pinned pre-fix commit, run the full audit (per develop-docs/audits/relay/AUDIT.md, read from the main checkout) against that worktree, and evaluate the PASS/FAIL criteria.
+2. Post the result to Slack #team-sdk-apple prefixed with the validation marker from REPORT_FORMAT.md, ending in VALIDATION PASSED or VALIDATION FAILED. If Slack fails, print everything and state the post FAILED.
+3. Remove the worktree when done.
+```
+
+## Migration path (later)
+
+1. Once report quality is proven over a few weekly runs, port the weekly prompt into a `.github/workflows/relay-conformance-audit.yml` cron workflow using `anthropics/claude-code-action` (`ANTHROPIC_API_KEY`, `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID` as repo secrets; bot-token posting recipe in `REPORT_FORMAT.md`), plus a `workflow_dispatch` input `mode=validate` that runs the validation prompt and fails the job on VALIDATION FAILED.
+2. Disable the claude.ai routine so there is exactly one source of truth.
+3. The planned develop-docs-spec audit is a **separate** sibling job (`develop-docs/audits/develop-docs-spec/`, ID namespace `SPEC-###`) — never merged into this one.

--- a/develop-docs/audits/relay/SURFACE_MAP.md
+++ b/develop-docs/audits/relay/SURFACE_MAP.md
@@ -1,0 +1,73 @@
+# Audit surface map — Cocoa ↔ Relay
+
+One section per protocol area. Each = Cocoa files to read · develop-docs to fetch · Relay source to diff · **what to check**. Spawn one subagent per area (parallel). Paths are relative to the sentry-cocoa repo root. Relay's `master` is the source of truth; if a Relay path 404s, search the repo for the named symbol and fix this file by PR.
+
+Relay raw base: `https://raw.githubusercontent.com/getsentry/relay/master/`
+Develop-docs base: `https://develop.sentry.dev/sdk/`
+
+> [!NOTE]
+> File paths drift as the SDK is refactored. If a listed Cocoa file is missing, search for the named symbol (e.g. `SentryDataCategory`, `SentryEnvelopeItemTypes`) and note the moved path in the report.
+
+---
+
+## 1. HTTP header reads — case-sensitivity (the #8322 class)
+
+- **Cocoa:** `Sources/Sentry/SentryNetworkTracker.m`, `Sources/Sentry/SentryTracePropagation.m`, `Sources/Swift/Networking/DefaultRateLimits.swift`, `Sources/Swift/Core/Tools/URLSessionTaskHelper.swift`, `Sources/Swift/Tools/SentryURLRequestFactory.swift`.
+- **Spec:** RFC 9113 §8.2.1 (HTTP/2) and RFC 9114 §4.2 (HTTP/3) — field names are lowercased on the wire; `expected-features/rate-limiting/`.
+- **What to check:** every **single-header read**. A subscript on `allHeaderFields[...]` or `allHTTPHeaderFields[...]` is **case-SENSITIVE → unsafe** (server may send lowercased names). `valueForHTTPHeaderField:` / the Swift `value(forHTTPHeaderFieldCaseInsensitive:)` helper is safe. Reading the _whole_ dictionary (iteration) is fine. Flag any unsafe subscript, especially on a **response**.
+- Also check the **linters** guarding this: `.swiftlint.yml` (`avoid_all_header_fields`), `scripts/check-objc-banned-pattern.sh`, `Makefile` (`lint`/`lint-staged`), and whether a CI workflow runs the ObjC linter.
+
+## 2. Rate-limit / Retry-After parsing
+
+- **Cocoa:** `Sources/Swift/Networking/RateLimitParser.swift`, `Sources/Swift/Networking/RetryAfterHeaderParser.swift`, `Sources/Swift/Networking/DefaultRateLimits.swift`.
+- **Spec:** `expected-features/rate-limiting/`. Relay: `relay-quotas/` (rate-limit format).
+- **What to check:** `X-Sentry-Rate-Limits` format `retry_after:categories:scope:reason_code:namespaces`, comma-separated quotas. Must: ignore spaces ("the header may contain spaces which must be ignored"); empty categories field → **all** categories; a limit whose categories are **all unknown** → **ignored** (never applied to `default`); `metric_bucket` namespaces handled; `Retry-After` on a 429 → treat like `categories=[]`; 429 with neither header → 60s all-categories. **Both header reads must be case-insensitive** (the #8324 fix — a regression here is HIGH).
+
+## 3. Data categories
+
+- **Cocoa:** `Sources/Swift/Networking/SentryDataCategory.swift` (enum + wire-name strings), `Sources/Swift/Networking/SentryDataCategory+EnvelopeItemType.swift` (item-type → category mapping).
+- **Relay:** `relay-base-schema/src/data_category.rs` — the `DataCategory` enum, its `#[serde(rename)]`/`name()` strings, and numeric discriminants.
+- **What to check:** every category **name** Cocoa emits/parses must match Relay's `name()`/`from_name` **exactly** (lowercase). Flag: (a) name mismatch; (b) a category Relay defines that Cocoa maps to `.unknown` (→ silently mishandled rate limits/outcomes) — especially newly-added Relay categories; (c) the `profile_chunk` (item) → `profile_chunk_ui` (category) inference; (d) any place a numeric **index** is put on the wire (must be none — Cocoa's raw values intentionally DIFFER from Relay's discriminants; indices are internal-only). Cross-ref §2: unknown names get dropped in `RateLimitParser.swift`.
+
+## 4. Envelope item types
+
+- **Cocoa:** `Sources/Swift/Helper/SentryEnvelopeItemType.swift` (the `SentryEnvelopeItemTypes` constants), `Sources/Swift/Tools/SentryEnvelopeItem.swift` (item construction, incl. replay msgpack keys `replay_event`/`replay_recording`/`replay_video`), `Sources/Sentry/Profiling/SentryProfilerSerialization.m` (`profile`/`profile_chunk`), `Sources/Swift/Tools/TelemetryProcessor/TelemetryScheduler.swift` (`log`/`trace_metric`).
+- **Relay:** `relay-server/src/envelope/item.rs` — `ItemType` enum + `from_str`/serde renames.
+- **Spec:** `data-model/envelope-items/`.
+- **What to check:** every item-type string Cocoa **emits** must be recognized by Relay's `ItemType::from_str` with exact casing/spelling (e.g. `log`, not `otel_log`). Unrecognized → Relay `ItemType::Unknown` (preserved, but a sign of drift). Flag any Cocoa item type Relay doesn't recognize, and any hardcoded item-type literal that bypasses the `SentryEnvelopeItemTypes` constants.
+
+## 5. Client reports / discard reasons / outcomes
+
+- **Cocoa:** `Sources/Sentry/SentryDiscardReasonMapper.m`, `Sources/Swift/Networking/SentryDiscardReason.swift`, `Sources/Swift/Tools/SentryClientReport.swift`, `Sources/Swift/Tools/SentryDiscardedEvent.swift`, and drop-recording sites (`Sources/Sentry/SentryHttpTransport.m`, `SentryClient.m`, `SentryHub.m`, `SentryTransportAdapter.m`).
+- **Spec:** `telemetry/client-reports/` (allowed `reason` values). **Relay:** `relay-event-schema/src/protocol/client_report.rs` (`ClientReport`/`DiscardedEvent` shape), `relay-server/src/processing/client_reports/process.rs` (reason handling), `relay-server/src/services/outcome.rs`.
+- **What to check:** every discard **reason** string in the client-report path must be in the develop-docs allowlist — watch spelling (`ratelimit_backoff`, NOT `rate_limit_backoff`). Client-report payload shape must be `{timestamp, discarded_events:[{reason, category, quantity}]}`; SDK must NOT populate Relay-reserved arrays (`rate_limited_events`/`filtered_events`/`filtered_sampling_events`). Verify 429s are **not** double-counted client-side (Relay records them server-side). Verify rate-limit drops attribute to the right category with `ratelimit_backoff`.
+
+## 6. Auth / request format
+
+- **Cocoa:** `Sources/Swift/Tools/SentryURLRequestFactory.swift`, `Sources/Swift/SentryDsn.swift`, `Sources/Swift/Networking/SentryNSURLRequestBuilder.swift`.
+- **Spec:** `overview/` (authentication / `X-Sentry-Auth`), `data-model/envelopes/` (envelope endpoint).
+- **What to check:** `X-Sentry-Auth: Sentry sentry_version=7,sentry_client=<name>/<ver>,sentry_key=<publicKey>[,sentry_secret=…]`; `sentry_version` value (`7`); `Content-Type: application/x-sentry-envelope`; `Content-Encoding: gzip` (+ body gzipped); `POST`; endpoint path `<dsn-extra-path>/api/<projectId>/envelope/` derived from the DSN. Flag any token/spelling/version divergence.
+
+## 7. Dynamic Sampling Context (baggage)
+
+- **Cocoa:** `Sources/Sentry/SentryBaggage.m` (`toHTTPHeaderWithOriginalBaggage:` — the `sentry-`prefixed keys), `Sources/Sentry/SentryTraceContext.m` (`initWithDict:` un-prefixed keys + `serialize` + the trace-only constructor), `Sources/Swift/Core/Helper/SentryBaggageSerialization.swift`.
+- **Spec:** `foundations/trace-propagation/dynamic-sampling-context/`.
+- **What to check:** required/optional DSC keys present and exactly named: `trace_id, public_key, release, environment, transaction, sample_rate, sample_rand, sampled, replay_id, org_id`. Specifically check `sample_rand` (required since v1.1.0) and `org_id` (since v1.2.0) are generated/propagated. Flag: missing keys on any DSC path; numeric serialization precision of `sample_rand`/`sample_rate` (rounding can break the `sample_rand < sample_rate ⟺ sampled` invariant); `sentry-sampled` value strings (`true`/`false`).
+
+## 8. sentry-trace header
+
+- **Cocoa:** `Sources/Sentry/SentryTraceHeader.m` (`value`).
+- **Spec:** `foundations/trace-propagation/`.
+- **What to check:** wire format `traceid-spanid-sampled`; `trace_id` = 32 hex, `span_id` = 16 hex; sampled = `1`/`0`/omitted; header always includes trace+span. Flag divergence.
+
+## 9. Sessions
+
+- **Cocoa:** `Sources/Swift/SentrySession.swift` (model + `serialize`), session-envelope build sites, `Sources/Swift/Helper/SentryMigrateSessionInit.swift`.
+- **Spec:** `telemetry/sessions/`.
+- **What to check:** payload fields + exact names: `sid, did, init, started, timestamp, status, errors, duration, seq, attrs{release, environment, ip_address, user_agent}`; status values `ok/exited/crashed/abnormal` (no `errored`/`unhandled` as a session status); `init`/`seq` dedup semantics + never-drop-init migration; `duration` omitted on init. Session **aggregates** are optional for a mobile client (Cocoa sends individual sessions — conformant). Flag missing/mis-named fields or wrong status strings.
+
+## 10. Sampling numbers & invariant
+
+- **Cocoa:** `Sources/Sentry/SentrySampling.m` (`_sentry_calcSample`), `Sources/Sentry/SentryTraceContext.m` (serialization of `sample_rand`/`sample_rate`).
+- **Spec:** `foundations/trace-propagation/dynamic-sampling-context/` (the `sample_rand < sample_rate ⟺ sampled` invariant).
+- **What to check:** decision computed at full precision but transmitted rounded; `<=` vs strict `<` at the boundary; `sample_rand` seeded once at trace start and reused. Flag precision/among-events consistency risks.

--- a/develop-docs/audits/relay/VALIDATION.md
+++ b/develop-docs/audits/relay/VALIDATION.md
@@ -1,0 +1,35 @@
+# Validation — Cocoa ↔ Relay audit self-test
+
+The audit itself needs a regression test: a pinned historical commit containing a real, serious conformance bug that a correct audit run MUST surface. If a validation run misses it, the audit — not the SDK — is broken.
+
+## The pinned target
+
+- **Commit:** `b557385bd02ba527f02b4b754caa056714c20274` (`build: remove podspec files (#8298)`) — the parent of the [#8324](https://github.com/getsentry/sentry-cocoa/pull/8324) merge, i.e. the last `main` commit **before** the rate-limit header fix.
+- **The bug present at that SHA (= RELAY-001):** `Sources/Swift/Networking/DefaultRateLimits.swift` `update(_:)` read `response.allHeaderFields["X-Sentry-Rate-Limits"]` and `["Retry-After"]` — case-sensitive subscripts. Over HTTP/2/3 (header names lowercased on the wire) both lookups return nil, so a 429 fell through to the all-categories fallback and the SDK **rate-limited all telemetry** (issue [#8322](https://github.com/getsentry/sentry-cocoa/issues/8322)).
+
+## When to run
+
+- Manually (claude.ai one-off run / "run now"), whenever `AUDIT.md`, `SURFACE_MAP.md`, or `ROUTINE_PROMPT.md` change materially, or the routine's model changes.
+- Not on the weekly schedule — the weekly run audits `main` only.
+
+## Procedure
+
+1. Check out sentry-cocoa `main` (for this audit config) and create a **second worktree at the pinned SHA**:
+   `git worktree add /tmp/cocoa-prefix-validation b557385bd02ba527f02b4b754caa056714c20274`
+   The audit config in `develop-docs/audits/relay/` is read from the `main` checkout; the **audited code** is the old worktree (these files don't exist at the pinned SHA).
+2. Run the full `AUDIT.md` procedure against the old worktree, classifying against `FINDINGS.md` from `main` as usual.
+3. Because RELAY-001 is a `fixed` tombstone in `FINDINGS.md`, the old code must classify it as a **REGRESSION (NEW / HIGH)**.
+
+## Pass / fail criteria
+
+- **PASS:** the report contains a NEW/HIGH REGRESSION finding located at `Sources/Swift/Networking/DefaultRateLimits.swift`, describing case-sensitive reads of `X-Sentry-Rate-Limits` and/or `Retry-After` (matching RELAY-001's fingerprint). Findings that were open at that SHA and are triaged in `FINDINGS.md` (e.g. the SentryNetworkTracker Content-Type reads, RELAY-002/003 — also `fixed` tombstones now) appearing as additional REGRESSIONs is expected and fine.
+- **FAIL:** RELAY-001 is missing, reported below HIGH, or classified as anything other than NEW/REGRESSION. The run must end its Slack post / output with `VALIDATION FAILED`, and must NOT post a normal weekly-style report.
+- Prefix all validation output with `🧪 VALIDATION RUN` (see `REPORT_FORMAT.md`) so it is never mistaken for a real drift report.
+
+## Sanity companion
+
+After a validation run, confirm the inverse: a normal run against current `main` must NOT report RELAY-001 (or any `fixed` tombstone) — expected result is "no new drift" with all registry entries classifying as KNOWN.
+
+## Cleanup
+
+`git worktree remove /tmp/cocoa-prefix-validation`


### PR DESCRIPTION
## 📜 Description

Adds `develop-docs/audits/relay/` — the definition of a weekly, agent-driven audit that diffs the Cocoa SDK's wire protocol against [Relay](<https://github.com/getsentry/relay>), hunting for the bug class behind getsentry/sentry-cocoa#8322 (hard-coded strings/wire formats that must match Relay exactly and fail silently when they don't).

<!-- linear:table-colwidths:400,400 -->
| File | Purpose |
| -- | -- |
| `audits/README.md` | Folder convention (copyable to other SDK repos; a future develop-docs-spec audit is a sibling folder) |
| `relay/AUDIT.md` | Read-only audit procedure: fan out per surface-map area, classify NEW / KNOWN / RESOLVED / REGRESSION |
| `relay/SURFACE_MAP.md` | 10 protocol areas: Cocoa files ↔ Relay source ↔ develop-docs pages |
| `relay/FINDINGS.md` | Deterministic registry with stable `RELAY-###` IDs: `open`, `accepted` (the ignore list, each with an explicit ignore-scenario), and `fixed` tombstones that re-alarm as regressions |
| `relay/REPORT_FORMAT.md` | Slack delta + TLDR + agent-pickup report templates, one-click pre-filled GitHub-issue links |
| `relay/VALIDATION.md` | Self-test: run the audit against `b557385bd` (the commit before getsentry/sentry-cocoa#8324) — it MUST re-surface the rate-limit header bug (RELAY-001) |
| `relay/ROUTINE_PROMPT.md` | The scheduler prompt ([claude.ai](<http://claude.ai>) routine now; GitHub Actions migration path documented) |

Only NEW findings make noise — a quiet week is a single ✅ line. The registry is maintained exclusively via human-reviewed PRs; the audit itself is read-only.

## 💡 Motivation and Context

getsentry/sentry-cocoa#8322 silently rate-limited **all** telemetry because of a case-sensitive header lookup. This sets up a recurring check that catches that whole class of drift between the SDK and Relay before users do.

#skip-changelog

## 💚 How did you test it?

Docs only. Verified all referenced Cocoa file paths exist on current `main` (updated paths that moved since the original baseline, e.g. `SentryDataCategory` now in `Sources/Swift/Networking/`), confirmed getsentry/sentry-cocoa#8388 (RELAY-002/003) is fixed on `main`, and confirmed the pinned validation SHA `b557385bd` is the parent of the getsentry/sentry-cocoa#8324 merge commit. A validation run per `VALIDATION.md` follows once this is merged.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).