### PR TITLE
fix: Forward device option in UI critical test lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,17 +244,19 @@ platform :ios do
     delete_keychain(name: "fastlane_tmp_keychain") if is_ci
   end
 
-  lane :ui_critical_tests_ios_swiftui_all do
+  lane :ui_critical_tests_ios_swiftui_all do |options|
     run_ui_tests(
       scheme: "SwiftUITestSampleAll",
-      result_bundle_name: "ui_critical_tests_ios_swiftui_all"
+      result_bundle_name: "ui_critical_tests_ios_swiftui_all",
+      device: options[:device]
     )
   end
 
-  lane :ui_critical_tests_ios_swiftui_envelope do
+  lane :ui_critical_tests_ios_swiftui_envelope do |options|
     run_ui_tests(
       scheme: "SwiftUITestSampleEnvelope",
-      result_bundle_name: "ui_critical_tests_ios_swiftui_envelope"
+      result_bundle_name: "ui_critical_tests_ios_swiftui_envelope",
+      device: options[:device]
     )
   end
 


### PR DESCRIPTION
## Description

The `ui_critical_tests_ios_swiftui_envelope` and `ui_critical_tests_ios_swiftui_all` Fastlane lanes were missing the `|options|` block parameter and weren't forwarding `device: options[:device]` to `run_ui_tests`.

The CI workflow (`ui-tests-common.yml`) passes `device:"iPhone 16 Pro (18.5)"` on the command line, but these two lanes silently ignored it. Fastlane then fell back to picking whatever simulator it found first — iPhone 14 Pro on iOS 16.4. Running UI tests on iOS 16.4 with Xcode 16.4 triggers the known "Test runner never began executing tests after launching" XCTest connection issue intermittently.

Every other UI test lane (`ui_tests_ios_swiftui`, `ui_tests_ios_swift6`, `ui_tests_ios_objc`, `ui_tests_ios_swift`) correctly accepts and forwards `options[:device]` — these two were the only ones missing it.

## How to verify

The "Test iOS 18 V4 / UI Tests Common" job in the `Test UI Critical` workflow should now consistently target the correct iOS 18.5 simulator instead of falling back to iOS 16.4.

#skip-changelog

Closes #8711