### PR TITLE
feat!: Default diagnostic logs to warning

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -19,6 +19,7 @@
 
 - Enable MetricKit integration by default (#8716)
 - Enable logging by default (#8717)
+- Change the default diagnostic level to warning (#8732)
 - Enable `swiftAsyncStacktraces` by default (#8718)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)
 - Remove Objective-C `@objc` attributes from SentrySDK (#8308)

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -45,7 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Minimum log level to be used if debug is enabled.
+#if SDK_V10
+ * @note Default is @c SentryObjCLevelWarning.
+#else
  * @note Default is @c SentryObjCLevelDebug.
+#endif // SDK_V10
  */
 @property (nonatomic) SentryObjCLevel diagnosticLevel;
 

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -43,14 +43,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL debug;
 
+#if SDK_V10
 /**
  * Minimum log level to be used if debug is enabled.
-#if SDK_V10
  * @note Default is @c SentryObjCLevelWarning.
-#else
- * @note Default is @c SentryObjCLevelDebug.
-#endif // SDK_V10
  */
+#else
+/**
+ * Minimum log level to be used if debug is enabled.
+ * @note Default is @c SentryObjCLevelDebug.
+ */
+#endif // SDK_V10
 @property (nonatomic) SentryObjCLevel diagnosticLevel;
 
 /**

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -41,8 +41,13 @@
     @objc public var debug: Bool = false
 
     /// Minimum LogLevel to be used if debug is enabled.
+    #if SDK_V10
+    /// @note Default is kSentryLevelWarning.
+    @objc public var diagnosticLevel: SentryLevel = .warning
+    #else
     /// @note Default is kSentryLevelDebug.
     @objc public var diagnosticLevel: SentryLevel = .debug
+    #endif // SDK_V10
 
     /// This property will be filled before the event is sent.
     @objc public var releaseName: String? = {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -153,8 +153,13 @@
 
 - (void)testInvalidDiagnosticLevel
 {
-    [self testDiagnosticlevelWith:@"fatala" expected:kSentryLevelDebug];
-    [self testDiagnosticlevelWith:@(YES) expected:kSentryLevelDebug];
+#if SDK_V10
+    SentryLevel defaultDiagnosticLevel = kSentryLevelWarning;
+#else
+    SentryLevel defaultDiagnosticLevel = kSentryLevelDebug;
+#endif // SDK_V10
+    [self testDiagnosticlevelWith:@"fatala" expected:defaultDiagnosticLevel];
+    [self testDiagnosticlevelWith:@(YES) expected:defaultDiagnosticLevel];
 }
 
 - (void)testDiagnosticlevelWith:(NSObject *)level expected:(SentryLevel)expected
@@ -744,7 +749,11 @@ typedef SentryLog *_Nullable (^SentryBeforeSendLogCallback)(SentryLog *_Nonnull 
     XCTAssertEqual(YES, options.enabled);
     XCTAssertEqual(2.0, options.shutdownTimeInterval);
     XCTAssertEqual(NO, options.debug);
+#if SDK_V10
+    XCTAssertEqual(kSentryLevelWarning, options.diagnosticLevel);
+#else
     XCTAssertEqual(kSentryLevelDebug, options.diagnosticLevel);
+#endif // SDK_V10
     XCTAssertEqualObjects(options.environment, [SentryOptions defaultEnvironment]);
     XCTAssertNil(options.dist);
     XCTAssertEqual(defaultMaxBreadcrumbs, options.maxBreadcrumbs);


### PR DESCRIPTION
## 📜 Description

Change the V10 default `diagnosticLevel` from debug to warning while preserving the V9 default. Invalid diagnostic-level values now fall back to the version-appropriate default.

## 💡 Motivation and Context

Debug mode currently produces enough SDK output that warnings and errors can be obscured. V10 should surface warnings and above by default, while users can still explicitly choose debug-level diagnostics.

Fixes getsentry/sentry-cocoa#4467

## 💚 How did you test it?

* `make test-ios-v10 FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryOptionsTest`
* `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryOptionsTest`

## :pencil: Checklist

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).

#skip-changelog