### PR TITLE
ci: exclude SentryDistribution from unrelated workflow filters

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -26,8 +26,6 @@ run_unit_tests_for_prs: &run_unit_tests_for_prs
   - "Sources/Sentry/**"
   - "Sources/SentryCppHelper/**"
   - "Sources/SentryCrash/**"
-  - "Sources/SentryDistribution/**"
-  - "Sources/SentryDistributionTests/**"
   - "Sources/SentryObjC/**"
   - "Sources/SentryObjCCompat/**"
   - "Sources/SentrySwiftUI/**"
@@ -71,6 +69,21 @@ run_unit_tests_for_prs: &run_unit_tests_for_prs
   - "fastlane/**"
   - "Makefile"
   - "Brewfile*"
+
+run_distribution_tests_for_prs: &run_distribution_tests_for_prs
+  - "Sources/SentryDistribution/**"
+  - "Sources/SentryDistributionTests/**"
+
+  # GH Actions
+  - ".github/workflows/test.yml"
+  - ".github/file-filters.yml"
+
+  # Scripts
+  - "scripts/ci-ensure-runtime-loaded.sh"
+  - "scripts/prepare-package.sh"
+
+  # Project files
+  - "Package*.swift"
 
 run_api_stability_for_prs: &run_api_stability_for_prs
   - "Sources/Configuration/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -80,6 +80,7 @@ run_distribution_tests_for_prs: &run_distribution_tests_for_prs
 
   # Scripts
   - "scripts/ci-ensure-runtime-loaded.sh"
+  - "scripts/ci-utils.sh"
   - "scripts/prepare-package.sh"
 
   # Project files

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -26,6 +26,8 @@ run_unit_tests_for_prs: &run_unit_tests_for_prs
   - "Sources/Sentry/**"
   - "Sources/SentryCppHelper/**"
   - "Sources/SentryCrash/**"
+  - "Sources/SentryDistribution/**"
+  - "Sources/SentryDistributionTests/**"
   - "Sources/SentryObjC/**"
   - "Sources/SentryObjCCompat/**"
   - "Sources/SentrySwiftUI/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -622,6 +622,8 @@ run_lint_swiftlint_for_prs: &run_lint_swiftlint_for_prs
   - "Sources/Sentry/**"
   - "Sources/SentryCppHelper/**"
   - "Sources/SentryCrash/**"
+  - "Sources/SentryDistribution/**"
+  - "Sources/SentryDistributionTests/**"
   - "Sources/SentryObjC/**"
   - "Sources/SentryObjCCompat/**"
   - "Sources/SentrySwiftUI/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -20,7 +20,16 @@ high_risk_code: &high_risk_code
   - ".github/file-filters.yml"
 
 run_unit_tests_for_prs: &run_unit_tests_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
   - "SentryTestUtils/**"
   - "SentryTestUtilsDynamic/**"
@@ -62,7 +71,16 @@ run_unit_tests_for_prs: &run_unit_tests_for_prs
   - "Brewfile*"
 
 run_api_stability_for_prs: &run_api_stability_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
 
   # GH Actions
   - ".github/workflows/api-stability.yml"
@@ -175,7 +193,16 @@ run_auto_update_tools_for_prs: &run_auto_update_tools_for_prs
   - ".swiftlint.yml"
 
 run_release_for_prs: &run_release_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
 
   # GH Actions
   - ".github/workflows/release.yml"
@@ -265,7 +292,16 @@ run_lint_dprint_for_prs: &run_lint_dprint_for_prs
   - "dprint.json"
 
 run_lint_xcode_analyze_for_prs: &run_lint_xcode_analyze_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
   - "Samples/**"
 
@@ -287,7 +323,16 @@ run_lint_xcode_analyze_for_prs: &run_lint_xcode_analyze_for_prs
   - "Makefile"
 
 run_v10_for_prs: &run_v10_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
 
   # GH Actions
@@ -311,10 +356,18 @@ run_v10_for_prs: &run_v10_for_prs
 
   # Build configuration
   - "Makefile"
-  - "Sources/Configuration/**"
 
 run_v10_with_kscrash_for_prs: &run_v10_with_kscrash_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
 
   # GH Actions
@@ -338,7 +391,6 @@ run_v10_with_kscrash_for_prs: &run_v10_with_kscrash_for_prs
 
   # Build configuration
   - "Makefile"
-  - "Sources/Configuration/**"
 
 run_build_for_prs: &run_build_for_prs
   - "Sources/**"
@@ -381,7 +433,16 @@ run_testflight_for_prs: &run_testflight_for_prs
   - "scripts/ci-utils.sh"
 
 run_testflight_for_pushes: &run_testflight_for_pushes
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Samples/iOS-Swift/**"
 
   # GH Actions
@@ -399,7 +460,16 @@ run_testflight_for_pushes: &run_testflight_for_pushes
   - "Makefile"
 
 run_codeql_analysis_for_prs: &run_codeql_analysis_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
 
   # GH Actions
   - ".github/workflows/codeql-analysis.yml"
@@ -450,7 +520,16 @@ run_apple_binaries_archive_for_prs: &run_apple_binaries_archive_for_prs
   - "distribution/**"
 
 run_ui_tests_for_prs: &run_ui_tests_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
 
   # GH Actions
@@ -484,7 +563,16 @@ run_ui_tests_for_prs: &run_ui_tests_for_prs
   - "Brewfile*"
 
 run_ui_tests_critical_for_prs: &run_ui_tests_critical_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "TestSamples/**"
 
   # GH Actions
@@ -513,7 +601,16 @@ run_ui_tests_critical_for_prs: &run_ui_tests_critical_for_prs
   - "Brewfile*"
 
 run_lint_swiftlint_for_prs: &run_lint_swiftlint_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Tests/**"
   - "Samples/**"
 
@@ -539,7 +636,16 @@ run_lint_swiftlint_for_prs: &run_lint_swiftlint_for_prs
   - "Brewfile*"
 
 run_size_analysis_for_prs: &run_size_analysis_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "Samples/**"
 
   # GH Actions
@@ -560,7 +666,16 @@ run_size_analysis_for_prs: &run_size_analysis_for_prs
   - "Brewfile*"
 
 run_xcode27_for_prs: &run_xcode27_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
 
   # GH Actions
   - ".github/workflows/xcode27-test.yml"
@@ -578,7 +693,16 @@ run_xcode27_for_prs: &run_xcode27_for_prs
   - "Package*.swift"
 
 run_3rd_party_integrations_tests_for_prs: &run_3rd_party_integrations_tests_for_prs
-  - "Sources/**"
+  - "Sources/Configuration/**"
+  - "Sources/include/**"
+  - "Sources/Resources/**"
+  - "Sources/Sentry/**"
+  - "Sources/SentryCppHelper/**"
+  - "Sources/SentryCrash/**"
+  - "Sources/SentryObjC/**"
+  - "Sources/SentryObjCCompat/**"
+  - "Sources/SentrySwiftUI/**"
+  - "Sources/Swift/**"
   - "3rd-party-integrations/**"
 
   # GH Actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       run_unit_tests_for_prs: ${{ steps.changes.outputs.run_unit_tests_for_prs }}
+      run_distribution_tests_for_prs: ${{ steps.changes.outputs.run_distribution_tests_for_prs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Get changed files
@@ -105,7 +106,7 @@ jobs:
     runs-on: macos-15
     # Don't run this on release branches, cause the SPM Package.swift points to the unreleased versions.
     # Also, skip when PR changes don't require running tests to save CI time.
-    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_unit_tests_for_prs == 'true')
+    if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_distribution_tests_for_prs == 'true')
     needs: files-changed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Description

SentryDistribution is a standalone SPM module that is **not** part of the Xcode project. The broad `Sources/**` glob in `file-filters.yml` caused 14 unrelated workflows to trigger on PRs that only touch SentryDistribution files, wasting CI resources.

This replaces the broad `Sources/**` glob with explicit subdirectory patterns (e.g., `Sources/Sentry/**`, `Sources/Swift/**`, `Sources/SentryCrash/**`) that enumerate all SDK modules except `SentryDistribution` and `SentryDistributionTests`.

### Why not `!` negation patterns?

`dorny/paths-filter` evaluates filter rules with **OR** logic (`predicate-quantifier: 'some'` by default). A negation pattern like `!Sources/SentryDistribution/**` matches any file that is NOT under that directory — including completely unrelated files. So even when only `SentryDistribution` files change, the negation pattern itself always evaluates to `true`, making the exclusion ineffective.

Using `predicate-quantifier: 'every'` would fix negation but would break all existing filters, since a file cannot simultaneously match `Sources/**` AND `Tests/**` AND `scripts/**`.

### Filters updated (14)
- `run_unit_tests_for_prs`
- `run_api_stability_for_prs`
- `run_release_for_prs`
- `run_lint_xcode_analyze_for_prs`
- `run_v10_for_prs`
- `run_v10_with_kscrash_for_prs`
- `run_testflight_for_pushes`
- `run_codeql_analysis_for_prs`
- `run_ui_tests_for_prs`
- `run_ui_tests_critical_for_prs`
- `run_lint_swiftlint_for_prs`
- `run_size_analysis_for_prs`
- `run_xcode27_for_prs`
- `run_3rd_party_integrations_tests_for_prs`

### Unchanged (still triggers correctly)
- `run_build_for_prs` — has the `build-distribution` job
- `run_lint_swift_formatting_for_prs` — swift-format applies to all `.swift` files

## How to verify

PR #8631 targets this branch and only touches `Sources/SentryDistribution/Updater.swift`. Check the `files-changed` job output in each workflow to confirm the excluded workflows skip correctly.

#skip-changelog