### PR TITLE
fix: Screenshots not being captured by hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix screenshots not being captured by hybrid SDKs (#8578)
 - Fix trace propagation for manually instrumented transactions when automatic performance tracing is disabled (#8522)
 - Remove x/y coordinates from UI breadcrumbs, as they are a potential security risk, for example leaking input on custom PIN code views (#8534)
 

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -350,25 +350,38 @@ extension SentryFileManager: SentryFileManagerProtocol { }
 
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
     private var _screenshotSource: SentryScreenshotSource?
-    @objc public lazy var screenshotSource: SentryScreenshotSource? = getOptionalLazyVar(\._screenshotSource) {
-        // The options could be null here, but this is a general issue in the dependency
-        // container and will be fixed in a future refactoring.
-        guard let options = self.startOptions else {
-            return nil
-        }
+    // Computed property (not a `lazy var`): a `lazy var` caches its first value
+    // forever. If `screenshotSource` is first accessed before `startOptions` is
+    // set — e.g. a hybrid SDK touching `SentrySDK.internal` before `SentrySDK.start` —
+    // the builder returns `nil` and a `lazy var` would cache that `nil` permanently,
+    // so screenshots could never be captured for the rest of the process. As a
+    // computed property, `getOptionalLazyVar` re-runs the builder until `startOptions`
+    // is available and only then caches the built source in `_screenshotSource`.
+    @objc public var screenshotSource: SentryScreenshotSource? {
+        get {
+            getOptionalLazyVar(\._screenshotSource) {
+                guard let options = self.startOptions else {
+                    return nil
+                }
 
-        let viewRenderer: SentryViewRenderer
-        if options.screenshot.enableViewRendererV2 {
-            viewRenderer = SentryViewRendererV2(enableFastViewRendering: options.screenshot.enableFastViewRendering)
-        } else {
-            viewRenderer = SentryDefaultViewRenderer()
-        }
+                let viewRenderer: SentryViewRenderer
+                if options.screenshot.enableViewRendererV2 {
+                    viewRenderer = SentryViewRendererV2(enableFastViewRendering: options.screenshot.enableFastViewRendering)
+                } else {
+                    viewRenderer = SentryDefaultViewRenderer()
+                }
 
-        let photographer = SentryViewPhotographer(
-            renderer: viewRenderer,
-            redactOptions: options.screenshot,
-            enableMaskRendererV2: options.screenshot.enableViewRendererV2)
-        return SentryScreenshotSource(photographer: photographer)
+                let photographer = SentryViewPhotographer(
+                    renderer: viewRenderer,
+                    redactOptions: options.screenshot,
+                    enableMaskRendererV2: options.screenshot.enableViewRendererV2)
+                return SentryScreenshotSource(photographer: photographer)
+            }
+        }
+        // Keep a setter (a `lazy var` was settable) so tests can inject a mock source.
+        set {
+            paramLock.synchronized { _screenshotSource = newValue }
+        }
     }
 
     private var _sessionReplayBreadcrumbConverter: SentryReplayBreadcrumbConverter?

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -26,6 +26,36 @@ final class SentryDependencyContainerTests: XCTestCase {
         SentryDependencyContainer.reset()
 
     }
+
+    // Regression test for getsentry/sentry-react-native#6497: `screenshotSource`
+    // must not permanently cache `nil` when it is first accessed before
+    // `startOptions` is set. Hybrid SDKs (e.g. React Native) touch
+    // `SentrySDK.internal` — which reads `screenshotSource` — before
+    // `SentrySDK.start`. When `screenshotSource` was a `lazy var`, that first
+    // pre-start access cached `nil` for the whole process, breaking all iOS
+    // screenshot capture (Feedback Widget, attachScreenshot, captureScreenshot).
+    func testScreenshotSource_AccessedBeforeStartOptions_RebuildsAfterStart() throws {
+        // `reset()` gives a fresh container (clearing the cached `_screenshotSource`)
+        // but intentionally preserves `startOptions`, so force the pre-start state
+        // explicitly to make this test independent of other tests' ordering.
+        SentryDependencyContainer.reset()
+        let sut = SentryDependencyContainer.sharedInstance()
+        sut.startOptions = nil
+
+        // Accessed before `startOptions` is set: `nil` is expected here...
+        XCTAssertNil(sut.screenshotSource)
+
+        // ...but it must not be cached. Once the options are set (SDK start), the
+        // source must be (re)built. With the previous `lazy var` it stayed `nil`.
+        let options = Options()
+        options.dsn = SentryDependencyContainerTests.dsn
+        sut.startOptions = options
+
+        XCTAssertNotNil(sut.screenshotSource)
+
+        sut.startOptions = nil
+        SentryDependencyContainer.reset()
+    }
 #endif
 
 #if os(macOS)


### PR DESCRIPTION
## 📜 Description

`SentryDependencyContainer.screenshotSource` was a `lazy var` wrapping `getOptionalLazyVar`. `getOptionalLazyVar` is designed to retry its builder until the value can be produced, but the `lazy var` defeats that: it runs the initializer once and caches whatever the first access returned. The builder returns `nil` when `startOptions` isn't set yet, so if `screenshotSource` is first read before the SDK is started, that `nil` gets cached permanently and no screenshot can be captured for the rest of the process.

This changes `screenshotSource` from a `lazy var` to a computed property so `getOptionalLazyVar` re-runs the builder until `startOptions` is available, then caches the built source. The setter is kept (a `lazy var` was settable, and tests inject a mock source). Adds a regression test.

## 💡 Motivation and Context

Hybrid SDKs touch `SentrySDK.internal` before `SentrySDK.start` (e.g. React Native reads SDK metadata / app-start data during init). Constructing `SentrySDK.internal` eagerly reads `screenshotSource`, which poisoned the `lazy var` and broke **all** screenshot capture on iOS — Feedback Widget screenshots, `attachScreenshot`, and `SentrySDK.internal.screenshot.capture()`. This shipped as a regression in sentry-react-native 8.19.0.

**This is the sentry-cocoa fix tracked by** getsentry/sentry-react-native#6507\*\*.\*\* That issue reverted the RN migration (getsentry/sentry-react-native#6380) as an interim fix; once this cocoa change ships and RN bumps the cocoa dependency, the RN migration will be reapplied.

* Original RN regression report: getsentry/sentry-react-native#6497
* Tracking / reapply follow-up: getsentry/sentry-react-native#6507

## 💚 How did you test it?

Added `testScreenshotSource_AccessedBeforeStartOptions_RebuildsAfterStart`, which reproduces the sequence: read `screenshotSource` before `startOptions` is set (→ `nil`, and must not be cached), set options, then assert it's rebuilt (non-`nil`). It fails on the old `lazy var` and passes with the fix.

Ran on the iOS 18.6 simulator across `SentryDependencyContainerTests`, `SentryScreenshotIntegrationTests`, `SentryScreenshotSourceTests`, and `UserFeedbackIntegrationTests` — all passing.

## :pencil: Checklist

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)