### PR TITLE
ci: Replace secrets: inherit with explicit secret maps

### DIFF
--- a/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
@@ -22,6 +22,15 @@ on:
           For release workflows, the version to inject into the SDK.
         required: false
         type: string
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD:
+        required: false
+      MATCH_GIT_PRIVATE_KEY:
+        required: false
+      MATCH_PASSWORD:
+        required: false
+      MATCH_USERNAME:
+        required: false
 
 jobs:
   assemble-sentryobjc-dynamic-xcframework:

--- a/.github/workflows/assemble-sentryobjc-static-xcframework.yml
+++ b/.github/workflows/assemble-sentryobjc-static-xcframework.yml
@@ -22,6 +22,15 @@ on:
           For release workflows, the version to inject into the SDK.
         required: false
         type: string
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD:
+        required: false
+      MATCH_GIT_PRIVATE_KEY:
+        required: false
+      MATCH_PASSWORD:
+        required: false
+      MATCH_USERNAME:
+        required: false
 
 jobs:
   assemble-sentryobjc-static-xcframework:

--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -62,6 +62,15 @@ on:
           The name to use for the XCFramework. If not provided, the default name will be used.
         required: false
         type: string
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD:
+        required: false
+      MATCH_GIT_PRIVATE_KEY:
+        required: false
+      MATCH_PASSWORD:
+        required: false
+      MATCH_USERNAME:
+        required: false
 
 jobs:
   assemble-xcframework-variant:

--- a/.github/workflows/fast-pr-checks.yml
+++ b/.github/workflows/fast-pr-checks.yml
@@ -44,7 +44,6 @@ jobs:
     if: needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
     needs: files-changed
     uses: ./.github/workflows/unit-test-common.yml
-    secrets: inherit
     with:
       name: iOS 18 Sentry
       runs-on: sequoia

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -21,7 +21,6 @@ jobs:
   unit-tests:
     name: Unit ${{matrix.name}}
     uses: ./.github/workflows/unit-test-common.yml
-    secrets: inherit
     with:
       name: ${{matrix.name}}
       runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     name: Assemble XCFramework Variant
     uses: ./.github/workflows/assemble-xcframework-variant.yml
-    secrets: inherit
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+      MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
     with:
       scheme: ${{matrix.variant.scheme}}
       suffix: ${{matrix.variant.suffix}}
@@ -129,7 +133,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     needs: [files-changed, build-sentryobjc-slices, setup-matrix]
     uses: ./.github/workflows/assemble-sentryobjc-static-xcframework.yml
-    secrets: inherit
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+      MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
     with:
       signed: ${{ github.event_name != 'pull_request' }}
       release-version: ${{ github.event.inputs.version }}
@@ -140,7 +148,11 @@ jobs:
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_release_for_prs == 'true'
     needs: [files-changed, build-sentryobjc-slices, setup-matrix]
     uses: ./.github/workflows/assemble-sentryobjc-dynamic-xcframework.yml
-    secrets: inherit
+    secrets:
+      FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+      MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+      MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
     with:
       signed: ${{ github.event_name != 'pull_request' }}
       release-version: ${{ github.event.inputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,7 +257,6 @@ jobs:
     name: Unit ${{matrix.name}}
     needs: files-changed
     uses: ./.github/workflows/unit-test-common.yml
-    secrets: inherit
     with:
       name: ${{matrix.name}}
       runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
## Summary
- 6 jobs used `secrets: inherit`, exposing every repository secret to the called reusable workflows:
  - `test.yml`, `fast-pr-checks.yml`, `nightly-test.yml` (`unit-tests`/`fast-unit-tests` jobs) call `unit-test-common.yml`, which reads no secrets at all — removed `secrets: inherit` entirely.
  - `release.yml` (`assemble-xcframework-variant`, `assemble-sentryobjc-static-xcframework`, `assemble-sentryobjc-dynamic-xcframework` jobs) call reusable workflows that conditionally read `FASTLANE_KEYCHAIN_PASSWORD`, `MATCH_GIT_PRIVATE_KEY`, `MATCH_PASSWORD`, and `MATCH_USERNAME` (only when `signed: true`) but never declared them under `workflow_call.secrets`. Declared them explicitly (optional) and pass only those by name.

This completes the fix for VULN-2364 — the `changelog-preview.yml` location of this ticket (the 7th of 7) was already handled in #8683.

## Test plan
- [x] Confirmed `unit-test-common.yml` contains zero references to `secrets.*`
- [x] Confirmed the 3 release workflows only read `FASTLANE_KEYCHAIN_PASSWORD`, `MATCH_GIT_PRIVATE_KEY`, `MATCH_PASSWORD`, `MATCH_USERNAME`
- [x] Validated all touched workflow YAML parses correctly
- [ ] Verify unit test and release/signing jobs still succeed on this PR

Fixes VULN-2364

🤖 Generated with [Claude Code](https://claude.com/claude-code)