### PR TITLE
feat: Add SDK compliance manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ agents.lock
 # Temporary files created by the API build process
 sdk_api_objccompat.json
 sdk_api_objccompat_v10.json
+.pi-subagents

--- a/.gitignore
+++ b/.gitignore
@@ -146,4 +146,3 @@ agents.lock
 # Temporary files created by the API build process
 sdk_api_objccompat.json
 sdk_api_objccompat_v10.json
-.pi-subagents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ See [`scripts/AGENTS.md`](scripts/AGENTS.md) for the named-parameter template an
 ## Documentation
 
 - **When changing logic, keep docs in sync** — update any affected headerdocs, inline comments, readmes, `AGENTS.md` files, and maintainer docs in the same change
+- **Specification compliance** — when changing behavior covered by an SDK specification, update `sentry-spec-compliance.json` and follow [`develop-docs/SPEC_COMPLIANCE.md`](develop-docs/SPEC_COMPLIANCE.md)
 - **Docs**: [docs.sentry.io/platforms/apple](https://docs.sentry.io/platforms/apple/) — repo: [sentry-docs](https://github.com/getsentry/sentry-docs)
 - **SDK dev docs**: [develop.sentry.dev/sdk/](https://develop.sentry.dev/sdk/)
 - Maintainer docs: [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [`develop-docs/`](develop-docs/), [`Samples/README.md`](Samples/README.md)

--- a/REVIEWS.md
+++ b/REVIEWS.md
@@ -24,6 +24,7 @@ In order of importance:
 - **Session Replay** — privacy-sensitive; verify redaction/masking logic
 - **Envelope serialization** — correct byte ordering, length prefixes, JSON encoding
 - **SentryObjC wrapper** — any new public API must also be exposed in `SentryObjC` / `SentryObjCCompat`; see [`develop-docs/SENTRY-OBJC.md`](develop-docs/SENTRY-OBJC.md) for the wrapper pattern and naming convention
+- **Specification compliance** — for changes covered by an SDK specification, verify `sentry-spec-compliance.json` accurately reflects the implementation and follows [`develop-docs/SPEC_COMPLIANCE.md`](develop-docs/SPEC_COMPLIANCE.md)
 
 ## Conventions to Enforce
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -11,6 +11,7 @@ This is a collection of documents that can help you develop for the SentrySDK.
 - RELEASE.md: our release processes and best practices
 - OBJC-LOAD-AND-LINKING.md: how Objective-C +load interacts with build configurations and distribution formats
 - SDK_HISTORY.md: historical context and FAQ for the SDK
+- SPEC_COMPLIANCE.md: SDK specification compliance manifest maintenance
 - [Language Trends Report](https://getsentry.github.io/sentry-cocoa/language-trends.html): interactive chart of the repository's language breakdown over time, updated on every merge to main via GitHub Pages
 
 ## GitHub Pages

--- a/develop-docs/SPEC_COMPLIANCE.md
+++ b/develop-docs/SPEC_COMPLIANCE.md
@@ -1,0 +1,13 @@
+# SDK Specification Compliance
+
+`sentry-spec-compliance.json` records specification sections implemented by the SDK.
+
+- Update `last_updated` when changing compliance declarations.
+- Set each implemented section to the latest specification version its implementation satisfies.
+- Use `non_applicable` only when an entire section requires no Cocoa implementation.
+- Leave applicable but incomplete sections absent.
+- Set the spec-level `version` to the highest fully implemented version. Use `0.0.0` until the first complete version is implemented.
+
+## Proof-of-Concept Limitation
+
+Section-level tracking cannot represent partially applicable sections. For example, a section may combine supported HTTP controls with queue or GenAI categories that Cocoa does not collect. Such a section remains absent until the format supports requirement-level applicability or the specification splits it into smaller sections.

--- a/sentry-spec-compliance.json
+++ b/sentry-spec-compliance.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://develop.sentry.dev/schemas/spec-compliance.json",
+  "sdk": "sentry-cocoa",
+  "last_updated": "2026-08-04",
+  "specs": {
+    "sdk/foundations/client/data-collection": {
+      "version": "0.10.0",
+      "sections": {
+        "configuration-surface": "0.10.0",
+        "collection-defaults": "0.10.0",
+        "sensitive-denylist": "0.10.0",
+        "integration-overrides": "0.10.0",
+        "user-set-data-scrubbing": "0.10.0",
+        "option-types": "0.10.0",
+        "datacollection-options": "0.10.0"
+      },
+      "non_applicable": {
+        "data-sensitivity-levels": "Conceptual taxonomy with no SDK implementation requirement."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## :scroll: Description

Add a machine-readable compliance manifest for the current data-collection specification implementation. Document how to maintain it, require updates for specification-covered changes, and require reviewers to verify declarations against the implementation.

This is intentionally a minimal proof of concept for the compliance-manifest idea. The format and its schema are not standardized yet, and this PR does not add validation tooling or CI enforcement.

## :bulb: Motivation and Context

The SDK currently has no in-repository declaration of implemented specification coverage. This makes the current data-collection conformance point visible while establishing maintenance and review expectations for future specification-covered work.

Closes #8561

## :green_heart: How did you test it?

- `jq empty sentry-spec-compliance.json`
- `git diff --cached --check`
- Pre-commit hooks, including Markdown and JSON formatting

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog