### PR TITLE
chore: remove dynamic packages from apple-binaries

### DIFF
--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -56,6 +56,9 @@ jobs:
           test -f /tmp/apple-binaries-verify/Package.swift
           test -f /tmp/apple-binaries-verify/.gitignore
           test -f /tmp/apple-binaries-verify/Sources/SentryCppHelper/SentryCppHelper.swift
+          test -f /tmp/apple-binaries-verify/CHANGELOG.md
+          test -f /tmp/apple-binaries-verify/README.md
+          test -f /tmp/apple-binaries-verify/LICENSE.md
 
           # Verify version was stamped
           grep -q "releases/download/99.0.0/" /tmp/apple-binaries-verify/Package.swift
@@ -69,8 +72,8 @@ jobs:
 
           # Verify no extra files leaked into the archive
           FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)
-          if [ "$FILE_COUNT" -ne 3 ]; then
-            echo "Expected 3 files in archive but found $FILE_COUNT"
+          if [ "$FILE_COUNT" -ne 6 ]; then
+            echo "Expected 6 files in archive but found $FILE_COUNT"
             find /tmp/apple-binaries-verify -type f
             exit 1
           fi

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -56,9 +56,6 @@ jobs:
           test -f /tmp/apple-binaries-verify/Package.swift
           test -f /tmp/apple-binaries-verify/.gitignore
           test -f /tmp/apple-binaries-verify/Sources/SentryCppHelper/SentryCppHelper.swift
-          test -f /tmp/apple-binaries-verify/CHANGELOG.md
-          test -f /tmp/apple-binaries-verify/README.md
-          test -f /tmp/apple-binaries-verify/LICENSE.md
 
           # Verify version was stamped
           grep -q "releases/download/99.0.0/" /tmp/apple-binaries-verify/Package.swift
@@ -72,8 +69,8 @@ jobs:
 
           # Verify no extra files leaked into the archive
           FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)
-          if [ "$FILE_COUNT" -ne 6 ]; then
-            echo "Expected 6 files in archive but found $FILE_COUNT"
+          if [ "$FILE_COUNT" -ne 3 ]; then
+            echo "Expected 3 files in archive but found $FILE_COUNT"
             find /tmp/apple-binaries-verify -type f
             exit 1
           fi

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -38,8 +38,6 @@ jobs:
         run: |
           mkdir -p XCFrameworkBuildPath
           echo "<FAKE STATIC ZIP>" > XCFrameworkBuildPath/Sentry.xcframework.zip
-          echo "<FAKE DYNAMIC ZIP>" > XCFrameworkBuildPath/Sentry-Dynamic.xcframework.zip
-          echo "<FAKE SENTRYOBJC DYNAMIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Dynamic.xcframework.zip
           echo "<FAKE SENTRYOBJC STATIC ZIP>" > XCFrameworkBuildPath/SentryObjC-Static.xcframework.zip
 
       - name: Create archive
@@ -64,10 +62,10 @@ jobs:
 
           # Verify checksums were updated (should match the fake zips)
           EXPECTED_STATIC=$(sha256sum XCFrameworkBuildPath/Sentry.xcframework.zip | awk '{print $1}')
-          EXPECTED_OBJC_DYN=$(sha256sum XCFrameworkBuildPath/SentryObjC-Dynamic.xcframework.zip | awk '{print $1}')
+          EXPECTED_OBJC_STATIC=$(sha256sum XCFrameworkBuildPath/SentryObjC-Static.xcframework.zip | awk '{print $1}')
 
           grep -q "checksum: \"${EXPECTED_STATIC}\" //Sentry-Static" /tmp/apple-binaries-verify/Package.swift
-          grep -q "checksum: \"${EXPECTED_OBJC_DYN}\" //SentryObjC-Dynamic" /tmp/apple-binaries-verify/Package.swift
+          grep -q "checksum: \"${EXPECTED_OBJC_STATIC}\" //SentryObjC-Static" /tmp/apple-binaries-verify/Package.swift
 
           # Verify no extra files leaked into the archive
           FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)

--- a/distribution/apple-binaries/LICENSE.md
+++ b/distribution/apple-binaries/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/distribution/apple-binaries/Package.swift
+++ b/distribution/apple-binaries/Package.swift
@@ -6,8 +6,6 @@ let package = Package(
     platforms: [.iOS(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v9), .visionOS(.v1)],
     products: [
         .library(name: "Sentry-Static", targets: ["Sentry-Static", "SentryCppHelper"]),
-        .library(name: "Sentry-Dynamic", targets: ["Sentry-Dynamic"]),
-        .library(name: "SentryObjC-Dynamic", targets: ["SentryObjC-Dynamic"]),
         .library(name: "SentryObjC-Static", targets: ["SentryObjC-Static"])
     ],
     dependencies: [],
@@ -16,16 +14,6 @@ let package = Package(
             name: "Sentry-Static",
             url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.24.0/Sentry.xcframework.zip",
             checksum: "c530edd27b20f7c151e73d84a34ee03474e3d5ddab65ffe9d30366f80149668a" //Sentry-Static
-        ),
-        .binaryTarget(
-            name: "Sentry-Dynamic",
-            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.24.0/Sentry-Dynamic.xcframework.zip",
-            checksum: "4728d7524ca65caa5640ce1f34032db074c8409b7e4b37257e82839703f0473e" //Sentry-Dynamic
-        ),
-        .binaryTarget(
-            name: "SentryObjC-Dynamic",
-            url: "https://github.com/getsentry/sentry-cocoa/releases/download/9.24.0/SentryObjC-Dynamic.xcframework.zip",
-            checksum: "e8d9bca34221e32147707824542819044542201fec4ae8e25399f1e060c03b22" //SentryObjC-Dynamic
         ),
         .binaryTarget(
             name: "SentryObjC-Static",

--- a/distribution/apple-binaries/README.md
+++ b/distribution/apple-binaries/README.md
@@ -1,0 +1,58 @@
+<div align="center">
+    <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+        <img src="https://sentry-brand.storage.googleapis.com/github-banners/github-sdk-cocoa.jpg" alt="Sentry for Apple">
+    </a>
+</div>
+
+_Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
+
+# Sentry Cocoa Binaries
+
+[![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
+[![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.com/invite/sentry)
+
+This repository distributes **pre-built XCFramework binaries** of the [Sentry Cocoa SDK](https://github.com/getsentry/sentry-cocoa) via Swift Package Manager.
+
+If you want to build from source, use the main [sentry-cocoa](https://github.com/getsentry/sentry-cocoa) repository instead.
+
+## Available Libraries
+
+| Library             | Linking | Description               |
+| ------------------- | ------- | ------------------------- |
+| `Sentry-Static`     | Static  | Sentry SDK (Swift + ObjC) |
+| `SentryObjC-Static` | Static  | Sentry SDK (ObjC only)    |
+
+## Installation
+
+Add this package to your project via Swift Package Manager:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/getsentry/sentry-cocoa-binaries.git", from: "9.22.0")
+]
+```
+
+Then add the desired library product to your target's dependencies:
+
+```swift
+.target(
+    name: "YourApp",
+    dependencies: [
+        .product(name: "Sentry-Static", package: "sentry-cocoa-binaries"),
+    ]
+)
+```
+
+For full installation options and integration guides, see the [Sentry Apple documentation](https://docs.sentry.io/platforms/apple/install/).
+
+## Platform Support
+
+iOS 15+, macOS 10.14+, tvOS 15+, watchOS 8+, visionOS 1+
+
+## Resources
+
+- [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/apple/)
+- [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-cocoa.svg)](https://github.com/getsentry/sentry-cocoa/discussions)
+- [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.com/invite/sentry)
+- [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-sentry-green.svg)](https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md)
+- [![X Follow](https://img.shields.io/twitter/follow/sentry?label=sentry&style=social)](https://x.com/intent/follow?screen_name=sentry)

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -62,8 +62,6 @@ fi
 
 ZIPS_AND_MARKERS=(
     "Sentry.xcframework.zip|Sentry-Static"
-    "Sentry-Dynamic.xcframework.zip|Sentry-Dynamic"
-    "SentryObjC-Dynamic.xcframework.zip|SentryObjC-Dynamic"
     "SentryObjC-Static.xcframework.zip|SentryObjC-Static"
 )
 

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -16,7 +16,7 @@ Usage: $(basename "$0") [options]
 Create a .tgz archive for the sentry-apple-binaries distribution repo.
 Copies the binary Package.swift template, stamps in the release version
 and xcframework checksums, and tars the result alongside the SentryCppHelper
-source, CHANGELOG.md, README.md, LICENSE.md, and .gitignore.
+source and .gitignore.
 
 OPTIONS:
     --version <ver>             Release version, e.g. 9.24.0 (required)
@@ -75,15 +75,8 @@ trap 'rm -rf "$STAGING_DIR"' EXIT
 
 cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
 cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
-cp "$DIST_DIR/README.md" "$STAGING_DIR/README.md"
-cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
-
-log_info "Preparing CHANGELOG.md for version $VERSION"
-cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
-sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
-rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
@@ -108,9 +101,6 @@ tar -czf "$ARCHIVE_PATH" \
     -C "$STAGING_DIR" \
     Package.swift \
     Sources/SentryCppHelper/SentryCppHelper.swift \
-    CHANGELOG.md \
-    README.md \
-    LICENSE.md \
     .gitignore
 
 log_info "Created $ARCHIVE_PATH"

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -16,7 +16,7 @@ Usage: $(basename "$0") [options]
 Create a .tgz archive for the sentry-apple-binaries distribution repo.
 Copies the binary Package.swift template, stamps in the release version
 and xcframework checksums, and tars the result alongside the SentryCppHelper
-source and .gitignore.
+source, CHANGELOG.md, README.md, LICENSE.md, and .gitignore.
 
 OPTIONS:
     --version <ver>             Release version, e.g. 9.24.0 (required)
@@ -75,8 +75,15 @@ trap 'rm -rf "$STAGING_DIR"' EXIT
 
 cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
 cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
+cp "$DIST_DIR/README.md" "$STAGING_DIR/README.md"
+cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
+
+log_info "Preparing CHANGELOG.md for version $VERSION"
+cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
+sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
+rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
@@ -101,6 +108,9 @@ tar -czf "$ARCHIVE_PATH" \
     -C "$STAGING_DIR" \
     Package.swift \
     Sources/SentryCppHelper/SentryCppHelper.swift \
+    CHANGELOG.md \
+    README.md \
+    LICENSE.md \
     .gitignore
 
 log_info "Created $ARCHIVE_PATH"

--- a/scripts/verify-package-sha.sh
+++ b/scripts/verify-package-sha.sh
@@ -196,18 +196,6 @@ if [ -f "$DIST_PACKAGE" ]; then
         exit 1
     fi
 
-    UPDATED_PACKAGE_SHA=$(grep "checksum.*Sentry-Dynamic" "$DIST_PACKAGE" | cut -d '"' -f 2)
-    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_DYNAMIC_CHECKSUM" ]; then
-        log_error "Expected dynamic checksum to be $EXPECTED_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
-        exit 1
-    fi
-
-    UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Dynamic" "$DIST_PACKAGE" | cut -d '"' -f 2)
-    if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM" ]; then
-        log_error "Expected SentryObjC-Dynamic checksum to be $EXPECTED_SENTRYOBJC_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"
-        exit 1
-    fi
-
     UPDATED_PACKAGE_SHA=$(grep "checksum.*SentryObjC-Static" "$DIST_PACKAGE" | cut -d '"' -f 2)
     if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_SENTRYOBJC_STATIC_CHECKSUM" ]; then
         log_error "Expected SentryObjC-Static checksum to be $EXPECTED_SENTRYOBJC_STATIC_CHECKSUM but got $UPDATED_PACKAGE_SHA in $DIST_PACKAGE"


### PR DESCRIPTION
## Description

Remove dynamic XCFramework references from the apple-binaries distribution. The `sentry-apple-binaries` mirror repo will only ship static binaries (`Sentry-Static`, `SentryObjC-Static`).

Also added the License.md file

#skip-changelog

## Changes

- **`distribution/apple-binaries/Package.swift`** — remove `Sentry-Dynamic` and `SentryObjC-Dynamic` products and binary targets
- **`distribution/apple-binaries/README.md`** — add README; Available Libraries table lists only static variants
- **`distribution/apple-binaries/LICENSE.md`** — add MIT license
- **`scripts/create-apple-binaries-archive.sh`** — remove dynamic entries from `ZIPS_AND_MARKERS`
- **`scripts/verify-package-sha.sh`** — remove dynamic checksum verification for `distribution/apple-binaries/Package.swift`
- **`.github/workflows/apple-binaries-archive.yml`** — remove fake dynamic zips; add missing `SentryObjC-Static` checksum verification

Closes #8603