### PR TITLE
fix: release replay frames when video render times out

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -198,6 +198,7 @@ func removeReplayFile(at fileURL: URL) {
         }
     }
     
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     public func createVideoWith(beginning: Date, end: Date) -> [SentryVideoInfo] {
         SentrySDKLog.debug("[Session Replay] Creating video with beginning: \(beginning), end: \(end)")
 
@@ -235,7 +236,7 @@ func removeReplayFile(at fileURL: URL) {
             var currentError: Error?
 
             group.enter()
-            self.renderVideo(with: videoFrames, fromIndex: frameCount, until: end, at: outputFileURL) { result in
+            let frameProcessor = self.renderVideo(with: videoFrames, fromIndex: frameCount, until: end, at: outputFileURL) { result in
                 switch result {
                 case .success(let videoResult):
                     // Set the frame count/offset to the new index that is returned by the completion block.
@@ -261,6 +262,15 @@ func removeReplayFile(at fileURL: URL) {
             // Otherwise, it could lead to queue starvation and a deadlock/timeout.
             guard group.wait(timeout: .now() + 10) == .success else {
                 SentrySDKLog.error("[Session Replay] Timeout while waiting for video rendering to finish, returning \(videos.count) videos")
+                // Tear down the stalled writer so AVFoundation releases the media-data-ready
+                // callback. The callback retains the frame processor and its frames (including
+                // in-memory images), which would otherwise stay alive for the process lifetime.
+                // Cancel on the asset worker queue to serialize with any in-flight processing.
+                if let frameProcessor = frameProcessor {
+                    assetWorkerQueue.dispatchAsync {
+                        frameProcessor.cancel()
+                    }
+                }
                 return videos
             }
 
@@ -290,24 +300,29 @@ func removeReplayFile(at fileURL: URL) {
     }
 
     // swiftlint:disable function_body_length cyclomatic_complexity
+    /// Starts rendering a video segment and returns the frame processor driving it, or `nil`
+    /// when rendering failed before a processor was created. The caller uses the returned
+    /// processor to cancel the render session if it stalls (see `createVideoWith`).
     private func renderVideo(
         with videoFrames: [SentryReplayFrame],
         fromIndex: Int,
         until videoEnd: Date,
         at outputFileURL: URL,
         completion: @escaping (Result<SentryRenderVideoResult, Error>) -> Void
-    ) {
+    ) -> SentryVideoFrameProcessor? {
         SentrySDKLog.debug("[Session Replay] Rendering video with \(videoFrames.count) frames, from index: \(fromIndex), to output url: \(outputFileURL)")
 
         guard fromIndex < videoFrames.count else {
             SentrySDKLog.error("[Session Replay] Failed to render video, reason: index out of bounds")
-            return completion(.failure(SentryOnDemandReplayError.indexOutOfBounds))
+            completion(.failure(SentryOnDemandReplayError.indexOutOfBounds))
+            return nil
         }
         guard let image = videoFrames[fromIndex].image
             ?? UIImage(contentsOfFile: videoFrames[fromIndex].imagePath)
         else {
             SentrySDKLog.error("[Session Replay] Failed to render video, reason: can't resolve image at path: \(videoFrames[fromIndex].imagePath)")
-            return completion(.failure(SentryOnDemandReplayError.cantReadImage))
+            completion(.failure(SentryOnDemandReplayError.cantReadImage))
+            return nil
         }
         
         let videoWidth = image.size.width * CGFloat(videoScale)
@@ -320,14 +335,16 @@ func removeReplayFile(at fileURL: URL) {
             videoWriter = try AVAssetWriter(url: outputFileURL, fileType: .mp4)
         } catch {
             SentrySDKLog.error("[Session Replay] Failed to create video writer, reason: \(error)")
-            return completion(.failure(error))
+            completion(.failure(error))
+            return nil
         }
 
         SentrySDKLog.debug("[Session Replay] Creating pixel buffer based video writer input")
         let videoWriterInput = AVAssetWriterInput(mediaType: .video, outputSettings: createVideoSettings(width: videoWidth, height: videoHeight))
         guard let currentPixelBuffer = SentryPixelBuffer(size: pixelSize, videoWriterInput: videoWriterInput) else {
             SentrySDKLog.error("[Session Replay] Failed to render video, reason: pixel buffer creation failed")
-            return completion(.failure(SentryOnDemandReplayError.cantCreatePixelBuffer))
+            completion(.failure(SentryOnDemandReplayError.cantCreatePixelBuffer))
+            return nil
         }
         videoWriter.add(videoWriterInput)
         videoWriter.startWriting()
@@ -359,6 +376,7 @@ func removeReplayFile(at fileURL: URL) {
         videoWriterInput.requestMediaDataWhenReady(on: assetWorkerQueue.queue) {
             frameProcessor.processFrames(videoWriterInput: videoWriterInput, onCompletion: completion)
         }
+        return frameProcessor
     }
 
     internal func createVideoSettings(width: CGFloat, height: CGFloat) -> [String: Any] {

--- a/Sources/Swift/Integrations/SessionReplay/SentryVideoFrameProcessor.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryVideoFrameProcessor.swift
@@ -6,6 +6,7 @@ import CoreGraphics
 import Foundation
 import UIKit
 
+// swiftlint:disable:next type_body_length
 class SentryVideoFrameProcessor {
     private enum AppendFrameResult {
         case success
@@ -61,6 +62,21 @@ class SentryVideoFrameProcessor {
         self.lastImageSize = initialImageSize
         self.usedFrames = []
         self.isFinished = false
+    }
+
+    /// Cancels an in-flight render session.
+    ///
+    /// Marks the writer inputs as finished and cancels the writing session so AVFoundation
+    /// releases the `requestMediaDataWhenReady` block. That block retains this processor and,
+    /// through `videoFrames`, the in-memory frame images — without this, a stalled writer would
+    /// keep them alive indefinitely. Must be called on the asset worker queue to serialize with
+    /// `processFrames(videoWriterInput:onCompletion:)`.
+    func cancel() {
+        guard !isFinished else { return }
+        isFinished = true
+        SentrySDKLog.warning("[Session Replay] Cancelling stalled video render session")
+        videoWriter.inputs.forEach { $0.markAsFinished() }
+        videoWriter.cancelWriting()
     }
 
     // swiftlint:disable function_body_length cyclomatic_complexity

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
@@ -385,6 +385,47 @@ class SentryVideoFrameProcessorTests: XCTestCase {
         XCTAssertEqual(completionInvocations.count, 0)
     }
 
+    func testCancel_ShouldMarkInputsFinishedAndCancelWriting() {
+        let sut = fixture.getSut()
+        let videoWriterInput = TestAVAssetWriterInput(mediaType: .video, outputSettings: nil)
+        fixture.videoWriter.add(videoWriterInput)
+
+        sut.cancel()
+
+        XCTAssertTrue(sut.isFinished)
+        XCTAssertEqual(videoWriterInput.markAsFinishedInvocations.count, 1)
+        XCTAssertTrue(fixture.videoWriter.cancelWritingCalled)
+    }
+
+    func testCancel_AfterFinished_ShouldDoNothing() {
+        let sut = fixture.getSut()
+        let videoWriterInput = TestAVAssetWriterInput(mediaType: .video, outputSettings: nil)
+        fixture.videoWriter.add(videoWriterInput)
+        let completionInvocations = Invocations<Result<SentryRenderVideoResult, any Error>>()
+
+        // Processing all frames finishes the video.
+        sut.processFrames(videoWriterInput: videoWriterInput) { completionInvocations.record($0) }
+        XCTAssertTrue(sut.isFinished)
+
+        sut.cancel()
+
+        XCTAssertFalse(fixture.videoWriter.cancelWritingCalled)
+        XCTAssertEqual(videoWriterInput.markAsFinishedInvocations.count, 1)
+    }
+
+    func testCancel_ShouldStopSubsequentProcessing() {
+        let sut = fixture.getSut()
+        let videoWriterInput = TestAVAssetWriterInput(mediaType: .video, outputSettings: nil)
+        fixture.videoWriter.add(videoWriterInput)
+        let completionInvocations = Invocations<Result<SentryRenderVideoResult, any Error>>()
+
+        sut.cancel()
+        sut.processFrames(videoWriterInput: videoWriterInput) { completionInvocations.record($0) }
+
+        XCTAssertEqual(fixture.currentPixelBuffer.appendInvocations.count, 0)
+        XCTAssertEqual(completionInvocations.count, 0)
+    }
+
     func testProcessFrames_WhenImageSizeChanges_ShouldFinishVideo() {
         let videoWriterInput = TestAVAssetWriterInput(mediaType: .video, outputSettings: nil)
         fixture.videoWriter.add(videoWriterInput)


### PR DESCRIPTION
## :scroll: Description

When `createVideoWith` hits its 10s render timeout, it returned without tearing down the stalled `AVAssetWriter`. The `requestMediaDataWhenReady` callback retains the `SentryVideoFrameProcessor`, which retains its `videoFrames` array — and since #8636 frames carry decompressed in-memory `UIImage`s, each timed-out segment stranded the whole frame set (~40MB on iPhone, up to ~170MB on iPad in buffer mode) for the process lifetime. Repeated stalls compound, since each segment spins up a fresh writer/processor.

`renderVideo` now returns its frame processor, and the timeout path cancels it on the asset worker queue: mark the writer inputs as finished and `cancelWriting()`, so AVFoundation releases the callback and with it the processor and frames. `cancel()` is idempotent and serialized with `processFrames` via the asset worker queue.

Follow-up to #8636 (the leak existed before, but only held file paths — the in-memory images are what make it expensive).

_#skip-changelog_ — the retention this fixes was introduced by the unreleased #8636.

## :bulb: Motivation and Context

A stalled `AVAssetWriter` (memory pressure, encoder contention, background transitions) is exactly the environment where stranding tens of MB of unpurgeable bitmaps risks a jetsam kill.

## :green_heart: How did you test it?

New unit tests in `SentryVideoFrameProcessorTests`: `cancel()` marks inputs finished and cancels writing; it is a no-op after the processor already finished; and a cancelled processor ignores subsequent `processFrames` calls. Ran `SentryOnDemandReplayTests` + `SentryVideoFrameProcessorTests` on iOS 18.6 sim (52 tests, 0 failures).

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).