### PR TITLE
fix: Stream envelopes to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
-- Reduce memory usage when storing envelopes with large attachments (#3630)
+- Reduce memory usage when storing envelopes with large attachments (#8649)
 - Fix incorrect `duration` sent for active sessions (#8612)
   - Session `duration` is now set only when the session ends. Active sessions (including on error increments) no longer emit a bogus `duration`.
 - Fix a race that could prevent consecutive app hangs from being reported (#8627)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- Reduce memory usage when storing envelopes with large attachments (#3630)
 - Fix incorrect `duration` sent for active sessions (#8612)
   - Session `duration` is now set only when the session ends. Active sessions (including on error increments) no longer emit a bogus `duration`.
 - Fix a race that could prevent consecutive app hangs from being reported (#8627)

--- a/Sources/Sentry/SentryFileManagerHelper.m
+++ b/Sources/Sentry/SentryFileManagerHelper.m
@@ -198,15 +198,15 @@ _non_thread_safe_removeFileAtPath(NSString *path)
 
 #pragma mark - Envelope
 
-- (nullable NSString *)storeEnvelopeData:(NSData *)envelopeData
-                             currentTime:(NSTimeInterval)currentTime
+- (nullable NSString *)storeEnvelopeWithCurrentTime:(NSTimeInterval)currentTime
+                                        writeToPath:(BOOL (^)(NSString *path))writeToPath
 {
     @synchronized(self) {
         NSString *path = [self.envelopesPath
             stringByAppendingPathComponent:[self uniqueAscendingJsonName:currentTime]];
         SENTRY_LOG_DEBUG(@"Writing envelope to path: %@", path);
 
-        if (![self writeData:envelopeData toPath:path]) {
+        if (!writeToPath(path)) {
             SENTRY_LOG_WARN(@"Failed to store envelope.");
             return nil;
         }

--- a/Sources/Sentry/include/SentryFileManagerHelper.h
+++ b/Sources/Sentry/include/SentryFileManagerHelper.h
@@ -41,8 +41,8 @@ SENTRY_NO_INIT
 
 #pragma mark - Envelope
 
-- (nullable NSString *)storeEnvelopeData:(NSData *)envelopeData
-                             currentTime:(NSTimeInterval)currentTime;
+- (nullable NSString *)storeEnvelopeWithCurrentTime:(NSTimeInterval)currentTime
+                                        writeToPath:(BOOL (^)(NSString *path))writeToPath;
 /**
  * Only used for testing.
  */

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -47,12 +47,9 @@ internal import _SentryPrivate
     }
 
     @discardableResult @objc(storeEnvelope:) public func store(_ envelope: SentryEnvelope) -> String? {
-        let envelopeData = SentrySerializationSwift.data(with: envelope)
-        guard let envelopeData else {
-            SentrySDKLog.error("Serialization of envelope failed. Can't store envelope.")
-            return nil
+        helper.storeEnvelope(withCurrentTime: dateProvider.date().timeIntervalSince1970) { [weak self] path in
+            self?.write(envelope, toPath: path) ?? false
         }
-        return helper.storeEnvelopeData(envelopeData, currentTime: self.dateProvider.date().timeIntervalSince1970)
     }
     
     @objc public func getEnvelopesPath(_ filePath: String) -> String? {
@@ -313,6 +310,55 @@ internal import _SentryPrivate
             removeFile(atPath: envelopeFilePath)
         }
         SentrySDKLog.debug("Removed \(numberOfEnvelopesToRemove) file(s) from <\((envelopesPath as NSString).lastPathComponent)>")
+    }
+}
+
+private extension SentryFileManager {
+    func write(_ envelope: SentryEnvelope, toPath path: String) -> Bool {
+        let temporaryPath = (sentryPath as NSString).appendingPathComponent("\(UUID().uuidString).tmp")
+        guard FileManager.default.createFile(atPath: temporaryPath, contents: nil) else {
+            SentrySDKLog.error("Failed to create temporary envelope file at path: \(temporaryPath)")
+            return false
+        }
+
+        guard let fileHandle = FileHandle(forWritingAtPath: temporaryPath) else {
+            SentrySDKLog.error("Failed to open temporary envelope file at path: \(temporaryPath)")
+            removeFile(atPath: temporaryPath)
+            return false
+        }
+
+        var isFileOpen = true
+        defer {
+            if isFileOpen {
+                try? fileHandle.close()
+            }
+            try? FileManager.default.removeItem(atPath: temporaryPath)
+        }
+
+        let serialized = SentrySerializationSwift.writeEnvelopeData(envelope) { data in
+            do {
+                try fileHandle.write(contentsOf: data)
+                return true
+            } catch {
+                SentrySDKLog.error("Failed to write envelope data to temporary file: \(error)")
+                return false
+            }
+        }
+        guard serialized else {
+            SentrySDKLog.error("Serialization of envelope failed. Can't store envelope.")
+            return false
+        }
+
+        do {
+            try fileHandle.synchronize()
+            try fileHandle.close()
+            isFileOpen = false
+            try FileManager.default.moveItem(atPath: temporaryPath, toPath: path)
+            return true
+        } catch {
+            SentrySDKLog.error("Failed to atomically store envelope at path \(path): \(error)")
+            return false
+        }
     }
 }
 // swiftlint:enable missing_docs

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -315,33 +315,37 @@ internal import _SentryPrivate
 
 private extension SentryFileManager {
     func write(_ envelope: SentryEnvelope, toPath path: String) -> Bool {
-        let temporaryPath = FileManager.default.temporaryDirectory
+        let destinationURL = URL(fileURLWithPath: path)
+        let temporaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(UUID().uuidString).tmp")
-            .path
-        guard FileManager.default.createFile(atPath: temporaryPath, contents: nil) else {
-            SentrySDKLog.error("Failed to create temporary envelope file at path: \(temporaryPath)")
+        guard FileManager.default.createFile(atPath: temporaryURL.path, contents: nil) else {
+            SentrySDKLog.error("Failed to create temporary envelope file at path: \(temporaryURL.path)")
             return false
         }
-        defer { removeTemporaryFile(atPath: temporaryPath) }
+        defer { removeTemporaryFile(at: temporaryURL) }
 
-        guard writeEnvelope(envelope, toTemporaryPath: temporaryPath) else {
+        guard writeEnvelope(envelope, toTemporaryURL: temporaryURL) else {
             return false
         }
 
         do {
-            try FileManager.default.moveItem(atPath: temporaryPath, toPath: path)
+            try FileManager.default.moveItem(at: temporaryURL, to: destinationURL)
             return true
         } catch {
-            SentrySDKLog.error("Failed to publish envelope at path \(path): \(error)")
+            SentrySDKLog.error("Failed to publish envelope at path \(destinationURL.path): \(error)")
             return false
         }
     }
 
-    func writeEnvelope(_ envelope: SentryEnvelope, toTemporaryPath path: String) -> Bool {
-        guard let fileHandle = FileHandle(forWritingAtPath: path) else {
-            SentrySDKLog.error("Failed to open temporary envelope file at path: \(path)")
+    func writeEnvelope(_ envelope: SentryEnvelope, toTemporaryURL url: URL) -> Bool {
+        let fileHandle: FileHandle
+        do {
+            fileHandle = try FileHandle(forWritingTo: url)
+        } catch {
+            SentrySDKLog.error("Failed to open temporary envelope file at path \(url.path): \(error)")
             return false
         }
+        defer { close(fileHandle, at: url) }
 
         let serialized = SentrySerializationSwift.writeEnvelopeData(envelope) { data in
             do {
@@ -353,7 +357,6 @@ private extension SentryFileManager {
             }
         }
         guard serialized else {
-            close(fileHandle, atPath: path)
             SentrySDKLog.error("Serialization of envelope failed. Can't store envelope.")
             return false
         }
@@ -361,32 +364,28 @@ private extension SentryFileManager {
         do {
             try fileHandle.synchronize()
         } catch {
-            close(fileHandle, atPath: path)
-            SentrySDKLog.error("Failed to synchronize temporary envelope file at path \(path): \(error)")
+            SentrySDKLog.error("Failed to synchronize temporary envelope file at path \(url.path): \(error)")
             return false
         }
-        return close(fileHandle, atPath: path)
+        return true
     }
 
-    @discardableResult
-    func close(_ fileHandle: FileHandle, atPath path: String) -> Bool {
+    func close(_ fileHandle: FileHandle, at url: URL) {
         do {
             try fileHandle.close()
-            return true
         } catch {
-            SentrySDKLog.debug("Failed to close temporary envelope file at path \(path): \(error)")
-            return false
+            SentrySDKLog.debug("Failed to close temporary envelope file at path \(url.path): \(error)")
         }
     }
 
-    func removeTemporaryFile(atPath path: String) {
-        guard FileManager.default.fileExists(atPath: path) else {
+    func removeTemporaryFile(at url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else {
             return
         }
         do {
-            try FileManager.default.removeItem(atPath: path)
+            try FileManager.default.removeItem(at: url)
         } catch {
-            SentrySDKLog.debug("Failed to remove temporary envelope file at path \(path): \(error)")
+            SentrySDKLog.debug("Failed to remove temporary envelope file at path \(url.path): \(error)")
         }
     }
 }

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -47,8 +47,8 @@ internal import _SentryPrivate
     }
 
     @discardableResult @objc(storeEnvelope:) public func store(_ envelope: SentryEnvelope) -> String? {
-        helper.storeEnvelope(withCurrentTime: dateProvider.date().timeIntervalSince1970) { [weak self] path in
-            self?.write(envelope, toPath: path) ?? false
+        helper.storeEnvelope(withCurrentTime: dateProvider.date().timeIntervalSince1970) { [self] path in
+            write(envelope, toPath: path)
         }
     }
     

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -315,7 +315,9 @@ internal import _SentryPrivate
 
 private extension SentryFileManager {
     func write(_ envelope: SentryEnvelope, toPath path: String) -> Bool {
-        let temporaryPath = (sentryPath as NSString).appendingPathComponent("\(UUID().uuidString).tmp")
+        let temporaryPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).tmp")
+            .path
         guard FileManager.default.createFile(atPath: temporaryPath, contents: nil) else {
             SentrySDKLog.error("Failed to create temporary envelope file at path: \(temporaryPath)")
             return false

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -320,19 +320,25 @@ private extension SentryFileManager {
             SentrySDKLog.error("Failed to create temporary envelope file at path: \(temporaryPath)")
             return false
         }
+        defer { removeTemporaryFile(atPath: temporaryPath) }
 
-        guard let fileHandle = FileHandle(forWritingAtPath: temporaryPath) else {
-            SentrySDKLog.error("Failed to open temporary envelope file at path: \(temporaryPath)")
-            removeFile(atPath: temporaryPath)
+        guard writeEnvelope(envelope, toTemporaryPath: temporaryPath) else {
             return false
         }
 
-        var isFileOpen = true
-        defer {
-            if isFileOpen {
-                try? fileHandle.close()
-            }
-            try? FileManager.default.removeItem(atPath: temporaryPath)
+        do {
+            try FileManager.default.moveItem(atPath: temporaryPath, toPath: path)
+            return true
+        } catch {
+            SentrySDKLog.error("Failed to publish envelope at path \(path): \(error)")
+            return false
+        }
+    }
+
+    func writeEnvelope(_ envelope: SentryEnvelope, toTemporaryPath path: String) -> Bool {
+        guard let fileHandle = FileHandle(forWritingAtPath: path) else {
+            SentrySDKLog.error("Failed to open temporary envelope file at path: \(path)")
+            return false
         }
 
         let serialized = SentrySerializationSwift.writeEnvelopeData(envelope) { data in
@@ -345,19 +351,40 @@ private extension SentryFileManager {
             }
         }
         guard serialized else {
+            close(fileHandle, atPath: path)
             SentrySDKLog.error("Serialization of envelope failed. Can't store envelope.")
             return false
         }
 
         do {
             try fileHandle.synchronize()
+        } catch {
+            close(fileHandle, atPath: path)
+            SentrySDKLog.error("Failed to synchronize temporary envelope file at path \(path): \(error)")
+            return false
+        }
+        return close(fileHandle, atPath: path)
+    }
+
+    @discardableResult
+    func close(_ fileHandle: FileHandle, atPath path: String) -> Bool {
+        do {
             try fileHandle.close()
-            isFileOpen = false
-            try FileManager.default.moveItem(atPath: temporaryPath, toPath: path)
             return true
         } catch {
-            SentrySDKLog.error("Failed to atomically store envelope at path \(path): \(error)")
+            SentrySDKLog.debug("Failed to close temporary envelope file at path \(path): \(error)")
             return false
+        }
+    }
+
+    func removeTemporaryFile(atPath path: String) {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return
+        }
+        do {
+            try FileManager.default.removeItem(atPath: path)
+        } catch {
+            SentrySDKLog.debug("Failed to remove temporary envelope file at path \(path): \(error)")
         }
     }
 }

--- a/Sources/Swift/Helper/SentrySerializationSwift.swift
+++ b/Sources/Swift/Helper/SentrySerializationSwift.swift
@@ -49,43 +49,56 @@ internal import _SentryPrivate
     
     @objc(dataWithEnvelope:) public static func data(with envelope: SentryEnvelope) -> Data? {
         var envelopeData = Data()
+        guard writeEnvelopeData(envelope, writer: { data in
+            envelopeData.append(data)
+            return true
+        }) else {
+            return nil
+        }
+        return envelopeData
+    }
+
+    static func writeEnvelopeData(_ envelope: SentryEnvelope, writer: (Data) -> Bool) -> Bool {
+        guard let header = envelopeHeaderData(envelope.header) else {
+            return false
+        }
+        guard writer(header) else {
+            return false
+        }
+
+        let newLineData = Data("\n".utf8)
+        return envelope.items.allSatisfy { item in
+            writeEnvelopeItem(item, newLineData: newLineData, writer: writer)
+        }
+    }
+
+    private static func envelopeHeaderData(_ header: SentryEnvelopeHeader) -> Data? {
         var serializedData: [String: Any] = [:]
-        if let eventId = envelope.header.eventId {
-            serializedData["event_id"] = eventId.sentryIdString
-        }
-        
-        if let sdkInfo = envelope.header.sdkInfo {
-            serializedData["sdk"] = sdkInfo.serialize()
-        }
-        
-        if let traceContext = envelope.header.traceContext {
-            serializedData["trace"] = traceContext.serialize()
-        }
-        
-        if let sentAt = envelope.header.sentAt {
+        serializedData["event_id"] = header.eventId?.sentryIdString
+        serializedData["sdk"] = header.sdkInfo?.serialize()
+        serializedData["trace"] = header.traceContext?.serialize()
+        if let sentAt = header.sentAt {
             serializedData["sent_at"] = sentry_toIso8601String(sentAt)
         }
-        guard let header = SentrySerializationSwift.data(withJSONObject: serializedData) else {
+        guard let data = SentrySerializationSwift.data(withJSONObject: serializedData) else {
             SentrySDKLog.error("Envelope header cannot be converted to JSON.")
             return nil
         }
-        envelopeData.append(header)
-        let newLineData = Data("\n".utf8)
-        for i in 0..<envelope.items.count {
-            envelopeData.append(newLineData)
-            let serializedItemHeaderData = envelope.items[i].header.serialize()
-            guard let itemHeader = SentrySerializationSwift.data(withJSONObject: serializedItemHeaderData) else {
-                SentrySDKLog.error("Envelope item header cannot be converted to JSON.")
-                return nil
-            }
-            envelopeData.append(itemHeader)
-            envelopeData.append(newLineData)
-            if let itemData = envelope.items[i].data {
-                envelopeData.append(itemData)
-            }
+        return data
+    }
+
+    private static func writeEnvelopeItem(_ item: SentryEnvelopeItem, newLineData: Data, writer: (Data) -> Bool) -> Bool {
+        guard writer(newLineData) else {
+            return false
         }
-        
-        return envelopeData
+        guard let itemHeader = SentrySerializationSwift.data(withJSONObject: item.header.serialize()) else {
+            SentrySDKLog.error("Envelope item header cannot be converted to JSON.")
+            return false
+        }
+        guard writer(itemHeader), writer(newLineData) else {
+            return false
+        }
+        return item.data.map(writer) ?? true
     }
     
     @objc(dataWithSession:) public static func data(with session: SentrySession) -> Data? {

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -186,7 +186,6 @@ class SentryFileManagerTests: XCTestCase {
         // -- Assert --
         XCTAssertNil(path)
         XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
-        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
 
     func testStore_whenEnvelopeItemHeaderIsInvalid_shouldReturnNilWithoutLeavingFiles() {
@@ -203,7 +202,6 @@ class SentryFileManagerTests: XCTestCase {
         // -- Assert --
         XCTAssertNil(path)
         XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
-        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
 
     func testStore_whenSentryRootIsReadOnly_shouldStoreEnvelope() throws {
@@ -237,7 +235,6 @@ class SentryFileManagerTests: XCTestCase {
         let storedData = try Data(contentsOf: URL(fileURLWithPath: XCTUnwrap(path)))
         let storedEnvelope = try XCTUnwrap(SentrySerializationSwift.envelope(with: storedData))
         XCTAssertEqual(storedEnvelope.items.first?.data, attachmentData)
-        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
 
     func testStore_whenFinalEnvelopeCannotBePublished_shouldReturnNilWithoutLeavingFiles() throws {
@@ -250,7 +247,6 @@ class SentryFileManagerTests: XCTestCase {
         // -- Assert --
         XCTAssertNil(path)
         XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
-        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
     
     func testDeleteOldEnvelopes() throws {

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -206,6 +206,21 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
 
+    func testStore_whenSentryRootIsReadOnly_shouldStoreEnvelope() throws {
+        // -- Arrange --
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: sut.sentryPath)
+        defer {
+            XCTAssertNoThrow(try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: sut.sentryPath))
+        }
+
+        // -- Act --
+        let path = sut.store(TestConstants.envelope)
+
+        // -- Assert --
+        XCTAssertNotNil(path)
+        XCTAssertEqual(sut.getAllEnvelopes().count, 1)
+    }
+
     func testStore_whenEnvelopeHasLargeAttachment_shouldStoreValidEnvelope() throws {
         // -- Arrange --
         let attachmentData = Data(repeating: 0x2A, count: 20 * 1_024 * 1_024)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -174,13 +174,68 @@ class SentryFileManagerTests: XCTestCase {
         try compareEnvelopes(expectedData, actualData as Data, message: "Envelopes are not equal")
     }
     
-    func testStoreInvalidEnvelope_ReturnsNil() {
+    func testStore_whenEnvelopeHeaderIsInvalid_shouldReturnNilWithoutLeavingFiles() {
+        // -- Arrange --
         let sdkInfoWithInvalidJSON = SentrySdkInfo(name: SentryInvalidJSONString() as String, version: "8.0.0", integrations: [], features: [], packages: [], settings: SentrySDKSettings(dict: [:]))
         let headerWithInvalidJSON = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfoWithInvalidJSON, traceContext: nil)
-        
         let envelope = SentryEnvelope(header: headerWithInvalidJSON, items: [])
-        
-        XCTAssertNil(sut.store(envelope))
+
+        // -- Act --
+        let path = sut.store(envelope)
+
+        // -- Assert --
+        XCTAssertNil(path)
+        XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
+        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
+    }
+
+    func testStore_whenEnvelopeItemHeaderIsInvalid_shouldReturnNilWithoutLeavingFiles() {
+        // -- Arrange --
+        let itemHeader = SentryEnvelopeItemHeader(type: SentryInvalidJSONString() as String, length: 0)
+        let envelope = SentryEnvelope(
+            header: SentryEnvelopeHeader(id: SentryId()),
+            singleItem: SentryEnvelopeItem(header: itemHeader, data: Data())
+        )
+
+        // -- Act --
+        let path = sut.store(envelope)
+
+        // -- Assert --
+        XCTAssertNil(path)
+        XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
+        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
+    }
+
+    func testStore_whenEnvelopeHasLargeAttachment_shouldStoreValidEnvelope() throws {
+        // -- Arrange --
+        let attachmentData = Data(repeating: 0x2A, count: 20 * 1_024 * 1_024)
+        let itemHeader = SentryEnvelopeItemHeader(type: SentryEnvelopeItemTypes.attachment, length: UInt(attachmentData.count))
+        let envelope = SentryEnvelope(
+            header: SentryEnvelopeHeader(id: SentryId()),
+            singleItem: SentryEnvelopeItem(header: itemHeader, data: attachmentData)
+        )
+
+        // -- Act --
+        let path = sut.store(envelope)
+
+        // -- Assert --
+        let storedData = try Data(contentsOf: URL(fileURLWithPath: XCTUnwrap(path)))
+        let storedEnvelope = try XCTUnwrap(SentrySerializationSwift.envelope(with: storedData))
+        XCTAssertEqual(storedEnvelope.items.first?.data, attachmentData)
+        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
+    }
+
+    func testStore_whenFinalEnvelopeCannotBePublished_shouldReturnNilWithoutLeavingFiles() throws {
+        // -- Arrange --
+        try FileManager.default.removeItem(atPath: sut.envelopesPath)
+
+        // -- Act --
+        let path = sut.store(TestConstants.envelope)
+
+        // -- Assert --
+        XCTAssertNil(path)
+        XCTAssertTrue(sut.getAllEnvelopes().isEmpty)
+        XCTAssertTrue(sut.allFilesInFolder(sut.sentryPath).filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
     
     func testDeleteOldEnvelopes() throws {

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -61,6 +61,47 @@ class SentrySerializationTests: XCTestCase {
         
         XCTAssertNil(SentrySerializationSwift.data(with: envelope))
     }
+
+    func testWriteEnvelopeData_whenWriterSucceeds_shouldWriteItemBodiesAsSeparateChunks() throws {
+        // -- Arrange --
+        let firstItemData = Data("first".utf8)
+        let secondItemData = Data("second".utf8)
+        let envelope = SentryEnvelope(id: SentryId(), items: [
+            SentryEnvelopeItem(header: SentryEnvelopeItemHeader(type: "first", length: UInt(firstItemData.count)), data: firstItemData),
+            SentryEnvelopeItem(header: SentryEnvelopeItemHeader(type: "second", length: UInt(secondItemData.count)), data: secondItemData)
+        ])
+        var chunks: [Data] = []
+
+        // -- Act --
+        let success = SentrySerializationSwift.writeEnvelopeData(envelope) { data in
+            chunks.append(data)
+            return true
+        }
+
+        // -- Assert --
+        XCTAssertTrue(success)
+        XCTAssertTrue(chunks.contains(firstItemData))
+        XCTAssertTrue(chunks.contains(secondItemData))
+        let deserializedEnvelope = try XCTUnwrap(SentrySerializationSwift.envelope(with: chunks.reduce(into: Data()) { $0.append($1) }))
+        XCTAssertEqual(deserializedEnvelope.header.eventId, envelope.header.eventId)
+        XCTAssertEqual(deserializedEnvelope.items.map(\.data), [firstItemData, secondItemData])
+    }
+
+    func testWriteEnvelopeData_whenWriterFails_shouldStopWriting() {
+        // -- Arrange --
+        let envelope = SentryEnvelope(id: SentryId(), singleItem: SentryEnvelopeItem(event: Event()))
+        var writeCount = 0
+
+        // -- Act --
+        let success = SentrySerializationSwift.writeEnvelopeData(envelope) { _ in
+            writeCount += 1
+            return false
+        }
+
+        // -- Assert --
+        XCTAssertFalse(success)
+        XCTAssertEqual(writeCount, 1)
+    }
     
     func testEnvelopeWithData_WithSingleEvent() throws {
         // Arrange


### PR DESCRIPTION
## 📜 Description

Write envelope headers and item bodies directly to a temporary file instead of assembling a second envelope-sized `Data` buffer. Synchronize and close the temporary file before moving it to the final envelope path.

Keep the existing in-memory serializer for networking and SPI callers. Path-backed attachment streaming remains separate work.

## 💡 Motivation and Context

Large attachments currently remain in memory while `SentrySerializationSwift.data(with:)` allocates another contiguous buffer for the complete envelope. This can cause `NSMallocException` or a Swift allocation trap under memory pressure.

Temporary files use the system temporary directory, so cache enumeration cannot observe partial envelopes and the OS manages files left after process termination. Serialization, write, sync, close, and publication failures remove the temporary file and return no stored path. This is especially important because an earlier direct-write implementation caused corrupted partial envelopes.

**Known Limitation**

Publication is atomic when the system temporary directory and envelope destination are on the same volume, which is the standard app sandbox configuration. If a custom `cacheDirectoryPath` points to another volume, `FileManager.moveItem` may copy and delete instead of performing an atomic rename. An interrupted cross-volume move may therefore leave a partial envelope at the destination. We accept this limitation to avoid SDK-managed cleanup of temporary files.

Fixes getsentry/sentry-cocoa#3630

## 💚 How did you test it?

* `make format`
* `make analyze`
* `make build-ios FOR_AGENTS=true`
* `make build-macos FOR_AGENTS=true`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySerializationTests,SentryTests/SentryFileManagerTests`
* `make test-macos FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySerializationTests,SentryTests/SentryFileManagerTests`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHttpTransportTests`

Production examples of the existing whole-envelope allocation path: [SDK-CRASHES-COCOA-N2Q](<https://sentry.sentry.io/issues/6856890288/>) and [SDK-CRASHES-COCOA-TR7](<https://sentry.sentry.io/issues/7189212322/>).

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).