### PR TITLE
impr: remove mergeable-library metadata from dynamic xcframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Add `SentrySDK.feedback.enableOnShake()` and `disableOnShake()` to toggle the shake-to-report gesture at runtime (#8591)
 
+### Improvements
+
+- Reduce Sentry-Dynamic.xcframework binary size by ~7.6 MB per arm64 slice by removing unused mergeable-library metadata (LC_ATOM_INFO) (#8342)
+
 ### Fixes
 
 - Fix incorrect `duration` sent for active sessions (#8612)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Improvements
 
-- Reduce Sentry-Dynamic.xcframework binary size by ~7.6 MB per arm64 slice by removing unused mergeable-library metadata (LC_ATOM_INFO) (#8342)
+- Reduce Sentry-Dynamic.xcframework binary size by ~7.6 MB per arm64 slice by removing unused mergeable-library metadata (LC_ATOM_INFO) (#8658)
 
 ### Fixes
 

--- a/scripts/build-xcframework-slice.sh
+++ b/scripts/build-xcframework-slice.sh
@@ -83,12 +83,6 @@ fi
 
 rm -rf XCFrameworkBuildPath/DerivedData
 
-## watchos and watchsimulator don't support make_mergeable: ld: unknown option: -make_mergeable
-## For other dynamic frameworks, add -make_mergeable (append to existing flags)
-if [[ "$sdk" != "watchos" && "$sdk" != "watchsimulator" ]] && [ "$MACH_O_TYPE" != "staticlib" ]; then
-    OTHER_LDFLAGS="$OTHER_LDFLAGS -Wl,-make_mergeable"
-fi
-
 slice_id="${scheme}${suffix}-${sdk}"
 
 output_xcarchive_path="XCFrameworkBuildPath/archive/${scheme}${suffix}"


### PR DESCRIPTION
## Summary

Removes the `-Wl,-make_mergeable` linker flag from `scripts/build-xcframework-slice.sh`.

This flag was added in #4381 and causes every dynamic framework slice to embed `LC_ATOM_INFO` metadata. This metadata is only consumed when the app links the framework with `-merge_framework` / `MERGEABLE_LIBRARY`, but **SPM does not support mergeable libraries**, so consumers ship this as dead weight that counts toward App Store download size.

### Binary size reduction

Compared `Sentry-Dynamic.xcframework` built from `main` (old) vs this branch (new):

| Slice | Old | New | Reduction |
|---|---|---|---|
| ios-arm64 | 12.20 MB | 3.73 MB | -8.46 MB (69.3%) |
| ios-arm64_x86_64-simulator | 23.55 MB | 7.32 MB | -16.22 MB (68.8%) |
| ios-arm64_x86_64-maccatalyst | 29.05 MB | 12.67 MB | -16.37 MB (56.3%) |
| macos-arm64_x86_64 | 16.89 MB | 5.43 MB | -11.46 MB (67.8%) |
| tvos-arm64 | 10.67 MB | 3.31 MB | -7.36 MB (68.9%) |
| xros-arm64 | 9.23 MB | 2.87 MB | -6.36 MB (68.8%) |
| watchos-arm64_arm64_32 | 4.79 MB | 4.79 MB | 0 (was already excluded) |

**Total xcframework zip: 136 MB → 88 MB**

Removing the flag does not change the runtime image — exported symbols are byte-identical, confirming `LC_ATOM_INFO` is link-time-only metadata. watchOS was already excluded since the watchOS linker doesn't support `-make_mergeable`.

Closes #8342

#skip-changelog

## Test plan

- [x] `make build-ios FOR_AGENTS=true` passes
- [x] Verified built xcframework no longer contains `LC_ATOM_INFO` via `otool -l`
- [x] Verified watchOS slice is unchanged (was already excluded)