### PR TITLE
ref: Lint allHTTPHeaderFields case-sensitivity

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -132,11 +132,13 @@ custom_rules:
       - "./Tests/.*\\.swift"
   avoid_all_header_fields:
     name: "Careful with allHeaderFields"
-    message: "Double-check how you use allHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but its subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see #8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in HTTPURLResponse+Sentry.swift. If your usage is intentional, suppress this rule with a comment explaining why."
-    regex: "allHeaderFields"
+    message: "Double-check how you use allHeaderFields / allHTTPHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but their subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see #8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in HTTPURLResponse+Sentry.swift. If your usage is intentional, suppress this rule with a comment explaining why."
+    regex: "all(HTTP)?HeaderFields"
     match_kinds:
       - identifier
     severity: error
+    included:
+      - "./Sources/.*\\.swift"
   avoid_direct_associated_object_access:
     name: "Avoid direct associated object access"
     message: "Use AssociatedObjectAccessor instead of calling the Objective-C associated object APIs directly."

--- a/Makefile
+++ b/Makefile
@@ -1397,7 +1397,7 @@ STAGED_OBJC_HEADER_FILES := $(shell git diff --cached --diff-filter=d --name-onl
 
 # Message for the allHeaderFields banned-pattern lint, aligned with the SwiftLint
 # rule in PR #8387 (rule id avoid_all_header_fields).
-AVOID_ALL_HEADER_FIELDS_MSG := Double-check how you use allHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but its subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see \#8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in HTTPURLResponse+Sentry.swift. If your usage is intentional, suppress this rule with a comment explaining why.
+AVOID_ALL_HEADER_FIELDS_MSG := Double-check how you use allHeaderFields / allHTTPHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but their subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see \#8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in HTTPURLResponse+Sentry.swift. If your usage is intentional, suppress this rule with a comment explaining why.
 
 ## Run linting checks on all files
 #
@@ -1408,7 +1408,7 @@ lint:
 	./scripts/check-clang-format.py -r Sources Tests
 	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
 	./scripts/check-objc-banned-pattern.sh --path Sources \
-		--rule avoid_all_header_fields --pattern 'allHeaderFields' \
+		--rule avoid_all_header_fields --pattern 'all(HTTP)?HeaderFields' \
 		--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"
 	swiftlint --strict --quiet
 	dprint check "**/*.{md,json,yaml,yml}"
@@ -1429,7 +1429,7 @@ lint-staged:
 	@if [ -n "$(STAGED_CLANG_FILES)" ]; then \
 		for f in $(STAGED_CLANG_FILES); do \
 			./scripts/check-objc-banned-pattern.sh --path "$$f" \
-				--rule avoid_all_header_fields --pattern 'allHeaderFields' \
+				--rule avoid_all_header_fields --pattern 'all(HTTP)?HeaderFields' \
 				--message "$(AVOID_ALL_HEADER_FIELDS_MSG)" || exit 1; \
 		done; \
 	fi

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -425,8 +425,11 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     request.fragment = url.fragment;
     request.queryString = url.query;
     request.bodySize = [NSNumber numberWithLongLong:sessionTask.countOfBytesSent];
+    // Safe: reading the whole dictionary, not a case-sensitive single-header lookup.
+    // sentry-lint:disable avoid_all_header_fields
     if (nil != currentRequest.allHTTPHeaderFields) {
         NSDictionary<NSString *, NSString *> *headers = currentRequest.allHTTPHeaderFields.copy;
+        // sentry-lint:enable avoid_all_header_fields
 #if SDK_V10
         HTTPHeaderSanitizationResultObjC *sanitizedHeaders = [HTTPHeaderSanitizerObjC
             sanitizeRequestHeaders:headers
@@ -758,10 +761,14 @@ static const void *SentryNetworkDetailsKey = &SentryNetworkDetailsKey;
     NSNumber *requestSize = rawBody ? [NSNumber numberWithUnsignedInteger:rawBody.length] : nil;
     NSData *bodyData = networkCaptureBodies ? rawBody : nil;
 
+    // Safe: passing the whole dictionary, not a case-sensitive single-header lookup.
+    // sentry-lint:disable avoid_all_header_fields
+    NSDictionary<NSString *, NSString *> *_Nullable allHeaders = request.allHTTPHeaderFields;
+    // sentry-lint:enable avoid_all_header_fields
     [details setRequestWithSize:requestSize
                        bodyData:bodyData
                     contentType:[request valueForHTTPHeaderField:@"content-type"]
-                     allHeaders:request.allHTTPHeaderFields
+                     allHeaders:allHeaders
               configuredHeaders:networkRequestHeaders];
 }
 #endif // SENTRY_TARGET_REPLAY_SUPPORTED

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -31,8 +31,7 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
     NSString *baggageHeader = @"";
 
     if (baggage != nil) {
-        NSString *_Nullable rawHeader
-            = SENTRY_UNWRAP_NULLABLE(NSString, request.allHTTPHeaderFields[SENTRY_BAGGAGE_HEADER]);
+        NSString *_Nullable rawHeader = [request valueForHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
         NSDictionary *originalBaggage = [SentryBaggageSerialization decode:rawHeader ?: @""];
         if (originalBaggage[@"sentry-trace_id"] == nil) {
             baggageHeader = [baggage toHTTPHeaderWithOriginalBaggage:originalBaggage];


### PR DESCRIPTION
Surfaced by the `relay-conformance-audit` skill (getsentry/sentry-cocoa#8574).

The `allHeaderFields` linters (getsentry/sentry-cocoa#8387, getsentry/sentry-cocoa#8389) only matched the response property, not the request property `allHTTPHeaderFields`. Broaden both to `all(HTTP)?HeaderFields` and read the baggage header via `valueForHTTPHeaderField:`.

No behavior change — `NSURLRequest.allHTTPHeaderFields` already resolves subscripts case-insensitively in ObjC; this closes the linter gap for the getsentry/sentry-cocoa#8322 bug class.

#skip-changelog

<details><summary>Audit report that surfaced this</summary>

**< />HIGH< /> 1. HTTP header reads — case-sensitive baggage header read**

When the SDK adds Sentry's trace-linking info to an outgoing request, it first checks whether the request already carries that info — but the check only recognizes an exact lowercase header name. If something else (another library, a proxy, the app itself) set that header with different capitalization, the SDK doesn't notice, and silently overwrites it with brand-new trace info instead of merging in the original. The practical effect: a trace can silently fork into two instead of being followed end-to-end, with no error or warning. This can affect any request path where something else sets that header before Sentry does.

Location: `Sources/Sentry/SentryTracePropagation.m:35`, `+[SentryTracePropagation addBaggageHeader:traceHeader:propagateTraceparent:tracePropagationTargets:toRequest:]` `NSString *_Nullable rawHeader = SENTRY_UNWRAP_NULLABLE(NSString, request.allHTTPHeaderFields[SENTRY_BAGGAGE_HEADER]);` where `SENTRY_BAGGAGE_HEADER = @"baggage"` — a case-sensitive `NSDictionary` subscript read of a request header.

Spec: RFC 9113 §8.2.1 / RFC 9114 §4.2 (HTTP/2/3 lowercase field names on the wire). Same bug class as getsentry/sentry-cocoa#8322 (case-sensitive X-Sentry-Rate-Limits read).

Failure mode: any casing other than exactly `baggage` (e.g. `Baggage`) makes this subscript return nil. The code then treats no baggage as present and writes a freshly synthesized baggage header via the case-insensitive `setValue:forHTTPHeaderField:` — silently overwriting the original, differently-cased header and discarding its `sentry-trace_id` and other members.

Verify:

* Set a request header via `setValue:@"..." forHTTPHeaderField:@"Baggage"` (capital B) before calling `addBaggageHeader:...:toRequest:`.
* Confirm the original baggage members are lost, replaced by a freshly synthesized string.
* Contrast with the same file's correct pattern (< />lines 69/73) using `valueForHTTPHeaderField:` for sentry-trace/traceparent, which is unaffected.

</details>