### PR TITLE
feat: enable MetricKit integration by default in v10

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -17,6 +17,7 @@
 
 ### Breaking Changes
 
+- Enable MetricKit integration by default (#TBD)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)
 - Remove deprecated `locale` from device context; use `locale` in culture context instead (#8325)

--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -17,7 +17,7 @@
 
 ### Breaking Changes
 
-- Enable MetricKit integration by default (#TBD)
+- Enable MetricKit integration by default (#8716)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)
 - Remove deprecated `locale` from device context; use `locale` in culture context instead (#8325)

--- a/SentryTestUtils/Sources/TestOptions.swift
+++ b/SentryTestUtils/Sources/TestOptions.swift
@@ -23,6 +23,9 @@ public extension Options {
         #endif
         enableMetrics = false
         beforeSendMetric = { metric in metric }
+        #if canImport(MetricKit) && !os(tvOS)
+        enableMetricKit = false
+        #endif
     }
 
     static func noIntegrations() -> Options {

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -601,8 +601,14 @@
     /// @c MXHangDiagnostic to Sentry. The SDK supports this feature from iOS 15 and later and macOS 12
     /// and later because, on these versions, @c MetricKit delivers diagnostic reports immediately, which
     /// allows the Sentry SDK to apply the current data from the scope.
-    /// @note This feature is disabled by default.
-    @objc public var enableMetricKit = false
+    /// @note Default value is @c true in v10, @c false in earlier versions.
+    @objc public var enableMetricKit: Bool = {
+        #if SDK_V10
+        return true
+        #else
+        return false
+        #endif // SDK_V10
+    }()
 
     /// When enabled, the SDK adds the raw MXDiagnosticPayloads as an attachment to the converted
     /// SentryEvent. You need to enable @c enableMetricKit for this flag to work.

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length
+// swiftlint:disable type_body_length
 /// Configuration options for the Sentry SDK.
 @objc(SentryOptions) public final class Options: NSObject {
 
@@ -754,4 +755,5 @@ extension NSNumber {
     }
 }
 
+// swiftlint:enable type_body_length
 // swiftlint:enable file_length

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -43,6 +43,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     
     func testOptionDisabled_MetricKitManagerNotInitialized() {
           let options = Options()
+          options.enableMetricKit = false
           let sut = SentryMetricKitIntegration(with: options, dependencies: ())
           XCTAssertNil(sut)
     }

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -27,6 +27,9 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableSwizzling = false
         options.enableMetrics = false
         options.enableCrashHandler = false
+        #if canImport(MetricKit) && !os(tvOS)
+        options.enableMetricKit = false
+        #endif
 
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)
@@ -56,6 +59,9 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableSwizzling = false
         options.enableMetrics = false
         options.enableCrashHandler = false
+        #if canImport(MetricKit) && !os(tvOS)
+        options.enableMetricKit = false
+        #endif
 
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2159,6 +2159,9 @@ final class SentryClientTests: XCTestCase {
 #if os(iOS) || os(tvOS) || os(visionOS)
         expectedIntegrations.append("FramesTracking")
 #endif // os(iOS) || os(tvOS)
+#if canImport(MetricKit) && !os(tvOS) && SDK_V10
+        expectedIntegrations.append("MetricKit")
+#endif
 
         let actual = try lastSentEvent()
         assertArrayEquals(

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -795,7 +795,11 @@ typedef SentryLog *_Nullable (^SentryBeforeSendLogCallback)(SentryLog *_Nonnull 
     XCTAssertFalse(options.swiftAsyncStacktraces);
 
 #if SENTRY_HAS_METRIC_KIT
+#    if SDK_V10
+    XCTAssertEqual(YES, options.enableMetricKit);
+#    else
     XCTAssertEqual(NO, options.enableMetricKit);
+#    endif // SDK_V10
     XCTAssertEqual(NO, options.enableMetricKitRawPayload);
 #endif // SENTRY_HAS_METRIC_KIT
 
@@ -978,7 +982,11 @@ typedef SentryLog *_Nullable (^SentryBeforeSendLogCallback)(SentryLog *_Nonnull 
 
 - (void)testEnableMetricKit
 {
+#    if SDK_V10
+    [self testBooleanField:@"enableMetricKit" defaultValue:YES];
+#    else
     [self testBooleanField:@"enableMetricKit" defaultValue:NO];
+#    endif // SDK_V10
 }
 
 - (void)testenableMetricKitRawPayload

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -144,6 +144,9 @@ class SentrySDKTests: XCTestCase {
         #else
         expectedIntegrations.append("SentryCrashIntegration")
         #endif
+#if canImport(MetricKit) && !os(tvOS) && SDK_V10
+        expectedIntegrations.append("SentryMetricKitIntegration")
+#endif
 
         assertIntegrationsInstalled(integrations: expectedIntegrations)
     }


### PR DESCRIPTION
## Description

Enable the MetricKit integration (`enableMetricKit`) by default when building with the `SDK_V10` compiler flag. MetricKit has minimal overhead since the OS measures the data whether we upload it or not, so it makes sense to have it on by default for v10.

## Changes

- `Options.swift`: Flip `enableMetricKit` default from `false` to `true` under `#if SDK_V10`
- `SentryOptionsTest.m`: Update default value assertions to expect `YES` under `SDK_V10`
- `CHANGELOG_V10.md`: Add breaking change entry

## How tested

- `make build-ios FOR_AGENTS=true` — builds clean
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryOptionsTest` — 134 tests, 0 failures
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryMetricKitIntegrationTests` — 10 tests, 0 failures

Closes COCOA-1080

#skip-changelog