### PR TITLE
ref(replay): Remove preview display link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Improvements
 
 - Session Replay keeps captured frames in memory for live video encode while still writing PNGs to disk for crash durability. Encode prefers the in-memory image and only falls back to disk for frames recovered after a crash, avoiding a PNG readback on the streaming hot path. (#8636)
+- Remove the per-frame render loop from the Session Replay masking preview. (#8730)
 
 ### Fixes
 

--- a/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
@@ -235,6 +235,6 @@ struct SecondView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .sentryReplayPreviewMask(opacity: 0.1)
+            .sentryReplayPreviewMask(opacity: 0.3)
     }
 }

--- a/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
+++ b/Samples/iOS-SwiftUI/App/Sources/ContentView.swift
@@ -1,77 +1,71 @@
 import Sentry
 import SwiftUI
 
-// This sample app also serves as a build-time validation that the Sentry module
-// correctly exposes all public APIs (SentryTracedView, sentryTrace(), sentryReplayMask(),
-// sentryReplayUnmask(), etc.). If any of these APIs are accidentally removed or renamed,
-// the build for this sample will fail in CI.
-
-//This is for test purpose
 class DataBag {
-
     static let shared = DataBag()
 
     var info = [String: Any]()
 
-    private init() {
-    }
+    private init() {}
 }
 
 struct ContentView: View {
 
     @State var TTDInfo: String = ""
     @State var errorId: SentryId?
-    
+
     var addBreadcrumbAction: () -> Void = {
         let crumb = Breadcrumb(level: SentryLevel.info, category: "Debug")
         crumb.message = "tapped addBreadcrumb"
         crumb.type = "user"
         SentrySDK.addBreadcrumb(crumb)
     }
-    
+
     var captureMessageAction: () -> Void = {
         SentrySDK.capture(message: "Yeah captured a message")
     }
-    
+
     func captureErrorAction() {
-        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Object does not exist"
+        ])
         errorId = SentrySDK.capture(error: error) { (scope) in
             scope.setTag(value: "value", key: "myTag")
         }
     }
-    
+
     var captureNSExceptionAction: () -> Void = {
         let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
         let scope = Scope()
         scope.setLevel(.fatal)
         SentrySDK.capture(exception: exception, scope: scope)
     }
-    
+
     var captureTransactionAction: () -> Void = {
         let transaction = SentrySDK.startTransaction(name: "Some Transaction", operation: "some operation")
         DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
             transaction.finish()
         })
     }
-    
+
     func asyncCrash1() {
         DispatchQueue.main.async {
             self.asyncCrash2()
         }
     }
-    
+
     func asyncCrash2() {
         DispatchQueue.main.async {
             SentrySDK.crash()
         }
     }
-    
+
     var oomCrashAction: () -> Void = {
         DispatchQueue.main.async {
             let megaByte = 1_024 * 1_024
             let memoryPageSize = NSPageSize()
             let memoryPages = megaByte / memoryPageSize
-            
+
             while true {
                 // Allocate one MB and set one element of each memory page to something.
                 let ptr = UnsafeMutablePointer<Int8>.allocate(capacity: megaByte)
@@ -84,35 +78,34 @@ struct ContentView: View {
 
     func showTTD() {
         guard let tracer = getCurrentTracer() else { return }
-        
+
         var log = [String]()
-        
+
         if !hasTTID(tracer: tracer) { log.append("TTID not found") }
         if !hasTTFD(tracer: tracer) { log.append("TTFD not found") }
-        
+
         if log.isEmpty {
             log.append("TTID and TTFD found")
         }
         TTDInfo = log.joined(separator: "\n")
     }
-    
+
     func getCurrentTracer() -> SentryTracer? {
         if DataBag.shared.info["initialTransaction"] == nil {
             DataBag.shared.info["initialTransaction"] = SentrySDK.span as? SentryTracer
         }
         return DataBag.shared.info["initialTransaction"] as? SentryTracer
     }
-    
+
     func hasTTID(tracer: SentryTracer?) -> Bool {
         tracer?.children.contains { $0.spanDescription?.contains("initial display") == true } == true
     }
-    
+
     func hasTTFD(tracer: SentryTracer?) -> Bool {
         tracer?.children.contains { $0.spanDescription?.contains("full display") == true } == true
     }
 
     func getCurrentSpan() -> Span? {
-
         let tracker = SentryPerformanceTracker.shared
         guard let currentSpanId = tracker.activeSpanId() else {
             return DataBag.shared.info["lastSpan"] as? Span
@@ -128,7 +121,7 @@ struct ContentView: View {
 
         return DataBag.shared.info["lastSpan"] as? Span
     }
- 
+
     var body: some View {
         return SentryTracedView("Content View Body", waitForFullDisplay: true) {
             NavigationView {
@@ -136,57 +129,54 @@ struct ContentView: View {
                     Group {
                         Text(getCurrentTracer()?.transactionContext.name ?? "NO SPAN")
                             .accessibilityIdentifier("TRANSACTION_NAME")
-                            
+
                         Text(getCurrentTracer()?.transactionContext.spanId.sentrySpanIdString ?? "NO ID")
                             .accessibilityIdentifier("TRANSACTION_ID")
                             .sentryReplayMask()
-                        
+
                         Text(getCurrentTracer()?.transactionContext.origin ?? "NO ORIGIN")
                             .accessibilityIdentifier("TRACE_ORIGIN")
-                    }.sentryReplayUnmask()
-                        .onAppear {
-                            SentrySDK.reportFullyDisplayed()
-                        }
+                    }
+                    .sentryReplayUnmask()
+                    .onAppear {
+                        SentrySDK.reportFullyDisplayed()
+                    }
                     SentryTracedView("Child Span") {
                         VStack {
                             Text(getCurrentSpan()?.spanDescription ?? "NO SPAN")
                                 .accessibilityIdentifier("CHILD_NAME")
                             Text(getCurrentSpan()?.parentSpanId?.sentrySpanIdString ?? "NO SPAN")
                                 .accessibilityIdentifier("CHILD_PARENT_SPANID")
-                            
+
                             Text(getCurrentSpan()?.origin ?? "NO CHILD ORIGIN")
                                 .accessibilityIdentifier("CHILD_TRACE_ORIGIN")
                         }
                     }
                     HStack (spacing: 30) {
                         VStack(spacing: 16) {
-
                             Button(action: addBreadcrumbAction) {
                                 Text("Add Breadcrumb")
                             }
-
                             Button(action: captureMessageAction) {
                                 Text("Capture Message")
                             }
-
                             Button(action: captureErrorAction) {
                                 Text("Capture Error")
                             }
-
                             Button(action: captureNSExceptionAction) {
                                 Text("Capture NSException")
                             }
-
                             Button(action: captureTransactionAction) {
                                 Text("Capture Transaction")
                             }
                             // This is used by a UI test since UIApplication.shared is nil in unit tests.
                             Button("UIApplication sendEmptyEvent") {
-                              UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                             }
                             Button(action: showTTD) {
                                 Text("Show TTD")
-                            }.sentryReplayUnmask()
+                            }
+                            .sentryReplayUnmask()
                         }
                         VStack(spacing: 16) {
                             Button(action: {
@@ -194,7 +184,6 @@ struct ContentView: View {
                             }) {
                                 Text("Crash")
                             }
-                            
                             Button(action: {
                                 DispatchQueue.main.async {
                                     self.asyncCrash1()
@@ -202,27 +191,21 @@ struct ContentView: View {
                             }) {
                                 Text("Async Crash")
                             }
-                            
                             Button(action: oomCrashAction) {
                                 Text("OOM Crash")
                             }
-                            
                             NavigationLink(destination: SecondView()) {
                                 Text("Show Detail View 1")
                             }
-                            
                             NavigationLink(destination: LoremIpsumView()) {
                                 Text("Lorem Ipsum")
                             }
-                            
                             NavigationLink(destination: UIKitScreen()) {
                                 Text("UIKit Screen")
                             }
-                            
                             NavigationLink(destination: FormScreen()) {
                                 Text("Form Screen")
                             }
-
                             NavigationLink(destination: FeedbackScreen()) {
                                 Text("Feedback Screen")
                             }
@@ -230,10 +213,10 @@ struct ContentView: View {
                         .background(Color.white)
                     }
                     SecondView()
-                  if let errorId {
-                    Text(errorId.sentryIdString)
-                      .accessibilityIdentifier("errorId")
-                  }
+                    if let errorId {
+                        Text(errorId.sentryIdString)
+                            .accessibilityIdentifier("errorId")
+                    }
                     Text(TTDInfo)
                         .accessibilityIdentifier("TTDInfo")
                 }
@@ -252,6 +235,6 @@ struct SecondView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .sentryReplayPreviewMask(opacity: 0.3)
+            .sentryReplayPreviewMask(opacity: 0.1)
     }
 }

--- a/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
+++ b/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
@@ -14,17 +14,18 @@ import UIKit
             }
         }
     }
-    
+
     private let photographer: SentryViewPhotographer
-    private var displayLink: CADisplayLink?
     private var imageView = UIImageView()
     private var idle = true
-    
+    private var needsUpdate = false
+    private var updateScheduled = false
+
     public var opacity: Float {
         get { return Float(imageView.alpha) }
-        set { imageView.alpha = CGFloat(newValue)}
+        set { imageView.alpha = CGFloat(newValue) }
     }
-    
+
     public init(redactOptions: SentryRedactOptions) {
         self.photographer = SentryViewPhotographer(
             renderer: PreviewRenderer(),
@@ -33,40 +34,89 @@ import UIKit
         )
         super.init(frame: .zero)
         self.isUserInteractionEnabled = false
-        
+
         imageView.sentryReplayUnmask()
         imageView.frame = bounds
         imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         addSubview(imageView)
     }
-        
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    deinit {
-        displayLink?.invalidate()
-    }
-    
+
     public override func didMoveToSuperview() {
-        if displayLink == nil {
-            displayLink = CADisplayLink(target: self, selector: #selector(update))
-            displayLink?.add(to: .main, forMode: .common)
+        super.didMoveToSuperview()
+
+        guard let superview else {
+            cancelPendingUpdate()
+            return
         }
 
-        if let superview = self.superview {
-            self.frame = superview.bounds
+        frame = superview.bounds
+        setNeedsPreviewUpdate()
+    }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        if window == nil {
+            cancelPendingUpdate()
+        } else {
+            setNeedsPreviewUpdate()
         }
     }
-    
-    @objc
+
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        setNeedsPreviewUpdate()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setNeedsPreviewUpdate()
+    }
+
+    private func setNeedsPreviewUpdate() {
+        guard superview != nil, window != nil else { return }
+
+        needsUpdate = true
+        scheduleUpdate()
+    }
+
+    private func scheduleUpdate() {
+        guard needsUpdate, idle, !updateScheduled else { return }
+
+        updateScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            self.updateScheduled = false
+            self.update()
+        }
+    }
+
+    private func cancelPendingUpdate() {
+        needsUpdate = false
+    }
+
     private func update() {
-        guard let superview = self.superview, idle else { return }
+        guard needsUpdate, let superview, window != nil, idle else { return }
+
+        needsUpdate = false
         idle = false
-        self.photographer.image(view: superview) { maskedViewImage in
+        photographer.image(view: superview) { [weak self] maskedViewImage in
             DispatchQueue.main.async {
-                self.imageView.image = maskedViewImage
+                guard let self else { return }
+
                 self.idle = true
+                guard self.superview != nil, self.window != nil else { return }
+                guard !self.needsUpdate else {
+                    self.scheduleUpdate()
+                    return
+                }
+
+                self.imageView.image = maskedViewImage
             }
         }
     }

--- a/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
+++ b/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
@@ -54,6 +54,7 @@ import UIKit
         }
 
         frame = superview.bounds
+        autoresizingMask = [.flexibleWidth, .flexibleHeight]
         setNeedsPreviewUpdate()
     }
 

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -838,6 +838,20 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertEqual(window.subviews.count, 1, "Mask preview did not appear in production" )
         XCTAssertTrue(window.subviews.first is SentryMaskingPreviewView)
     }
+
+    func testMaskPreview_whenSuperviewResizes_shouldResize() {
+        // -- Arrange --
+        let superview = UIView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        let preview = SentryMaskingPreviewView(redactOptions: SentryReplayOptions())
+        superview.addSubview(preview)
+
+        // -- Act --
+        superview.frame.size = .init(width: 200, height: 200)
+        superview.layoutIfNeeded()
+
+        // -- Assert --
+        XCTAssertEqual(preview.frame.size, superview.bounds.size)
+    }
     
     func testDontShowMaskPreviewForRelese() throws {
         SentryDependencyContainer.sharedInstance().crashWrapper = TestCrashWrapper(traced: false)


### PR DESCRIPTION
## 📜 Description

Replace the masking preview's per-frame `CADisplayLink` rendering with a lifecycle-driven, main-queue-coalesced refresh. The preview now refreshes when it is attached, enters a window, lays out, or receives trait changes. It keeps the existing single-render-in-flight behavior and schedules one follow-up render when an update arrives during masking.

Also format the SwiftUI sample `ContentView`

## 💡 Motivation and Context

The masking preview rendered the redaction image on every display frame while attached. This removes the remaining Session Replay preview `CADisplayLink`, avoids continuous work while the preview is offscreen, and renders only in response to relevant UIKit lifecycle and layout changes.

Fixes getsentry/sentry-cocoa#8615

## 💚 How did you test it?

* `make format`
* `make analyze`
* `make build-ios FOR_AGENTS=true`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySessionReplayIntegrationTests`

## :pencil: Checklist

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).