### PR TITLE
ref(networking): Remove legacy macOS fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ### Breaking Changes
 
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,6 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
-> [!WARNING]
-> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
-
-### Breaking Changes
-
-- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8595, #8113, #8189)
-
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
   - You can re-enable this feature by setting the option `enableMemoryIntrospection` to true
   - When this option is disabled, string stack contents found near the crash site will not be included in the event sent to Sentry. These contents are displayed in the 'message' subtitle shown underneath the main issue title in Sentry.
 
+> [!WARNING]
+> This release raises the minimum deployment targets to macOS 12 and watchOS 9. Apps that support older OS versions must use an earlier Sentry Cocoa release.
+
+### Breaking Changes
+
+- Bump the minimum deployment targets to macOS 12 and watchOS 9 because Xcode 27 no longer supports earlier versions. This lets the SDK adopt Xcode 27 without blocking users from building and submitting their apps with the latest Xcode. (#8113, #8189)
+
 ### Features
 
 - Add `Breadcrumb.setData(value:key:)` to set a single breadcrumb data entry and deprecate the `Breadcrumb.data` setter in its favor. (#8572)

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayNetworkDetails.swift
@@ -76,7 +76,7 @@ enum NetworkBodyWarning: String {
             if mimeType == "application/x-www-form-urlencoded" {
                 if isTruncated { warnings.append(.textTruncated) }
                 self = Body.parseFormEncoded(slice, encoding: encoding, warnings: &warnings)
-            } else if #available(macOS 11, *), let parsed = Body.parseByMimeType(mimeType, data: slice, encoding: encoding, isTruncated: isTruncated, warnings: &warnings) {
+            } else if let parsed = Body.parseByMimeType(mimeType, data: slice, encoding: encoding, isTruncated: isTruncated, warnings: &warnings) {
                 self = parsed
             } else {
                 let description = "[Body not captured: contentType=\(contentType ?? "unknown") (\(data.count) bytes)]"
@@ -125,8 +125,6 @@ enum NetworkBodyWarning: String {
 
         /// Uses UTType to detect JSON/text content types. Returns nil for
         /// unrecognized types so the caller can fall through to a placeholder.
-        /// UTType requires macOS 11+;  so this will not compile there.
-        @available(macOS 11, *)
         private static func parseByMimeType(_ mimeType: String?, data: Data, encoding: String.Encoding, isTruncated: Bool, warnings: inout [NetworkBodyWarning]) -> Body? {
             guard let utType = mimeType.flatMap({ UTType(mimeType: $0) }) else {
                 return nil

--- a/Sources/Swift/Networking/HTTPURLResponse+Sentry.swift
+++ b/Sources/Swift/Networking/HTTPURLResponse+Sentry.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// The instance methods are `internal` (not `private`) so the pre-macOS-10.15 fallback can be
-// unit-tested; `#available` makes it unreachable on the OS versions our tests run on.
 extension HTTPURLResponse {
 
     /// Reads a header case-insensitively.
@@ -9,41 +7,12 @@ extension HTTPURLResponse {
     /// - https://www.rfc-editor.org/rfc/rfc9113#section-8.2.1
     /// - https://www.rfc-editor.org/rfc/rfc9114#section-4.2
     func value(forHTTPHeaderFieldCaseInsensitive name: String) -> String? {
-        if #available(macOS 10.15, *) {
-            // `value(forHTTPHeaderField:)` retrieves the header case-insensitively.
-            return value(forHTTPHeaderField: name)
-        }
-        return sentryCaseInsensitiveHeaderValue(forName: name)
-    }
-
-    /// Pre-macOS-10.15 fallback is an extra method so it can be unit tested. We plan on bumping to macOS 12
-    /// in August 2026, so we don't use this implementation for all platforms.
-    ///
-    /// `allHeaderFields` subscripting is case-sensitive, so we scan all keys and compare them
-    /// case-insensitively against `name`. This is O(n), which is acceptable for the small number of
-    /// response headers.
-    func sentryCaseInsensitiveHeaderValue(forName name: String) -> String? {
-        let lowercasedName = name.lowercased()
-        // The linter forbids `allHeaderFields` because its subscript is case-sensitive, and it points
-        // callers to `value(forHTTPHeaderField:)`. That API is only available on macOS 10.15+, so this
-        // pre-10.15 fallback has to iterate `allHeaderFields` instead. The case-sensitivity bug the
-        // linter guards against doesn't apply here: we don't subscript, we compare every key against
-        // `name` with both sides lowercased.
-        // swiftlint:disable avoid_all_header_fields
-        for (key, value) in allHeaderFields {
-            if let key = key as? String, key.lowercased() == lowercasedName {
-                return value as? String
-            }
-        }
-        // swiftlint:enable avoid_all_header_fields
-        return nil
+        value(forHTTPHeaderField: name)
     }
 }
 
 /// Objective-C bridge for the case-insensitive header lookup. Objective-C can't call the Swift
-/// `HTTPURLResponse` extension method above, so this thin static wrapper exposes it. We can't call
-/// `-[NSHTTPURLResponse valueForHTTPHeaderField:]` from Objective-C directly because it isn't
-/// available before macOS 10.15.
+/// `HTTPURLResponse` extension method above, so this thin static wrapper exposes it.
 @objc(SentryHTTPHeaderReader) @_spi(Private)
 public final class HTTPHeaderReader: NSObject {
 

--- a/Tests/SentryTests/Networking/HTTPURLResponse+SentryTests.swift
+++ b/Tests/SentryTests/Networking/HTTPURLResponse+SentryTests.swift
@@ -45,66 +45,6 @@ class HTTPURLResponseSentryTests: XCTestCase {
         XCTAssertNil(value)
     }
 
-    // MARK: - sentryCaseInsensitiveHeaderValue (pre-macOS-10.15 fallback)
-
-    /// The fallback runs on macOS < 10.15, which our tests never run on, so we exercise it directly.
-    /// Looking up an uppercase name must find a header the server sent lowercase.
-    func testCaseInsensitiveHeaderValueFallback_whenLowercaseResponseAndUppercaseName_returnsValue() throws {
-        // -- Arrange --
-        let response = try TestResponseFactory.createRateLimitResponse(
-            headerValue: "60:replay:organization:replay_usage_exceeded")
-
-        // -- Act --
-        let value = response.sentryCaseInsensitiveHeaderValue(forName: "X-Sentry-Rate-Limits")
-
-        // -- Assert --
-        XCTAssertEqual(value, "60:replay:organization:replay_usage_exceeded")
-    }
-
-    /// Looking up a lowercase name must find a header the server sent in the conventional casing.
-    func testCaseInsensitiveHeaderValueFallback_whenCanonicalResponseAndLowercaseName_returnsValue() throws {
-        // -- Arrange --
-        let response = try TestResponseFactory.createRateLimitResponseHTTP1_1(
-            headerValue: "60:replay:organization:replay_usage_exceeded")
-
-        // -- Act --
-        let value = response.sentryCaseInsensitiveHeaderValue(forName: "x-sentry-rate-limits")
-
-        // -- Assert --
-        XCTAssertEqual(value, "60:replay:organization:replay_usage_exceeded")
-    }
-
-    /// The scan compares keys case-insensitively, so even an unconventional mixed casing resolves.
-    func testCaseInsensitiveHeaderValueFallback_whenMixedCaseResponseKey_returnsValue() throws {
-        // -- Arrange --
-        let response = try XCTUnwrap(HTTPURLResponse(
-            url: URL(fileURLWithPath: ""),
-            statusCode: 429,
-            httpVersion: "2.0",
-            headerFields: ["X-SeNtRy-RaTe-LiMiTs": "60:replay:organization:replay_usage_exceeded"]))
-
-        // -- Act --
-        let value = response.sentryCaseInsensitiveHeaderValue(forName: "x-sentry-rate-limits")
-
-        // -- Assert --
-        XCTAssertEqual(value, "60:replay:organization:replay_usage_exceeded")
-    }
-
-    func testCaseInsensitiveHeaderValueFallback_whenHeaderMissing_returnsNil() throws {
-        // -- Arrange --
-        let response = try XCTUnwrap(HTTPURLResponse(
-            url: URL(fileURLWithPath: ""),
-            statusCode: 429,
-            httpVersion: "2.0",
-            headerFields: ["some-other-header": "value"]))
-
-        // -- Act --
-        let value = response.sentryCaseInsensitiveHeaderValue(forName: "x-sentry-rate-limits")
-
-        // -- Assert --
-        XCTAssertNil(value)
-    }
-
     // MARK: - SentryHTTPHeaderReader (Objective-C bridge)
 
     func testHTTPHeaderReader_forwardsToCaseInsensitiveLookup() throws {

--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -70,8 +70,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
     /// Captures the SDK logs so tests can assert on them. `tearDown()` restores the default log
     /// configuration so the captured output doesn't leak into other tests.
     ///
-    /// Note: we reset in `tearDown()` rather than `addTeardownBlock`, because the latter is only
-    /// available on macOS 10.15+ while the test target deploys down to macOS 10.14.
+    /// Note: we reset in `tearDown()` so captured output is cleared consistently after each test.
     private func givenCapturedLogs() -> TestLogOutput {
         let logOutput = TestLogOutput()
         SentrySDKLog.setLogOutput(logOutput)


### PR DESCRIPTION
Remove networking fallbacks for unsupported macOS versions.

HTTP header lookup now uses Foundation directly, and Session Replay MIME parsing always uses Uniform Type Identifiers. Tests that existed only for the deleted pre-macOS 10.15 path are removed. This PR is stacked on getsentry/sentry-cocoa#8598.

Refs getsentry/sentry-cocoa#8113

#skip-changelog