### PR TITLE
fix: stamp sentry-cocoa version in 3rd-party archives

### DIFF
--- a/.github/workflows/3rd-party-integrations-archive.yml
+++ b/.github/workflows/3rd-party-integrations-archive.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           ./scripts/create-3rd-party-integration-archive.sh \
             --all \
+            --version 0.0.0 \
             --output-dir /tmp/3rd-party-archives
 
       - name: Verify archives

--- a/.github/workflows/3rd-party-integrations-archive.yml
+++ b/.github/workflows/3rd-party-integrations-archive.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           ./scripts/create-3rd-party-integration-archive.sh \
             --all \
-            --version 0.0.0 \
+            --version 0.1.0 \
             --output-dir /tmp/3rd-party-archives
 
       - name: Verify archives
@@ -69,6 +69,13 @@ jobs:
             test -f "$verify_dir/LICENSE.md"
             test -f "$verify_dir/Sources/$source_file"
             test -f "$verify_dir/Tests/$test_file"
+
+            # Verify the sentry-cocoa dependency was stamped to the requested version
+            grep -q 'sentry-cocoa", from: "0.1.0"' "$verify_dir/Package.swift" || {
+              echo "Version stamp failed in ${archive_name}/Package.swift:";
+              grep 'sentry-cocoa' "$verify_dir/Package.swift";
+              exit 1;
+            }
 
             echo "${archive_name} verified successfully"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,6 +517,7 @@ jobs:
         run: |
           ./scripts/create-3rd-party-integration-archive.sh \
             --all \
+            --version "${{ github.event.inputs.version }}" \
             --output-dir XCFrameworkBuildPath
 
       - name: Archive XCFrameworks for Craft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,18 +506,22 @@ jobs:
 
       - name: Create apple-binaries archive
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           ./scripts/create-apple-binaries-archive.sh \
-            --version "${{ github.event.inputs.version }}" \
+            --version "$VERSION" \
             --xcframework-dir XCFrameworkBuildPath \
             --output-dir XCFrameworkBuildPath
 
       - name: Create 3rd-party integration archives
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           ./scripts/create-3rd-party-integration-archive.sh \
             --all \
-            --version "${{ github.event.inputs.version }}" \
+            --version "$VERSION" \
             --output-dir XCFrameworkBuildPath
 
       - name: Archive XCFrameworks for Craft

--- a/scripts/ci-utils.sh
+++ b/scripts/ci-utils.sh
@@ -231,7 +231,7 @@ create_tgz_from_staging() {
   local archive_path
   archive_path="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
 
-  (cd "$staging_dir" && find . -type f -print0 | sed -z 's|^\./||' | sort -z | xargs -0 tar -czf "$archive_path" --)
+  (cd "$staging_dir" && find . -type f | sed 's|^\./||' | sort | tr '\n' '\0' | xargs -0 tar -czf "$archive_path" --)
 
   rm -rf "$staging_dir"
 

--- a/scripts/create-3rd-party-integration-archive.sh
+++ b/scripts/create-3rd-party-integration-archive.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./ci-utils.sh disable=SC1091
 source "$SCRIPT_DIR/ci-utils.sh"
 
+VERSION=""
 OUTPUT_DIR=""
 INTEGRATION=""
 ALL=false
@@ -29,8 +30,10 @@ Usage: $(basename "$0") [options]
 
 Create .tgz archives for 3rd-party integration distribution repos.
 Copies sources, tests, README, .gitignore, and LICENSE.md.
+Stamps the sentry-cocoa dependency version in Package.swift.
 
 OPTIONS:
+    --version <ver>             Release version, e.g. 9.25.0 (required)
     --integration <name>        Directory name under $INTEGRATIONS_DIR
                                 (e.g. SentrySwiftLog)
     --all                       Archive all integrations
@@ -38,9 +41,9 @@ OPTIONS:
     -h, --help                  Show this help message
 
 EXAMPLES:
-    $(basename "$0") --all
-    $(basename "$0") --integration SentrySwiftLog
-    $(basename "$0") --all --output-dir XCFrameworkBuildPath
+    $(basename "$0") --all --version 9.25.0
+    $(basename "$0") --integration SentrySwiftLog --version 9.25.0
+    $(basename "$0") --all --version 9.25.0 --output-dir XCFrameworkBuildPath
 
 EOF
     exit 1
@@ -48,6 +51,7 @@ EOF
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+        --version)     VERSION="$2";     shift 2 ;;
         --integration) INTEGRATION="$2"; shift 2 ;;
         --all)         ALL=true;         shift ;;
         --output-dir)  OUTPUT_DIR="$2";  shift 2 ;;
@@ -55,6 +59,11 @@ while [[ $# -gt 0 ]]; do
         *)             log_error "Unknown option: $1"; usage ;;
     esac
 done
+
+if [ -z "$VERSION" ]; then
+    log_error "--version is required"
+    usage
+fi
 
 if [ "$ALL" = false ] && [ -z "$INTEGRATION" ]; then
     log_error "Either --all or --integration <name> is required"
@@ -94,6 +103,11 @@ create_archive() {
     staging_dir=$(create_staging_dir)
 
     cp "$src_dir/Package.swift" "$staging_dir/Package.swift"
+
+    log_info "Stamping sentry-cocoa dependency to version $VERSION"
+    sed -i.bak "s|sentry-cocoa\", from: \"[^\"]*\"|sentry-cocoa\", from: \"${VERSION}\"|" "$staging_dir/Package.swift"
+    rm -f "$staging_dir/Package.swift.bak"
+
     cp "$src_dir/.gitignore" "$staging_dir/.gitignore"
     cp "$src_dir/README.md" "$staging_dir/README.md"
     cp "$REPO_ROOT/LICENSE.md" "$staging_dir/LICENSE.md"


### PR DESCRIPTION
## Description

The 3rd-party integration archives (`.tgz`) were built **before** Craft bumped the version via `bump.sh`. This meant the tagged `Package.swift` in each mirror repo contained the **previous** release's `sentry-cocoa` dependency (e.g., `from: "9.24.0"` instead of `from: "9.25.0"`). The mirror workflow later pushed the correct version to `main`, but the tag was already created pointing at the stale content.

All four mirror repos were affected:
- `sentry-apple-swift-log`
- `sentry-apple-cocoalumberjack`
- `sentry-apple-pulse`
- `sentry-apple-swiftybeaver`

This applies the same pattern used by `create-apple-binaries-archive.sh`: accept a `--version` parameter and stamp it into `Package.swift` before archiving.

## Changes

- `scripts/create-3rd-party-integration-archive.sh` — added mandatory `--version` param; `sed`-stamps the sentry-cocoa dependency version in the staged `Package.swift`
- `.github/workflows/release.yml` — passes `--version` from the release input
- `.github/workflows/3rd-party-integrations-archive.yml` — passes a dummy `--version 0.0.0` (test-only workflow)

#skip-changelog

Closes #8700