### PR TITLE
fix: finalize ANR state before notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- Fix a race that could prevent consecutive app hangs from being reported (#5831)
 - Fix incorrect `duration` sent for active sessions (#8612)
   - Session `duration` is now set only when the session ends. Active sessions (including on error increments) no longer emit a bogus `duration`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 
 ### Fixes
 
-- Fix a race that could prevent consecutive app hangs from being reported (#5831)
 - Fix incorrect `duration` sent for active sessions (#8612)
   - Session `duration` is now set only when the session ends. Active sessions (including on error increments) no longer emit a bogus `duration`.
+- Fix a race that could prevent consecutive app hangs from being reported (#8627)
 
 ## 9.24.0
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -187,16 +187,16 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
                 NSTimeInterval appHangDurationMaximum
                     = nanosecondsToTimeInterval(appHangDurationNanos + sleepIntervalInNanos);
 
+                lastAppHangStoppedSystemTime = nowSystemTime;
+                reported = NO;
+                wasInBackground = NO;
+                accumulatedBackgroundTime = 0;
+
                 // The App Hang stopped, don't block the App Hangs thread or the main thread with
                 // calling ANRStopped listeners.
                 [self.dispatchQueueWrapper dispatchAsyncWithBlock:^{
                     [self ANRStopped:appHangDurationMinimum to:appHangDurationMaximum];
                 }];
-
-                lastAppHangStoppedSystemTime = dateProvider.systemTime;
-                reported = NO;
-                wasInBackground = NO;
-                accumulatedBackgroundTime = 0;
             }
 
             continue;

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
@@ -251,7 +251,12 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         defer { sut.clear() }
         
         // We use multiple listeners here, because we can't reset the XCTestExpectation
-        let firstListener = SentryANRTrackerV2TestDelegate()
+        let secondHangDuration = timeoutInterval + 0.1
+        let firstListener = SentryANRTrackerV2TestDelegate(blockOnFirstANRStopped: { [currentDate, secondHangDuration] in
+            // TestSentryDispatchQueueWrapper executes async blocks synchronously. Advancing the
+            // clock here deterministically starts the second hang before stop notification returns.
+            currentDate.advance(by: secondHangDuration)
+        })
         firstListener.anrDetectedExpectation.expectedFulfillmentCount = 2
         firstListener.anrStoppedExpectation.expectedFulfillmentCount = 2
         sut.add(listener: firstListener)
@@ -264,16 +269,14 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         triggerFullyBlockingAppHang(currentDate)
         
         wait(for: [secondListener.anrDetectedExpectation], timeout: waitTimeout)
+
+        let thirdListener = SentryANRTrackerV2TestDelegate()
+        thirdListener.anrStoppedExpectation.expectedFulfillmentCount = 2
+        sut.add(listener: thirdListener)
         
         renderNormalFramesToStopAppHang(displayLinkWrapper)
         
         wait(for: [secondListener.anrStoppedExpectation], timeout: waitTimeout)
-        
-        let thirdListener = SentryANRTrackerV2TestDelegate()
-        sut.add(listener: thirdListener)
-        
-        triggerFullyBlockingAppHang(currentDate)
-        
         wait(for: [thirdListener.anrDetectedExpectation], timeout: waitTimeout)
         
         renderNormalFramesToStopAppHang(displayLinkWrapper)
@@ -736,8 +739,11 @@ class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
     let anrStoppedExpectation  = XCTestExpectation(description: "Test Delegate ANR Stopped")
     let anrsDetected = Invocations<Sentry.SentryANRType>()
     let anrStoppedResults = Invocations<SentryANRStoppedResult>()
+    private let blockOnFirstANRStopped: (() -> Void)?
     
-    init(shouldANRBeDetected: Bool = true, shouldStoppedBeCalled: Bool = true) {
+    init(shouldANRBeDetected: Bool = true, shouldStoppedBeCalled: Bool = true, blockOnFirstANRStopped: (() -> Void)? = nil) {
+        self.blockOnFirstANRStopped = blockOnFirstANRStopped
+
         if !shouldANRBeDetected {
             anrDetectedExpectation.isInverted = true
         }
@@ -757,6 +763,10 @@ class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
         }
         
         anrStoppedResults.record(nonNilResult)
+
+        if anrStoppedResults.count == 1 {
+            blockOnFirstANRStopped?()
+        }
         
         anrStoppedExpectation.fulfill()
     }


### PR DESCRIPTION
## :scroll: Description

- Finalize `SentryANRTrackerV2` state _before_ notifying `ANRStopped` listeners.
- Record the stop timestamp using the already captured `nowSystemTime`.
- Make `testFullyBlockingFollowedByFullyBlocking_BothReported` deterministically reproduce the race by starting the second fake hang from the first stop callback.

## :bulb: Motivation and Context

`SentryANRTrackerV2` previously dispatched the stop notification before resetting its state and recording the stop timestamp. If a listener ran immediately, it **could advance the clock before the tracker recorded that timestamp**.

This caused the second hang to be treated as occurring too soon after the first. Because the tests use a fake clock, increasing the real-time expectation timeout could not resolve the failure.

Finalizing the state first provides a commit boundary: once listeners are notified, the tracker is ready to detect another hang.

Likely the better fix for #5831. Follow-up to #5832.

A [recent example of this hang](https://github.com/getsentry/sentry-cocoa/actions/runs/30449396011/job/90607041625?pr=8589#step:6:1989).

## :green_heart: How did you test it?

Verified the adapted regression test reproduces the original three timeouts without the fix.

Ran the full iOS test suite.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
