### PR TITLE
ref!(feedback): remove deprecated widget types in v10

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -25,6 +25,7 @@
 - Remove deprecated `locale` from device context; use `locale` in culture context instead (#8325)
 - Change `SentryRequest.cookies` from a string to a dictionary of cookie names and values (#8460)
 - Remove data collection options without applicable Cocoa collectors (#8563)
+- Removed deprecated user feedback widget configuration and API (#8731)
 
 ### Fixes
 

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
@@ -37,9 +37,9 @@ public final class SentryUserFeedbackConfiguration: NSObject {
         }
     }
     var _configureWidget: ((SentryUserFeedbackWidgetConfiguration) -> Void)?
-    #endif
 
     lazy var widgetConfig = SentryUserFeedbackWidgetConfiguration()
+    #endif
 
     /**
      * Use a shake gesture to display the form.
@@ -225,8 +225,8 @@ extension SentryUserFeedbackConfiguration {
         #if !SDK_V10
         _configureWidget = nil
         _customButton = nil
-        #endif
         widgetConfig = SentryUserFeedbackWidgetConfiguration()
+        #endif
         useShakeGesture = false
         showFormForScreenshots = false
     }

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
@@ -1,3 +1,4 @@
+#if !SDK_V10
 import Foundation
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 import UIKit
@@ -144,3 +145,4 @@ public final class SentryUserFeedbackWidgetConfiguration: NSObject {
 }
 
 #endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK
+#endif // !SDK_V10

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -14,14 +14,15 @@ final class SentryUserFeedbackIntegrationDriver: NSObject {
     private weak var activeForm: SentryUserFeedbackFormController?
     private var isObservingShakeGesture = false
     let screenshotSource: SentryScreenshotSource
-    let windowFactory: SentryUserFeedbackWindowFactory
     private let notificationCenter: SentryNSNotificationCenterWrapper
     #if !SDK_V10
     private var widget: SentryUserFeedbackWidget?
     private var shouldRestoreWidgetOnFormClose = false
     weak var customButton: UIButton?
+    let windowFactory: SentryUserFeedbackWindowFactory
     #endif
-
+    
+#if !SDK_V10
     init(
         configuration: SentryUserFeedbackConfiguration,
         screenshotSource: SentryScreenshotSource,
@@ -36,7 +37,6 @@ final class SentryUserFeedbackIntegrationDriver: NSObject {
 
         configuration.applyConfigurationBuilders()
 
-        #if !SDK_V10
         if let customButton = configuration.customButton {
             self.customButton = customButton
             customButton.addTarget(self, action: #selector(showForm(sender:)), for: .touchUpInside)
@@ -59,11 +59,27 @@ final class SentryUserFeedbackIntegrationDriver: NSObject {
                 widget = SentryUserFeedbackWidget(config: configuration, delegate: self, windowFactory: windowFactory)
             }
         }
-        #endif
 
         observeScreenshots()
         observeShakeGesture()
     }
+    #else
+    init(
+        configuration: SentryUserFeedbackConfiguration,
+        screenshotSource: SentryScreenshotSource,
+        notificationCenter: SentryNSNotificationCenterWrapper = NotificationCenter.default
+    ) {
+        self.configuration = configuration
+        self.screenshotSource = screenshotSource
+        self.notificationCenter = notificationCenter
+        super.init()
+
+        configuration.applyConfigurationBuilders()
+
+        observeScreenshots()
+        observeShakeGesture()
+    }
+    #endif
 
     deinit {
         #if !SDK_V10

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
@@ -1,5 +1,5 @@
 // swiftlint:disable todo
-
+#if !SDK_V10
 import Foundation
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 import UIKit
@@ -142,7 +142,7 @@ final class SentryUserFeedbackWidget {
         }
     }
 }
-
 #endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK
+#endif // !SDK_V10
 
 // swiftlint:enable todo

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonMegaphoneIconView.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonMegaphoneIconView.swift
@@ -1,3 +1,4 @@
+#if !SDK_V10
 import Foundation
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 internal import _SentryPrivate
@@ -38,3 +39,4 @@ final class SentryUserFeedbackWidgetButtonMegaphoneIconView: UIView {
 }
 
 #endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK
+#endif // !SDK_V10

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonView.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidgetButtonView.swift
@@ -1,3 +1,4 @@
+#if !SDK_V10
 import Foundation
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 internal import _SentryPrivate
@@ -192,3 +193,4 @@ final class SentryUserFeedbackWidgetButtonView: UIView {
 }
 
 #endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK
+#endif // !SDK_V10

--- a/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/UserFeedbackIntegration.swift
@@ -6,11 +6,15 @@ protocol ScreenshotSourceProvider {
     var screenshotSource: SentryScreenshotSource? { get }
 }
 
+#if SDK_V10
+typealias UserFeedbackIntegrationProvider = ScreenshotSourceProvider
+#else
 protocol WindowFactoryProvider {
     var windowFactory: SentryUserFeedbackWindowFactory { get }
 }
 
 typealias UserFeedbackIntegrationProvider = ScreenshotSourceProvider & WindowFactoryProvider
+#endif
 
 final class UserFeedbackIntegration<Dependencies: UserFeedbackIntegrationProvider>: NSObject, SwiftIntegration {
 
@@ -27,7 +31,18 @@ final class UserFeedbackIntegration<Dependencies: UserFeedbackIntegrationProvide
             return nil
         }
 
-        driver = SentryUserFeedbackIntegrationDriver(configuration: configuration, screenshotSource: screenshotSource, windowFactory: dependencies.windowFactory)
+        #if !SDK_V10
+        driver = SentryUserFeedbackIntegrationDriver(
+            configuration: configuration,
+            screenshotSource: screenshotSource,
+            windowFactory: dependencies.windowFactory
+        )
+        #else
+        driver = SentryUserFeedbackIntegrationDriver(
+            configuration: configuration,
+            screenshotSource: screenshotSource
+        )
+        #endif
     }
 
     func uninstall() { /* Empty on purpose. Nothing to uninstall. */ }

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -100,7 +100,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
 
 #if SENTRY_TEST || SENTRY_TEST_CI
     var applicationOverride: SentryApplication?
-#if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
+#if os(iOS) && !SENTRY_NO_UI_FRAMEWORK && !SDK_V10
     var windowFactoryOverride: SentryUserFeedbackWindowFactory?
 #endif
 #endif
@@ -497,17 +497,19 @@ extension SentryFileManager: SentryFileManagerProtocol { }
 
 #if os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 extension SentryDependencyContainer: ScreenshotSourceProvider { }
+#if !SDK_V10
 extension SentryDependencyContainer: WindowFactoryProvider {
     var windowFactory: SentryUserFeedbackWindowFactory {
 #if SENTRY_TEST || SENTRY_TEST_CI
         if let override = windowFactoryOverride {
             return override
         }
-#endif
+#endif // SENTRY_TEST || SENTRY_TEST_CI
         return SentryUserFeedbackWidget.defaultWindowFactory
     }
 }
-#endif
+#endif // !SDK_V10
+#endif // os(iOS) && !SENTRY_NO_UI_FRAMEWORK
 
 protocol ClientProvider {
     var client: SentryClientInternal? { get }

--- a/Tests/SentryTests/Integrations/Feedback/UserFeedbackIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/UserFeedbackIntegrationTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 @_spi(Private) import SentryTestUtils
 @_spi(Private) @testable import Sentry
 import XCTest
@@ -15,10 +16,12 @@ final class UserFeedbackIntegrationTests: XCTestCase {
         return window
     }
 
+    #if !SDK_V10
     private let mockWindowFactory: SentryUserFeedbackWindowFactory = { config in
         let window = SentryUserFeedbackWidget.Window(config: config, windowScene: mockWindowScene)
         return window
     }
+    #endif
 
     override func tearDown() {
         super.tearDown()
@@ -34,9 +37,11 @@ final class UserFeedbackIntegrationTests: XCTestCase {
 
     private struct TestDependencies: UserFeedbackIntegrationProvider {
         let screenshotSource: SentryScreenshotSource?
+        #if !SDK_V10
         var windowFactory: SentryUserFeedbackWindowFactory {
             SentryUserFeedbackWidget.defaultWindowFactory
         }
+        #endif
     }
 
     private func makeScreenshotSource() -> SentryScreenshotSource {
@@ -53,25 +58,36 @@ final class UserFeedbackIntegrationTests: XCTestCase {
     }
 
     @available(*, deprecated, message: "Testing deprecated widget configuration")
-    func testWidgetAccessibilityLabel_whenLabelTextChangedBeforeAccess_shouldUseUpdatedLabelText() {
+    func testWidgetAccessibilityLabel_whenLabelTextChangedBeforeAccess_shouldUseUpdatedLabelText() throws {
+        #if SDK_V10
+        throw XCTSkip("Not available in SDK version 10")
+        #else
         let sut = SentryUserFeedbackWidgetConfiguration()
 
         sut.labelText = "Send Feedback"
 
         XCTAssertEqual(sut.widgetAccessibilityLabel, "Send Feedback")
+        #endif
     }
 
     @available(*, deprecated, message: "Testing deprecated widget configuration")
-    func testWidgetAccessibilityLabel_whenExplicitlySetToNil_shouldRemainNil() {
+    func testWidgetAccessibilityLabel_whenExplicitlySetToNil_shouldRemainNil() throws {
+        #if SDK_V10
+        throw XCTSkip("Not available in SDK version 10")
+        #else
         let sut = SentryUserFeedbackWidgetConfiguration()
 
         sut.widgetAccessibilityLabel = nil
 
         XCTAssertNil(sut.widgetAccessibilityLabel)
+        #endif
     }
 
     @available(*, deprecated, message: "Testing deprecated widget configuration")
-    func testWidgetConfiguration_whenDeprecatedPropertiesAreSet_shouldRoundTripValues() {
+    func testWidgetConfiguration_whenDeprecatedPropertiesAreSet_shouldRoundTripValues() throws {
+        #if SDK_V10
+        throw XCTSkip("Not available in SDK version 10")
+        #else
         let sut = SentryUserFeedbackWidgetConfiguration()
         let layoutOffset = UIOffset(horizontal: 10, vertical: 20)
         let windowLevel = UIWindow.Level.alert + 1
@@ -92,6 +108,7 @@ final class UserFeedbackIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.location, [.top, .leading])
         XCTAssertEqual(sut.layoutUIOffset.horizontal, layoutOffset.horizontal)
         XCTAssertEqual(sut.layoutUIOffset.vertical, layoutOffset.vertical)
+        #endif
     }
 
     @available(*, deprecated, message: "Testing deprecated widget configuration")
@@ -873,7 +890,9 @@ final class UserFeedbackIntegrationTests: XCTestCase {
         let options = Options()
         options.configureUserFeedback = configure
         SentrySDK.setStart(with: options)
+        #if !SDK_V10
         SentryDependencyContainer.sharedInstance().windowFactoryOverride = mockWindowFactory
+        #endif
         let integration = try XCTUnwrap(UserFeedbackIntegration<SentryDependencyContainer>(
             with: options,
             dependencies: SentryDependencyContainer.sharedInstance()))
@@ -983,3 +1002,4 @@ final class UserFeedbackIntegrationTests: XCTestCase {
 }
 
 #endif
+// swiftlint:enable file_length


### PR DESCRIPTION
## 📜 Description

Adds compiler flag gates to remove user feedback widget configuration and API in V10

## 💡 Motivation and Context

Closes getsentry/sentry-cocoa#8049

## 💚 How did you test it?

Ran the test suite using the Makefile

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

#skip-changelog