### PR TITLE
test: Mark ObjC profiling test as flaky

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -87,6 +87,9 @@
     },
     {
       "parallelizable" : false,
+      "skippedTests" : [
+        "SentryObjCInternalProfilingApiIntegrationTests\/testCollect_shouldContainTransactionInfo"
+      ],
       "target" : {
         "containerPath" : "container:Sentry.xcodeproj",
         "identifier" : "D4B67CFB2FC5E6F20022BC67",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -45,6 +45,16 @@
         "identifier" : "8431EECF29B27B1100D8DC56",
         "name" : "SentryProfilerTests"
       }
+    },
+    {
+      "selectedTests" : [
+        "SentryObjCInternalProfilingApiIntegrationTests\/testCollect_shouldContainTransactionInfo"
+      ],
+      "target" : {
+        "containerPath" : "container:Sentry.xcodeproj",
+        "identifier" : "D4B67CFB2FC5E6F20022BC67",
+        "name" : "SentryObjCTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
Move `SentryObjCInternalProfilingApiIntegrationTests.testCollect_shouldContainTransactionInfo` from the regular test plan to the retry-on-failure flaky test plan. The test remains exercised, but an intermittent first-attempt failure can now be retried.

This prevents the same profiling-test flake from failing another unit-test job as it did in [this macOS 26 run](<https://github.com/getsentry/sentry-cocoa/actions/runs/30795276219?pr=8638>).

#skip-changelog

Closes getsentry/sentry-cocoa#8647