### PR TITLE
docs: discourage redundant internal comments

### DIFF
--- a/REVIEWS.md
+++ b/REVIEWS.md
@@ -34,6 +34,7 @@ In order of importance:
 - File renames preserve git history (`git mv`)
 - No AI assistant references in commits or PR descriptions
 - ObjC uses `[[Class alloc] init]`, not `[Class new]`
+- No redundant comments on internal code (see [Sources/AGENTS.md](Sources/AGENTS.md)); only _why_-comments and public headerdocs
 
 ## What NOT to Flag
 

--- a/Sources/AGENTS.md
+++ b/Sources/AGENTS.md
@@ -86,6 +86,12 @@ final class Buffer<Storage: StorageProtocol, Item: ItemProtocol> {
 - Tests should override dependencies through `SentryDependencyContainer.sharedInstance()` when possible
 - Do not use `PrivateSentrySDKOnly` as a test injection path when a dependency-container provider fits
 
+### Comments
+
+- Do not add comments to internal code that merely restate what the code does
+- Comment only to explain non-obvious _why_ (rationale, workaround, gotcha)
+- Public API: headerdocs are expected; write them once, properly
+
 ## Public API Surface
 
 - **Backward compatibility** — do not remove or rename public symbols; deprecate first


### PR DESCRIPTION
Codifies that internal code should not carry comments that merely restate what the code does — only *why*-comments (rationale, workaround, gotcha) and public headerdocs.

- `Sources/AGENTS.md` — authoring rule (new `### Comments` subsection)
- `REVIEWS.md` — enforcement bullet for review agents, cross-linked

#skip-changelog

Closes #8657