### PR TITLE
docs: fix repository URLs in 3rd-party integration READMEs

### DIFF
--- a/3rd-party-integrations/SentryCocoaLumberjack/README.md
+++ b/3rd-party-integrations/SentryCocoaLumberjack/README.md
@@ -13,7 +13,7 @@ Add the following dependencies to your `Package.swift` or Xcode package dependen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/getsentry/sentry-cocoa-cocoalumberjack", from: "9.0.0")
+    .package(url: "https://github.com/getsentry/sentry-apple-cocoalumberjack", from: "9.0.0")
 ]
 ```
 

--- a/3rd-party-integrations/SentryPulse/README.md
+++ b/3rd-party-integrations/SentryPulse/README.md
@@ -13,7 +13,7 @@ Add the following dependencies to your `Package.swift` or Xcode package manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/getsentry/sentry-cocoa-pulse", from: "9.0.0")
+    .package(url: "https://github.com/getsentry/sentry-apple-pulse", from: "9.0.0")
 ]
 ```
 

--- a/3rd-party-integrations/SentrySwiftLog/README.md
+++ b/3rd-party-integrations/SentrySwiftLog/README.md
@@ -13,7 +13,7 @@ Add the following dependencies to your `Package.swift` or Xcode package dependen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/getsentry/sentry-cocoa-swiftlog", from: "1.0.0")
+    .package(url: "https://github.com/getsentry/sentry-apple-swift-log", from: "1.0.0")
 ]
 ```
 

--- a/3rd-party-integrations/SentrySwiftyBeaver/README.md
+++ b/3rd-party-integrations/SentrySwiftyBeaver/README.md
@@ -13,7 +13,7 @@ Add the following dependencies to your `Package.swift` or Xcode package dependen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/getsentry/sentry-cocoa-swiftybeaver", from: "9.0.0")
+    .package(url: "https://github.com/getsentry/sentry-apple-swiftybeaver", from: "9.0.0")
 ]
 ```
 


### PR DESCRIPTION
## Summary

* Updates SPM package URLs in all 4 integration READMEs to match the actual repository names
  * `sentry-cocoa-swiftlog` → `sentry-apple-swift-log`
  * `sentry-cocoa-cocoalumberjack` → `sentry-apple-cocoalumberjack`
  * `sentry-cocoa-pulse` → `sentry-apple-pulse`
  * `sentry-cocoa-swiftybeaver` → `sentry-apple-swiftybeaver`

#skip-changelog

Closes getsentry/sentry-cocoa#8645