### PR TITLE
test: check GH-1355 on real iOS 15 devices

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+      # TEMPORARY — delete before merging GH-8548. Lets the GH-1355 iOS 15 suite run from the
+      # probe branch, reusing this workflow's working code signing and SauceLabs setup
+      # instead of duplicating it. See Samples/iOS-Swift/Benchmarking/Sources/GH1355OldOrderingTests.m.
+      - test/gh1355-ios15-saucelabs-probe
   workflow_dispatch:
 
 concurrency:
@@ -73,7 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: ["High-end device", "Low-end device"]
+        # "GH-1355 iOS 15" is TEMPORARY — delete before merging GH-8548.
+        suite: ["High-end device", "Low-end device", "GH-1355 iOS 15"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -77,8 +77,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # "GH-1355 iOS 15" is TEMPORARY — delete before merging GH-8548.
-        suite: ["High-end device", "Low-end device", "GH-1355 iOS 15"]
+        # TEMPORARY — restore to ["High-end device", "Low-end device"] before merging GH-8548.
+        # Only the GH-1355 suite runs on this branch: the benchmark suites aren't needed for that
+        # verification and they compete with it for SauceLabs devices.
+        suite: ["GH-1355 iOS 15"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -32,9 +32,9 @@ suites:
   # regression class on the lowest iOS 15 real devices available, the closest we can get to the
   # iOS 15.0 where that crash was reported. See GH1355OldOrderingTests.m.
   - name: "GH-1355 iOS 15"
-    # These tests only launch the app and open one screen, so cap the wait well below the 60m
-    # default: if the app crashes as GH-1355 did, we want the failure quickly, not a timeout.
-    timeout: 15m
+    # The tests themselves take about a minute, but this timeout also covers waiting for a device.
+    # A 15m cap expired in the queue before the tests ever started, so keep the 60m default rather
+    # than reporting a queue wait as a failed suite.
     testOptions:
       class:
         - GH1355OldOrderingTests

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -12,11 +12,34 @@ xcuitest:
   testApp: ./DerivedData/Build/Products/Debug-iphoneos/iOS-Benchmarking-Runner.app
 
 suites:
+  # TEMPORARY, remove with GH-8548: the two class filters below only exist so these suites keep
+  # running just the benchmark, instead of also picking up GH1355OldOrderingTests and timing out.
   - name: "High-end device"
+    testOptions:
+      class:
+        - SentrySDKPerformanceBenchmarkTests
     devices:
       - name: "iPad Pro 11 2024"
         platformVersion: "17"
   - name: "Low-end device"
+    testOptions:
+      class:
+        - SentrySDKPerformanceBenchmarkTests
     devices:
       - name: "iPhone SE 2022"
         platformVersion: "18"
+  # TEMPORARY — delete before merging GH-8548, with GH1355OldOrderingTests.m. Runs only the GH-1355
+  # regression class on the lowest iOS 15 real devices available, the closest we can get to the
+  # iOS 15.0 where that crash was reported. See GH1355OldOrderingTests.m.
+  - name: "GH-1355 iOS 15"
+    # These tests only launch the app and open one screen, so cap the wait well below the 60m
+    # default: if the app crashes as GH-1355 did, we want the failure quickly, not a timeout.
+    timeout: 15m
+    testOptions:
+      class:
+        - GH1355OldOrderingTests
+    devices:
+      - name: "iPhone 11 Pro"
+        platformVersion: "15.3.1"
+      - name: "iPhone 11"
+        platformVersion: "15.7"

--- a/Samples/iOS-Swift/Benchmarking/Sources/GH1355OldOrderingTests.m
+++ b/Samples/iOS-Swift/Benchmarking/Sources/GH1355OldOrderingTests.m
@@ -1,0 +1,81 @@
+// TEMPORARY — DELETE BEFORE MERGING GH-8548, together with the iOS 15 suite in
+// .sauce/benchmarking-config.yml, the workflow_dispatch input in
+// .github/workflows/benchmarking.yml, and the gh1355-old-ordering branch in
+// SentryUIViewControllerSwizzlingHelper.m.
+//
+// GH-1355 (the convenience-initializer crash behind removing init swizzling in GH-1361) was only
+// ever reported on iOS 15.0, on physical devices, in Release/TestFlight builds. iOS 15.0 cannot be
+// installed as a simulator on current macOS hosts, and the crash never reproduced on any simulator
+// we could run, so the deferred-swizzling funnel has never been checked against real iOS 15
+// hardware.
+//
+// This lives in the iOS-Benchmarking target because that target already builds, signs and runs the
+// iOS-Swift sample on real SauceLabs devices. It launches the same sample app with a launch
+// argument that switches the funnel to the pre-GH-1361 ordering, then drives the
+// ConvenienceInitViewController fixture. A crash here is the red proof that has been missing since
+// 2021; a pass narrows the remaining uncertainty to iOS 15.0 exactly.
+
+#import <XCTest/XCTest.h>
+
+@interface GH1355OldOrderingTests : XCTestCase
+@end
+
+@implementation GH1355OldOrderingTests
+
+static NSString *const kOldOrderingArg
+    = @"--io.sentry.uiviewcontroller-tracing.gh1355-old-ordering";
+
+- (void)setUp
+{
+    self.continueAfterFailure = NO;
+    [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
+}
+
+- (XCUIApplication *)launchAppWithOldOrdering
+{
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    app.launchArguments = [app.launchArguments arrayByAddingObject:kOldOrderingArg];
+    [app launch];
+    return app;
+}
+
+/// The app must survive launch with the crash-inducing ordering active. Every view controller
+/// created during startup runs through the funnel in the old order.
+- (void)testAppLaunchesUnderOldOrdering
+{
+    XCUIApplication *app = [self launchAppWithOldOrdering];
+    XCTAssertTrue([app.tabBars[@"Tab Bar"] waitForExistenceWithTimeout:30],
+        @"The app did not reach its main screen under the pre-GH-1361 swizzle ordering.");
+}
+
+/// Opens the GH-1355 fixture (UITableViewController, convenience init -> custom designated init ->
+/// super.init(style:), no @objc) twice. Reporters crashed on the SECOND instance, where the
+/// initializer runs through an already-mutated method list.
+- (void)testConvenienceInitFixtureUnderOldOrdering
+{
+    XCUIApplication *app = [self launchAppWithOldOrdering];
+    XCTAssertTrue([app.tabBars[@"Tab Bar"] waitForExistenceWithTimeout:30], @"No main screen.");
+
+    XCUIElement *extraTab = app.tabBars[@"Tab Bar"].buttons[@"Extra"];
+    XCTAssertTrue([extraTab waitForExistenceWithTimeout:15], @"Extra tab not found.");
+    [extraTab tap];
+
+    for (NSUInteger attempt = 1; attempt <= 2; attempt++) {
+        XCUIElement *openButton = app.buttons[@"ConvenienceInit #1355"];
+        XCTAssertTrue([openButton waitForExistenceWithTimeout:15],
+            @"ConvenienceInit button missing on attempt %lu.", (unsigned long)attempt);
+        [openButton tap];
+
+        XCUIElement *screen = app.staticTexts[@"convenienceInitScreen"];
+        XCTAssertTrue([screen waitForExistenceWithTimeout:15],
+            @"ConvenienceInit screen did not appear on attempt %lu — the app likely crashed.",
+            (unsigned long)attempt);
+
+        [app.navigationBars.buttons.firstMatch tap];
+    }
+
+    XCTAssertTrue(app.state == XCUIApplicationStateRunningForeground,
+        @"The app is no longer running after exercising the GH-1355 fixture.");
+}
+
+@end

--- a/Sources/Sentry/SentryUIViewControllerSwizzlingHelper.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzlingHelper.m
@@ -88,10 +88,33 @@ static BOOL swizzlingIsActive = FALSE;
     // SentryNSDataSwizzlingHelper.m uses this same macro path for -[NSData
     // initWithContentsOfFile:options:error:], another +1 initializer. The retain handshake is
     // covered by testInitFunnel_whenViewControllersInstantiated_doesNotOverRetainThem.
+    // TEMPORARY (delete with the GH-1355 iOS 15 SauceLabs suite, before merging GH-8548): when the
+    // host app passes --io.sentry.uiviewcontroller-tracing.gh1355-old-ordering, use the pre-GH-1361
+    // ordering instead — message the class and swizzle it BEFORE the original initializer runs.
+    // This exists only to get a red proof on real iOS 15 hardware, which is the one environment
+    // where GH-1355 was ever observed and which cannot be simulated on current macOS hosts.
+    //
+    // Gated on the same flags the rest of this file uses for test-only code, so it cannot reach a
+    // release build. DEBUG alone is not enough: the sample's Test configuration defines only
+    // SENTRY_TEST, so a DEBUG-only gate compiled this out and produced a meaningless green run.
+#    if DEBUG || SENTRY_TEST || SENTRY_TEST_CI
+    BOOL useOldCrashingOrdering = [NSProcessInfo.processInfo.arguments
+        containsObject:@"--io.sentry.uiviewcontroller-tracing.gh1355-old-ordering"];
+    if (useOldCrashingOrdering) {
+        NSLog(@"[GH-1355 PROBE] Using the pre-GH-1361 crash-inducing swizzle ordering.");
+    }
+#    else
+    BOOL useOldCrashingOrdering = NO;
+#    endif
+
     SEL nibSelector = NSSelectorFromString(@"initWithNibName:bundle:");
     SentrySwizzleInstanceMethod(UIViewController.class, nibSelector, SentrySWReturnType(id),
         SentrySWArguments(NSString * nibName, NSBundle * bundle), SentrySWReplacement({
             id<SentryUIViewControllerInitSwizzlingDelegate> delegate = _initSwizzlingDelegate;
+            if (useOldCrashingOrdering) {
+                [delegate viewControllerInitialized:[self class]];
+                return SentrySWCallOriginal(nibName, bundle);
+            }
             id result = SentrySWCallOriginal(nibName, bundle);
             Class resultClass = object_getClass(result);
             if (resultClass != Nil) {
@@ -105,6 +128,10 @@ static BOOL swizzlingIsActive = FALSE;
     SentrySwizzleInstanceMethod(UIViewController.class, coderSelector, SentrySWReturnType(id),
         SentrySWArguments(NSCoder * coder), SentrySWReplacement({
             id<SentryUIViewControllerInitSwizzlingDelegate> delegate = _initSwizzlingDelegate;
+            if (useOldCrashingOrdering) {
+                [delegate viewControllerInitialized:[self class]];
+                return SentrySWCallOriginal(coder);
+            }
             id result = SentrySWCallOriginal(coder);
             Class resultClass = object_getClass(result);
             if (resultClass != Nil) {


### PR DESCRIPTION
## 📜 Description

**Temporary, not for merge.** Stacked on #8625 (base = `fix/deferred-uiviewcontroller-swizzling`), so the diff here is only the probe.

Checks whether the deferred `UIViewController` init-swizzling funnel from #8625 survives on **real iOS 15 hardware**, under both the current ordering and the pre-#1361 ordering that caused GH-1355.

Split out of #8625 so it stops blocking that PR while SauceLabs is busy.

## 💡 Motivation and Context

GH-1355 — `NSInternalInconsistencyException: UIViewController is missing its initial trait collection` — is why init swizzling was removed in #1361. #8625 reintroduces init swizzling behind an experimental, off-by-default option, so the crash matters.

It could not be reproduced anywhere we can test locally:

- Reported **only on iOS 15.0**, on **physical devices**, in **Release/TestFlight** builds — never in Debug on the same device and commit.
- **iOS 15.0 cannot be installed as a simulator on current macOS hosts** (`simctl`: "not supported on hosts after macOS 14.99.0").
- A standalone probe with no Sentry code, implementing the pre-#1361 ordering and instrumented to confirm it **ADDED** all six lifecycle methods to a Swift `UITableViewController` subclass mid-init (`class_replaceMethod` returning `nil`), stayed **crash-free** across orderings {old, new} × iOS {15.5 on three devices, 18.6, 26.4} × {Debug, Release `-O -wmo`}.

So the mechanism #1361 blamed is reproducible on demand and is **not sufficient** to cause the crash on anything testable here. Real iOS 15 hardware is the one remaining gap.

## 🔬 What this does

- `Samples/iOS-Swift/Benchmarking/Sources/GH1355OldOrderingTests.m` — launches the iOS-Swift sample with `--io.sentry.uiviewcontroller-tracing.gh1355-old-ordering` and opens the `ConvenienceInitViewController` fixture **twice** (reporters crashed on the *second* instance of the same subclass).
- `SentryUIViewControllerSwizzlingHelper.m` — a launch-argument branch selecting the pre-#1361 ordering (message the class and swizzle it *before* the original init). Gated on `DEBUG || SENTRY_TEST || SENTRY_TEST_CI`, so it cannot reach a release build.
- `.sauce/benchmarking-config.yml` — a `GH-1355 iOS 15` suite on **iPhone 11 Pro @ 15.3.1** and **iPhone 11 @ 15.7**, the lowest iOS 15 real devices available.
- `.github/workflows/benchmarking.yml` — temporary branch trigger + matrix entry.

It reuses the **benchmarking** workflow rather than adding a new one, because that workflow already builds, signs and runs this sample on real devices.

## 💚 How did you test it?

- `make format`, `make build-ios` — clean.
- The old-ordering path verified to actually engage: `[GH-1355 PROBE]` appears in the device log (5 occurrences in a Test-config run), so a green result is not a silently-disabled no-op.
- On the iOS 15.5 **simulator** all three old-ordering tests pass — expected, and exactly why real hardware is needed.

## ⚠️ Reading the result

- **Failure on 15.3.1/15.7** → the red proof missing since 2021. That would argue for changing the funnel in #8625.
- **Pass** → narrows the remaining uncertainty to iOS 15.0 exactly. It does **not** prove safety on 15.0, and these are Sauce `Test`-config builds rather than true TestFlight-Release.

No device is exactly 15.0 (lowest available is 15.3.1).

<details>
<summary>Known history of this probe</summary>

Two earlier bespoke-workflow attempts failed on repo details worth recording:

1. `build_ios_swift_ui_test` builds `-scheme iOS-Swift-UITests`, but that is a **target**, not a scheme — the lane is dead code that fails with "workspace does not contain a scheme named iOS-Swift-UITests".
2. Every fastlane lane that signs ends with `delete_keychain`, so splitting "sign" and "build" into separate steps fails with `No signing certificate "iOS Development" found`.

A third run timed out: the pre-existing SauceLabs suites had no class filter, so adding a class made them run the 20-iteration profiling benchmark plus the new tests and exceed the 60m timeout (`ERR Suite failed. error="User Abandoned Test -- User terminated"`). Hence the class scoping and the 15m cap on this suite.

</details>

#skip-changelog
