### PR TITLE
chore: read -[UIApplication applicationState] from the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Session `duration` is now set only when the session ends. Active sessions (including on error increments) no longer emit a bogus `duration`.
 - Fix a race that could prevent consecutive app hangs from being reported (#8627)
 - Fix malformed itms-services URL in SentryDistribution updater (#8567)
+- Fix off-main thread reads of `-[UIApplication applicationState]` (8672)
 
 ## 9.24.0
 

--- a/Sources/Swift/Helper/SentryApplication.swift
+++ b/Sources/Swift/Helper/SentryApplication.swift
@@ -8,14 +8,14 @@ import UIKit
 
 @objc @_spi(Private) public protocol SentryApplication {
 
-    // This can only be accessed on the main thread
     var mainThread_isActive: Bool { get }
 
 #if !os(macOS) && !os(watchOS) && !SENTRY_NO_UI_FRAMEWORK
 
     /**
-     * Returns the application state available at @c UIApplication.sharedApplication.applicationState
-     * Must be called on the main thread.
+     * Returns the application state. If called off the main thread, dispatches synchronously
+     * to the main thread with a short timeout and returns @c .active as a fallback if the
+     * main thread does not respond in time.
      */
     var unsafeApplicationState: UIApplication.State { get }
 

--- a/Sources/Swift/Helper/SentryApplicationExtensions.swift
+++ b/Sources/Swift/Helper/SentryApplicationExtensions.swift
@@ -29,7 +29,11 @@ import UIKit
     }
     
     @objc public var unsafeApplicationState: State {
-        applicationState
+        var applicationState: State = .active
+        Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({ [weak self] in
+            applicationState = self?.applicationState ?? .active
+        }, timeout: 0.01)
+        return applicationState
     }
     
     @objc public var mainThread_isActive: Bool {

--- a/Sources/Swift/Helper/SentryApplicationExtensions.swift
+++ b/Sources/Swift/Helper/SentryApplicationExtensions.swift
@@ -27,8 +27,18 @@ import UIKit
     @objc public func relevantViewControllersNames() -> [String]? {
         internal_relevantViewControllersNames()
     }
-    
+
     @objc public var unsafeApplicationState: State {
+        // As of August 2026, this was only called along one code path - ThreadsafeApplication's initializer
+        // which uses it to determine the initial state exactly once. ThreadsafeApplication then uses Notifications
+        // to change it's state from there on.
+        //
+        // ThreadsafeApplication is initialized at part of the DependencyContainer initialization which happens 2x:
+        // 1. When the profiler kicks off it's pre-main startup (using `+[load]`) - always on main
+        // 2. When the SDK starts up post-main - up to the caller
+        //
+        // We dispatch this to the main thread as Apple states it should be called from the main thread only
+        // and accept any slowdown as a one-time, limited affect.
         var applicationState: State = .active
         Dependencies.dispatchQueueWrapper.dispatchSyncOnMainQueue({ [weak self] in
             applicationState = self?.applicationState ?? .active


### PR DESCRIPTION
## 📜 Description

Read `-[UIApplication applicationState]` from the main thread.

## 💡 Motivation and Context

Xcode will produce a warning when this property is read from a background thread. This can happen if the user start the SDK from a background thread. Enforce main thread reads via the dispatch queue wrapper which will allow main thread calls to happen with no change, and hop to the main thread if it's on the background thread.

The only time this value is read is at `SentryThreadSafeApplication` init - which is when the `SentryDependencyContainer` is accessed, which can happen from any thread.

Alternatives considered:

* Making it lazy and reading it in SDK startup's main thread block
  * I decided this was a complexity that would be prone to breakage later on
* Seeding the initial value from the main thread after the dependency container is used (it's used before the main thread SDK start block happens)
  * See above

Since this is only read in one place I decided the thread hop downside was worth the correctness.

## 💚 How did you test it?

* CI
* Sample apps to ensure the Xcode warning is gone

Fixes getsentry/sentry-cocoa#6591