### PR TITLE
test: verify network tracking end to end

### DIFF
--- a/Plans/Sentry_TestServer.xctestplan
+++ b/Plans/Sentry_TestServer.xctestplan
@@ -14,6 +14,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "SentryNetworkTrackerIntegrationTestServerTests\/testDataTask_whenRequestCompletes_shouldCaptureNetworkBreadcrumb()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testFailedRequest_whenCaptureEnabled_shouldMatchEnvelopeSnapshot()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testGetCaptureFailedRequestsEnabled()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testGetRequest_CompareSentryTraceHeader()",

--- a/Plans/Sentry_TestServer.xctestplan
+++ b/Plans/Sentry_TestServer.xctestplan
@@ -15,6 +15,7 @@
     {
       "selectedTests" : [
         "SentryNetworkTrackerIntegrationTestServerTests\/testDataTask_whenRequestCompletes_shouldCaptureNetworkBreadcrumb()",
+        "SentryNetworkTrackerIntegrationTestServerTests\/testDataTask_whenResponseIsDelayed_shouldIncludeDelayInSpanDuration()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testFailedRequest_whenCaptureEnabled_shouldMatchEnvelopeSnapshot()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testGetCaptureFailedRequestsEnabled()",
         "SentryNetworkTrackerIntegrationTestServerTests\/testGetRequest_CompareSentryTraceHeader()",

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -23,7 +23,7 @@ make test-ui-critical                                          # important UI te
 
 ### Test Server
 
-Only needed for `SentryNetworkTrackerIntegrationTestServerTests` (7 tests). Most tests run without it.
+Only needed for `SentryNetworkTrackerIntegrationTestServerTests`. Most tests run without it.
 
 ```bash
 make -C test-server start-debug

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -23,7 +23,7 @@ make test-ui-critical                                          # important UI te
 
 ### Test Server
 
-Only needed for `SentryNetworkTrackerIntegrationTestServerTests` (6 tests). Most tests run without it.
+Only needed for `SentryNetworkTrackerIntegrationTestServerTests` (7 tests). Most tests run without it.
 
 ```bash
 make -C test-server start-debug

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -23,7 +23,7 @@ make test-ui-critical                                          # important UI te
 
 ### Test Server
 
-Only needed for `SentryNetworkTrackerIntegrationTestServerTests` (5 tests). Most tests run without it.
+Only needed for `SentryNetworkTrackerIntegrationTestServerTests` (6 tests). Most tests run without it.
 
 ```bash
 make -C test-server start-debug

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -55,6 +55,55 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         XCTAssertEqual(NSNumber(value: 200), networkSpan.data["http.response.status_code"] as? NSNumber)
     }
 
+    func testDataTask_whenRequestCompletes_shouldCaptureNetworkBreadcrumb() throws {
+        // -- Arrange --
+        try ensureTestServerIsRunning()
+        let url = try XCTUnwrap(URL(string: "http://localhost:8081/echo-sentry-trace"))
+        let requestCompleted = expectation(description: "Request completed")
+        requestCompleted.assertForOverFulfill = false
+        let breadcrumbCaptured = expectation(description: "Network breadcrumb captured")
+        let capturedBreadcrumb = SentryMutex<Breadcrumb?>(nil)
+
+        startSDK {
+            $0.enableSwizzling = true
+            $0.enableNetworkBreadcrumbs = true
+            $0.beforeBreadcrumb = { breadcrumb in
+                guard breadcrumb.category == "http",
+                      (breadcrumb.data?["url"] as? String) == url.absoluteString else {
+                    return breadcrumb
+                }
+
+                capturedBreadcrumb.withLock { $0 = breadcrumb }
+                breadcrumbCaptured.fulfill()
+                return breadcrumb
+            }
+        }
+
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: url) { _, response, error in
+            self.assertNetworkError(error)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            requestCompleted.fulfill()
+        }
+        defer { session.finishTasksAndInvalidate() }
+
+        // -- Act --
+        task.resume()
+        wait(for: [requestCompleted, breadcrumbCaptured], timeout: 10)
+
+        // -- Assert --
+        let breadcrumb = try XCTUnwrap(capturedBreadcrumb.withLock { $0 })
+        let data = try XCTUnwrap(breadcrumb.data)
+        let requestStart = try XCTUnwrap(data["request_start"] as? Date)
+        let requestEnd = try XCTUnwrap(breadcrumb.timestamp)
+
+        XCTAssertEqual(breadcrumb.type, "http")
+        XCTAssertEqual(data["url"] as? String, url.absoluteString)
+        XCTAssertEqual(data["method"] as? String, "GET")
+        XCTAssertEqual(data["status_code"] as? Int, 200)
+        XCTAssertGreaterThan(requestEnd.timeIntervalSince(requestStart), 0)
+    }
+
     func testGetRequest_CompareSentryTraceHeader() throws {
         try ensureTestServerIsRunning()
 
@@ -263,6 +312,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
             expectedEnvelopeItemType: SentryEnvelopeItemTypes.event
         ) {
             self.configureEnvelopeSnapshotOptions($0)
+            $0.enableNetworkBreadcrumbs = false
             $0.enableCaptureFailedRequests = true
             $0.failedRequestStatusCodes = [HttpStatusCodeRange(statusCode: 400)]
         }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -55,6 +55,48 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         XCTAssertEqual(NSNumber(value: 200), networkSpan.data["http.response.status_code"] as? NSNumber)
     }
 
+    func testDataTask_whenResponseIsDelayed_shouldIncludeDelayInSpanDuration() throws {
+        // -- Arrange --
+        try ensureTestServerIsRunning()
+        let url = try XCTUnwrap(URL(string: "http://localhost:8081/delayed-response"))
+        let requestCompleted = expectation(description: "Request completed")
+        requestCompleted.assertForOverFulfill = false
+
+        startSDK()
+
+        let transaction = try XCTUnwrap(SentrySDK.startTransaction(
+            name: "Test Transaction",
+            operation: "TEST",
+            bindToScope: true
+        ) as? SentryTracer)
+        let session = URLSession(configuration: .default)
+        let task = session.dataTask(with: url) { _, response, error in
+            self.assertNetworkError(error)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            requestCompleted.fulfill()
+        }
+        let taskCompleted = keyValueObservingExpectation(
+            for: task,
+            keyPath: "state"
+        ) { object, _ in
+            (object as? URLSessionTask)?.state == .completed
+        }
+        defer { session.finishTasksAndInvalidate() }
+
+        // -- Act --
+        task.resume()
+        wait(for: [requestCompleted, taskCompleted], timeout: 10)
+
+        // -- Assert --
+        let networkSpan = try XCTUnwrap(transaction.children.first)
+        let spanStartedAt = try XCTUnwrap(networkSpan.startTimestamp)
+        let spanEndedAt = try XCTUnwrap(networkSpan.timestamp)
+        let spanDuration = spanEndedAt.timeIntervalSince(spanStartedAt)
+
+        XCTAssertTrue(networkSpan.isFinished)
+        XCTAssertGreaterThanOrEqual(spanDuration, 0.9)
+    }
+
     func testDataTask_whenRequestCompletes_shouldCaptureNetworkBreadcrumb() throws {
         // -- Arrange --
         try ensureTestServerIsRunning()

--- a/test-server/Sources/App/routes.swift
+++ b/test-server/Sources/App/routes.swift
@@ -17,6 +17,12 @@ public func routes(_ app: Application) {
         echoedHeader(named: "sentry-trace", from: request)
     }
 
+    app.get("delayed-response") { request -> EventLoopFuture<String> in
+        request.eventLoop.scheduleTask(in: .seconds(1)) {
+            "OK"
+        }.futureResult
+    }
+
     app.post("echo-sentry-trace") { request -> String in
         let trace_id = request.headers["sentry-trace"]
         if let sentryTraceHeader = trace_id.first {


### PR DESCRIPTION
## :scroll: Description

- Add a real `URLSession` request test that verifies network breadcrumb URL, method, status code, and duration.
- Add a delayed local response and verify the resulting HTTP span includes the server delay.
- Include both end-to-end tests in the local test-server plan.
- Keep failed-request envelope snapshots isolated from unrelated network breadcrumbs.

## :bulb: Motivation and Context

Verify that network breadcrumbs and HTTP performance span timing remain correct with potential Swift-backed networking changes in iOS 27.

Refs #8127

## :green_heart: How did you test it?

- `swift test --package-path test-server`
- Network breadcrumb end-to-end test on an iOS 27 simulator
- HTTP span timing end-to-end test on an iOS 27 simulator using `test-without-building`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
