### PR TITLE
ci: remove Cirrus CI runners, use Bitrise only

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,6 @@
 self-hosted-runner:
   labels:
     - bitrise_pool_name:xcode-beta
+    - bitrise_pool_name:sequoia
+    - bitrise_pool_name:tahoe
+    - bitrise_pool_name:sonoma

--- a/.github/workflows/fast-pr-checks.yml
+++ b/.github/workflows/fast-pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
       sdk-list: '["iphoneos"]'
 
   fast-unit-tests:
-    name: Fast Unit Tests (iOS 18) on ${{matrix.runner_provider}}
+    name: Fast Unit Tests (iOS 18)
     if: needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
     needs: files-changed
     uses: ./.github/workflows/unit-test-common.yml
@@ -53,10 +53,6 @@ jobs:
       xcode: "16"
       platform: iOS
       scheme: Sentry
-      runner_provider: ${{matrix.runner_provider}}
-    strategy:
-      matrix:
-        runner_provider: ["cirrus", "bitrise"]
 
   sentrycrash-import-ratchet:
     name: SentryCrash Import Ratchet

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    name: Unit ${{matrix.name}} on ${{matrix.runner_provider}}
+    name: Unit ${{matrix.name}}
     uses: ./.github/workflows/unit-test-common.yml
     secrets: inherit
     with:
@@ -31,46 +31,24 @@ jobs:
       timeout: ${{matrix.timeout || 20}}
       device: ${{matrix.device}}
       scheme: "Sentry"
-      runner_provider: ${{matrix.runner_provider}}
     strategy:
       fail-fast: false
       matrix:
         # Additional devices and platforms not covered by the regular CI matrix in test.yml.
         include:
           - name: iOS 26 iPad Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "iOS"
-            device: "iPad Pro 13-inch (M5)"
-          - name: iOS 26 iPad Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "iOS"
             device: "iPad Pro 13-inch (M5)"
 
           - name: watchOS 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "watchOS"
-            timeout: 30
-          - name: watchOS 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "watchOS"
             timeout: 30
 
           - name: visionOS 2.5 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "26"
-            platform: "visionOS"
-            timeout: 30
-          - name: visionOS 2.5 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             platform: "visionOS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
         if: failure()
 
   duplication-tests:
-    name: Test Sentry Duplication V4 on ${{matrix.runner_provider}}
+    name: Test Sentry Duplication V4
     uses: ./.github/workflows/ui-tests-common.yml
     needs: [files-changed, assemble-xcframework-variant]
     # Run the job only for PRs with related changes or non-PR events.
@@ -392,10 +392,6 @@ jobs:
       macos_version: sequoia
       needs_xcframework: true
       platform: macOS
-      runner_provider: ${{matrix.runner_provider}}
-    strategy:
-      matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
 
   app-metrics:
     name: Collect App Metrics

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -50,14 +50,11 @@ jobs:
   # We only build the Static variant since 3rd-party integrations only use the "Sentry" product.
   # Intentionally skipped on release branches.
   build-xcframeworks:
-    name: Build XCFrameworks on ${{matrix.runner_provider}}
+    name: Build XCFrameworks
     needs: files-changed
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
+    runs-on: ["bitrise_pool_name:sequoia"]
     timeout-minutes: 30
-    strategy:
-      matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
     steps:
       - name: Warm CoreSimulator
         run: xcrun simctl list runtimes -j > /dev/null 2>&1 &
@@ -75,21 +72,20 @@ jobs:
       - name: Upload XCFrameworks
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: xcframeworks-for-3rd-party-integration-tests-${{ matrix.runner_provider }}
+          name: xcframeworks-for-3rd-party-integration-tests
           path: "Sentry.xcframework.zip"
           retention-days: 1
 
   # SPM tests for all 3rd-party integrations
   test-integrations-spm:
-    name: SPM Tests | ${{matrix.integration_dir}} on ${{matrix.runner_provider}}
+    name: SPM Tests | ${{matrix.integration_dir}}
     needs: [files-changed, build-xcframeworks]
     if: startsWith(github.ref, 'refs/heads/release/') == false && (github.event_name != 'pull_request' || needs.files-changed.outputs.run_3rd_party_integrations_tests_for_prs == 'true')
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
+    runs-on: ["bitrise_pool_name:sequoia"]
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
         integration_dir: [
           "SentrySwiftLog",
           "SentrySwiftyBeaver",
@@ -108,7 +104,7 @@ jobs:
       - name: Download XCFrameworks
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: xcframeworks-for-3rd-party-integration-tests-${{ matrix.runner_provider }}
+          name: xcframeworks-for-3rd-party-integration-tests
       - name: Modify Package.swift to use local xcframeworks
         run: ./scripts/prepare-package.sh --package-file Package.swift --is-pr true --remove-duplicate true --change-path true
       - name: Use local sentry-cocoa
@@ -122,7 +118,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-output-${{matrix.integration_dir}}-${{matrix.runner_provider}}-integration
+          name: raw-output-${{matrix.integration_dir}}-integration
           path: |
             3rd-party-integrations/${{matrix.integration_dir}}/.build/**/*.log
       - name: Run CI Diagnostics

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,12 +299,6 @@ jobs:
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 15 is minimal.
           # We are running tests on macOS 15 and later, as there were OS-internal changes introduced in succeeding versions.
 
-          # macOS 15 pinned to Xcode 16.2 to preserve OS matrix coverage from the retired macOS 14 runner.
-          - name: macOS 15 Compat Sentry
-            runs-on: sequoia
-            xcode: "16.2"
-            platform: "macOS"
-
           # macOS 14
           - name: macOS 14 Sentry
             runs-on: sonoma
@@ -325,11 +319,6 @@ jobs:
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          # In addition we run Catalyst with Xcode 16.2 on macOS 15, preserving OS matrix coverage from the retired macOS 14 runner.
-          - name: Catalyst 15 Compat Sentry
-            runs-on: sequoia
-            xcode: "16.2"
-            platform: "Catalyst"
 
           # Catalyst 14
           - name: Catalyst 14 Sentry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,15 +150,14 @@ jobs:
   # We don't run this matrix for all different OS versions, because the chances
   # of a bug solely on a specific OS version is minimal.
   unit-tests-with-test-server:
-    name: Unit with Test Server ${{matrix.name}} on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
+    name: Unit with Test Server ${{matrix.name}}
+    runs-on: ["bitrise_pool_name:sequoia"]
     timeout-minutes: 20
     needs: build-test-server
 
     strategy:
       fail-fast: false
       matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
         include:
           # Running the tests with simulators is incredibly flaky. Our assumption is that simulators might have difficulties
           # with communicating with the test server in CI.
@@ -222,7 +221,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: steps.build_tests.outcome == 'failure'
         with:
-          name: derived-data-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}-${{ matrix.runner_provider }}
+          name: derived-data-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
@@ -230,7 +229,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-output-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}-${{ matrix.runner_provider }}
+          name: raw-output-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}
           path: |
             raw-build-output.log
             raw-build-for-testing-output.log
@@ -240,7 +239,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: crash-logs-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}-${{ matrix.runner_provider }}
+          name: crash-logs-test-server-${{matrix.platform}}-xcode-${{matrix.xcode}}
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
@@ -255,7 +254,7 @@ jobs:
           suffix: ${{ matrix.platform }}-xcode-${{ matrix.xcode }}
 
   unit-tests:
-    name: Unit ${{matrix.name}} on ${{matrix.runner_provider}}
+    name: Unit ${{matrix.name}}
     needs: files-changed
     uses: ./.github/workflows/unit-test-common.yml
     secrets: inherit
@@ -263,8 +262,7 @@ jobs:
       name: ${{matrix.name}}
       runs-on: ${{ matrix.runs-on }}
       timeout: ${{matrix.timeout || 20}}
-      should_skip: ${{ (github.event_name == 'pull_request' && needs.files-changed.outputs.run_unit_tests_for_prs != 'true') || (matrix.runner_provider == 'cirrus' && matrix.runs-on == 'sonoma') || (github.event_name != 'pull_request' && matrix.runner_provider == 'cirrus') }}
-      runner_provider: ${{matrix.runner_provider}}
+      should_skip: ${{ github.event_name == 'pull_request' && needs.files-changed.outputs.run_unit_tests_for_prs != 'true' }}
       xcode: ${{matrix.xcode}}
       test-destination-os: ${{matrix.test-destination-os}}
       platform: ${{matrix.platform}}
@@ -279,14 +277,6 @@ jobs:
 
           # iOS 17
           - name: iOS 17 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            test-destination-os: "17.5"
-            platform: "iOS"
-            device: "iPhone 15 Pro"
-          - name: iOS 17 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             test-destination-os: "17.5"
@@ -295,24 +285,12 @@ jobs:
 
           # iOS 18
           - name: iOS 18 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            platform: "iOS"
-          - name: iOS 18 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             platform: "iOS"
 
           # iOS 26
           - name: iOS 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "iOS"
-          - name: iOS 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "iOS"
@@ -323,38 +301,24 @@ jobs:
 
           # macOS 15 pinned to Xcode 16.2 to preserve OS matrix coverage from the retired macOS 14 runner.
           - name: macOS 15 Compat Sentry
-            runner_provider: cirrus
             runs-on: sequoia
             xcode: "16.2"
             platform: "macOS"
 
-          # macOS 14 — Bitrise only (sonoma pool still available)
+          # macOS 14
           - name: macOS 14 Sentry
-            runner_provider: bitrise
             runs-on: sonoma
             xcode: "16"
             platform: "macOS"
 
           # macOS 15
           - name: macOS 15 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            platform: "macOS"
-          - name: macOS 15 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             platform: "macOS"
 
           # macOS 26
           - name: macOS 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "macOS"
-          - name: macOS 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "macOS"
@@ -363,38 +327,24 @@ jobs:
           # on an older iOS or macOS version is low.
           # In addition we run Catalyst with Xcode 16.2 on macOS 15, preserving OS matrix coverage from the retired macOS 14 runner.
           - name: Catalyst 15 Compat Sentry
-            runner_provider: cirrus
             runs-on: sequoia
             xcode: "16.2"
             platform: "Catalyst"
 
-          # Catalyst 14 — Bitrise only (sonoma pool still available)
+          # Catalyst 14
           - name: Catalyst 14 Sentry
-            runner_provider: bitrise
             runs-on: sonoma
             xcode: "16"
             platform: "Catalyst"
 
           # Catalyst 15
           - name: Catalyst 15 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            platform: "Catalyst"
-          - name: Catalyst 15 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             platform: "Catalyst"
 
           # Catalyst 26
           - name: Catalyst 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "Catalyst"
-          - name: Catalyst 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "Catalyst"
@@ -405,13 +355,6 @@ jobs:
 
           # tvOS 17
           - name: tvOS 17 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            test-destination-os: "17.5"
-            platform: "tvOS"
-          - name: tvOS 17 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             test-destination-os: "17.5"
@@ -419,25 +362,12 @@ jobs:
 
           # tvOS 18
           - name: tvOS 18 Sentry
-            runner_provider: cirrus
-            runs-on: sequoia
-            xcode: "16"
-            platform: "tvOS"
-          - name: tvOS 18 Sentry
-            runner_provider: bitrise
             runs-on: sequoia
             xcode: "16"
             platform: "tvOS"
 
           # tvOS 26
           - name: tvOS 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "tvOS"
-            device: "Apple TV"
-          - name: tvOS 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "tvOS"
@@ -445,13 +375,6 @@ jobs:
 
           # visionOS 26
           - name: visionOS 26 Sentry
-            runner_provider: cirrus
-            runs-on: tahoe
-            xcode: "26"
-            platform: "visionOS"
-            timeout: 30
-          - name: visionOS 26 Sentry
-            runner_provider: bitrise
             runs-on: tahoe
             xcode: "26"
             platform: "visionOS"

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -50,16 +50,11 @@ on:
         required: false
         default: false
         type: boolean
-      runner_provider:
-        description: "CI runner provider: cirrus (default) or bitrise"
-        required: false
-        default: "cirrus"
-        type: string
 jobs:
   common-ui-tests:
     if: ${{ !inputs.should_skip }}
     name: UI Tests Common
-    runs-on: ${{ inputs.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', inputs.macos_version)) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', inputs.macos_version, github.run_id)) }}
+    runs-on: ${{ fromJSON(format('["bitrise_pool_name:{0}"]', inputs.macos_version)) }}
     timeout-minutes: 40
     steps:
       - name: Warm CoreSimulator
@@ -77,8 +72,7 @@ jobs:
           restore-keys: |
             ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-
 
-      - name: Install Ruby (Bitrise)
-        if: inputs.runner_provider == 'bitrise'
+      - name: Install Ruby
         env:
           CACHE_HIT: ${{ steps.cache-ruby.outputs.cache-hit }}
         run: |
@@ -91,12 +85,6 @@ jobs:
             rbenv rehash
           fi
           bundle install
-
-      - name: Setup Ruby
-        if: inputs.runner_provider != 'bitrise'
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        with:
-          bundler-cache: true
 
       - name: Setup Xcode
         id: setup-xcode
@@ -182,7 +170,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}-${{ inputs.runner_provider }}
+          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}
           path: |
             fastlane/test_results/**/*.xcresult
 
@@ -190,7 +178,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}_crash_logs-${{ inputs.runner_provider }}
+          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}_crash_logs
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
@@ -198,7 +186,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}_raw_output-${{ inputs.runner_provider }}
+          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}_raw_output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -207,7 +195,7 @@ jobs:
         uses: ./.github/actions/capture-screenshot
         if: failure()
         with:
-          suffix: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}-${{ inputs.runner_provider }}
+          suffix: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}
 
       - name: Run CI Diagnostics
         uses: ./.github/actions/ci-diagnostics

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -42,7 +42,7 @@ jobs:
   run-tests:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_critical_for_prs == 'true'
     needs: files-changed
-    name: Test ${{matrix.name}} V4 on ${{matrix.runner_provider}} # Up the version with every change to keep track of flaky tests
+    name: Test ${{matrix.name}} V4 # Up the version with every change to keep track of flaky tests
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_critical_tests_ios_swiftui_envelope
@@ -51,11 +51,9 @@ jobs:
       files_suffix: _${{matrix.platform.xcode}}
       xcode_version: ${{matrix.platform.xcode}}
       platform: ${{matrix.platform.platform}}
-      runner_provider: ${{matrix.runner_provider}}
     strategy:
       fail-fast: false
       matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
         include:
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
@@ -77,11 +75,8 @@ jobs:
   run-swiftui-crash-test:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_critical_for_prs == 'true'
     needs: files-changed
-    name: Run SwiftUI Crash Test on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', 'sequoia')) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', 'sequoia', github.run_id)) }}
-    strategy:
-      matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
+    name: Run SwiftUI Crash Test
+    runs-on: ["bitrise_pool_name:sequoia"]
     timeout-minutes: 15
     steps:
       - name: Warm CoreSimulator
@@ -121,7 +116,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
-          name: swiftui-crash-test-screenshots-${{ matrix.runner_provider }}
+          name: swiftui-crash-test-screenshots
           path: swiftui-crash-test-screenshots
 
       - name: Collect Logs
@@ -132,7 +127,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
-          name: swiftui-crash-test-log-${{ matrix.runner_provider }}.logarchive
+          name: swiftui-crash-test-log.logarchive
           path: swiftui-crash-test-log.logarchive
 
       - name: Run CI Diagnostics

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -42,12 +42,11 @@ jobs:
   ui-tests:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_for_prs == 'true'
     needs: files-changed
-    name: Test ${{matrix.name}} on ${{matrix.runner_provider}} V4 # Up the version with every change to keep track of flaky tests
+    name: Test ${{matrix.name}} V4 # Up the version with every change to keep track of flaky tests
     uses: ./.github/workflows/ui-tests-common.yml
     strategy:
       fail-fast: false
       matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
         job_id:
           - ios_objc
           - tvos_swift
@@ -67,12 +66,11 @@ jobs:
       macos_version: "sequoia"
       files_suffix: _${{matrix.target}}_
       platform: ${{matrix.platform}}
-      runner_provider: ${{matrix.runner_provider}}
 
   ui-tests-swift-ui:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_for_prs == 'true'
     needs: files-changed
-    name: Test SwiftUI on ${{matrix.runner_provider}} V5 # Up the version with every change to keep track of flaky tests
+    name: Test SwiftUI V5 # Up the version with every change to keep track of flaky tests
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_tests_ios_swiftui
@@ -81,20 +79,15 @@ jobs:
       macos_version: "sequoia"
       files_suffix: _swiftui_
       platform: "iOS"
-      runner_provider: ${{matrix.runner_provider}}
-    strategy:
-      matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
 
   ui-tests-swift:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_for_prs == 'true'
     needs: files-changed
-    name: Test Swift ${{matrix.name}} on ${{matrix.runner_provider}} V6 # Up the version with every change to keep track of flaky tests
+    name: Test Swift ${{matrix.name}} V6 # Up the version with every change to keep track of flaky tests
     uses: ./.github/workflows/ui-tests-common.yml
     strategy:
       fail-fast: false
       matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
         job_id:
           - ios_17
           - ios_18
@@ -128,12 +121,11 @@ jobs:
       test-destination-os: ${{matrix.test_destination_os}}
       platform: ${{matrix.platform}}
       device: ${{matrix.device}}
-      runner_provider: ${{matrix.runner_provider}}
 
   ui-tests-swift6:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_for_prs == 'true'
     needs: files-changed
-    name: Test iOS Swift6 on ${{matrix.runner_provider}} V4 # Up the version with every change to keep track of flaky tests
+    name: Test iOS Swift6 V4 # Up the version with every change to keep track of flaky tests
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_tests_ios_swift6
@@ -142,10 +134,6 @@ jobs:
       macos_version: "sequoia"
       platform: iOS
       files_suffix: _swift6_
-      runner_provider: ${{matrix.runner_provider}}
-    strategy:
-      matrix:
-        runner_provider: ${{ github.event_name == 'pull_request' && fromJSON('["cirrus", "bitrise"]') || fromJSON('["bitrise"]') }}
 
   # This check validates that either UI tests passed or were skipped, which allows us
   # to make UI tests a required check with only running the UI tests when required.

--- a/.github/workflows/unit-test-common.yml
+++ b/.github/workflows/unit-test-common.yml
@@ -24,12 +24,6 @@ on:
         default: false
         type: boolean
 
-      runner_provider:
-        description: "CI runner provider: cirrus (default) or bitrise"
-        required: false
-        default: "cirrus"
-        type: string
-
       xcode:
         description: the Xcode version to use for the job
         required: true
@@ -62,7 +56,7 @@ on:
 jobs:
   unit-tests:
     name: Unit ${{inputs.name}}
-    runs-on: ${{ inputs.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', inputs.runs-on)) || fromJSON(format('["ghcr.io/cirruslabs/macos-runner:{0},runner_concurrency_group={1}", "runner_group_id:10"]', inputs.runs-on, github.run_id)) }}
+    runs-on: ${{ fromJSON(format('["bitrise_pool_name:{0}"]', inputs.runs-on)) }}
     timeout-minutes: ${{inputs.timeout}}
     if: ${{!inputs.should_skip}}
     steps:
@@ -76,8 +70,7 @@ jobs:
           version: ${{ inputs.xcode }}
 
       - name: Install simulator runtime
-        # Bitrise is missing tvOS 17.5 runtime, so we need to install it manually.
-        if: ${{ inputs.runner_provider == 'bitrise' && inputs.test-destination-os == '17.5' && inputs.platform == 'tvOS' }}
+        if: ${{ inputs.test-destination-os == '17.5' && inputs.platform == 'tvOS' }}
         timeout-minutes: 5
         env:
           PLATFORM: ${{ inputs.platform }}
@@ -103,8 +96,7 @@ jobs:
           restore-keys: |
             ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}-
 
-      - name: Install Ruby (Bitrise)
-        if: inputs.runner_provider == 'bitrise'
+      - name: Install Ruby
         env:
           CACHE_HIT: ${{ steps.cache-ruby.outputs.cache-hit }}
         run: |
@@ -117,12 +109,6 @@ jobs:
             rbenv rehash
           fi
           bundle install
-
-      - name: Setup Ruby
-        if: inputs.runner_provider != 'bitrise'
-        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
-        with:
-          bundler-cache: true
 
       - name: Ensure required runtime is loaded
         if: ${{ inputs.platform == 'iOS' || inputs.platform == 'tvOS' || inputs.platform == 'visionOS' }}
@@ -253,7 +239,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: steps.build_tests.outcome == 'failure'
         with:
-          name: derived-data-${{ inputs.runner_provider }}-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
+          name: derived-data-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
@@ -261,7 +247,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-output-${{ inputs.runner_provider }}-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
+          name: raw-output-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
           path: |
             raw-build-output.log
             raw-build-for-testing-output.log
@@ -271,7 +257,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: crash-logs-${{ inputs.runner_provider }}-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
+          name: crash-logs-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
@@ -279,7 +265,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}
         with:
-          name: result-bundle-${{ inputs.runner_provider }}-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
+          name: result-bundle-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
           path: |
             results.xcresult
             flaky-results.xcresult
@@ -288,7 +274,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ (failure() || cancelled()) && inputs.scheme == 'Sentry' && steps.collect_sentrytests_metadata.outcome == 'success' }}
         with:
-          name: sentrytests-metadata-${{ inputs.runner_provider }}-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
+          name: sentrytests-metadata-${{inputs.platform}}-xcode-${{inputs.xcode}}-os-${{steps.resolve-test-destination.outputs.TEST_OS}}
           if-no-files-found: error
           path: |
             sentrytests-metadata/**
@@ -301,4 +287,4 @@ jobs:
         uses: ./.github/actions/capture-screenshot
         if: failure()
         with:
-          suffix: unit-tests-${{ inputs.runner_provider }}-${{ inputs.platform }}-xcode-${{ inputs.xcode }}-os-${{ steps.resolve-test-destination.outputs.TEST_OS }}
+          suffix: unit-tests-${{ inputs.platform }}-xcode-${{ inputs.xcode }}-os-${{ steps.resolve-test-destination.outputs.TEST_OS }}


### PR DESCRIPTION
## Description

Remove all Cirrus CI runner configuration from GitHub Actions workflows. All CI jobs now run exclusively on Bitrise runners.

## Changes

- Removed the `runner_provider` input from reusable workflows (`unit-test-common.yml`, `ui-tests-common.yml`)
- Removed the `runner_provider` matrix dimension from all caller workflows
- Removed Cirrus-specific `ruby/setup-ruby` step (kept only Bitrise rbenv-based Ruby install)
- Simplified `runs-on` expressions that previously chose between Cirrus and Bitrise
- Simplified `should_skip` logic in `test.yml` that had Cirrus-specific skip conditions
- Cleaned up job names and artifact names that referenced `runner_provider`
- Added Bitrise pool labels (`sequoia`, `tahoe`, `sonoma`) to `actionlint.yaml` (previously hidden from the linter behind `format()` expressions)

## Affected workflows

- `unit-test-common.yml` — reusable unit test workflow
- `ui-tests-common.yml` — reusable UI test workflow
- `test.yml` — main unit test matrix
- `fast-pr-checks.yml` — fast PR feedback
- `nightly-test.yml` — nightly test matrix
- `ui-tests.yml` — UI test matrix
- `ui-tests-critical.yml` — critical UI tests
- `release.yml` — release workflow (duplication tests)
- `test-3rd-party-integrations.yml` — 3rd party integration tests

#skip-changelog

Closes #8676