### PR TITLE
ref: replace import SentrySwiftUI with import Sentry in samples

### DIFF
--- a/Samples/XCFramework-Validation/XCFramework/CheckTracedView.swift
+++ b/Samples/XCFramework-Validation/XCFramework/CheckTracedView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Sentry
 import SwiftUI
 
 @available(iOS 15.0, *)

--- a/Samples/XCFramework-Validation/XCFramework/CheckTracedView.swift
+++ b/Samples/XCFramework-Validation/XCFramework/CheckTracedView.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SentrySwiftUI
 import SwiftUI
 
 @available(iOS 15.0, *)

--- a/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
@@ -1,8 +1,7 @@
 import Sentry
-import SentrySwiftUI
 import SwiftUI
 
-// This sample app also serves as a build-time validation that the SentrySwiftUI module
+// This sample app also serves as a build-time validation that the Sentry module
 // correctly exposes all public APIs (SentryTracedView, sentryTrace(), sentryReplayMask(),
 // sentryReplayUnmask(), etc.). If any of these APIs are accidentally removed or renamed,
 // the build for this sample will fail in CI.

--- a/Samples/iOS-SwiftUI/App/Sources/FeedbackScreen.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/FeedbackScreen.swift
@@ -1,5 +1,4 @@
 import Sentry
-import SentrySwiftUI
 import SwiftUI
 
 struct FeedbackScreen: View {

--- a/Samples/iOS-SwiftUI/App/Sources/FormScreen.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/FormScreen.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SentrySwiftUI
+import Sentry
 import SwiftUI
 
 struct FormScreen: View {

--- a/Samples/iOS-SwiftUI/App/Sources/LoremIpsumView.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/LoremIpsumView.swift
@@ -1,6 +1,6 @@
 import Foundation
+import Sentry
 import SentrySampleShared
-import SentrySwiftUI
 import SwiftUI
 
 struct LoremIpsumView: View {

--- a/Samples/iOS-SwiftUI/App/Sources/UIKitScreen.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/UIKitScreen.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SentrySwiftUI
+import Sentry
 import SwiftUI
 import UIKit
 

--- a/Samples/macOS-SPM-CommandLine/Package.swift
+++ b/Samples/macOS-SPM-CommandLine/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .target(
             name: "macOS-SPM-CommandLine",
-            dependencies: ["Sentry", .product(name: "SentrySwiftUI", package: "Sentry")],
+            dependencies: ["Sentry"],
             swiftSettings: [
                 .unsafeFlags(["-warnings-as-errors"])
             ])

--- a/Samples/macOS-Swift/App/Sources/SwiftUIView.swift
+++ b/Samples/macOS-Swift/App/Sources/SwiftUIView.swift
@@ -1,4 +1,4 @@
-import SentrySwiftUI
+import Sentry
 import SwiftUI
 
 struct SwiftUIView: View {

--- a/Samples/visionOS-Swift/App/Sources/ContentView.swift
+++ b/Samples/visionOS-Swift/App/Sources/ContentView.swift
@@ -1,6 +1,5 @@
 import RealityKit
 import Sentry
-import SentrySwiftUI
 import SwiftUI
 
 struct ContentView: View {

--- a/Samples/visionOS-Swift/App/Sources/LoremIpsumView.swift
+++ b/Samples/visionOS-Swift/App/Sources/LoremIpsumView.swift
@@ -1,6 +1,6 @@
 import Foundation
+import Sentry
 import SentrySampleShared
-import SentrySwiftUI
 import SwiftUI
 
 struct LoremIpsumView: View {


### PR DESCRIPTION
## Description

SentrySwiftUI types are now re-exported from the Sentry module, so the separate `import SentrySwiftUI` is no longer needed. This removes the redundant import across all sample apps:

- Files that already had `import Sentry`: removed the redundant `import SentrySwiftUI`
- Files that only had `import SentrySwiftUI`: replaced with `import Sentry`
- `Samples/macOS-SPM-CommandLine/Package.swift`: removed the `SentrySwiftUI` product dependency

No source `import SentrySwiftUI` remains outside `SentrySwiftUIExports.swift` (the re-export shim). Xcode project framework references (`SentrySwiftUI.framework` in `.pbxproj`) are unchanged since the framework still ships as a build product.

#skip-changelog

Closes #8635