### PR TITLE
ci: Run ObjC banned-pattern lint in CI

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -108,6 +108,8 @@ run_lint_clang_formatting_for_prs: &run_lint_clang_formatting_for_prs
   # Scripts
   - "scripts/ci-diagnostics.sh"
   - "scripts/ci-utils.sh"
+  - "scripts/check-objc-id-usage.rb"
+  - "scripts/check-objc-banned-pattern.sh"
 
   # Build configuration
   - "Makefile"

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -67,8 +67,24 @@ jobs:
         uses: ./.github/actions/ci-diagnostics
         if: failure()
 
+  check-objc-patterns:
+    name: Check ObjC Patterns
+    # Run the job only for PRs with related changes or non-PR events.
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_clang_formatting_for_prs == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Check ObjC id usage
+        run: make check-objc-id-usage
+      - name: Check ObjC banned patterns
+        run: make check-objc-banned-patterns
+      - name: Run CI Diagnostics
+        uses: ./.github/actions/ci-diagnostics
+        if: failure()
+
   lint_clang_formatting-required-check:
-    needs: [files-changed, lint]
+    needs: [files-changed, lint, check-objc-patterns]
     name: Lint Clang
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()

--- a/Makefile
+++ b/Makefile
@@ -1399,6 +1399,22 @@ STAGED_OBJC_HEADER_FILES := $(shell git diff --cached --diff-filter=d --name-onl
 # rule in PR #8387 (rule id avoid_all_header_fields).
 AVOID_ALL_HEADER_FIELDS_MSG := Double-check how you use allHeaderFields / allHTTPHeaderFields (https://developer.apple.com/documentation/foundation/httpurlresponse/allheaderfields). Reading all headers is fine, but their subscript is case-sensitive while HTTP/2 and HTTP/3 lowercase field names, so a single-header lookup can silently miss the header (see \#8322). For a lookup, use value(forHTTPHeaderField:) or the HTTPURLResponse.value(forHTTPHeaderFieldCaseInsensitive:) extension in HTTPURLResponse+Sentry.swift. If your usage is intentional, suppress this rule with a comment explaining why.
 
+## Check Objective-C header files for bare 'id' usage without SENTRY_SWIFT_MIGRATION_ID
+#
+# Standalone target so CI can run this check without a macOS runner.
+.PHONY: check-objc-id-usage
+check-objc-id-usage:
+	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
+
+## Check Objective-C sources for banned patterns (e.g. case-sensitive header lookups)
+#
+# Standalone target so CI can run this check without a macOS runner.
+.PHONY: check-objc-banned-patterns
+check-objc-banned-patterns:
+	./scripts/check-objc-banned-pattern.sh --path Sources \
+		--rule avoid_all_header_fields --pattern 'all(HTTP)?HeaderFields' \
+		--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"
+
 ## Run linting checks on all files
 #
 # Runs SwiftLint, Clang-Format checks, Objective-C id usage checks, Objective-C banned-pattern checks, actionlint, and dprint checks without modifying files.
@@ -1406,10 +1422,8 @@ AVOID_ALL_HEADER_FIELDS_MSG := Double-check how you use allHeaderFields / allHTT
 lint:
 	@echo "--> Running Swiftlint and Clang-Format"
 	./scripts/check-clang-format.py -r Sources Tests
-	ruby ./scripts/check-objc-id-usage.rb -r Sources/Sentry
-	./scripts/check-objc-banned-pattern.sh --path Sources \
-		--rule avoid_all_header_fields --pattern 'all(HTTP)?HeaderFields' \
-		--message "$(AVOID_ALL_HEADER_FIELDS_MSG)"
+	"$(MAKE)" check-objc-id-usage
+	"$(MAKE)" check-objc-banned-patterns
 	swiftlint --strict --quiet
 	dprint check "**/*.{md,json,yaml,yml}"
 	actionlint


### PR DESCRIPTION
## Summary
- Add a `check-objc-patterns` job to Lint Clang, running `check-objc-id-usage.rb` and `check-objc-banned-pattern.sh` on `ubuntu-latest`
- These checks previously only ran via the local pre-commit hook, so skipping it gave zero protection

## Test plan
- [x] `make check-objc-id-usage` and `make check-objc-banned-patterns` pass locally
- [x] `make lint` still passes end-to-end
- [x] Verified both checks fail on a deliberate violation

#skip-changelog

Closes #8580