### PR TITLE
fix: Data race in SentryFramesTracker frame data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix a data race in `SentryFramesTracker` that could crash the app while profiling is active. The display link callback appended to the profiling frame timeseries on the main thread while `currentFrames()` copied those arrays from whichever thread created or finished a tracer, or transmitted a profile chunk. Copying a Swift `Array` during a concurrent append retains a `_ContiguousArrayStorage` whose lifetime the appending thread owns, so a resize could free the buffer out from under the reader, crashing later when the snapshot deallocated. The frame counters and `currentFrameRate` were racing the same way.
+
 ## 9.23.0
 
 ### Features

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -14,8 +14,6 @@ sentry_threadSanitizerIsPresent(void)
 #    if defined(__has_feature)
 #        if __has_feature(thread_sanitizer)
     return YES;
-#            pragma clang diagnostic push
-#            pragma clang diagnostic ignored "-Wunreachable-code"
 #        endif // __has_feature(thread_sanitizer)
 #    endif // defined(__has_feature)
 

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
@@ -34,7 +34,19 @@ public class SentryFramesTracker: NSObject {
     }
     private var previousFrameTimestamp: CFTimeInterval = SentryFramesTracker.previousFrameInitialValue
     private var previousFrameSystemTimestamp: UInt64 = 0
-    private var currentFrameRate: UInt64 = 60
+
+    // Written by the display link callback on the main thread, but read off the main thread via
+    // `getFramesDelay(_:endSystemTimestamp:)` — the ANR tracker calls that from its own thread.
+    private let _currentFrameRate = SentryMutex<UInt64>(60)
+
+    private var currentFrameRate: UInt64 {
+        get {
+            _currentFrameRate.withLock { $0 }
+        }
+        set {
+            _currentFrameRate.withLock { $0 = newValue }
+        }
+    }
     // We hold listeners through `WeakReference` rather than `NSHashTable.weakObjects()`
     // because NSHashTable's internal buckets can be zeroed by the ObjC runtime on the
     // deallocating thread while the table is being iterated on another thread, causing
@@ -43,16 +55,24 @@ public class SentryFramesTracker: NSObject {
     // deallocation.
     private var listeners: [WeakReference<SentryFramesTrackerListener>] = []
 
+    // The frame counters and the profiling timeseries are written on the main thread by the display
+    // link callback, but `currentFrames()` reads them from whichever thread creates or finishes a
+    // tracer, or transmits a profile chunk. Copying a Swift `Array` while another thread appends to
+    // it retains a `_ContiguousArrayStorage` whose lifetime the appending thread owns, so a
+    // concurrent resize can free the buffer out from under the reader. Guarding every access with
+    // this mutex also makes the snapshot returned by `currentFrames()` internally consistent.
+    private struct FrameData {
+        var total: UInt = 0
+        var slow: UInt = 0
+        var frozen: UInt = 0
 #if os(iOS)
-    private var frozenFrameTimestamps = SentryFrameInfoTimeSeries()
-    private var slowFrameTimestamps = SentryFrameInfoTimeSeries()
-    private var frameRateTimestamps = SentryFrameInfoTimeSeries()
+        var slowTimestamps = SentryFrameInfoTimeSeries()
+        var frozenTimestamps = SentryFrameInfoTimeSeries()
+        var frameRateTimestamps = SentryFrameInfoTimeSeries()
 #endif // os(iOS)
+    }
 
-    // Frame counters - accessed only from main thread (display link callback)
-    private var totalFrames: UInt = 0
-    private var slowFrames: UInt = 0
-    private var frozenFrames: UInt = 0
+    private let frameData = SentryMutex<FrameData>(FrameData())
 
     private var displayLinkWrapper: SentryDisplayLinkWrapper
     private let dateProvider: SentryCurrentDateProvider
@@ -154,20 +174,21 @@ public class SentryFramesTracker: NSObject {
 
     @objc
     public func currentFrames() -> SentryScreenFrames {
+        let data = frameData.withLock { $0 }
 #if os(iOS)
         return SentryScreenFrames(
-            total: totalFrames,
-            frozen: frozenFrames,
-            slow: slowFrames,
-            slowFrameTimestamps: slowFrameTimestamps,
-            frozenFrameTimestamps: frozenFrameTimestamps,
-            frameRateTimestamps: frameRateTimestamps
+            total: data.total,
+            frozen: data.frozen,
+            slow: data.slow,
+            slowFrameTimestamps: data.slowTimestamps,
+            frozenFrameTimestamps: data.frozenTimestamps,
+            frameRateTimestamps: data.frameRateTimestamps
         )
 #else
         return SentryScreenFrames(
-            total: totalFrames,
-            frozen: frozenFrames,
-            slow: slowFrames
+            total: data.total,
+            frozen: data.frozen,
+            slow: data.slow
         )
 #endif
     }
@@ -283,9 +304,11 @@ public class SentryFramesTracker: NSObject {
 #endif
 
     @objc func resetFrames() {
-        totalFrames = 0
-        frozenFrames = 0
-        slowFrames = 0
+        frameData.withLock {
+            $0.total = 0
+            $0.frozen = 0
+            $0.slow = 0
+        }
 
         previousFrameTimestamp = Self.previousFrameInitialValue
 
@@ -364,14 +387,16 @@ public class SentryFramesTracker: NSObject {
             NSNumber(value: thisFrameSystemTimestamp)
 
         if SentryTraceProfiler.isCurrentlyProfiling() || isContinuousProfiling {
-            let hasNoFrameRatesYet = frameRateTimestamps.isEmpty
-            let previousFrameRate = frameRateTimestamps.last?["value"]?.uint64Value ?? 0
-            let frameRateChanged = previousFrameRate != currentFrameRate
-            let shouldRecordNewFrameRate = hasNoFrameRatesYet || frameRateChanged
+            let shouldRecordNewFrameRate = frameData.withLock { data -> Bool in
+                let hasNoFrameRatesYet = data.frameRateTimestamps.isEmpty
+                let previousFrameRate = data.frameRateTimestamps.last?["value"]?.uint64Value ?? 0
+                let frameRateChanged = previousFrameRate != currentFrameRate
+                return hasNoFrameRatesYet || frameRateChanged
+            }
 
             if shouldRecordNewFrameRate {
                 SentrySDKLog.debug("Recording new frame rate at \(profilingTimestamp).")
-                recordTimestamp(profilingTimestamp, value: NSNumber(value: currentFrameRate), array: &frameRateTimestamps)
+                recordTimestamp(profilingTimestamp, value: NSNumber(value: currentFrameRate), keyPath: \.frameRateTimestamps)
             }
         }
 #endif // os(iOS)
@@ -380,23 +405,23 @@ public class SentryFramesTracker: NSObject {
         let slowThreshold = Self.slowFrameThreshold(currentFrameRate)
 
         if frameDuration > slowThreshold && frameDuration <= Self.frozenFrameThreshold {
-            slowFrames += 1
+            frameData.withLock { $0.slow += 1 }
 #if os(iOS)
             SentrySDKLog.debug("Detected slow frame starting at \(profilingTimestamp) (frame tracker: \(self)).")
             recordTimestamp(
                 profilingTimestamp,
                 value: NSNumber(value: thisFrameSystemTimestamp - previousFrameSystemTimestamp),
-                array: &slowFrameTimestamps
+                keyPath: \.slowTimestamps
             )
 #endif // os(iOS)
         } else if frameDuration > Self.frozenFrameThreshold {
-            frozenFrames += 1
+            frameData.withLock { $0.frozen += 1 }
 #if os(iOS)
             SentrySDKLog.debug("Detected frozen frame starting at \(profilingTimestamp).")
             recordTimestamp(
                 profilingTimestamp,
                 value: NSNumber(value: thisFrameSystemTimestamp - previousFrameSystemTimestamp),
-                array: &frozenFrameTimestamps
+                keyPath: \.frozenTimestamps
             )
 #endif // os(iOS)
         }
@@ -412,7 +437,7 @@ public class SentryFramesTracker: NSObject {
             delayedFramesTracker.setPreviousFrameSystemTimestamp(thisFrameSystemTimestamp)
         }
 
-        totalFrames += 1
+        frameData.withLock { $0.total += 1 }
         previousFrameTimestamp = thisFrameTimestamp
         previousFrameSystemTimestamp = thisFrameSystemTimestamp
         reportNewFrame()
@@ -443,21 +468,23 @@ public class SentryFramesTracker: NSObject {
     }
 
 #if os(iOS)
-    private func recordTimestamp(_ timestamp: NSNumber, value: NSNumber, array: inout SentryFrameInfoTimeSeries) {
+    private func recordTimestamp(_ timestamp: NSNumber, value: NSNumber, keyPath: WritableKeyPath<FrameData, SentryFrameInfoTimeSeries>) {
         var shouldRecord = SentryTraceProfiler.isCurrentlyProfiling() || SentryContinuousProfiler.isCurrentlyProfiling()
 #if SENTRY_TEST || SENTRY_TEST_CI
         shouldRecord = true
 #endif
         if shouldRecord {
-            array.append(["timestamp": timestamp, "value": value])
+            frameData.withLock { $0[keyPath: keyPath].append(["timestamp": timestamp, "value": value]) }
         }
     }
     
     private func resetProfilingTimestampsInternal() {
         SentrySDKLog.debug("Resetting profiling GPU timeseries data.")
-        frozenFrameTimestamps = []
-        slowFrameTimestamps = []
-        frameRateTimestamps = []
+        frameData.withLock {
+            $0.frozenTimestamps = []
+            $0.slowTimestamps = []
+            $0.frameRateTimestamps = []
+        }
     }
 #endif // os(iOS)
     

--- a/Tests/SentryObjCTests/SentryObjCInternalProfilingApiIntegrationTests.m
+++ b/Tests/SentryObjCTests/SentryObjCInternalProfilingApiIntegrationTests.m
@@ -13,8 +13,12 @@
     [super setUp];
 
 #    if defined(__has_feature) && __has_feature(thread_sanitizer)
+    // No explicit return: XCTSkip raises _XCTSkipFailureException, so control never reaches the code
+    // below. _XCTSkipHandler is not marked noreturn, so the compiler cannot see that, and a return
+    // here would make the rest of setUp statically unreachable and trip -Wunreachable-code -Werror.
+    // Because this target then fails to compile under -enableThreadSanitizer, the whole scheme's test
+    // action fails before any test runs, which blocks running the sanitizer over the SDK at all.
     XCTSkip(@"Profiler does not run if thread sanitizer is attached.");
-    return;
 #    endif
 
     [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -1078,6 +1078,37 @@ final class SentryFramesTrackerTests: XCTestCase {
             self.fixture.displayLinkWrapper.normalFrame()
         }
     }
+    /// `currentFrames()` is called from arbitrary threads — a tracer reads it on creation and on
+    /// finish, and the profiler reads it when a tracer finishes or a chunk is transmitted — while the
+    /// display-link callback appends to the same profiling timeseries arrays on the main thread.
+    /// Copying a Swift `Array` while another thread appends to it retains a `_ContiguousArrayStorage`
+    /// whose lifetime the appending thread owns, so a concurrent resize can free the buffer out from
+    /// under the reader.
+    func testCurrentFrames_FromBackgroundThread_WhileRecordingSlowAndFrozenFrames() {
+        let sut = fixture.sut
+        sut.start()
+
+        let queue = DispatchQueue(label: "current frames", attributes: [.initiallyInactive, .concurrent])
+        let readsFinished = expectation(description: "All frame snapshots read")
+        readsFinished.expectedFulfillmentCount = 10_000
+
+        for _ in 0..<10_000 {
+            queue.async {
+                _ = sut.currentFrames()
+                readsFinished.fulfill()
+            }
+        }
+
+        queue.activate()
+
+        // Slow and frozen frames are the ones that append to the timeseries arrays.
+        for _ in 0..<1000 {
+            _ = self.fixture.displayLinkWrapper.fastestSlowFrame()
+            _ = self.fixture.displayLinkWrapper.fastestFrozenFrame()
+        }
+
+        wait(for: [readsFinished], timeout: 30)
+    }
 #endif // os(iOS) || os(tvOS)
     
     private func givenMoreDelayedFramesThanTransactionMaxDuration(_ framesTracker: SentryFramesTracker) -> (UInt64, UInt, Double) {


### PR DESCRIPTION
## 📜 Description

`SentryFramesTracker` keeps its frame counters and the profiling frame timeseries in unsynchronized properties. The display link callback writes them on the main thread, but `currentFrames()` reads them from whichever thread creates or finishes a tracer, or transmits a continuous profile chunk.

Copying a Swift `Array` while another thread appends to it retains a `_ContiguousArrayStorage` whose lifetime the appending thread owns, so a concurrent resize can free the buffer out from under the reader. That surfaces either as a refcount imbalance in the writer during resize, or as a crash when the reader's `SentryScreenFrames` snapshot deallocates.

This guards the counters and the three timeseries with a single `SentryMutex`

## 💡 Motivation and Context

Production `EXC_BAD_ACCESS` crashes on the reader side, in an app that finishes GraphQL transactions on a background queue (an Apollo interceptor), which makes `currentFrames()` run there.

Our example, we had 4 instances so far.

<img src="https://github.com/user-attachments/assets/12b5b534-45db-4e99-803e-14df522a19bb " alt="Screenshot 2026-07-28 at 12 20 50" width="1087" data-linear-height="629" />

[https://ares-tech-inc-0213b9d1c.sentry.io/issues/7599685752/?project=4505912938659840](<https://ares-tech-inc-0213b9d1c.sentry.io/issues/7599685752/?project=4505912938659840>)

This appears to share a root cause with getsentry/sentry-cocoa#7828, which was reported from the opposite side of the race — that stack is the writer.  <br>getsentry/sentry-cocoa#7828 was closed by [#7839](<https://github.com/getsentry/sentry-cocoa/issues/7839>), which fixed the *listeners* race by replacing `NSHashTable.weakObjects()` with `WeakReference`; that change did not touch the timestamp arrays, which are still unsynchronized on `main`

## 💚 How did you test it?

Added `testCurrentFrames_FromBackgroundThread_WhileRecordingSlowAndFrozenFrames`, following the existing `testResetProfilingTimestamps_FromBackgroundThread` pattern.

**CI will not run it** No workflow I see now enables the thread sanitizer, so `scripts/tests-with-thread-sanitizer.sh` appears to be manual-only, and the guarded code paths never compile in CI. To reproduce:

```
xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Test \
  -enableThreadSanitizer YES \
  -destination "platform=iOS Simulator,name=iPhone 16" \
  -only-testing:SentryTests/SentryFramesTrackerTests \
  test
```

Tested with Xcode 26.6.0 and Xcode 27 beta 3.  <br>Without the fix I am getting: `TEST FAILED` — races reported on `frozenFrameTimestamps.modify : Swift.Array<Swift.Dictionary<Swift.String, __C.NSNumber>>` and on `currentFrameRate`

Note the test count: unpatched runs only reach \~22 of 53 tests, because the sanitizer terminates the process partway through. That's why there are extra 2 commits, to remove `return` ( and in the next commit also drop unreachable-code build error suppression, at least for Xcodes I tested it is not needed anymore with the second commit in place, but CI here may prove me wrong).

As far as I understand, `XCTSkip` stops execution by raising, but `_XCTSkipHandler` is not marked `noreturn`, so the compiler treats the rest of `setUp` as unreachable and `-Wunreachable-code -Werror` fails the build and the whole test action currently fails before any test runs — this is a prerequisite for running the sanitizer over the SDK at all.  <br>Verified redundant: with it removed, all 8 tests in that class still report `skipped`, 0 failures, 0 sanitizer findings.

Please correct me if I am wrong about this setup, and `return` after XCTSkip and suppression of `-Wunreachable-code -Werror` was intended as it was.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).