### PR TITLE
feat: promote standalone app start out of experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Promote `enableStandaloneAppStartTracing` from `options.experimental` to a top-level option on `Options` (#TBD)
 - Add experimental option `enableUIViewControllerInitSwizzling` that defers `UIViewController` swizzling to first instantiation instead of eagerly discovering and swizzling all subclasses at SDK start. This avoids realizing `@available`-gated `UIViewController` subclasses on OS versions below their gate, which crashes apps on start (#8687).
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Promote `enableStandaloneAppStartTracing` from `options.experimental` to a top-level option on `Options` (#TBD)
+- Promote `enableStandaloneAppStartTracing` from `options.experimental` to a top-level option on `Options` (#8715)
 - Add experimental option `enableUIViewControllerInitSwizzling` that defers `UIViewController` swizzling to first instantiation instead of eagerly discovering and swizzling all subclasses at SDK start. This avoids realizing `@available`-gated `UIViewController` subclasses on OS versions below their gate, which crashes apps on start (#8687).
 
 ### Fixes

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -201,7 +201,7 @@ public struct SentrySDKWrapper {
         options.enableUserInteractionTracing = !isBenchmarking && !SentrySDKOverrides.UIEventTracking.disableTracing.boolValue
 
         options.enablePreWarmedAppStartTracing = !isBenchmarking && !SentrySDKOverrides.AppStart.disablePrewarmedTracing.boolValue
-        options.experimental.enableStandaloneAppStartTracing = SentrySDKOverrides.AppStart.enableStandaloneTracing.boolValue
+        options.enableStandaloneAppStartTracing = SentrySDKOverrides.AppStart.enableStandaloneTracing.boolValue
         options.enableUIViewControllerTracing = !SentrySDKOverrides.UIViewControllerTracing.disable.boolValue
         options.experimental.enableUIViewControllerInitSwizzling = SentrySDKOverrides.UIViewControllerTracing.enableInitSwizzling.boolValue
 

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -573,6 +573,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL enablePreWarmedAppStartTracing;
 
 /**
+ * When enabled, the SDK sends a standalone app start transaction instead of attaching app
+ * start data to the first UIViewController transaction.
+ * @note Default value is @c NO.
+ */
+@property (nonatomic) BOOL enableStandaloneAppStartTracing;
+
+/**
  * When enabled, the SDK reports non-fully-blocking app hangs. A non-fully-blocking app hang is
  * when the app appears stuck to the user but can still render a few frames.
  * @note The default is @c YES.

--- a/Sources/SentryObjCCompat/SentryObjCOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCOptions.swift
@@ -344,6 +344,11 @@ import Foundation
         set { wrapped.enablePreWarmedAppStartTracing = newValue }
     }
 
+    @objc public var enableStandaloneAppStartTracing: Bool {
+        get { wrapped.enableStandaloneAppStartTracing }
+        set { wrapped.enableStandaloneAppStartTracing = newValue }
+    }
+
     @objc public var enableReportNonFullyBlockingAppHangs: Bool {
         get { wrapped.enableReportNonFullyBlockingAppHangs }
         set { wrapped.enableReportNonFullyBlockingAppHangs = newValue }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -52,9 +52,11 @@ import Foundation
         if options.enableMetrics {
             features.append("metrics")
         }
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         if options.enableStandaloneAppStartTracing {
             features.append("standaloneAppStartTracing")
         }
+#endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         if options.experimental.enableWatchdogTerminationsV2 {
             features.append("watchdogTerminationsV2")
         }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -52,7 +52,7 @@ import Foundation
         if options.enableMetrics {
             features.append("metrics")
         }
-        if options.experimental.enableStandaloneAppStartTracing {
+        if options.enableStandaloneAppStartTracing {
             features.append("standaloneAppStartTracing")
         }
         if options.experimental.enableWatchdogTerminationsV2 {

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -582,7 +582,7 @@ extension SentrySDK {
     /// func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     ///     SentrySDK.start(configureOptions: { options in
     ///         ...
-    ///         options.experimental.enableStandaloneAppStartTracing = true
+    ///         options.enableStandaloneAppStartTracing = true
     ///     })
     ///     SentrySDK.extendAppStart()
     ///

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -345,6 +345,12 @@
     /// @note Default value is @c true.
     @objc public var enablePreWarmedAppStartTracing: Bool = true
 
+    /// When enabled, the SDK sends a standalone app start transaction instead of attaching app
+    /// start data to the first UIViewController transaction.
+    ///
+    /// @note Default value is @c false.
+    @objc public var enableStandaloneAppStartTracing: Bool = false
+
     /// When enabled the SDK reports non-fully-blocking app hangs. A non-fully-blocking app hang is when
     /// the app appears stuck to the user but can still render a few frames.
     ///

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -324,7 +324,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
             appStateManager: appStateManager,
             framesTracker: framesTracker,
             enablePreWarmedAppStartTracing: options.enablePreWarmedAppStartTracing,
-            enableStandaloneAppStartTracing: options.experimental.enableStandaloneAppStartTracing,
+            enableStandaloneAppStartTracing: options.enableStandaloneAppStartTracing,
             dateProvider: dateProvider,
             sysctlWrapper: sysctlWrapper,
             appStartInfoProvider: appStartInfoProvider,

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -17,12 +17,6 @@ public final class SentryExperimentalOptions: NSObject {
     public var enableWatchdogTerminationsV2 = false
 
     /**
-     * When enabled, the SDK sends a standalone app start transaction instead of attaching app
-     * start data to the first UIViewController transaction.
-     */
-    public var enableStandaloneAppStartTracing = false
-
-    /**
      * Reduces SDK start overhead by swizzling each `UIViewController` subclass lazily, the first
      * time an instance of it is created, instead of eagerly discovering and swizzling every
      * subclass when the SDK starts.

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -306,6 +306,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
     }
 
     func testEnableStandaloneAppStartTracing_isEnabled_shouldAddFeature() throws {
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         // -- Arrange --
         let options = Options()
         options.enableStandaloneAppStartTracing = true
@@ -315,9 +316,13 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 
         // -- Assert --
         XCTAssertTrue(features.contains("standaloneAppStartTracing"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
     }
 
     func testEnableStandaloneAppStartTracing_isDisabled_shouldNotAddFeature() throws {
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         // -- Arrange --
         let options = Options()
         options.enableStandaloneAppStartTracing = false
@@ -327,9 +332,13 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 
         // -- Assert --
         XCTAssertFalse(features.contains("standaloneAppStartTracing"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
     }
 
     func testEnableStandaloneAppStartTracing_whenDefault_shouldNotAddFeature() throws {
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         // -- Arrange --
         let options = Options()
 
@@ -338,6 +347,9 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 
         // -- Assert --
         XCTAssertFalse(features.contains("standaloneAppStartTracing"))
+#else
+        throw XCTSkip("Test not supported on this platform")
+#endif
     }
 
     func testEnableWatchdogTerminationsV2_isEnabled_shouldAddFeature() throws {

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -308,7 +308,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
     func testEnableStandaloneAppStartTracing_isEnabled_shouldAddFeature() throws {
         // -- Arrange --
         let options = Options()
-        options.experimental.enableStandaloneAppStartTracing = true
+        options.enableStandaloneAppStartTracing = true
 
         // -- Act --
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
@@ -320,7 +320,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
     func testEnableStandaloneAppStartTracing_isDisabled_shouldNotAddFeature() throws {
         // -- Arrange --
         let options = Options()
-        options.experimental.enableStandaloneAppStartTracing = false
+        options.enableStandaloneAppStartTracing = false
 
         // -- Act --
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)

--- a/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
+++ b/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
@@ -27,6 +27,7 @@ final class SentryOptionsDocumentationSyncTests: XCTestCase {
 
         #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         options.insert("screenshot")
+        options.insert("enableStandaloneAppStartTracing")
         #endif
 
         // Session replay (documented at https://docs.sentry.io/platforms/apple/session-replay/)

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -24399,6 +24399,82 @@
                 "declKind": "Accessor",
                 "implicit": true,
                 "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableStandaloneAppStartTracing"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableStandaloneAppStartTracing:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvp",
+            "moduleName": "Sentry",
+            "name": "enableStandaloneAppStartTracing",
+            "printedName": "enableStandaloneAppStartTracing",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableStandaloneAppStartTracing"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC15enableSwizzlingSbvg",
                 "moduleName": "Sentry",
                 "name": "Get",
@@ -38651,82 +38727,6 @@
             "overriding": true,
             "printedName": "init()",
             "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)init"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)enableStandaloneAppStartTracing"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setEnableStandaloneAppStartTracing:"
-              }
-            ],
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasStorage",
-              "ObjC"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvp",
-            "moduleName": "Sentry",
-            "name": "enableStandaloneAppStartTracing",
-            "printedName": "enableStandaloneAppStartTracing",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)enableStandaloneAppStartTracing"
           },
           {
             "accessors": [

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2077,6 +2077,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "enableStandaloneAppStartTracing",
+    "parent": "SentryObjCOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "enableSwizzling",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -5878,6 +5885,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setEnableStandaloneAppStartTracing:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setEnableSwizzling:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9125,6 +9139,12 @@
   {
     "kind": "ObjCPropertyDecl",
     "name": "enableSpotlight",
+    "parent": "SentryObjCOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "enableStandaloneAppStartTracing",
     "parent": "SentryObjCOptions",
     "type": "BOOL"
   },

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -2164,6 +2164,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "enableStandaloneAppStartTracing",
+    "parent": "SentryObjCOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "enableSwizzling",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -6028,6 +6035,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setEnableStandaloneAppStartTracing:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setEnableSwizzling:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9317,6 +9331,12 @@
   {
     "kind": "ObjCPropertyDecl",
     "name": "enableSpotlight",
+    "parent": "SentryObjCOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "enableStandaloneAppStartTracing",
     "parent": "SentryObjCOptions",
     "type": "BOOL"
   },

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -24472,6 +24472,82 @@
                 "declKind": "Accessor",
                 "implicit": true,
                 "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableStandaloneAppStartTracing"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableStandaloneAppStartTracing:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC31enableStandaloneAppStartTracingSbvp",
+            "moduleName": "Sentry",
+            "name": "enableStandaloneAppStartTracing",
+            "printedName": "enableStandaloneAppStartTracing",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableStandaloneAppStartTracing"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC15enableSwizzlingSbvg",
                 "moduleName": "Sentry",
                 "name": "Get",
@@ -39982,82 +40058,6 @@
             "overriding": true,
             "printedName": "init()",
             "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)init"
-          },
-          {
-            "accessors": [
-              {
-                "accessorKind": "get",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvg",
-                "moduleName": "Sentry",
-                "name": "Get",
-                "printedName": "Get()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)enableStandaloneAppStartTracing"
-              },
-              {
-                "accessorKind": "set",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  }
-                ],
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "declKind": "Accessor",
-                "implicit": true,
-                "kind": "Accessor",
-                "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvs",
-                "moduleName": "Sentry",
-                "name": "Set",
-                "printedName": "Set()",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)setEnableStandaloneAppStartTracing:"
-              }
-            ],
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declAttributes": [
-              "Final",
-              "HasStorage",
-              "ObjC"
-            ],
-            "declKind": "Var",
-            "hasStorage": true,
-            "kind": "Var",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC31enableStandaloneAppStartTracingSbvp",
-            "moduleName": "Sentry",
-            "name": "enableStandaloneAppStartTracing",
-            "printedName": "enableStandaloneAppStartTracing",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(py)enableStandaloneAppStartTracing"
           },
           {
             "accessors": [


### PR DESCRIPTION
## Summary

* Move `enableStandaloneAppStartTracing` from `options.experimental` to a top-level option on `Options` (default `false`)
* Add ObjC compatibility wrapper (`SentryObjCOptions.h` / `SentryObjCOptions.swift`)
* Update all references in source, tests, samples, and docs

## Test plan

- [X] `make build-ios` passes
- [X] `SentryAppStartTrackerTests` — 25 tests pass
- [X] `SentryEnabledFeaturesBuilderTests` — 35 tests pass
- [ ] `make generate-public-api` — needs Xcode 16 (CI will handle)
- [ ] Full CI with `run-full-ci` label

Closes getsentry/sentry-cocoa#8720