### PR TITLE
feat: enable logging by default in v10

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -17,6 +17,7 @@
 
 ### Breaking Changes
 
+- Enable logging by default (#TBD)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)
 - Remove deprecated `locale` from device context; use `locale` in culture context instead (#8325)

--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -17,7 +17,7 @@
 
 ### Breaking Changes
 
-- Enable logging by default (#TBD)
+- Enable logging by default (#8717)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)
 - Remove deprecated `locale` from device context; use `locale` in culture context instead (#8325)

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -138,8 +138,14 @@
 
     /// When enabled, the SDK sends logs to Sentry. Logs can be captured using the SentrySDK.logger
     /// API, which provides structured logging with attributes.
-    /// @note Default value is @c false.
-    @objc public var enableLogs: Bool = false
+    /// @note Default value is @c true in v10, @c false in earlier versions.
+    @objc public var enableLogs: Bool = {
+        #if SDK_V10
+        return true
+        #else
+        return false
+        #endif // SDK_V10
+    }()
 
     /// Use this callback to drop or modify a log before the SDK sends it to Sentry. Return nil to
     /// drop the log.

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -208,7 +208,11 @@
 
 - (void)testEnableLogs
 {
+#if SDK_V10
+    [self testBooleanField:@"enableLogs" defaultValue:YES];
+#else
     [self testBooleanField:@"enableLogs" defaultValue:NO];
+#endif // SDK_V10
 }
 
 - (void)testEnableMetrics


### PR DESCRIPTION
## Description

Enable `enableLogs` by default when building with the `SDK_V10` compiler flag. This follows the logging spec v2.0.0 which requires `enableLogs` to default to `true`. No logs are emitted unless the user explicitly calls `SentrySDK.logger` or enables a logging integration, so this is safe to flip.

## Changes

- `Options.swift`: Flip `enableLogs` default from `false` to `true` under `#if SDK_V10`
- `SentryOptionsTest.m`: Update `testBooleanField` call to expect `YES` under `SDK_V10`
- `CHANGELOG_V10.md`: Add breaking change entry

## How tested

- `make build-ios FOR_AGENTS=true` — builds clean
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryOptionsTest` — 134 tests, 0 failures

Closes COCOA-1421

#skip-changelog