### PR TITLE
feat: Add Breadcrumb.setData(value:key:)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -157,6 +157,3 @@ custom_rules:
     message: "Use `setData(value:key:)` instead of assigning the whole `Breadcrumb.data` dictionary. Assigning a bridged Swift dictionary can crash (see #7861); the `data` setter will become read-only in a future release. If you must assign a whole dictionary, suppress this rule with a comment explaining why."
     regex: '(crumb|breadcrumb|wrapped)\.data\s*=(?!=)'
     severity: error
-    included:
-      - "./Sources/.*\\.swift"
-      - "./Tests/.*\\.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -159,3 +159,4 @@ custom_rules:
     severity: error
     included:
       - "./Sources/.*\\.swift"
+      - "./Tests/.*\\.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -159,7 +159,3 @@ custom_rules:
     severity: error
     included:
       - "./Sources/.*\\.swift"
-    excluded:
-      # `wrapped` is a User / Mechanism here, not a Breadcrumb.
-      - "./Sources/SentryObjCCompat/SentryObjCUser.swift"
-      - "./Sources/SentryObjCCompat/SentryObjCMechanism.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -155,7 +155,11 @@ custom_rules:
   no_breadcrumb_data_setter:
     name: "Avoid the Breadcrumb.data setter"
     message: "Use `setData(value:key:)` instead of assigning the whole `Breadcrumb.data` dictionary. Assigning a bridged Swift dictionary can crash (see #7861); the `data` setter will become read-only in a future release. If you must assign a whole dictionary, suppress this rule with a comment explaining why."
-    regex: '(crumb|breadcrumb)\.data\s*=(?!=)'
+    regex: '(crumb|breadcrumb|wrapped)\.data\s*=(?!=)'
     severity: error
     included:
       - "./Sources/.*\\.swift"
+    excluded:
+      # `wrapped` is a User / Mechanism here, not a Breadcrumb.
+      - "./Sources/SentryObjCCompat/SentryObjCUser.swift"
+      - "./Sources/SentryObjCCompat/SentryObjCMechanism.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -152,3 +152,10 @@ custom_rules:
     message: "Use `internal import` (SE-0409) instead of `@_implementationOnly import`."
     regex: "@_implementationOnly import"
     severity: error
+  no_breadcrumb_data_setter:
+    name: "Avoid the Breadcrumb.data setter"
+    message: "Use `setData(value:key:)` instead of assigning the whole `Breadcrumb.data` dictionary. Assigning a bridged Swift dictionary can crash (see #7861); the `data` setter will become read-only in a future release. If you must assign a whole dictionary, suppress this rule with a comment explaining why."
+    regex: '(crumb|breadcrumb)\.data\s*=(?!=)'
+    severity: error
+    included:
+      - "./Sources/.*\\.swift"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry (#8572)
+
 ### Fixes
 
 - Fix trace propagation for manually instrumented transactions when automatic performance tracing is disabled (#8522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry (#8572)
+- Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1550,7 +1550,7 @@
 		8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransaction.m; sourceTree = "<group>"; };
 		8ECC674525C23A20000E2BF6 /* SentrySpanId.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySpanId.m; sourceTree = "<group>"; };
 		8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransactionContext.m; sourceTree = "<group>"; };
-		92672BB529C9A2A9006B021C /* SentryBreadcrumb+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SentryBreadcrumb+Private.h"; sourceTree = "<group>"; };
+		92672BB529C9A2A9006B021C /* SentryBreadcrumb+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SentryBreadcrumb+Private.h"; path = "include/SentryBreadcrumb+Private.h"; sourceTree = "<group>"; };
 		928207C32E251B8F009285A4 /* SentryScope+PrivateSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryScope+PrivateSwift.h"; path = "include/SentryScope+PrivateSwift.h"; sourceTree = "<group>"; };
 		9286059429A5096600F96038 /* SentryGeo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryGeo.h; path = Public/SentryGeo.h; sourceTree = "<group>"; };
 		9286059629A5098900F96038 /* SentryGeo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryGeo.m; sourceTree = "<group>"; };

--- a/SentryTestUtils/Sources/BreadcrumbExtension.swift
+++ b/SentryTestUtils/Sources/BreadcrumbExtension.swift
@@ -5,7 +5,7 @@ public extension Breadcrumb {
         
         result.type = "navigation"
         result.timestamp = date
-        result.data = ["screen": screen]
+        result.setData(value: screen, key: "screen")
         
         return result
     }

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -52,6 +52,15 @@ NS_SWIFT_NAME(Breadcrumb)
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *data;
 
 /**
+ * Sets a single value in the breadcrumb's @c data dictionary for the given key.
+ * Passing @c nil as the value removes the key. This is the preferred way of setting
+ * breadcrumb data; the @c data property setter will become read-only in a future release.
+ * @param value The value to store, or @c nil to remove the key.
+ * @param key The key to set.
+ */
+- (void)setDataValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setData(value:key:));
+
+/**
  * Initializer for @c SentryBreadcrumb
  * @param level SentryLevel
  * @param category String

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -52,6 +52,14 @@ NS_SWIFT_NAME(Breadcrumb)
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *data;
 
 /**
+ * @deprecated Use @c setDataValue:forKey: instead; the @c data property setter will become
+ * read-only in a future release.
+ */
+- (void)setData:(nullable NSDictionary<NSString *, id> *)data
+    __attribute__((deprecated("Use setData(value:key:) instead; the data property setter will "
+                              "become read-only in a future release.")));
+
+/**
  * Sets a single value in the breadcrumb's @c data dictionary for the given key.
  * Passing @c nil as the value removes the key. This is the preferred way of setting
  * breadcrumb data; the @c data property setter will become read-only in a future release.

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -278,7 +278,9 @@ sentry_deepCopyValue(id value)
     [serializedData setValue:type forKey:@"type"];
     [serializedData setValue:origin forKey:@"origin"];
     [serializedData setValue:message forKey:@"message"];
-    [serializedData setValue:sentry_sanitize_dictionary(data) forKey:@"data"];
+    if (data.count > 0) {
+        [serializedData setValue:sentry_sanitize_dictionary(data) forKey:@"data"];
+    }
     return serializedData;
 }
 

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -160,6 +160,10 @@ sentry_deepCopyValue(id value)
 {
     @synchronized(self) {
         if (_data == nil) {
+            // Don't allocate storage for a no-op remove; keep data nil.
+            if (value == nil) {
+                return;
+            }
             _data = [[NSMutableDictionary alloc] init];
         }
         // setValue:forKey: removes the key when value is nil.

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -42,7 +42,10 @@ sentry_deepCopyValue(id value)
     return value;
 }
 
-@implementation SentryBreadcrumb
+@implementation SentryBreadcrumb {
+    // Mutable so setDataValue:forKey: can update in place.
+    NSMutableDictionary<NSString *, id> *_data;
+}
 
 // Explicit @synthesize so we can provide thread-safe accessors via @synchronized(self).
 @synthesize level = _level;
@@ -51,7 +54,6 @@ sentry_deepCopyValue(id value)
 @synthesize type = _type;
 @synthesize message = _message;
 @synthesize origin = _origin;
-@synthesize data = _data;
 
 #pragma mark - Thread-safe property accessors
 
@@ -142,14 +144,26 @@ sentry_deepCopyValue(id value)
 - (void)setData:(NSDictionary<NSString *, id> *)data
 {
     @synchronized(self) {
-        _data = data ? sentry_deepCopyValue(data) : nil;
+        _data = data ? [sentry_deepCopyValue(data) mutableCopy] : nil;
     }
 }
 
 - (NSDictionary<NSString *, id> *)data
 {
     @synchronized(self) {
-        return _data;
+        // Immutable snapshot so callers can't mutate our storage.
+        return [_data copy];
+    }
+}
+
+- (void)setDataValue:(nullable id)value forKey:(NSString *)key
+{
+    @synchronized(self) {
+        if (_data == nil) {
+            _data = [[NSMutableDictionary alloc] init];
+        }
+        // setValue:forKey: removes the key when value is nil.
+        [_data setValue:value forKey:key];
     }
 }
 
@@ -197,6 +211,23 @@ sentry_deepCopyValue(id value)
     return self;
 }
 
+- (instancetype)initWithLevel:(SentryLevel)level
+                     category:(NSString *)category
+                         data:(nullable NSDictionary<NSString *, id> *)data
+{
+    self = [self initWithLevel:level category:category];
+    if (self) {
+        // initWithDictionary: bulk-materializes into native storage, avoiding the per-key
+        // re-bridge that crashes for lazily-bridged Swift dictionaries (see #7861). It doesn't
+        // route through the setData: deep copy, matching setDataValue:forKey: semantics.
+        _data = data != nil
+            ? [[NSMutableDictionary alloc]
+                  initWithDictionary:SENTRY_UNWRAP_NULLABLE_DICT(NSString *, id, data)]
+            : nil;
+    }
+    return self;
+}
+
 - (instancetype)init
 {
     return [self initWithLevel:kSentryLevelInfo category:@"default"];
@@ -212,7 +243,8 @@ sentry_deepCopyValue(id value)
         snapshot->_type = _type;
         snapshot->_message = _message;
         snapshot->_origin = _origin;
-        snapshot->_data = _data;
+        // Copy so the snapshot has independent storage.
+        snapshot->_data = [_data mutableCopy];
     }
     return snapshot;
 }
@@ -237,7 +269,8 @@ sentry_deepCopyValue(id value)
         type = _type;
         origin = _origin;
         message = _message;
-        data = _data;
+        // Copy under the lock; _data is mutated in place elsewhere.
+        data = [_data copy];
     }
 
     NSMutableDictionary *serializedData = [[NSMutableDictionary alloc] init];

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -217,9 +217,6 @@ sentry_deepCopyValue(id value)
 {
     self = [self initWithLevel:level category:category];
     if (self) {
-        // initWithDictionary: bulk-materializes into native storage, avoiding the per-key
-        // re-bridge that crashes for lazily-bridged Swift dictionaries (see #7861). It doesn't
-        // route through the setData: deep copy, matching setDataValue:forKey: semantics.
         _data = [[NSMutableDictionary alloc] initWithDictionary:data];
     }
     return self;

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -213,17 +213,14 @@ sentry_deepCopyValue(id value)
 
 - (instancetype)initWithLevel:(SentryLevel)level
                      category:(NSString *)category
-                         data:(nullable NSDictionary<NSString *, id> *)data
+                         data:(NSDictionary<NSString *, id> *)data
 {
     self = [self initWithLevel:level category:category];
     if (self) {
         // initWithDictionary: bulk-materializes into native storage, avoiding the per-key
         // re-bridge that crashes for lazily-bridged Swift dictionaries (see #7861). It doesn't
         // route through the setData: deep copy, matching setDataValue:forKey: semantics.
-        _data = data != nil
-            ? [[NSMutableDictionary alloc]
-                  initWithDictionary:SENTRY_UNWRAP_NULLABLE_DICT(NSString *, id, data)]
-            : nil;
+        _data = [[NSMutableDictionary alloc] initWithDictionary:data];
     }
     return self;
 }

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -1,5 +1,6 @@
 #import "SentryBreadcrumb.h"
 #import "SentryBreadcrumb+Private.h"
+#import "SentryCompiler.h"
 #import "SentryDateUtils.h"
 #import "SentryInternalDefines.h"
 #import "SentryLevel.h"
@@ -197,7 +198,9 @@ sentry_deepCopyValue(id value)
             } else if ([key isEqualToString:@"message"] && isString) {
                 self.message = value;
             } else if ([key isEqualToString:@"data"] && isDictionary) {
+                ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                 self.data = value;
+                ALLOW_DEPRECATED_DECLARATIONS_END
             }
         }
     }

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -196,11 +196,14 @@ static NSString *const SentryCrashReportConverterErrorDomain
     if (nil != self.userContext[@"breadcrumbs"]) {
         NSArray *storedBreadcrumbs = self.userContext[@"breadcrumbs"];
         for (NSDictionary *storedCrumb in storedBreadcrumbs) {
-            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc]
-                initWithLevel:[self sentryLevelFromString:storedCrumb[@"level"]]
-                     category:storedCrumb[@"category"]
-                    ?: @"default"]; // The default value is the same as the one in
-                                    // SentryBreadcrumb.init
+            SentryLevel level = [self sentryLevelFromString:storedCrumb[@"level"]];
+            NSString *category
+                = storedCrumb[@"category"] ?: @"default"; // The default value is the same as the
+                                                          // one in SentryBreadcrumb.init
+            NSDictionary *data = storedCrumb[@"data"];
+            SentryBreadcrumb *crumb = data
+                ? [[SentryBreadcrumb alloc] initWithLevel:level category:category data:data]
+                : [[SentryBreadcrumb alloc] initWithLevel:level category:category];
             crumb.message = storedCrumb[@"message"];
             crumb.type = storedCrumb[@"type"];
             crumb.origin = storedCrumb[@"origin"];
@@ -208,7 +211,6 @@ static NSString *const SentryCrashReportConverterErrorDomain
                 crumb.timestamp = sentry_fromIso8601String(
                     SENTRY_UNWRAP_NULLABLE(NSString, storedCrumb[@"timestamp"]));
             }
-            crumb.data = storedCrumb[@"data"];
             [breadcrumbs addObject:crumb];
         }
     }

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -1,5 +1,6 @@
 #import "SentryNetworkTracker.h"
 #import "SentryBaggage.h"
+#import "SentryBreadcrumb+Private.h"
 #import "SentryBreadcrumb.h"
 #import "SentryClient+Private.h"
 #import "SentryDefaultThreadInspector.h"
@@ -514,9 +515,6 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     SentryLevel breadcrumbLevel = [self getBreadcrumbLevel:sessionTask
                                         responseStatusCode:responseStatusCode];
 
-    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:breadcrumbLevel
-                                                                  category:@"http"];
-
 #if SDK_V10
     SentryDataCollectionObjCOptions *_Nullable dataCollectionOptions = options.dataCollectionObjC;
     UrlSanitized *urlComponents = [[UrlSanitized alloc]
@@ -527,7 +525,6 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         [[UrlSanitized alloc] initWithURL:SENTRY_UNWRAP_NULLABLE(NSURL, currentRequest.URL)];
 #endif // SDK_V10
 
-    breadcrumb.type = @"http";
     NSMutableDictionary<NSString *, id> *breadcrumbData = [[NSMutableDictionary alloc] init];
     breadcrumbData[@"url"] = urlComponents.sanitizedUrl;
     breadcrumbData[@"method"] = currentRequest.HTTPMethod;
@@ -569,7 +566,10 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     }
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED
 
-    breadcrumb.data = breadcrumbData;
+    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:breadcrumbLevel
+                                                                  category:@"http"
+                                                                      data:breadcrumbData];
+    breadcrumb.type = @"http";
     [SentrySDKInternal addBreadcrumb:breadcrumb];
 
     objc_setAssociatedObject(sessionTask, &SENTRY_NETWORK_REQUEST_TRACKER_BREADCRUMB,

--- a/Sources/Sentry/include/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/SentryBreadcrumb+Private.h
@@ -8,31 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryBreadcrumb ()
 
-/**
- * Initializes a SentryBreadcrumb with a level, category and data dictionary.
- * Convenience for constructing a breadcrumb with data in one call instead of multiple
- * @c setDataValue:forKey: calls.
- * @param level The severity level of the breadcrumb.
- * @param category The category string for the breadcrumb.
- * @param data The data dictionary.
- * @return The SentryBreadcrumb.
- */
 - (instancetype)initWithLevel:(SentryLevel)level
                      category:(NSString *)category
                          data:(NSDictionary<NSString *, id> *)data;
 
-/**
- * Initializes a SentryBreadcrumb from a JSON object.
- * @param dictionary The dictionary containing breadcrumb data.
- * @return The SentryBreadcrumb.
- */
 - (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
 
-/**
- * Returns a snapshot copy with its own strong references to all property values.
- * The copy is independent of the original: deallocating either one does not
- * affect the other's ivars.
- */
 - (SentryBreadcrumb *_Nonnull)snapshotCopy;
 @end
 

--- a/Sources/Sentry/include/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/SentryBreadcrumb+Private.h
@@ -9,6 +9,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryBreadcrumb ()
 
 /**
+ * Initializes a SentryBreadcrumb with a level, category and data dictionary.
+ * Convenience for constructing a breadcrumb with data in one call instead of multiple
+ * @c setDataValue:forKey: calls.
+ * @param level The severity level of the breadcrumb.
+ * @param category The category string for the breadcrumb.
+ * @param data The data dictionary, or @c nil.
+ * @return The SentryBreadcrumb.
+ */
+- (instancetype _Nonnull)initWithLevel:(SentryLevel)level
+                              category:(NSString *_Nonnull)category
+                                  data:(NSDictionary<NSString *, id> *_Nullable)data;
+
+/**
  * Initializes a SentryBreadcrumb from a JSON object.
  * @param dictionary The dictionary containing breadcrumb data.
  * @return The SentryBreadcrumb.

--- a/Sources/Sentry/include/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/SentryBreadcrumb+Private.h
@@ -14,12 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @c setDataValue:forKey: calls.
  * @param level The severity level of the breadcrumb.
  * @param category The category string for the breadcrumb.
- * @param data The data dictionary, or @c nil.
+ * @param data The data dictionary.
  * @return The SentryBreadcrumb.
  */
 - (instancetype _Nonnull)initWithLevel:(SentryLevel)level
                               category:(NSString *_Nonnull)category
-                                  data:(NSDictionary<NSString *, id> *_Nullable)data;
+                                  data:(NSDictionary<NSString *, id> *_Nonnull)data;
 
 /**
  * Initializes a SentryBreadcrumb from a JSON object.

--- a/Sources/Sentry/include/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/SentryBreadcrumb+Private.h
@@ -17,9 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @param data The data dictionary.
  * @return The SentryBreadcrumb.
  */
-- (instancetype _Nonnull)initWithLevel:(SentryLevel)level
-                              category:(NSString *_Nonnull)category
-                                  data:(NSDictionary<NSString *, id> *_Nonnull)data;
+- (instancetype)initWithLevel:(SentryLevel)level
+                     category:(NSString *)category
+                         data:(NSDictionary<NSString *, id> *)data;
 
 /**
  * Initializes a SentryBreadcrumb from a JSON object.

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -42,6 +42,7 @@
 #import "SentryAppStartMeasurementProvider.h"
 #import "SentryAppStartTrackerHelper.h"
 #import "SentryAsyncLog.h"
+#import "SentryBreadcrumb+Private.h"
 #import "SentryContinuousProfiler.h"
 #import "SentryCoreDataSwizzlingHelper.h"
 #import "SentryCoreDataTracker.h"

--- a/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
+++ b/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
@@ -39,6 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Arbitrary additional data that will be sent with the breadcrumb.
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *data;
 
+/// @deprecated Use `setDataValue:forKey:` instead; the `data` property setter will become
+/// read-only in a future release.
+- (void)setData:(nullable NSDictionary<NSString *, id> *)data
+    __attribute__((deprecated("Use setData(value:key:) instead; the data property setter will "
+                              "become read-only in a future release.")));
+
 /**
  * Sets a single value in the breadcrumb's @c data dictionary for the given key.
  * Passing @c nil as the value removes the key. This is the preferred way of setting

--- a/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
+++ b/Sources/SentryObjC/Public/SentryObjCBreadcrumb.h
@@ -40,6 +40,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, id> *data;
 
 /**
+ * Sets a single value in the breadcrumb's @c data dictionary for the given key.
+ * Passing @c nil as the value removes the key. This is the preferred way of setting
+ * breadcrumb data; the @c data property setter will become read-only in a future release.
+ * @param value The value to store, or @c nil to remove the key.
+ * @param key The key to set.
+ */
+- (void)setDataValue:(nullable id)value forKey:(NSString *)key;
+
+/**
  * Initializer for @c SentryObjCBreadcrumb.
  * @param level The severity level of the breadcrumb.
  * @param category The category string for the breadcrumb.

--- a/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
+++ b/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
@@ -53,8 +53,9 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        // swiftlint:disable:next no_breadcrumb_data_setter
+        // swiftlint:disable no_breadcrumb_data_setter
         set { wrapped.data = newValue } // pass-through mirroring the data setter; removed in V10
+        // swiftlint:enable no_breadcrumb_data_setter
     }
 
     @objc(setDataValue:forKey:) public func setData(value: Any?, key: String) {

--- a/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
+++ b/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
@@ -55,6 +55,10 @@ import Foundation
         get { wrapped.data }
         set { wrapped.data = newValue }
     }
+
+    @objc(setDataValue:forKey:) public func setData(value: Any?, key: String) {
+        wrapped.setData(value: value, key: key)
+    }
 }
 
 // swiftlint:enable missing_docs

--- a/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
+++ b/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
@@ -53,7 +53,8 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        set { wrapped.data = newValue }
+        // swiftlint:disable:next no_breadcrumb_data_setter
+        set { wrapped.data = newValue } // pass-through mirroring the data setter; removed in V10
     }
 
     @objc(setDataValue:forKey:) public func setData(value: Any?, key: String) {

--- a/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
+++ b/Sources/SentryObjCCompat/SentryObjCBreadcrumb.swift
@@ -53,6 +53,7 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
+        @available(*, deprecated, message: "Use setData(value:key:) instead.")
         // swiftlint:disable no_breadcrumb_data_setter
         set { wrapped.data = newValue } // pass-through mirroring the data setter; removed in V10
         // swiftlint:enable no_breadcrumb_data_setter

--- a/Sources/SentryObjCCompat/SentryObjCMechanism.swift
+++ b/Sources/SentryObjCCompat/SentryObjCMechanism.swift
@@ -29,8 +29,9 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        // swiftlint:disable:next no_breadcrumb_data_setter
+        // swiftlint:disable no_breadcrumb_data_setter
         set { wrapped.data = newValue } // `wrapped` is a Mechanism, not a Breadcrumb
+        // swiftlint:enable no_breadcrumb_data_setter
     }
 
     @objc public var handled: NSNumber? {

--- a/Sources/SentryObjCCompat/SentryObjCMechanism.swift
+++ b/Sources/SentryObjCCompat/SentryObjCMechanism.swift
@@ -29,7 +29,8 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        set { wrapped.data = newValue }
+        // swiftlint:disable:next no_breadcrumb_data_setter
+        set { wrapped.data = newValue } // `wrapped` is a Mechanism, not a Breadcrumb
     }
 
     @objc public var handled: NSNumber? {

--- a/Sources/SentryObjCCompat/SentryObjCUser.swift
+++ b/Sources/SentryObjCCompat/SentryObjCUser.swift
@@ -56,7 +56,8 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        set { wrapped.data = newValue }
+        // swiftlint:disable:next no_breadcrumb_data_setter
+        set { wrapped.data = newValue } // `wrapped` is a User, not a Breadcrumb
     }
 }
 

--- a/Sources/SentryObjCCompat/SentryObjCUser.swift
+++ b/Sources/SentryObjCCompat/SentryObjCUser.swift
@@ -56,8 +56,9 @@ import Foundation
 
     @objc public var data: [String: Any]? {
         get { wrapped.data }
-        // swiftlint:disable:next no_breadcrumb_data_setter
+        // swiftlint:disable no_breadcrumb_data_setter
         set { wrapped.data = newValue } // `wrapped` is a User, not a Breadcrumb
+        // swiftlint:enable no_breadcrumb_data_setter
     }
 }
 

--- a/Sources/Swift/Integrations/Breadcrumbs/SentryBreadcrumbTracker.swift
+++ b/Sources/Swift/Integrations/Breadcrumbs/SentryBreadcrumbTracker.swift
@@ -225,7 +225,7 @@ import Cocoa
                     }
                 }
                 
-                let crumb = Breadcrumb(level: .info, category: "touch", data: data)
+                let crumb = Breadcrumb(level: .info, category: "touch", data: data ?? [:])
                 crumb.type = "user"
                 crumb.message = action
                 self.delegate?.add(crumb)

--- a/Sources/Swift/Integrations/Breadcrumbs/SentryBreadcrumbTracker.swift
+++ b/Sources/Swift/Integrations/Breadcrumbs/SentryBreadcrumbTracker.swift
@@ -91,7 +91,7 @@ import Cocoa
             guard let self = self else { return }
             let crumb = Breadcrumb(level: .warning, category: "device.event")
             crumb.type = "system"
-            crumb.data = ["action": "LOW_MEMORY"]
+            crumb.setData(value: "LOW_MEMORY", key: "action")
             crumb.message = "Low memory"
             self.delegate?.add(crumb)
         }
@@ -176,7 +176,7 @@ import Cocoa
     private func addBreadcrumb(type: String, category: String, level: SentryLevel, dataKey: String, dataValue: String) {
         let crumb = Breadcrumb(level: level, category: category)
         crumb.type = type
-        crumb.data = [dataKey: dataValue]
+        crumb.setData(value: dataValue, key: dataKey)
         delegate?.add(crumb)
     }
     
@@ -225,10 +225,9 @@ import Cocoa
                     }
                 }
                 
-                let crumb = Breadcrumb(level: .info, category: "touch")
+                let crumb = Breadcrumb(level: .info, category: "touch", data: data)
                 crumb.type = "user"
                 crumb.message = action
-                crumb.data = data
                 self.delegate?.add(crumb)
             },
             forKey: Self.swizzleSendActionKey
@@ -240,9 +239,8 @@ import Cocoa
             { [weak self] viewController in
                 guard let self = self else { return }
                 
-                let crumb = Breadcrumb(level: .info, category: "ui.lifecycle")
+                let crumb = Breadcrumb(level: .info, category: "ui.lifecycle", data: Self.fetchInfo(about: viewController))
                 crumb.type = "navigation"
-                crumb.data = Self.fetchInfo(about: viewController)
                 self.delegate?.add(crumb)
             },
             forKey: Self.swizzleViewDidAppearKey
@@ -310,7 +308,7 @@ extension SentryBreadcrumbTracker: SentryReachabilityObserver {
     public func connectivityChanged(_ connected: Bool, typeDescription: String) {
         let crumb = Breadcrumb(level: .info, category: "device.connectivity")
         crumb.type = "connectivity"
-        crumb.data = ["connectivity": typeDescription]
+        crumb.setData(value: typeDescription, key: "connectivity")
         delegate?.add(crumb)
     }
 }

--- a/Sources/Swift/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbs.swift
+++ b/Sources/Swift/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbs.swift
@@ -157,9 +157,8 @@ final class SentrySystemEventBreadcrumbs: NSObject {
 
         let batteryData = getBatteryStatus(currentDevice)
 
-        let crumb = Breadcrumb(level: .info, category: "device.event")
+        let crumb = Breadcrumb(level: .info, category: "device.event", data: batteryData)
         crumb.type = "system"
-        crumb.data = batteryData
         delegate?.add(crumb)
     }
 
@@ -221,9 +220,9 @@ final class SentrySystemEventBreadcrumbs: NSObject {
         }
 
         if currentOrientation.isLandscape {
-            crumb.data = ["position": "landscape"]
+            crumb.setData(value: "landscape", key: "position")
         } else {
-            crumb.data = ["position": "portrait"]
+            crumb.setData(value: "portrait", key: "position")
         }
         crumb.type = "navigation"
         delegate?.add(crumb)
@@ -253,7 +252,7 @@ final class SentrySystemEventBreadcrumbs: NSObject {
     @objc private func systemEventTriggered(_ notification: Notification) {
         let crumb = Breadcrumb(level: .info, category: "device.event")
         crumb.type = "system"
-        crumb.data = ["action": notification.name.rawValue]
+        crumb.setData(value: notification.name.rawValue, key: "action")
         delegate?.add(crumb)
     }
 
@@ -299,10 +298,7 @@ final class SentrySystemEventBreadcrumbs: NSObject {
     private func timezoneEventTriggered(storedTimezoneOffset: NSNumber?) {
         let storedOffset = storedTimezoneOffset ?? fileManager.readTimezoneOffset()
 
-        let crumb = Breadcrumb(level: .info, category: "device.event")
         let offset = dateProvider.timezoneOffset()
-
-        crumb.type = "system"
 
         var dataDict: [String: Any] = [
             "action": "TIMEZONE_CHANGE",
@@ -313,7 +309,8 @@ final class SentrySystemEventBreadcrumbs: NSObject {
             dataDict["previous_seconds_from_gmt"] = storedOffset
         }
 
-        crumb.data = dataDict
+        let crumb = Breadcrumb(level: .info, category: "device.event", data: dataDict)
+        crumb.type = "system"
         delegate?.add(crumb)
 
         updateStoredTimezone()
@@ -347,7 +344,7 @@ final class SentrySystemEventBreadcrumbs: NSObject {
         crumb.type = "system"
 
         // We don't add the timezone here, because we already add it in timezoneEventTriggered.
-        crumb.data = ["action": "SIGNIFICANT_TIME_CHANGE"]
+        crumb.setData(value: "SIGNIFICANT_TIME_CHANGE", key: "action")
 
         delegate?.add(crumb)
     }

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -8,7 +8,7 @@ final class BreadcrumbDecodable: Breadcrumb {
 }
 
 extension BreadcrumbDecodable: Decodable {
-    
+
     private enum CodingKeys: String, CodingKey {
         case level
         case category
@@ -21,21 +21,23 @@ extension BreadcrumbDecodable: Decodable {
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        
-        self.init()
-        
+
         let rawLevel = try container.decode(String.self, forKey: .level)
         let level = SentryLevelHelper.levelForName(rawLevel)
-        self.level = level
-        
-        self.category = try container.decode(String.self, forKey: .category)
+        let category = try container.decode(String.self, forKey: .category)
+        let data = decodeArbitraryData {
+            try container.decodeIfPresent([String: ArbitraryData].self, forKey: .data)
+        }
+
+        if let data = data {
+            self.init(level: level, category: category, data: data)
+        } else {
+            self.init(level: level, category: category)
+        }
+
         self.timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp)
         self.type = try container.decodeIfPresent(String.self, forKey: .type)
         self.message = try container.decodeIfPresent(String.self, forKey: .message)
         self.origin = try container.decodeIfPresent(String.self, forKey: .origin)
-        
-        self.data = decodeArbitraryData {
-            try container.decodeIfPresent([String: ArbitraryData].self, forKey: .data)
-        }
     }
 }

--- a/Tests/SentryObjCTests/SentryObjCBreadcrumbTests.m
+++ b/Tests/SentryObjCTests/SentryObjCBreadcrumbTests.m
@@ -133,7 +133,10 @@
                                                                      category:@"test"];
 
     // -- Act --
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     crumb.data = @{ @"url" : @"/home" };
+#pragma clang diagnostic pop
 
     // -- Assert --
     XCTAssertEqualObjects(crumb.data[@"url"], @"/home");
@@ -144,10 +147,13 @@
     // -- Arrange --
     SentryObjCBreadcrumb *crumb = [[SentryObjCBreadcrumb alloc] initWithLevel:SentryObjCLevelInfo
                                                                      category:@"test"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     crumb.data = @{ @"key" : @"value" };
 
     // -- Act --
     crumb.data = nil;
+#pragma clang diagnostic pop
 
     // -- Assert --
     XCTAssertNil(crumb.data);

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -4,22 +4,25 @@ import XCTest
 
 class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbAppLifecycleForeground() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
         crumb.type = "navigation"
         crumb.data = ["state": "foreground"]
         let result = sut.convert(from: crumb)
-        
+
         let event = result?.serialize()
         let eventData = event?["data"] as? [String: Any]
         let eventPayload = eventData?["payload"] as? [String: Any]
-        
+
         XCTAssertEqual(event?["type"] as? Int, 5)
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "app.foreground")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbAppLifecycleActive() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -35,7 +38,9 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "app.active")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbAppLifecycleInactive() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -51,7 +56,9 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "app.inactive")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbAppLifecycleBackground() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -67,48 +74,54 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "app.background")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbOrientation() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "device.orientation")
         crumb.type = "navigation"
         crumb.data = ["position": "portrait"]
         let result = sut.convert(from: crumb)
-        
+
         let event = result?.serialize()
         let eventData = event?["data"] as? [String: Any]
         let eventPayload = eventData?["payload"] as? [String: Any]
         let payloadData = eventPayload?["data"] as? [String: Any]
-        
+
         XCTAssertEqual(event?["type"] as? Int, 5)
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "device.orientation")
         XCTAssertEqual(payloadData?["position"] as? String, "portrait")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNavigationBreadcrumbNavigate() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "ui.lifecycle")
         crumb.type = "navigation"
         crumb.data = ["screen": "TestViewController"]
         let result = sut.convert(from: crumb)
-        
+
         let event = result?.serialize()
         let eventData = event?["data"] as? [String: Any]
         let eventPayload = eventData?["payload"] as? [String: Any]
         let payloadData = eventPayload?["data"] as? [String: Any]
-        
+
         XCTAssertEqual(event?["type"] as? Int, 5)
         XCTAssertEqual(eventData?["tag"] as? String, "breadcrumb")
         XCTAssertEqual(eventPayload?["category"] as? String, "navigation")
         XCTAssertEqual(payloadData?["to"] as? String, "TestViewController")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testHttpBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "http")
         let start = Date(timeIntervalSince1970: 5)
-        
+
         breadcrumb.data = [
             "url": "https://test.com",
             "method": "GET",
@@ -134,7 +147,8 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData["query"] as? String, "query=value")
         XCTAssertEqual(payloadData["fragment"] as? String, "frag")
     }
-    
+    // swiftlint:enable no_breadcrumb_data_setter
+
     func testTouchBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "touch")
@@ -148,6 +162,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payload["message"] as? String, "TestTapped:")
     }
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testConnectivityBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "device.connectivity")
@@ -195,6 +210,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payload["message"] as? String, "Custom message")
         XCTAssertEqual(payloadData["SomeInfo"] as? String, "Info")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     // MARK: - Network Details (partial data)
 
@@ -270,6 +286,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     /// runs it through the converter, and returns the payload data dictionary.
     ///
     /// - Parameter method: Optional HTTP method to set on the network details.
+    // swiftlint:disable no_breadcrumb_data_setter
     private func convertHttpBreadcrumbWithNetworkDetails(
         method: String? = nil,
         configure: (SentryReplayNetworkDetails) -> Void
@@ -292,6 +309,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         let payload = try XCTUnwrap(crumbData["payload"] as? [String: Any])
         return try XCTUnwrap(payload["data"] as? [String: Any])
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testSerializedSRBreadcrumbLevelIsString() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverterTests.swift
@@ -5,6 +5,7 @@ import XCTest
 class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbAppLifecycleForeground() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -23,6 +24,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbAppLifecycleActive() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -41,6 +43,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbAppLifecycleInactive() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -59,6 +62,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbAppLifecycleBackground() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "app.lifecycle")
@@ -77,6 +81,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbOrientation() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "device.orientation")
@@ -97,6 +102,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNavigationBreadcrumbNavigate() {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let crumb = Breadcrumb(level: .info, category: "ui.lifecycle")
@@ -117,6 +123,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testHttpBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "http")
@@ -163,6 +170,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     }
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testConnectivityBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "device.connectivity")
@@ -178,6 +186,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData["state"] as? String, "Wifi")
     }
     
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testBatteryBreadcrumb() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "device.event")
@@ -194,6 +203,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData["charging"] as? Bool, true)
     }
     
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testCustomBreadcrumbs() throws {
         let sut = SentrySRDefaultBreadcrumbConverter()
         let breadcrumb = Breadcrumb(level: .info, category: "MyApp.MyBreadcrumb")
@@ -219,6 +229,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     /// are unset, they are simply omitted from the RRWebEvent payload rather than
     /// replaced with defaults or causing the details to be dropped entirely.
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
     func testHttpBreadcrumb_withNetworkDetails_onlyStatusCode() throws {
         let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
             details.setResponse(statusCode: 200, size: nil, bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
@@ -232,6 +243,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData.count, 1)
     }
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
     func testHttpBreadcrumb_withNetworkDetails_onlyMethod() throws {
         let payloadData = try convertHttpBreadcrumbWithNetworkDetails(method: "POST") { _ in
             // method is set via the initializer; no response/request set
@@ -245,6 +257,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData.count, 1)
     }
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
     func testHttpBreadcrumb_withNetworkDetails_onlyResponseBodySize() throws {
         let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
             details.setResponse(statusCode: 0, size: NSNumber(value: 512), bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
@@ -257,6 +270,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData.count, 3)
     }
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
     func testHttpBreadcrumb_withNetworkDetails_onlyRequestBodySize() throws {
         let payloadData = try convertHttpBreadcrumbWithNetworkDetails { details in
             details.setRequest(size: NSNumber(value: 256), bodyData: nil, contentType: nil, allHeaders: nil, configuredHeaders: nil)
@@ -268,6 +282,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(payloadData.count, 2)
     }
 
+    @available(*, deprecated, message: "Testing deprecated convertHttpBreadcrumbWithNetworkDetails")
     func testHttpBreadcrumb_withNetworkDetails_emptyDetails_producesNoExtraKeys() throws {
         let payloadData = try convertHttpBreadcrumbWithNetworkDetails { _ in }
 
@@ -287,6 +302,7 @@ class SentrySRDefaultBreadcrumbConverterTests: XCTestCase {
     ///
     /// - Parameter method: Optional HTTP method to set on the network details.
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     private func convertHttpBreadcrumbWithNetworkDetails(
         method: String? = nil,
         configure: (SentryReplayNetworkDetails) -> Void

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
@@ -13,6 +13,7 @@ class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {
         let currentDate = TestCurrentDateProvider()
         let maxBreadcrumbs = 10
 
+        // swiftlint:disable no_breadcrumb_data_setter
         init() throws {
             breadcrumb = TestData.crumb
             breadcrumb.data = nil
@@ -27,6 +28,7 @@ class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )
         }
+        // swiftlint:enable no_breadcrumb_data_setter
 
         func getSut() -> SentryWatchdogTerminationBreadcrumbProcessor {
             return getSut(fileManager: self.fileManager)

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBreadcrumbProcessorTests.swift
@@ -14,6 +14,7 @@ class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {
         let maxBreadcrumbs = 10
 
         // swiftlint:disable no_breadcrumb_data_setter
+        @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
         init() throws {
             breadcrumb = TestData.crumb
             breadcrumb.data = nil
@@ -44,6 +45,7 @@ class SentryWatchdogTerminationBreadcrumbProcessorTests: XCTestCase {
     private var fixture: Fixture!
     private var sut: SentryWatchdogTerminationBreadcrumbProcessor!
 
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     override func setUpWithError() throws {
         try super.setUpWithError()
 

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -105,6 +105,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(fixture.breadcrumb, fixture2.breadcrumb)
     }
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testNotIsEqual() {
         testIsNotEqual { breadcrumb in breadcrumb.level = SentryLevel.error }
         testIsNotEqual { breadcrumb in breadcrumb.category = "" }
@@ -112,8 +113,9 @@ class SentryBreadcrumbTests: XCTestCase {
         testIsNotEqual { breadcrumb in breadcrumb.type = "" }
         testIsNotEqual { breadcrumb in breadcrumb.origin = "" }
         testIsNotEqual { breadcrumb in breadcrumb.message = "" }
-        testIsNotEqual { breadcrumb in breadcrumb.data?.removeAll() }
+        testIsNotEqual { breadcrumb in breadcrumb.data = [:] }
     }
+    // swiftlint:enable no_breadcrumb_data_setter
     
     private func testIsNotEqual(block: (Breadcrumb) -> Void ) {
         let breadcrumb = Fixture().breadcrumb

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -271,6 +271,14 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.data?["other"] as? String, "kept")
     }
 
+    func testSetDataValueForKey_whenValueIsNilAndDataIsNil_keepsDataNil() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test")
+
+        breadcrumb.setData(value: nil, key: "key")
+
+        XCTAssertNil(breadcrumb.data)
+    }
+
     func testSetDataValueForKey_whenCalledConcurrently_shouldNotCrash() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
 

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -15,7 +15,7 @@ class SentryBreadcrumbTests: XCTestCase {
         
         init() {
             date = Date(timeIntervalSince1970: 10)
-            
+
             breadcrumb = Breadcrumb()
             breadcrumb.level = SentryLevel.info
             breadcrumb.timestamp = date
@@ -23,8 +23,7 @@ class SentryBreadcrumbTests: XCTestCase {
             breadcrumb.type = type
             breadcrumb.origin = origin
             breadcrumb.message = message
-            // swiftlint:disable:next no_breadcrumb_data_setter
-            breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
+            breadcrumb.setData(value: ["data": "data", "date": date] as [String: Any], key: "some")
         }
         
         var dateAs8601String: String {
@@ -106,6 +105,7 @@ class SentryBreadcrumbTests: XCTestCase {
     }
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testNotIsEqual() {
         testIsNotEqual { breadcrumb in breadcrumb.level = SentryLevel.error }
         testIsNotEqual { breadcrumb in breadcrumb.category = "" }
@@ -124,6 +124,7 @@ class SentryBreadcrumbTests: XCTestCase {
     }
     
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSerialize() {
         let crumb = fixture.breadcrumb
         let actual = crumb.serialize()
@@ -212,6 +213,7 @@ class SentryBreadcrumbTests: XCTestCase {
     // MARK: - Thread Safety
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSerialize_whenPropertiesMutatedConcurrently_shouldNotCrash() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
         breadcrumb.message = "initial"
@@ -258,10 +260,9 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.data?["connectivity"] as? String, "wifi")
     }
 
-    // swiftlint:disable no_breadcrumb_data_setter
     func testSetDataValueForKey_whenDataExists_mergesWithoutRemovingOtherKeys() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
-        breadcrumb.data = ["existing": "value"]
+        breadcrumb.setData(value: "value", key: "existing")
 
         breadcrumb.setData(value: "wifi", key: "connectivity")
 
@@ -271,14 +272,14 @@ class SentryBreadcrumbTests: XCTestCase {
 
     func testSetDataValueForKey_whenValueIsNil_removesKey() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
-        breadcrumb.data = ["key": "value", "other": "kept"]
+        breadcrumb.setData(value: "value", key: "key")
+        breadcrumb.setData(value: "kept", key: "other")
 
         breadcrumb.setData(value: nil, key: "key")
 
         XCTAssertNil(breadcrumb.data?["key"])
         XCTAssertEqual(breadcrumb.data?["other"] as? String, "kept")
     }
-    // swiftlint:enable no_breadcrumb_data_setter
 
     func testSetDataValueForKey_whenValueIsNilAndDataIsNil_keepsDataNil() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
@@ -298,6 +299,7 @@ class SentryBreadcrumbTests: XCTestCase {
     }
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSerialize_whenDataContainsConcurrentlyMutatedNestedDict_shouldNotCrash() {
         // nonisolated(unsafe) silences the Sendable warning — this test intentionally
         // mutates the dictionary from multiple threads to verify deep-copy safety.
@@ -335,6 +337,7 @@ class SentryBreadcrumbTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSerialize_whenDataContainsConcurrentlyMutatedArray_shouldNotCrash() {
         // nonisolated(unsafe) silences the Sendable warning — this test intentionally
         // mutates the array from multiple threads to verify deep-copy safety.
@@ -372,6 +375,7 @@ class SentryBreadcrumbTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSerialize_whenDataReassignedConcurrently_shouldNotCrash() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
         breadcrumb.data = ["initial": "value"]
@@ -385,6 +389,8 @@ class SentryBreadcrumbTests: XCTestCase {
 
     // MARK: - Snapshot Copy
 
+    // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSnapshotCopy_copiesAllProperties() {
         let original = Breadcrumb(level: .error, category: "navigation")
         original.timestamp = Date(timeIntervalSince1970: 42)
@@ -406,6 +412,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(nested?["a"] as? Int, 1)
     }
 
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testSnapshotCopy_isIndependentOfOriginal() {
         let original = Breadcrumb(level: .info, category: "ui")
         original.message = "before"
@@ -423,6 +430,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(snapshot.message, "before")
         XCTAssertEqual(snapshot.data?["key"] as? String, "before")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testSnapshotCopy_isDifferentInstance() {
         let original = Breadcrumb(level: .info, category: "test")

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -53,6 +53,23 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.message, fixture.message)
         XCTAssertEqual(breadcrumb.data as? [String: String], ["foo": "bar"])
     }
+
+    func testInitWithLevelCategoryData() {
+        let breadcrumb = Breadcrumb(level: .warning, category: "test", data: ["foo": "bar", "baz": 1])
+
+        XCTAssertEqual(breadcrumb.level, SentryLevel.warning)
+        XCTAssertEqual(breadcrumb.category, "test")
+        XCTAssertNotNil(breadcrumb.timestamp)
+        XCTAssertEqual(breadcrumb.data?["foo"] as? String, "bar")
+        XCTAssertEqual(breadcrumb.data?["baz"] as? Int, 1)
+    }
+
+    func testInitWithLevelCategoryData_whenDataIsNil() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test", data: nil)
+
+        XCTAssertEqual(breadcrumb.category, "test")
+        XCTAssertNil(breadcrumb.data)
+    }
     
     func testHash() {
         let fixture2 = Fixture()
@@ -206,6 +223,45 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertNil(breadcrumb.data?["newKey"])
         let nested = breadcrumb.data?["nested"] as? NSDictionary
         XCTAssertEqual(nested?["inner"] as? String, "original")
+    }
+
+    // MARK: - setData(value:key:)
+
+    func testSetDataValueForKey_whenDataIsNil_createsDictionary() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test")
+
+        breadcrumb.setData(value: "wifi", key: "connectivity")
+
+        XCTAssertEqual(breadcrumb.data?["connectivity"] as? String, "wifi")
+    }
+
+    func testSetDataValueForKey_whenDataExists_mergesWithoutRemovingOtherKeys() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test")
+        breadcrumb.data = ["existing": "value"]
+
+        breadcrumb.setData(value: "wifi", key: "connectivity")
+
+        XCTAssertEqual(breadcrumb.data?["existing"] as? String, "value")
+        XCTAssertEqual(breadcrumb.data?["connectivity"] as? String, "wifi")
+    }
+
+    func testSetDataValueForKey_whenValueIsNil_removesKey() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test")
+        breadcrumb.data = ["key": "value", "other": "kept"]
+
+        breadcrumb.setData(value: nil, key: "key")
+
+        XCTAssertNil(breadcrumb.data?["key"])
+        XCTAssertEqual(breadcrumb.data?["other"] as? String, "kept")
+    }
+
+    func testSetDataValueForKey_whenCalledConcurrently_shouldNotCrash() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test")
+
+        testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 1_000) { i in
+            breadcrumb.setData(value: "value\(i)", key: "key\(i % 10)")
+            _ = breadcrumb.serialize()
+        }
     }
 
     func testSerialize_whenDataContainsConcurrentlyMutatedNestedDict_shouldNotCrash() {

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -64,11 +64,11 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.data?["baz"] as? Int, 1)
     }
 
-    func testInitWithLevelCategoryData_whenDataIsNil() {
-        let breadcrumb = Breadcrumb(level: .info, category: "test", data: nil)
+    func testInitWithLevelCategoryData_whenDataIsEmpty() {
+        let breadcrumb = Breadcrumb(level: .info, category: "test", data: [:])
 
         XCTAssertEqual(breadcrumb.category, "test")
-        XCTAssertNil(breadcrumb.data)
+        XCTAssertEqual(breadcrumb.data?.isEmpty, true)
     }
     
     func testHash() {

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -141,7 +141,23 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(fixture.message, actual["message"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": fixture.dateAs8601String]], actual["data"] as? Dictionary)
     }
-    
+
+    func testSerialize_whenDataIsEmpty_shouldOmitData() {
+        let crumb = Breadcrumb(level: .info, category: "test", data: [:])
+
+        let actual = crumb.serialize()
+
+        XCTAssertNil(actual["data"])
+    }
+
+    func testSerialize_whenDataIsNil_shouldOmitData() {
+        let crumb = Breadcrumb(level: .info, category: "test")
+
+        let actual = crumb.serialize()
+
+        XCTAssertNil(actual["data"])
+    }
+
     func testDescription() {
         let crumb = fixture.breadcrumb
         let actual = crumb.description

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -23,6 +23,7 @@ class SentryBreadcrumbTests: XCTestCase {
             breadcrumb.type = type
             breadcrumb.origin = origin
             breadcrumb.message = message
+            // swiftlint:disable:next no_breadcrumb_data_setter
             breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
         }
         
@@ -120,10 +121,11 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertNotEqual(fixture.breadcrumb, breadcrumb)
     }
     
+    // swiftlint:disable no_breadcrumb_data_setter
     func testSerialize() {
         let crumb = fixture.breadcrumb
         let actual = crumb.serialize()
-        
+
         // Changing the original doesn't modify the serialized
         crumb.level = SentryLevel.debug
         crumb.timestamp = nil
@@ -132,7 +134,7 @@ class SentryBreadcrumbTests: XCTestCase {
         crumb.origin = ""
         crumb.message = ""
         crumb.data = nil
-        
+
         XCTAssertEqual("info", actual["level"] as? String)
         XCTAssertEqual(fixture.dateAs8601String, actual["timestamp"] as? String)
         XCTAssertEqual(fixture.category, actual["category"] as? String)
@@ -141,6 +143,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(fixture.message, actual["message"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": fixture.dateAs8601String]], actual["data"] as? Dictionary)
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testSerialize_whenDataIsEmpty_shouldOmitData() {
         let crumb = Breadcrumb(level: .info, category: "test", data: [:])
@@ -206,6 +209,7 @@ class SentryBreadcrumbTests: XCTestCase {
 
     // MARK: - Thread Safety
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testSerialize_whenPropertiesMutatedConcurrently_shouldNotCrash() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
         breadcrumb.message = "initial"
@@ -219,6 +223,7 @@ class SentryBreadcrumbTests: XCTestCase {
             _ = breadcrumb.serialize()
         }
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testDataProperty_whenAssignedMutableDictionary_shouldDeepCopy() {
         let innerMutable = NSMutableDictionary(dictionary: ["inner": "original"])
@@ -251,6 +256,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.data?["connectivity"] as? String, "wifi")
     }
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testSetDataValueForKey_whenDataExists_mergesWithoutRemovingOtherKeys() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
         breadcrumb.data = ["existing": "value"]
@@ -270,6 +276,7 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertNil(breadcrumb.data?["key"])
         XCTAssertEqual(breadcrumb.data?["other"] as? String, "kept")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testSetDataValueForKey_whenValueIsNilAndDataIsNil_keepsDataNil() {
         let breadcrumb = Breadcrumb(level: .info, category: "test")
@@ -288,6 +295,7 @@ class SentryBreadcrumbTests: XCTestCase {
         }
     }
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testSerialize_whenDataContainsConcurrentlyMutatedNestedDict_shouldNotCrash() {
         // nonisolated(unsafe) silences the Sendable warning — this test intentionally
         // mutates the dictionary from multiple threads to verify deep-copy safety.
@@ -371,6 +379,7 @@ class SentryBreadcrumbTests: XCTestCase {
             _ = breadcrumb.serialize()
         }
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     // MARK: - Snapshot Copy
 

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -23,17 +23,15 @@ class TestData {
     // portably malformed.
     static let malformedURLString = "http://exa mple.com"
     
-    // swiftlint:disable no_breadcrumb_data_setter
     static var crumb: Breadcrumb {
         let crumb = Breadcrumb()
         crumb.level = SentryLevel.info
         crumb.timestamp = timestamp
         crumb.type = "user"
         crumb.message = "Clicked something"
-        crumb.data = ["some": ["data": "data", "date": timestamp] as [String: Any]]
+        crumb.setData(value: ["data": "data", "date": timestamp] as [String: Any], key: "some")
         return crumb
     }
-    // swiftlint:enable no_breadcrumb_data_setter
     
     static var event: Event {
         let event = Event(level: SentryLevel.info)

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -23,6 +23,7 @@ class TestData {
     // portably malformed.
     static let malformedURLString = "http://exa mple.com"
     
+    // swiftlint:disable no_breadcrumb_data_setter
     static var crumb: Breadcrumb {
         let crumb = Breadcrumb()
         crumb.level = SentryLevel.info
@@ -32,6 +33,7 @@ class TestData {
         crumb.data = ["some": ["data": "data", "date": timestamp] as [String: Any]]
         return crumb
     }
+    // swiftlint:enable no_breadcrumb_data_setter
     
     static var event: Event {
         let event = Event(level: SentryLevel.info)

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -369,7 +369,7 @@
                                                               category:@"http"];
     XCTAssertTrue(crumb2.level >= 0);
     XCTAssertNotNil(crumb2.category);
-    crumb2.data = @{ @"bla" : @"1" };
+    [crumb2 setDataValue:@"1" forKey:@"bla"];
     crumb2.type = @"type";
     crumb2.timestamp = date;
     crumb2.message = @"message";

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -47,8 +47,7 @@ class SentryScopeSwiftTests: XCTestCase {
             breadcrumb.timestamp = date
             breadcrumb.type = "user"
             breadcrumb.message = "Clicked something"
-            // swiftlint:disable:next no_breadcrumb_data_setter
-            breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
+            breadcrumb.setData(value: ["data": "data", "date": date] as [String: Any], key: "some")
 
             scope = Scope(maxBreadcrumbs: maxBreadcrumbs)
             scope.setUser(user)
@@ -773,6 +772,7 @@ class SentryScopeSwiftTests: XCTestCase {
     }
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testAddBreadcrumb_storesDefensiveCopy() {
         let scope = Scope(maxBreadcrumbs: 5)
         let crumb = Breadcrumb(level: .info, category: "ui")
@@ -796,6 +796,7 @@ class SentryScopeSwiftTests: XCTestCase {
     // swiftlint:enable no_breadcrumb_data_setter
 
     // swiftlint:disable no_breadcrumb_data_setter
+    @available(*, deprecated, message: "Testing deprecated Breadcrumb.data setter")
     func testAddBreadcrumb_evictionDoesNotCrash_whenReadConcurrently() {
         // Regression test for https://github.com/getsentry/sentry-cocoa/issues/8013
         // The ring buffer evicts old breadcrumbs when full. Without a defensive copy,

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -47,8 +47,9 @@ class SentryScopeSwiftTests: XCTestCase {
             breadcrumb.timestamp = date
             breadcrumb.type = "user"
             breadcrumb.message = "Clicked something"
+            // swiftlint:disable:next no_breadcrumb_data_setter
             breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
-            
+
             scope = Scope(maxBreadcrumbs: maxBreadcrumbs)
             scope.setUser(user)
             scope.setTag(value: tags["key"] ?? "", key: "key")
@@ -771,6 +772,7 @@ class SentryScopeSwiftTests: XCTestCase {
         })
     }
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testAddBreadcrumb_storesDefensiveCopy() {
         let scope = Scope(maxBreadcrumbs: 5)
         let crumb = Breadcrumb(level: .info, category: "ui")
@@ -791,7 +793,9 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(stored?.data?["key"] as? String, "before",
             "Stored breadcrumb data should not reflect mutations to the original")
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
+    // swiftlint:disable no_breadcrumb_data_setter
     func testAddBreadcrumb_evictionDoesNotCrash_whenReadConcurrently() {
         // Regression test for https://github.com/getsentry/sentry-cocoa/issues/8013
         // The ring buffer evicts old breadcrumbs when full. Without a defensive copy,
@@ -837,6 +841,7 @@ class SentryScopeSwiftTests: XCTestCase {
 
         wait(for: [expectation], timeout: 30)
     }
+    // swiftlint:enable no_breadcrumb_data_setter
 
     func testScopeObserver_passesDistinctCopyToObservers() {
         // Verify that observers receive a different object (copy) than the internal

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -5019,6 +5019,54 @@
             "usr": "c:objc(cs)SentryBreadcrumb(im)serialize"
           },
           {
+            "children": [
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "kind": "TypeNameAlias",
+                "name": "Void",
+                "printedName": "Swift.Void"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ProtocolComposition",
+                    "printedName": "Any"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Any?",
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declAttributes": [
+              "Dynamic",
+              "ObjC"
+            ],
+            "declKind": "Func",
+            "funcSelfKind": "NonMutating",
+            "isOpen": true,
+            "kind": "Function",
+            "moduleName": "Sentry",
+            "name": "setData",
+            "objc_name": "setDataValue:forKey:",
+            "printedName": "setData(value:key:)",
+            "usr": "c:objc(cs)SentryBreadcrumb(im)setDataValue:forKey:"
+          },
+          {
             "accessors": [
               {
                 "accessorKind": "get",

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -5240,10 +5240,12 @@
                   }
                 ],
                 "declAttributes": [
+                  "Available",
                   "Dynamic",
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "deprecated": true,
                 "isOpen": true,
                 "kind": "Accessor",
                 "moduleName": "Sentry",

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -5564,6 +5564,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "setDataValue:forKey:",
+    "parent": "SentryObjCBreadcrumb",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setDataValue:forKey:",
     "parent": "SentryObjCSpan",
     "returnType": "void",
     "instance": true

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -5782,6 +5782,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "setDataValue:forKey:",
+    "parent": "SentryObjCBreadcrumb",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setDataValue:forKey:",
     "parent": "SentryObjCSpan",
     "returnType": "void",
     "instance": true

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -5019,6 +5019,54 @@
             "usr": "c:objc(cs)SentryBreadcrumb(im)serialize"
           },
           {
+            "children": [
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "kind": "TypeNameAlias",
+                "name": "Void",
+                "printedName": "Swift.Void"
+              },
+              {
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ProtocolComposition",
+                    "printedName": "Any"
+                  }
+                ],
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Any?",
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "String",
+                "printedName": "Swift.String",
+                "usr": "s:SS"
+              }
+            ],
+            "declAttributes": [
+              "Dynamic",
+              "ObjC"
+            ],
+            "declKind": "Func",
+            "funcSelfKind": "NonMutating",
+            "isOpen": true,
+            "kind": "Function",
+            "moduleName": "Sentry",
+            "name": "setData",
+            "objc_name": "setDataValue:forKey:",
+            "printedName": "setData(value:key:)",
+            "usr": "c:objc(cs)SentryBreadcrumb(im)setDataValue:forKey:"
+          },
+          {
             "accessors": [
               {
                 "accessorKind": "get",

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -5240,10 +5240,12 @@
                   }
                 ],
                 "declAttributes": [
+                  "Available",
                   "Dynamic",
                   "ObjC"
                 ],
                 "declKind": "Accessor",
+                "deprecated": true,
                 "isOpen": true,
                 "kind": "Accessor",
                 "moduleName": "Sentry",


### PR DESCRIPTION
## 📜 Description

Add `Breadcrumb.setData(value:key:)` and a private `initWithLevel:category:data:` that build native storage instead of deep-copying, and migrate all internal breadcrumb `data` assignments to them. Adds a SwiftLint rule flagging the `data` setter and exposes the new method in the ObjC wrapper.

## 💡 Motivation and Context

Assigning a bridged Swift dictionary to `Breadcrumb.data` could crash with `EXC_BAD_ACCESS` in `sentry_deepCopyValue`.

Fixes getsentry/sentry-cocoa#7861.

**Why not fix** `sentry_deepCopyValue` **directly?** The crash in the report stems from an automatically generated breadcrumb, so migrating the SDK's own breadcrumbs to the new `setData(value:key:)` setter avoids the crashing deep-copy path entirely and makes it hit far less often. We deliberately kept the existing `data` deep copy as-is rather than fixing it, since we plan to remove it in the next major (getsentry/sentry-cocoa#8573).

Follow-up for V10: getsentry/sentry-cocoa#8573 (make `Breadcrumb.data` read-only).

## 💚 How did you test it?

Unit tests for the new API; `SentryBreadcrumbTests`, `SentrySystemEventBreadcrumbsTest`, `SentryBreadcrumbTrackerTests`, `SentryObjCBreadcrumbTests` pass.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).