### PR TITLE
ci: distribute 3rd-party integrations via Craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,6 +9,26 @@ targets:
     repositoryUrl: https://github.com/getsentry/sentry-apple-binaries
     branch: main
     createTag: true
+  - name: commit-on-git-repository
+    archive: /^sentry-apple-swift-log\.tgz$/
+    repositoryUrl: https://github.com/getsentry/sentry-apple-swift-log
+    branch: main
+    createTag: true
+  - name: commit-on-git-repository
+    archive: /^sentry-apple-swiftybeaver\.tgz$/
+    repositoryUrl: https://github.com/getsentry/sentry-apple-swiftybeaver
+    branch: main
+    createTag: true
+  - name: commit-on-git-repository
+    archive: /^sentry-apple-pulse\.tgz$/
+    repositoryUrl: https://github.com/getsentry/sentry-apple-pulse
+    branch: main
+    createTag: true
+  - name: commit-on-git-repository
+    archive: /^sentry-apple-cocoalumberjack\.tgz$/
+    repositoryUrl: https://github.com/getsentry/sentry-apple-cocoalumberjack
+    branch: main
+    createTag: true
   # The canonical name 'cocoapods:sentry-cocoa' is a historical artifact from when
   # the SDK was distributed via CocoaPods. Changing it requires manual surgery in
   # the sentry-release-registry repo, so we keep it as-is.

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -449,6 +449,12 @@ run_apple_binaries_archive_for_prs: &run_apple_binaries_archive_for_prs
   - "scripts/create-apple-binaries-archive.sh"
   - "distribution/**"
 
+run_3rd_party_integrations_archive_for_prs: &run_3rd_party_integrations_archive_for_prs
+  - ".github/workflows/3rd-party-integrations-archive.yml"
+  - ".github/file-filters.yml"
+  - "scripts/create-3rd-party-integration-archive.sh"
+  - "3rd-party-integrations/**"
+
 run_ui_tests_for_prs: &run_ui_tests_for_prs
   - "Sources/**"
   - "Tests/**"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -447,12 +447,14 @@ run_apple_binaries_archive_for_prs: &run_apple_binaries_archive_for_prs
   - ".github/workflows/apple-binaries-archive.yml"
   - ".github/file-filters.yml"
   - "scripts/create-apple-binaries-archive.sh"
+  - "scripts/ci-utils.sh"
   - "distribution/**"
 
 run_3rd_party_integrations_archive_for_prs: &run_3rd_party_integrations_archive_for_prs
   - ".github/workflows/3rd-party-integrations-archive.yml"
   - ".github/file-filters.yml"
   - "scripts/create-3rd-party-integration-archive.sh"
+  - "scripts/ci-utils.sh"
   - "3rd-party-integrations/**"
 
 run_ui_tests_for_prs: &run_ui_tests_for_prs

--- a/.github/workflows/3rd-party-integrations-archive.yml
+++ b/.github/workflows/3rd-party-integrations-archive.yml
@@ -1,0 +1,90 @@
+name: Test 3rd-Party Integrations Archive
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    outputs:
+      run_for_prs: ${{ steps.changes.outputs.run_3rd_party_integrations_archive_for_prs }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+  test-3rd-party-integrations-archive:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_for_prs == 'true'
+    needs: files-changed
+    name: Test 3rd-Party Integrations Archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create archives
+        run: |
+          ./scripts/create-3rd-party-integration-archive.sh \
+            --all \
+            --output-dir /tmp/3rd-party-archives
+
+      - name: Verify archives
+        run: |
+          INTEGRATIONS=(
+            "sentry-apple-swift-log:SentryLogHandler.swift:SentryLogHandlerTests.swift"
+            "sentry-apple-swiftybeaver:SentryDestination.swift:SentryDestinationTests.swift"
+            "sentry-apple-pulse:SentryPulse.swift:SentryPulseTests.swift"
+            "sentry-apple-cocoalumberjack:SentryCocoaLumberjackLogger.swift:SentryCocoaLumberjackLoggerTests.swift"
+          )
+
+          for entry in "${INTEGRATIONS[@]}"; do
+            IFS=':' read -r archive_name source_file test_file <<< "$entry"
+            archive="/tmp/3rd-party-archives/${archive_name}.tgz"
+            verify_dir="/tmp/3rd-party-verify/${archive_name}"
+
+            echo "=== Verifying ${archive_name} ==="
+
+            test -f "$archive" || { echo "Archive not found: $archive"; exit 1; }
+
+            mkdir -p "$verify_dir"
+            tar -xzf "$archive" -C "$verify_dir"
+
+            # Verify expected files exist
+            test -f "$verify_dir/Package.swift"
+            test -f "$verify_dir/.gitignore"
+            test -f "$verify_dir/README.md"
+            test -f "$verify_dir/LICENSE.md"
+            test -f "$verify_dir/Sources/$source_file"
+            test -f "$verify_dir/Tests/$test_file"
+
+            echo "${archive_name} verified successfully"
+          done
+
+          echo "All 3rd-party integration archives verified successfully"
+
+  third-party-integrations-archive-required-check:
+    needs:
+      [
+        files-changed,
+        test-3rd-party-integrations-archive,
+      ]
+    name: Test 3rd-Party Integrations Archive - Required Check
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "3rd-party integrations archive test failed." && exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,6 +516,13 @@ jobs:
             --xcframework-dir XCFrameworkBuildPath \
             --output-dir XCFrameworkBuildPath
 
+      - name: Create 3rd-party integration archives
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          ./scripts/create-3rd-party-integration-archive.sh \
+            --all \
+            --output-dir XCFrameworkBuildPath
+
       - name: Archive XCFrameworks for Craft
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/scripts/ci-utils.sh
+++ b/scripts/ci-utils.sh
@@ -213,3 +213,28 @@ append_summary() {
     echo "[summary] ${content}"
   fi
 }
+
+# Create a .tgz archive from a staging directory.
+#
+# Usage:
+#   staging_dir=$(create_staging_dir)
+#   # ... populate $staging_dir ...
+#   create_tgz_from_staging "$staging_dir" "/path/to/output.tgz"
+#
+# The staging directory is removed after the archive is created.
+create_staging_dir() {
+  mktemp -d
+}
+
+create_tgz_from_staging() {
+  local staging_dir="$1"
+  local archive_path="$2"
+
+  (cd "$staging_dir" && find . -type f | sed 's|^\./||' | sort | xargs tar -czf "$archive_path" -C "$staging_dir")
+
+  rm -rf "$staging_dir"
+
+  log_info "Created $archive_path"
+  log_info "Contents:"
+  tar -tzf "$archive_path"
+}

--- a/scripts/ci-utils.sh
+++ b/scripts/ci-utils.sh
@@ -231,7 +231,7 @@ create_tgz_from_staging() {
   local archive_path
   archive_path="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
-  (cd "$staging_dir" && find . -type f | sed 's|^\./||' | sort | xargs tar -czf "$archive_path")
+  (cd "$staging_dir" && find . -type f -print0 | sed -z 's|^\./||' | sort -z | xargs -0 tar -czf "$archive_path" --)
 
   rm -rf "$staging_dir"
 

--- a/scripts/ci-utils.sh
+++ b/scripts/ci-utils.sh
@@ -228,9 +228,10 @@ create_staging_dir() {
 
 create_tgz_from_staging() {
   local staging_dir="$1"
-  local archive_path="$2"
+  local archive_path
+  archive_path="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
-  (cd "$staging_dir" && find . -type f | sed 's|^\./||' | sort | xargs tar -czf "$archive_path" -C "$staging_dir")
+  (cd "$staging_dir" && find . -type f | sed 's|^\./||' | sort | xargs tar -czf "$archive_path")
 
   rm -rf "$staging_dir"
 

--- a/scripts/create-3rd-party-integration-archive.sh
+++ b/scripts/create-3rd-party-integration-archive.sh
@@ -67,6 +67,8 @@ if [ -z "$OUTPUT_DIR" ]; then
     OUTPUT_DIR="$REPO_ROOT"
 fi
 
+mkdir -p "$OUTPUT_DIR"
+
 create_archive() {
     local dir_name="$1"
     local archive_name

--- a/scripts/create-3rd-party-integration-archive.sh
+++ b/scripts/create-3rd-party-integration-archive.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ci-utils.sh disable=SC1091
+source "$SCRIPT_DIR/ci-utils.sh"
+
+OUTPUT_DIR=""
+INTEGRATION=""
+ALL=false
+
+INTEGRATIONS_DIR="3rd-party-integrations"
+
+ALL_DIR_NAMES="SentrySwiftLog SentrySwiftyBeaver SentryPulse SentryCocoaLumberjack"
+
+archive_name_for() {
+    case "$1" in
+        SentrySwiftLog)       echo "sentry-apple-swift-log" ;;
+        SentrySwiftyBeaver)   echo "sentry-apple-swiftybeaver" ;;
+        SentryPulse)          echo "sentry-apple-pulse" ;;
+        SentryCocoaLumberjack) echo "sentry-apple-cocoalumberjack" ;;
+        *) echo "" ;;
+    esac
+}
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Create .tgz archives for 3rd-party integration distribution repos.
+Copies sources, tests, README, .gitignore, and LICENSE.md.
+
+OPTIONS:
+    --integration <name>        Directory name under $INTEGRATIONS_DIR
+                                (e.g. SentrySwiftLog)
+    --all                       Archive all integrations
+    --output-dir <path>         Directory to write archives to (default: repo root)
+    -h, --help                  Show this help message
+
+EXAMPLES:
+    $(basename "$0") --all
+    $(basename "$0") --integration SentrySwiftLog
+    $(basename "$0") --all --output-dir XCFrameworkBuildPath
+
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --integration) INTEGRATION="$2"; shift 2 ;;
+        --all)         ALL=true;         shift ;;
+        --output-dir)  OUTPUT_DIR="$2";  shift 2 ;;
+        -h|--help)     usage ;;
+        *)             log_error "Unknown option: $1"; usage ;;
+    esac
+done
+
+if [ "$ALL" = false ] && [ -z "$INTEGRATION" ]; then
+    log_error "Either --all or --integration <name> is required"
+    usage
+fi
+
+REPO_ROOT="$SCRIPT_DIR/.."
+
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR="$REPO_ROOT"
+fi
+
+create_archive() {
+    local dir_name="$1"
+    local archive_name
+    archive_name=$(archive_name_for "$dir_name")
+    local src_dir="$REPO_ROOT/$INTEGRATIONS_DIR/$dir_name"
+
+    if [ -z "$archive_name" ]; then
+        log_error "Unknown integration: $dir_name"
+        exit 1
+    fi
+
+    if [ ! -d "$src_dir" ]; then
+        log_error "Directory not found: $src_dir"
+        exit 1
+    fi
+
+    local archive_file="$archive_name.tgz"
+    local archive_path="$OUTPUT_DIR/$archive_file"
+
+    begin_group "Create $archive_file"
+
+    local staging_dir
+    staging_dir=$(create_staging_dir)
+
+    cp "$src_dir/Package.swift" "$staging_dir/Package.swift"
+    cp "$src_dir/.gitignore" "$staging_dir/.gitignore"
+    cp "$src_dir/README.md" "$staging_dir/README.md"
+    cp "$REPO_ROOT/LICENSE.md" "$staging_dir/LICENSE.md"
+
+    cp -R "$src_dir/Sources" "$staging_dir/Sources"
+    cp -R "$src_dir/Tests" "$staging_dir/Tests"
+
+    create_tgz_from_staging "$staging_dir" "$archive_path"
+
+    end_group
+}
+
+if [ "$ALL" = true ]; then
+    for dir_name in $ALL_DIR_NAMES; do
+        create_archive "$dir_name"
+    done
+else
+    create_archive "$INTEGRATION"
+fi

--- a/scripts/create-apple-binaries-archive.sh
+++ b/scripts/create-apple-binaries-archive.sh
@@ -70,8 +70,7 @@ ARCHIVE_PATH="$OUTPUT_DIR/$ARCHIVE_NAME"
 
 begin_group "Create $ARCHIVE_NAME"
 
-STAGING_DIR=$(mktemp -d)
-trap 'rm -rf "$STAGING_DIR"' EXIT
+STAGING_DIR=$(create_staging_dir)
 
 cp "$DIST_DIR/Package.swift" "$STAGING_DIR/Package.swift"
 cp "$DIST_DIR/.gitignore" "$STAGING_DIR/.gitignore"
@@ -83,6 +82,7 @@ cp "$DIST_DIR/Sources/SentryCppHelper/SentryCppHelper.swift" "$STAGING_DIR/Sourc
 log_info "Preparing CHANGELOG.md for version $VERSION"
 cp "$REPO_ROOT/CHANGELOG.md" "$STAGING_DIR/CHANGELOG.md"
 sed -i.bak "s/^## Unreleased$/## ${VERSION}/" "$STAGING_DIR/CHANGELOG.md"
+rm -f "$STAGING_DIR/CHANGELOG.md.bak"
 
 log_info "Stamping version $VERSION into Package.swift"
 sed -i.bak "s|releases/download/[^/]*/|releases/download/${VERSION}/|g" "$STAGING_DIR/Package.swift"
@@ -103,17 +103,6 @@ for entry in "${ZIPS_AND_MARKERS[@]}"; do
     log_info "  ${marker}: ${checksum}"
 done
 
-tar -czf "$ARCHIVE_PATH" \
-    -C "$STAGING_DIR" \
-    Package.swift \
-    Sources/SentryCppHelper/SentryCppHelper.swift \
-    CHANGELOG.md \
-    README.md \
-    LICENSE.md \
-    .gitignore
-
-log_info "Created $ARCHIVE_PATH"
-log_info "Contents:"
-tar -tzf "$ARCHIVE_PATH"
+create_tgz_from_staging "$STAGING_DIR" "$ARCHIVE_PATH"
 
 end_group


### PR DESCRIPTION
## Summary

* Add Craft `commit-on-git-repository` targets so each 3rd-party integration package is pushed to its own repo on release:
  * `SentrySwiftLog` → `getsentry/sentry-apple-swift-log`
  * `SentrySwiftyBeaver` → `getsentry/sentry-apple-swiftybeaver`
  * `SentryPulse` → `getsentry/sentry-apple-pulse`
  * `SentryCocoaLumberjack` → `getsentry/sentry-apple-cocoalumberjack`
* New archive script (`scripts/create-3rd-party-integration-archive.sh`) bundles sources, tests, README, .gitignore, and LICENSE.md into `.tgz` archives
* Extract shared staging/tar helpers into `ci-utils.sh` and migrate both archive scripts to use them
* Add CI workflow to test archive creation on PRs

## Prerequisites

* The 4 target repos must exist on GitHub with a `main` branch
* The GitHub token used by Craft needs write access to all 4 repos

#skip-changelog

Closes getsentry/sentry-cocoa#8634