### PR TITLE
test: Mark Swift profiling test as flaky

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -43,6 +43,7 @@
         "SentryDispatchSourceWrapperTests\/testDispatchSourceWrapper_Repeats()",
         "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
+        "SentryInternalProfilingApiIntegrationTests\/testCollect_shouldContainProfileStructure()",
         "SentryHttpTransportTests\/testFlush_WhenNoInternet_BlocksAndFinishes()",
         "SentryNetworkTrackerIntegrationTestServerTests",
         "SentryNetworkTrackerIntegrationTestServerTests\/testGetRequest_SpanCreatedAndBaggageHeaderAdded()",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -26,6 +26,7 @@
         "SentryDispatchSourceWrapperTests\/testDispatchSourceWrapper_Repeats()",
         "SentryFileManagerTests\/testCreateDirectoryIfNotExists_successful_shouldNotLogError()",
         "SentryHttpTransportFlushIntegrationTests",
+        "SentryInternalProfilingApiIntegrationTests\/testCollect_shouldContainProfileStructure()",
         "SentryOnDemandReplayTests\/testAddFrameIsThreadSafe()",
         "SentrySubClassFinderTests\/testActOnSubclassesOfViewController()",
         "SentryWatchdogTerminationTrackerTests\/testTerminateApp_RunsOnMainThread()"


### PR DESCRIPTION
Move `SentryInternalProfilingApiIntegrationTests.testCollect_shouldContainProfileStructure` to the retry-on-failure test plan.

The test flaked in [this CI run](https://github.com/getsentry/sentry-cocoa/actions/runs/31086047847/job/92565660942?pr=8650), so running it separately prevents an intermittent failure from failing the regular unit-test job.

#skip-changelog

Closes #8705