### PR TITLE
chore: include CHANGELOG, README, LICENSE in apple-binaries archive

### DIFF
--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -56,6 +56,9 @@ jobs:
           test -f /tmp/apple-binaries-verify/Package.swift
           test -f /tmp/apple-binaries-verify/.gitignore
           test -f /tmp/apple-binaries-verify/Sources/SentryCppHelper/SentryCppHelper.swift
+          test -f /tmp/apple-binaries-verify/CHANGELOG.md
+          test -f /tmp/apple-binaries-verify/README.md
+          test -f /tmp/apple-binaries-verify/LICENSE.md
 
           # Verify version was stamped
           grep -q "releases/download/99.0.0/" /tmp/apple-binaries-verify/Package.swift
@@ -69,8 +72,8 @@ jobs:
 
           # Verify no extra files leaked into the archive
           FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)
-          if [ "$FILE_COUNT" -ne 3 ]; then
-            echo "Expected 3 files in archive but found $FILE_COUNT"
+          if [ "$FILE_COUNT" -ne 6 ]; then
+            echo "Expected 6 files in archive but found $FILE_COUNT"
             find /tmp/apple-binaries-verify -type f
             exit 1
           fi

--- a/.github/workflows/apple-binaries-archive.yml
+++ b/.github/workflows/apple-binaries-archive.yml
@@ -56,9 +56,6 @@ jobs:
           test -f /tmp/apple-binaries-verify/Package.swift
           test -f /tmp/apple-binaries-verify/.gitignore
           test -f /tmp/apple-binaries-verify/Sources/SentryCppHelper/SentryCppHelper.swift
-          test -f /tmp/apple-binaries-verify/CHANGELOG.md
-          test -f /tmp/apple-binaries-verify/README.md
-          test -f /tmp/apple-binaries-verify/LICENSE.md
 
           # Verify version was stamped
           grep -q "releases/download/99.0.0/" /tmp/apple-binaries-verify/Package.swift
@@ -72,8 +69,8 @@ jobs:
 
           # Verify no extra files leaked into the archive
           FILE_COUNT=$(find /tmp/apple-binaries-verify -type f | wc -l)
-          if [ "$FILE_COUNT" -ne 6 ]; then
-            echo "Expected 6 files in archive but found $FILE_COUNT"
+          if [ "$FILE_COUNT" -ne 3 ]; then
+            echo "Expected 3 files in archive but found $FILE_COUNT"
             find /tmp/apple-binaries-verify -type f
             exit 1
           fi

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -80,10 +80,7 @@ cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
 
-log_info "Preparing CHANGELOG.md for version $VERSION"
 cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
-sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
-rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -16,7 +16,7 @@ Usage: $(basename "$0") [options]
 Create a .tgz archive for the sentry-apple-binaries distribution repo.
 Copies the binary Package.swift template, stamps in the release version
 and xcframework checksums, and tars the result alongside the SentryCppHelper
-source, CHANGELOG.md, README.md, LICENSE.md, and .gitignore.
+source and .gitignore.
 
 OPTIONS:
     --version <ver>             Release version, e.g. 9.24.0 (required)
@@ -75,15 +75,8 @@ trap 'rm -rf "$STAGING_DIR"' EXIT
 
 cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
 cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
-cp "$DIST_DIR/README.md" "$STAGING_DIR/README.md"
-cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
-
-log_info "Preparing CHANGELOG.md for version $VERSION"
-cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
-sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
-rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
@@ -108,9 +101,6 @@ tar -czf "$ARCHIVE_PATH" \
     -C "$STAGING_DIR" \
     Package.swift \
     Sources/SentryCppHelper/SentryCppHelper.swift \
-    CHANGELOG.md \
-    README.md \
-    LICENSE.md \
     .gitignore
 
 log_info "Created $ARCHIVE_PATH"

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -80,7 +80,9 @@ cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
 
+log_info "Preparing CHANGELOG.md for version $VERSION"
 cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
+sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -16,7 +16,7 @@ Usage: $(basename "$0") [options]
 Create a .tgz archive for the sentry-apple-binaries distribution repo.
 Copies the binary Package.swift template, stamps in the release version
 and xcframework checksums, and tars the result alongside the SentryCppHelper
-source and .gitignore.
+source, CHANGELOG.md, README.md, LICENSE.md, and .gitignore.
 
 OPTIONS:
     --version <ver>             Release version, e.g. 9.24.0 (required)
@@ -75,8 +75,15 @@ trap 'rm -rf "$STAGING_DIR"' EXIT
 
 cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
 cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
+cp "$DIST_DIR/README.md" "$STAGING_DIR/README.md"
+cp "$DIST_DIR/LICENSE.md" "$STAGING_DIR/LICENSE.md"
 mkdir -p "$STAGING_DIR/Sources/SentryCppHelper"
 cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sources/SentryCppHelper/SentryCppHelper.swift"
+
+log_info "Preparing CHANGELOG.md for version $VERSION"
+cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
+sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
+rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
@@ -101,6 +108,9 @@ tar -czf "$ARCHIVE_PATH" \
     -C "$STAGING_DIR" \
     Package.swift \
     Sources/SentryCppHelper/SentryCppHelper.swift \
+    CHANGELOG.md \
+    README.md \
+    LICENSE.md \
     .gitignore
 
 log_info "Created $ARCHIVE_PATH"


### PR DESCRIPTION
## Description

Include `CHANGELOG.md`, `README.md`, and `LICENSE.md` in the `sentry-apple-binaries.tgz` distribution archive.

The changelog is copied from the repo root with the `## Unreleased` header replaced by the release version, so the mirror repo always has a properly versioned changelog.

Stacked on #8602.

#skip-changelog

## Changes

- **`scripts/create-apple-binaries-archive.sh`** — copy `CHANGELOG.md` (stamped with version), `README.md`, and `LICENSE.md` into the archive staging dir and include them in the tarball
- **`.github/workflows/apple-binaries-archive.yml`** — verify all 6 files exist in the archive; update file count check from 3 to 6