### PR TITLE
fix: Skip cryptex images in SDK validation

### DIFF
--- a/Sources/Swift/Tools/LoadValidator.swift
+++ b/Sources/Swift/Tools/LoadValidator.swift
@@ -31,8 +31,9 @@ import MachO
     class func internalCheckForDuplicatedSDK(_ imageName: String, _ imageAddress: UInt64, _ imageSize: UInt64, objcRuntimeWrapper: SentryObjCRuntimeWrapper, dispatchQueueWrapper: SentryDispatchQueueWrapper, resultHandler: ((Bool) -> Void)? = nil) {
         let systemLibraryPath = "/usr/lib/"
         let ignoredPathDevelopers = "/Library/Developer/CoreSimulator/Volumes/"
+        let ignoredPathCryptex = "/private/var/run/com.apple.security.cryptexd/mnt/"
         let ignoredPathSystem = "/System/Library/"
-        guard !imageName.hasPrefix(ignoredPathDevelopers) && !imageName.hasPrefix(ignoredPathSystem) && !imageName.hasPrefix(systemLibraryPath) else {
+        guard !imageName.hasPrefix(ignoredPathDevelopers) && !imageName.hasPrefix(ignoredPathCryptex) && !imageName.hasPrefix(ignoredPathSystem) && !imageName.hasPrefix(systemLibraryPath) else {
             resultHandler?(false)
             return
         }

--- a/Tests/SentryTests/Swift/Core/Tools/LoadValidatorTests.swift
+++ b/Tests/SentryTests/Swift/Core/Tools/LoadValidatorTests.swift
@@ -90,6 +90,34 @@ class LoadValidatorTests: XCTestCase {
         XCTAssertEqual(dispatchQueueWrapper.dispatchAsyncInvocations.count, 0)
     }
     
+    func testValidateSDKPresenceIn_CryptexSimulatorPath_DoesNotValidate() {
+        // Arrange
+        let imageName = "/private/var/run/com.apple.security.cryptexd/mnt/iOS_24A5279h/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 27.0.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIKit.framework/UIKit"
+        var getClassListCalled = false
+        testObjCRuntimeWrapper.beforeGetClassList = {
+            getClassListCalled = true
+        }
+        let expectation = XCTestExpectation(description: "LoadValidation should complete")
+
+        // Act
+        var validationResult = false
+        LoadValidator.internalCheckForDuplicatedSDK(imageName,
+                                                    defaultImageAddress,
+                                                    defaultImageSize,
+                                                    objcRuntimeWrapper: testObjCRuntimeWrapper,
+                                                    dispatchQueueWrapper: dispatchQueueWrapper) { result in
+            validationResult = result
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+
+        // Assert
+        XCTAssertFalse(validationResult, "Validation should return false for cryptex simulator libraries")
+        XCTAssertFalse(getClassListCalled, "ObjectiveC Wrapper should not be called for a cryptex simulator library")
+        XCTAssertFalse(testOutput.loggedMessages.contains { $0.contains("❌ Sentry SDK was loaded multiple times") })
+        XCTAssertEqual(dispatchQueueWrapper.dispatchAsyncInvocations.count, 0)
+    }
+
     func testValidateSDKPresenceIn_SystemPath_DoesNotValidate() {
         // Arrange
         let imageName = "/System/Library/system.dylib"


### PR DESCRIPTION
#skip-changelog

## 📜 Description

Exclude xOS 27 simulator images mounted through cryptex from duplicate-SDK validation. This prevents expensive system-image scans from blocking Sentry’s shared queue and delaying launch-profiling work. Adds regression coverage for cryptex simulator paths.

The failing iOS 27 tests were:

* LaunchProfilingVCTransactionUITests/testVCTransactionsCapturedDuringLaunchProfiling
* ProfilingUITests/testAppLaunchesWithContinuousProfilerV2ManualLifeCycle
* ProfilingUITests/testAppLaunchesWithContinuousProfilerV2TraceLifecycle

## 💡 Motivation and Context

Closes getsentry/sentry-cocoa#8575

## 💚 How did you test it?

* Running tests locally with iOS 27 beta 3.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).