### PR TITLE
ref: remove SentrySwiftUI from release matrix

### DIFF
--- a/scripts/generate_release_matrix.sh
+++ b/scripts/generate_release_matrix.sh
@@ -37,13 +37,11 @@ fi
 BASE_SLICES_JSON='[
   {"name": "Sentry", "macho-type": "mh_dylib", "suffix": "-Dynamic", "id": "sentry-dynamic"},
   {"name": "Sentry", "macho-type": "staticlib", "id": "sentry-static"},
-  {"name": "SentrySwiftUI", "macho-type": "mh_dylib", "id": "sentry-swiftui"},
   {"name": "Sentry", "macho-type": "mh_dylib", "suffix": "-WithoutUIKitOrAppKit", "configuration-suffix": "WithoutUIKit", "id": "sentry-withoutuikit-dynamic"}
 ]'
 BASE_VARIANTS_JSON='[
   {"scheme": "Sentry", "macho-type": "mh_dylib", "suffix": "-Dynamic", "id": "sentry-dynamic", "excluded-archs": "arm64e"},
   {"scheme": "Sentry", "macho-type": "staticlib", "id": "sentry-static"},
-  {"scheme": "SentrySwiftUI", "macho-type": "mh_dylib", "id": "sentry-swiftui"},
   {"scheme": "Sentry", "macho-type": "mh_dylib", "suffix": "-WithoutUIKitOrAppKit", "configuration-suffix": "WithoutUIKit", "id": "sentry-withoutuikit-dynamic", "excluded-archs": "arm64e"}
 ]'
 BASE_SDKS_JSON='[


### PR DESCRIPTION
## Description

Remove SentrySwiftUI from the release workflow's slice/variant matrix in `generate_release_matrix.sh`. 
The SentrySwiftUI is part of Sentry target now, so we don't need the binary anymore.

Part of COCOA-1685

#skip-changelog

This is a v10 change