### PR TITLE
ref(crash): Remove obsolete availability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
-> [!WARNING]
-> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
-
-### Breaking Changes
-
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
-
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
+> [!WARNING]
+> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
+
+### Breaking Changes
+
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### Breaking Changes
 
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
 
 ### Features
 

--- a/SentryTestUtils/Sources/TestSentryNSProcessInfoWrapper.swift
+++ b/SentryTestUtils/Sources/TestSentryNSProcessInfoWrapper.swift
@@ -38,12 +38,10 @@
         overrides.environment ?? ProcessInfo.processInfo.environment
     }
 
-    @available(macOS 11.0, *)
     public var isiOSAppOnMac: Bool {
         return overrides.isiOSAppOnMac ?? ProcessInfo.processInfo.isiOSAppOnMac
     }
 
-    @available(macOS 11.0, *)
     public var isMacCatalystApp: Bool {
         return overrides.isMacCatalystApp ?? ProcessInfo.processInfo.isMacCatalystApp
     }
@@ -52,7 +50,6 @@
         return overrides.isiOSAppOnVisionOS ?? ProcessInfo.processInfo.isiOSAppOnVisionOS
     }
 
-    @available(macOS 12.0, *)
     public var isLowPowerModeEnabled: Bool {
         return overrides.isLowPowerModeEnabled ?? ProcessInfo.processInfo.isLowPowerModeEnabled
     }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -52,27 +52,15 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
 
-// backtrace_async api is only available from xcode 13 and macOS 12.0+ / iOS 15.0+
-#if __clang_major__ >= 13
     int backtraceLength;
     if (stitchSwiftAsync) {
         SENTRY_ASYNC_SAFE_LOG_DEBUG("Retrieving backtrace with async swift stitching...");
-        if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
-            backtraceLength
-                = (int)backtrace_async((void **)context->backtrace, MAX_BACKTRACE_LENGTH, NULL);
-        } else {
-            SENTRY_ASYNC_SAFE_LOG_DEBUG("Retrieving backtrace without async swift stitching...");
-            backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
-        }
+        backtraceLength
+            = (int)backtrace_async((void **)context->backtrace, MAX_BACKTRACE_LENGTH, NULL);
     } else {
         SENTRY_ASYNC_SAFE_LOG_DEBUG("Retrieving backtrace without async swift stitching...");
         backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
     }
-#else
-    SENTRY_ASYNC_SAFE_LOG_DEBUG(
-        "Retrieving backtrace without async swift stitching (old Xcode versions)...");
-    int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
-#endif
 
     SENTRY_ASYNC_SAFE_LOG_DEBUG("Finished retrieving backtrace.");
     sentrycrashsc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);

--- a/Sources/Swift/Helper/SentryExtraContextProvider.swift
+++ b/Sources/Swift/Helper/SentryExtraContextProvider.swift
@@ -53,9 +53,7 @@ internal import _SentryPrivate
             SentrySDKLog.warning("Unexpected thermal state enum value: \(thermalState)")
         }
 
-        if #available(macOS 12.0, *) {
-            extraDeviceContext["low_power_mode"] = NSNumber(value: processInfoWrapper.isLowPowerModeEnabled)
-        }
+        extraDeviceContext["low_power_mode"] = NSNumber(value: processInfoWrapper.isLowPowerModeEnabled)
         
         #if (os(iOS)) && !SENTRY_NO_UI_FRAMEWORK
         if deviceWrapper.orientation != .unknown {

--- a/Sources/Swift/Helper/SentryProcessInfo.swift
+++ b/Sources/Swift/Helper/SentryProcessInfo.swift
@@ -6,15 +6,9 @@
     var thermalState: ProcessInfo.ThermalState { get }
     var environment: [String: String] { get }
 
-    @available(macOS 12.0, *)
     var isiOSAppOnMac: Bool { get }
-
-    @available(macOS 12.0, *)
     var isMacCatalystApp: Bool { get }
-
     var isiOSAppOnVisionOS: Bool { get }
-
-    @available(macOS 12.0, *)
     var isLowPowerModeEnabled: Bool { get }
 }
 
@@ -28,11 +22,11 @@
     public var processDirectoryPath: String {
         Bundle.main.bundlePath
     }
-    
+
     public var processPath: String? {
         Bundle.main.executablePath
     }
-    
+
     public var isiOSAppOnVisionOS: Bool {
         if #available(iOS 26.1, visionOS 26.1, *) {
             // Use official API when available

--- a/Sources/Swift/Integrations/SentryCrash/SentryCrashIntegration.swift
+++ b/Sources/Swift/Integrations/SentryCrash/SentryCrashIntegration.swift
@@ -119,13 +119,11 @@ final class SentryCrashIntegration<Dependencies: CrashIntegrationProvider>: NSOb
         )
     #endif
 
-        if #available(macOS 12.0, *) {
-            NotificationCenter.default.removeObserver(
-                self,
-                name: NSNotification.Name.NSProcessInfoPowerStateDidChange,
-                object: nil
-            )
-        }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSNotification.Name.NSProcessInfoPowerStateDidChange,
+            object: nil
+        )
     }
 
     // MARK: - Crash Handler
@@ -260,15 +258,13 @@ final class SentryCrashIntegration<Dependencies: CrashIntegrationProvider>: NSOb
         )
 #endif
 
-        if #available(macOS 12.0, *) {
-            updateLowPowerModeContext(ProcessInfo.processInfo)
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(powerStateDidChange(notification:)),
-                name: NSNotification.Name.NSProcessInfoPowerStateDidChange,
-                object: nil
-            )
-        }
+        updateLowPowerModeContext(ProcessInfo.processInfo)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(powerStateDidChange(notification:)),
+            name: NSNotification.Name.NSProcessInfoPowerStateDidChange,
+            object: nil
+        )
     }
 
 #if !SDK_V10
@@ -291,8 +287,7 @@ final class SentryCrashIntegration<Dependencies: CrashIntegrationProvider>: NSOb
     }
 #endif
 
-    @objc @available(macOS 12.0, *)
-    private func powerStateDidChange(notification: Notification) {
+    @objc private func powerStateDidChange(notification: Notification) {
         let processInfo = if let notificationProcessInfo = notification.object as? ProcessInfo {
             notificationProcessInfo
         } else {
@@ -302,7 +297,6 @@ final class SentryCrashIntegration<Dependencies: CrashIntegrationProvider>: NSOb
         updateLowPowerModeContext(processInfo)
     }
 
-    @available(macOS 12.0, *)
     private func updateLowPowerModeContext(_ processInfo: ProcessInfo) {
         let isLowPowerMode = processInfo.isLowPowerModeEnabled
         SentrySDKInternal.currentHub().configureScope { scope in

--- a/Sources/Swift/SentryCrash/SentryDefaultCrashReporter.swift
+++ b/Sources/Swift/SentryCrash/SentryDefaultCrashReporter.swift
@@ -187,13 +187,11 @@ public final class SentryDefaultCrashReporter: NSObject, SentryCrashReporter {
         // Only include these boolean flags when they are `true` to reduce payload size.
         // These flags are `false` for the vast majority of events (regular iOS apps, native macOS apps, etc.),
         // so omitting them when `false` significantly reduces the payload size without losing meaningful information.
-        if #available(macOS 12, *) {
-            if self.processInfoWrapper.isiOSAppOnMac {
-                deviceData["ios_app_on_macos"] = true
-            }
-            if self.processInfoWrapper.isMacCatalystApp {
-                deviceData["mac_catalyst_app"] = true
-            }
+        if self.processInfoWrapper.isiOSAppOnMac {
+            deviceData["ios_app_on_macos"] = true
+        }
+        if self.processInfoWrapper.isMacCatalystApp {
+            deviceData["mac_catalyst_app"] = true
         }
         if self.processInfoWrapper.isiOSAppOnVisionOS {
             deviceData["ios_app_on_visionos"] = true
@@ -225,22 +223,20 @@ public final class SentryDefaultCrashReporter: NSObject, SentryCrashReporter {
     private func enrichScopeWithRuntimeData(_ scope: Scope) {
         var runtimeContext: [String: Any] = [:]
 
-        if #available(macOS 12, *) {
-            // We set this info on the runtime context because the app context has no existing fields
-            // suitable for representing Catalyst or iOS-on-Mac execution modes. We also wanted to avoid
-            // adding two new Apple-specific fields to the app context. Coming up with a generic,
-            // reusable property on the app context proved difficult, so instead we reuse the "name"
-            // field of the runtime context as a pragmatic and semantically acceptable solution.
-            // isiOSAppOnMac and isMacCatalystApp are mutually exclusive, so we only set one of them.
-            if self.processInfoWrapper.isiOSAppOnMac {
-                runtimeContext["name"] = "iOS App on Mac"
-                runtimeContext["raw_description"] = "ios-app-on-mac"
-            }
+        // We set this info on the runtime context because the app context has no existing fields
+        // suitable for representing Catalyst or iOS-on-Mac execution modes. We also wanted to avoid
+        // adding two new Apple-specific fields to the app context. Coming up with a generic,
+        // reusable property on the app context proved difficult, so instead we reuse the "name"
+        // field of the runtime context as a pragmatic and semantically acceptable solution.
+        // isiOSAppOnMac and isMacCatalystApp are mutually exclusive, so we only set one of them.
+        if self.processInfoWrapper.isiOSAppOnMac {
+            runtimeContext["name"] = "iOS App on Mac"
+            runtimeContext["raw_description"] = "ios-app-on-mac"
+        }
 
-            if self.processInfoWrapper.isMacCatalystApp {
-                runtimeContext["name"] = "Mac Catalyst App"
-                runtimeContext["raw_description"] = "mac-catalyst-app"
-            }
+        if self.processInfoWrapper.isMacCatalystApp {
+            runtimeContext["name"] = "Mac Catalyst App"
+            runtimeContext["raw_description"] = "mac-catalyst-app"
         }
 
         if !runtimeContext.isEmpty {

--- a/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashWrapperTests.swift
@@ -147,7 +147,6 @@ final class SentryDefaultCrashReporterTests: XCTestCase {
             #endif
     }
     
-    @available(macOS 12.0, *)
     func testEnrichScope_DeviceContext_iOSAppOnMac() throws {
         let mockProcessInfo = MockSentryProcessInfo()
         mockProcessInfo.overrides.isiOSAppOnMac = true
@@ -179,7 +178,6 @@ final class SentryDefaultCrashReporterTests: XCTestCase {
         XCTAssertNil(deviceContext["mac_catalyst_app"])
     }
     
-    @available(macOS 12.0, *)
     func testEnrichScope_DeviceContext_MacCatalyst() throws {
         let mockProcessInfo = MockSentryProcessInfo()
         mockProcessInfo.overrides.isiOSAppOnMac = false
@@ -239,7 +237,6 @@ final class SentryDefaultCrashReporterTests: XCTestCase {
         XCTAssertEqual(deviceContext["ios_app_on_visionos"] as? Bool, true)
     }
     
-    @available(macOS 12.0, *)
     func testEnrichScope_DeviceContext_FlagsNotIncludedWhenFalse() throws {
         // Verify that boolean flags are not included when they are false to reduce payload size
         let mockProcessInfo = MockSentryProcessInfo()

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -71,7 +71,6 @@ class SentryStacktraceBuilderTests: XCTestCase {
         )
     }
 
-    @available(macOS 10.15, *)
     func testConcurrentStacktraces() throws {
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
@@ -93,7 +92,6 @@ class SentryStacktraceBuilderTests: XCTestCase {
         wait(for: [waitForAsyncToRun], timeout: 10)
     }
 
-    @available(macOS 10.15, *)
     func testConcurrentStacktraces_noStitching() throws {
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
@@ -115,13 +113,11 @@ class SentryStacktraceBuilderTests: XCTestCase {
         wait(for: [waitForAsyncToRun], timeout: 10)
     }
 
-    @available(macOS 10.15, *)
     private func firstFrame() async -> Int {
         print("\(Date()) [Sentry] [TEST] first async frame about to await...")
         return await innerFrame1()
     }
 
-    @available(macOS 10.15, *)
     private func innerFrame1() async -> Int {
         print("\(Date()) [Sentry] [TEST] second async frame about to await on task...")
         await Task { @MainActor in


### PR DESCRIPTION
Remove obsolete availability fallbacks from crash stack collection and crash-context enrichment.

Async stack stitching now calls `backtrace_async` directly. Low-power mode, Catalyst, and iOS-on-Mac metadata also use APIs guaranteed by the new deployment floors. This PR is stacked on getsentry/sentry-cocoa#8597.

Refs getsentry/sentry-cocoa#8113<br>Refs getsentry/sentry-cocoa#8189

#skip-changelog