### PR TITLE
test: verify SentryDistribution file filter exclusions

### DIFF
--- a/Sources/SentryDistribution/Updater.swift
+++ b/Sources/SentryDistribution/Updater.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 #if canImport(UIKit)
 import UIKit
 #endif


### PR DESCRIPTION
## Description

Test PR to verify that the file filter exclusions from #8630 work correctly.

This PR only touches `Sources/SentryDistribution/Updater.swift` (a trivial blank line). With the updated filters, the 14 excluded workflows should show `false` in their `files-changed` job output and skip their main jobs.

### Expected results
- **Should trigger**: `build.yml` (has `build-distribution` job), `lint-swift-formatting.yml`
- **Should skip**: unit tests, API stability, release, v10 builds, UI tests, size analysis, CodeQL, TestFlight, Xcode analyze, Xcode 27, 3rd-party integrations, SwiftLint

#skip-changelog