### PR TITLE
docs: add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,42 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 
 # Installation
 
-SPM is the recommended way to include Sentry into your project.
-We also provide pre-built XCFrameworks on [our GitHub Releases page](https://github.com/getsentry/sentry-cocoa/releases).
+### Sentry Wizard (Recommended)
 
-To see all available installation options and how to integrate Sentry into your project, please refer to our [documentation](https://docs.sentry.io/platforms/apple/install/).
+The quickest way to get started:
+
+```bash
+brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios
+```
+
+This patches your project and configures the SDK automatically.
+
+### Swift Package Manager
+
+**In Xcode:** File > Add Packages, then paste:
+
+```
+https://github.com/getsentry/sentry-cocoa.git
+```
+
+**In `Package.swift`:**
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.24.0"),
+],
+targets: [
+    .target(name: "YourApp", dependencies: [
+        .product(name: "SentrySPM", package: "sentry-cocoa"),
+    ]),
+]
+```
+
+### Pre-built XCFrameworks
+
+Download pre-built static or dynamic XCFrameworks from [GitHub Releases](https://github.com/getsentry/sentry-cocoa/releases).
+
+For all installation options (Objective-C, dynamic linking, manual install), see the [full installation docs](https://docs.sentry.io/platforms/apple/install/).
 
 > [!NOTE]
 > CocoaPods support has been dropped. The last version available via CocoaPods is [9.19.1](https://github.com/getsentry/sentry-cocoa/releases/tag/9.19.1). Please migrate to SPM or XCFrameworks.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ brew install getsentry/tools/sentry-wizard && sentry-wizard -i ios
 
 This patches your project and configures the SDK automatically.
 
-### Swift Package Manager
+### Swift Package Manager (Compile from Source)
+
+Use this repository to build the SDK from source:
 
 **In Xcode:** File > Add Packages, then paste:
 
@@ -54,7 +56,9 @@ targets: [
 
 ### Pre-built XCFrameworks
 
-Download pre-built static or dynamic XCFrameworks from [GitHub Releases](https://github.com/getsentry/sentry-cocoa/releases).
+For pre-built static binaries via SPM, use the [sentry-apple-binaries](https://github.com/getsentry/sentry-apple-binaries) repository.
+
+You can also download XCFrameworks directly from [GitHub Releases](https://github.com/getsentry/sentry-cocoa/releases).
 
 For all installation options (Objective-C, dynamic linking, manual install), see the [full installation docs](https://docs.sentry.io/platforms/apple/install/).
 


### PR DESCRIPTION
## Description

Add inline installation instructions to the README so users can get started without leaving the repo. Covers:

- **Sentry Wizard** — recommended one-liner for automatic setup
- **Swift Package Manager** — Xcode UI steps and `Package.swift` snippet
- **Pre-built XCFrameworks** — link to GitHub Releases
- Link to full docs for additional options (Objective-C, dynamic linking, manual install)

Closes COCOA-1431

#skip-changelog