### PR TITLE
ref(metrickit): Remove obsolete availability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
-> [!WARNING]
-> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
-
-### Breaking Changes
-
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
-
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
+> [!WARNING]
+> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
+
+### Breaking Changes
+
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Breaking Changes
 
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
 
 ### Features
 

--- a/Sources/Swift/Core/Integrations/Integrations.swift
+++ b/Sources/Swift/Core/Integrations/Integrations.swift
@@ -87,9 +87,7 @@ private struct AnyIntegration {
         #endif
         
         #if os(iOS) || os(macOS) || os(visionOS)
-        if #available(macOS 12.0, *) {
-            integrations.append(.init(SentryMetricKitIntegration.self))
-        }
+        integrations.append(.init(SentryMetricKitIntegration.self))
         #endif
         
         integrations.forEach { anyIntegration in

--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -9,21 +9,15 @@ private let diskWriteMechanism = "mx_disk_write_exception"
 private let cpuExceptionMechanism = "mx_cpu_exception"
 private let hangDiagnosticMechanism = "mx_hang_diagnostic"
 
-@available(macOS 12.0, *)
 protocol CallStackTreeProviding {
     var callStackTree: MXCallStackTree { get }
 }
 
-@available(macOS 12.0, *)
 extension MXCrashDiagnostic: CallStackTreeProviding { }
-@available(macOS 12.0, *)
 extension MXDiskWriteExceptionDiagnostic: CallStackTreeProviding { }
-@available(macOS 12.0, *)
 extension MXCPUExceptionDiagnostic: CallStackTreeProviding { }
-@available(macOS 12.0, *)
 extension MXHangDiagnostic: CallStackTreeProviding { }
 
-@available(macOS 12.0, *)
 final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
     
     let disableCrashDiagnostics: Bool

--- a/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
@@ -1,7 +1,6 @@
 #if os(iOS) || os(macOS) || os(visionOS)
 import MetricKit
 
-@available(macOS 12.0, *)
 final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration {
     
     let mxManager: SentryMXManager

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
@@ -6,7 +6,6 @@ import XCTest
 
 import MetricKit
 
-@available(macOS 12.0, *)
 final class SentryMXManagerTests: XCTestCase {
     
     override func tearDown() {
@@ -49,7 +48,6 @@ final class SentryMXManagerTests: XCTestCase {
     }
 }
 
-@available(macOS 12.0, *)
 class TestMXDiagnosticPayload: MXDiagnosticPayload {
     struct Override {
         var crashDiagnostics: [MXCrashDiagnostic]?

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -11,7 +11,6 @@ import XCTest
 import MetricKit
 #endif // canImport(MetricKit)
 
-@available(macOS 12.0, *)
 final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     
     var callStackTreePerThread: SentryMXCallStackTree!
@@ -320,7 +319,6 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(macOS 12.0, *)
 class TestMXCallStackTree: MXCallStackTree {
     struct Override {
         var jsonRepresentation = Data()
@@ -335,7 +333,6 @@ class TestMXCallStackTree: MXCallStackTree {
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(macOS 12.0, *)
 class TestMXCrashDiagnostic: MXCrashDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
@@ -350,7 +347,6 @@ class TestMXCrashDiagnostic: MXCrashDiagnostic {
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(macOS 12.0, *)
 class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
@@ -373,7 +369,6 @@ class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(macOS 12.0, *)
 class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
@@ -392,7 +387,6 @@ class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
 
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(macOS 12.0, *)
 class TestMXHangDiagnostic: MXHangDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()


### PR DESCRIPTION
Remove macOS 12 availability annotations and runtime checks from MetricKit registration, implementation, and tests.

macOS 12 is now the SDK minimum, so these guards no longer protect a reachable code path. This PR is stacked on getsentry/sentry-cocoa#8596.

Refs getsentry/sentry-cocoa#8113

#skip-changelog