### PR TITLE
test: isolate shake detector cooldown

### DIFF
--- a/Sources/Swift/Integrations/UserFeedback/SentryShakeDetector.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryShakeDetector.swift
@@ -103,6 +103,12 @@ public final class SentryShakeDetector: NSObject {
         enabled = false
         SentrySDKLog.debug("Shake detector: disabled")
     }
+
+#if SENTRY_TEST || SENTRY_TEST_CI
+    static func resetCooldown() {
+        swizzleState.withLock { $0.lastShakeTimestamp = 0 }
+    }
+#endif
 #else
     /// No-op on non-iOS platforms.
     @objc public static func enable() {}

--- a/Tests/SentryTests/Integrations/Feedback/SentryShakeDetectorTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryShakeDetectorTests.swift
@@ -1,7 +1,7 @@
 @testable import Sentry
 import XCTest
 
-#if os(iOS)
+#if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 import UIKit
 
 final class SentryShakeDetectorTests: XCTestCase {
@@ -102,4 +102,4 @@ final class SentryShakeDetectorTests: XCTestCase {
     }
 }
 
-#endif
+#endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK

--- a/Tests/SentryTests/Integrations/Feedback/SentryShakeDetectorTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryShakeDetectorTests.swift
@@ -12,9 +12,15 @@ final class SentryShakeDetectorTests: XCTestCase {
         UIWindow(windowScene: Self.mockWindowScene)
     }
 
+    override func setUp() {
+        super.setUp()
+        SentryShakeDetector.resetCooldown()
+    }
+
     override func tearDown() {
-        super.tearDown()
         SentryShakeDetector.disable()
+        SentryShakeDetector.resetCooldown()
+        super.tearDown()
     }
 
     func testEnable_whenShakeOccurs_shouldPostNotification() {


### PR DESCRIPTION
## :scroll: Description

- add a test-only reset for `SentryShakeDetector`'s process-wide cooldown state
- reset the cooldown before and after each `SentryShakeDetectorTests` test
- prevent shake events from one test suppressing events in a subsequent test

## :bulb: Motivation and Context

`SentryShakeDetectorTests.testEnable_whenShakeOccurs_shouldPostNotification` can fail depending on test order and timing. A shake from the preceding test updates the process-wide `lastShakeTimestamp`, and `disable()` does not reset it. If the next shake occurs within the one-second cooldown, its notification is suppressed.

This was observed in a [CI run](https://github.com/getsentry/sentry-cocoa/actions/runs/30449396011/job/90567660482) for #8589.

Resetting the cooldown in `disable()` itself may be reasonable because re-enabling could be considered a new detection session. However, doing so would change production behavior by allowing a shake immediately after a disable/re-enable cycle, which could make sense, but I am not sure whether separating the life-cycle from the cooldown wasn't intentional. If it wasn't, I am happy to integrate it into `disable()` instead.

## :green_heart: How did you test it?

I only ran the affected tests to check that nothing broke there. No production code was modified (yet, see above).

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
