### PR TITLE
chore(agents): remove huge list of default skills

### DIFF
--- a/agents.toml
+++ b/agents.toml
@@ -15,13 +15,5 @@ name = "*"
 source = "getsentry/dotagents"
 
 [[skills]]
-name = "*"
-source = "obra/superpowers"
-
-[[skills]]
-name = "*"
-source = "getsentry/sentry-skills"
-
-[[skills]]
 name = "relay-conformance-audit"
 source = "path:./skills/relay-conformance-audit"


### PR DESCRIPTION
## 📜 Description

Removes the include-all skills of `getsentry/sentry-skills` and `obra/superpowers` which bloats the local harness with unrelated skills (e.g. `django-access-review` or `sred-project-organizer`).

With this pull request I would like to propose that instead you use dotagents and install the skills system-wide, e.g. `npx @sentry/dotagents install --user`.

#skip-changelog

Closes getsentry/sentry-cocoa#8587