### PR TITLE
ref(samples): Remove obsolete availability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
-> [!WARNING]
-> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
-
-### Breaking Changes
-
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
-
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
+> [!WARNING]
+> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
+
+### Breaking Changes
+
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Breaking Changes
 
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
 
 ### Features
 

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -185,11 +185,9 @@ public struct SentrySDKWrapper {
 #endif // !os(macOS) && !os(watchOS) && !os(visionOS)
 
 #if !os(tvOS) && !os(watchOS)
-        if #available(iOS 15.0, macOS 12.0, *) {
-            options.enableMetricKit = !SentrySDKOverrides.MetricKit.disable.boolValue
-            options.enableMetricKitRawPayload =
-                options.enableMetricKit && !SentrySDKOverrides.MetricKit.disableRawPayloads.boolValue
-        }
+        options.enableMetricKit = !SentrySDKOverrides.MetricKit.disable.boolValue
+        options.enableMetricKitRawPayload =
+            options.enableMetricKit && !SentrySDKOverrides.MetricKit.disableRawPayloads.boolValue
 #endif // !os(tvOS) && !os(watchOS)
 
         configurePerformanceTracing(options)

--- a/Samples/macOS-Swift/App/Sources/SwiftUIView.swift
+++ b/Samples/macOS-Swift/App/Sources/SwiftUIView.swift
@@ -1,7 +1,6 @@
 import SentrySwiftUI
 import SwiftUI
 
-@available(macOS 10.15, *)
 struct SwiftUIView: View {
     var body: some View {
         SentryTracedView("SwiftUI View (macOS)") {
@@ -10,7 +9,6 @@ struct SwiftUIView: View {
     }
 }
 
-@available(macOS 10.15, *)
 struct SwiftUIView_Previews: PreviewProvider {
     static var previews: some View {
         SwiftUIView()

--- a/Samples/macOS-Swift/App/Sources/ViewController.swift
+++ b/Samples/macOS-Swift/App/Sources/ViewController.swift
@@ -109,7 +109,6 @@ class ViewController: NSViewController {
         SentrySDK.span?.finish()
     }
 
-    @available(macOS 10.15, *)
     @IBAction func showSwiftUIView(_ sender: Any) {
         let controller = NSHostingController(rootView: SwiftUIView())
         let window = NSWindow(contentViewController: controller)


### PR DESCRIPTION
Remove sample-app availability checks that became redundant after raising the minimum deployment targets.

MetricKit configuration and macOS SwiftUI examples now use their supported APIs directly. This PR is stacked on the deployment-target change in getsentry/sentry-cocoa#8595.

Refs getsentry/sentry-cocoa#8113<br>Refs getsentry/sentry-cocoa#8189

#skip-changelog