### PR TITLE
fix: embed watchOS sample frameworks

### DIFF
--- a/Samples/watchOS-Swift/watchOS-Swift.yml
+++ b/Samples/watchOS-Swift/watchOS-Swift.yml
@@ -82,7 +82,9 @@ targets:
           - "**/.gitkeep"
     dependencies:
       - target: Sentry/Sentry
+        embed: true
       - target: SentrySampleShared/SentrySampleShared
+        embed: true
     configFiles:
       Debug: Extension/Configurations/watchOS-Swift-Extension.xcconfig
       Release: Extension/Configurations/watchOS-Swift-Extension.xcconfig


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

<!--- Describe your changes in detail and optionally add screenshots -->

Embed Sentry.framework and SentrySampleShared.framework in the generated watchOS extension.

This prevents the sample from crashing outside Xcode with:

```text
Library not loaded: @rpath/Sentry.framework/Sentry
```

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #8583

## :green_heart: How did you test it?

Run sample app without debugger attached.

<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
