### PR TITLE
fix(tests): Synchronize network task mock

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
@@ -30,32 +30,55 @@
 
 - (NSURLRequest *)originalRequest
 {
-    return _request;
+    [_lock lock];
+    NSURLRequest *request = _request;
+    [_lock unlock];
+    return request;
 }
 
 - (NSURLResponse *)response
 {
-    return _response;
+    [_lock lock];
+    NSURLResponse *response = _response;
+    [_lock unlock];
+    return response;
 }
 
 - (void)setResponse:(NSURLResponse *)response
 {
+    [_lock lock];
     _response = response;
+    [_lock unlock];
 }
 
 - (NSError *)error
 {
-    return _error;
+    [_lock lock];
+    NSError *error = _error;
+    [_lock unlock];
+    return error;
 }
 
 - (void)setError:(NSError *)error
 {
+    [_lock lock];
     _error = error;
+    [_lock unlock];
+}
+
+- (NSDate *)resumeDate
+{
+    [_lock lock];
+    NSDate *resumeDate = _resumeDate;
+    [_lock unlock];
+    return resumeDate;
 }
 
 - (void)resume
 {
+    [_lock lock];
     _resumeDate = SentryDependencyContainer.sharedInstance.dateProvider.date;
+    [_lock unlock];
 }
 
 - (int64_t)countOfBytesSent
@@ -114,50 +137,71 @@
     NSURLResponse *_response;
     NSURLSessionTaskState _state;
     NSError *_error;
+    NSLock *_lock;
 }
 
 @dynamic state;
 
 - (void)setState:(NSURLSessionTaskState)state
 {
+    [_lock lock];
     _state = state;
+    [_lock unlock];
 }
 
 - (NSURLSessionTaskState)state
 {
-    return _state;
+    [_lock lock];
+    NSURLSessionTaskState state = _state;
+    [_lock unlock];
+    return state;
 }
 
 @dynamic error;
 
 - (void)setError:(NSError *)error
 {
+    [_lock lock];
     _error = error;
+    [_lock unlock];
 }
 
 - (NSError *)error
 {
-    return _error;
+    [_lock lock];
+    NSError *error = _error;
+    [_lock unlock];
+    return error;
 }
 
 - (NSURLRequest *)currentRequest
 {
-    return _currentRequest;
+    [_lock lock];
+    NSURLRequest *request = _currentRequest;
+    [_lock unlock];
+    return request;
 }
 
 - (void)setCurrentRequest:(NSURLRequest *)request
 {
+    [_lock lock];
     _currentRequest = request;
+    [_lock unlock];
 }
 
 - (NSURLResponse *)response
 {
-    return _response;
+    [_lock lock];
+    NSURLResponse *response = _response;
+    [_lock unlock];
+    return response;
 }
 
 - (void)setResponse:(NSURLResponse *)response
 {
+    [_lock lock];
     _response = response;
+    [_lock unlock];
 }
 
 - (int64_t)countOfBytesSent
@@ -175,6 +219,7 @@
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super init]) {
+        _lock = [[NSLock alloc] init];
         _request = request;
         _currentRequest = [_request mutableCopy];
     }
@@ -189,50 +234,71 @@
     NSURLResponse *_response;
     NSURLSessionTaskState _state;
     NSError *_error;
+    NSLock *_lock;
 }
 
 @dynamic state;
 
 - (void)setState:(NSURLSessionTaskState)state
 {
+    [_lock lock];
     _state = state;
+    [_lock unlock];
 }
 
 - (NSURLSessionTaskState)state
 {
-    return _state;
+    [_lock lock];
+    NSURLSessionTaskState state = _state;
+    [_lock unlock];
+    return state;
 }
 
 @dynamic error;
 
 - (void)setError:(NSError *)error
 {
+    [_lock lock];
     _error = error;
+    [_lock unlock];
 }
 
 - (NSError *)error
 {
-    return _error;
+    [_lock lock];
+    NSError *error = _error;
+    [_lock unlock];
+    return error;
 }
 
 - (NSURLRequest *)currentRequest
 {
-    return _currentRequest;
+    [_lock lock];
+    NSURLRequest *request = _currentRequest;
+    [_lock unlock];
+    return request;
 }
 
 - (void)setCurrentRequest:(NSURLRequest *)request
 {
+    [_lock lock];
     _currentRequest = request;
+    [_lock unlock];
 }
 
 - (NSURLResponse *)response
 {
-    return _response;
+    [_lock lock];
+    NSURLResponse *response = _response;
+    [_lock unlock];
+    return response;
 }
 
 - (void)setResponse:(NSURLResponse *)response
 {
+    [_lock lock];
     _response = response;
+    [_lock unlock];
 }
 
 - (int64_t)countOfBytesSent
@@ -250,6 +316,7 @@
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super init]) {
+        _lock = [[NSLock alloc] init];
         _request = request;
         _currentRequest = [_request mutableCopy];
     }
@@ -262,33 +329,47 @@
     NSURLRequest *_request;
     NSURLResponse *_response;
     NSURLSessionTaskState _state;
+    NSLock *_lock;
 }
 
 @dynamic state;
 
 - (void)setState:(NSURLSessionTaskState)state
 {
+    [_lock lock];
     _state = state;
+    [_lock unlock];
 }
 
 - (NSURLSessionTaskState)state
 {
-    return _state;
+    [_lock lock];
+    NSURLSessionTaskState state = _state;
+    [_lock unlock];
+    return state;
 }
 
 - (NSURLRequest *)currentRequest
 {
-    return _request;
+    [_lock lock];
+    NSURLRequest *request = _request;
+    [_lock unlock];
+    return request;
 }
 
 - (NSURLResponse *)response
 {
-    return _response;
+    [_lock lock];
+    NSURLResponse *response = _response;
+    [_lock unlock];
+    return response;
 }
 
 - (void)setResponse:(NSURLResponse *)response
 {
+    [_lock lock];
     _response = response;
+    [_lock unlock];
 }
 
 #pragma clang diagnostic push
@@ -296,6 +377,7 @@
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super init]) {
+        _lock = [[NSLock alloc] init];
         _request = request;
     }
     return self;
@@ -330,6 +412,8 @@
 
 @implementation VolatileRequestTaskMock {
     NSUInteger _currentRequestAccessCount;
+    NSUInteger _currentRequestAccessLimit;
+    NSLock *_lock;
 }
 
 #pragma clang diagnostic push
@@ -337,16 +421,36 @@
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super initWithRequest:request]) {
+        _lock = [[NSLock alloc] init];
         _currentRequestAccessLimit = 1;
     }
     return self;
 }
 #pragma clang diagnostic pop
 
+- (NSUInteger)currentRequestAccessLimit
+{
+    [_lock lock];
+    NSUInteger limit = _currentRequestAccessLimit;
+    [_lock unlock];
+    return limit;
+}
+
+- (void)setCurrentRequestAccessLimit:(NSUInteger)currentRequestAccessLimit
+{
+    [_lock lock];
+    _currentRequestAccessLimit = currentRequestAccessLimit;
+    [_lock unlock];
+}
+
 - (NSURLRequest *)currentRequest
 {
+    [_lock lock];
     _currentRequestAccessCount++;
-    if (_currentRequestAccessCount > self.currentRequestAccessLimit) {
+    BOOL isBeyondAccessLimit = _currentRequestAccessCount > _currentRequestAccessLimit;
+    [_lock unlock];
+
+    if (isBeyondAccessLimit) {
         return nil;
     }
     return [super currentRequest];
@@ -357,6 +461,7 @@
 @implementation MutableRequestTaskMock {
     NSMutableURLRequest *_initialCurrentRequest;
     NSUInteger _setCurrentRequestCallCount;
+    NSLock *_lock;
 }
 
 #pragma clang diagnostic push
@@ -364,6 +469,7 @@
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super initWithRequest:request]) {
+        _lock = [[NSLock alloc] init];
         _initialCurrentRequest = (NSMutableURLRequest *)[super currentRequest];
     }
     return self;
@@ -372,17 +478,25 @@
 
 - (NSMutableURLRequest *)initialCurrentRequest
 {
-    return _initialCurrentRequest;
+    [_lock lock];
+    NSMutableURLRequest *request = _initialCurrentRequest;
+    [_lock unlock];
+    return request;
 }
 
 - (NSUInteger)setCurrentRequestCallCount
 {
-    return _setCurrentRequestCallCount;
+    [_lock lock];
+    NSUInteger callCount = _setCurrentRequestCallCount;
+    [_lock unlock];
+    return callCount;
 }
 
 - (void)setCurrentRequest:(NSURLRequest *)request
 {
+    [_lock lock];
     _setCurrentRequestCallCount++;
+    [_lock unlock];
     [super setCurrentRequest:request];
 }
 

--- a/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
@@ -8,22 +8,24 @@
     NSError *_error;
     NSDate *_resumeDate;
     NSURLSessionTaskState _state;
+    NSLock *_lock;
 }
 
 @dynamic state;
 
 - (void)setState:(NSURLSessionTaskState)state
 {
-    @synchronized(self) {
-        _state = state;
-    }
+    [_lock lock];
+    _state = state;
+    [_lock unlock];
 }
 
 - (NSURLSessionTaskState)state
 {
-    @synchronized(self) {
-        return _state;
-    }
+    [_lock lock];
+    NSURLSessionTaskState state = _state;
+    [_lock unlock];
+    return state;
 }
 
 - (NSURLRequest *)originalRequest
@@ -68,16 +70,17 @@
 
 - (NSURLRequest *)currentRequest
 {
-    @synchronized(self) {
-        return _currentRequest;
-    }
+    [_lock lock];
+    NSURLRequest *request = _currentRequest;
+    [_lock unlock];
+    return request;
 }
 
 - (void)setCurrentRequest:(NSURLRequest *)request
 {
-    @synchronized(self) {
-        _currentRequest = request;
-    }
+    [_lock lock];
+    _currentRequest = request;
+    [_lock unlock];
 }
 
 #pragma clang diagnostic push
@@ -85,13 +88,16 @@
 
 - (instancetype)init
 {
-    self = [super init];
+    if (self = [super init]) {
+        _lock = [[NSLock alloc] init];
+    }
     return self;
 }
 
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super init]) {
+        _lock = [[NSLock alloc] init];
         _request = request;
         _currentRequest = [_request mutableCopy];
     }

--- a/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/Performance/Network/URLSessionTaskMock.m
@@ -14,12 +14,16 @@
 
 - (void)setState:(NSURLSessionTaskState)state
 {
-    _state = state;
+    @synchronized(self) {
+        _state = state;
+    }
 }
 
 - (NSURLSessionTaskState)state
 {
-    return _state;
+    @synchronized(self) {
+        return _state;
+    }
 }
 
 - (NSURLRequest *)originalRequest
@@ -64,12 +68,16 @@
 
 - (NSURLRequest *)currentRequest
 {
-    return _currentRequest;
+    @synchronized(self) {
+        return _currentRequest;
+    }
 }
 
 - (void)setCurrentRequest:(NSURLRequest *)request
 {
-    _currentRequest = request;
+    @synchronized(self) {
+        _currentRequest = request;
+    }
 }
 
 #pragma clang diagnostic push


### PR DESCRIPTION
## :scroll: Description

Synchronize mutable state and request access across the URL session task mocks used by concurrent network tracker tests.

### Investigation Root Cause

The visionOS 26.5 CI failure crashed in `objc_retain` while
`SentryDefaultNetworkTracker.urlSessionTask(_:setState:)` read
`URLSessionDataTaskMock.currentRequest`. The test runs the tracker resume and
terminal-state callbacks concurrently. Resume adds trace-propagation headers
by replacing the mock's current request through `setCurrentRequest:`, while
the terminal callback reads that same raw ivar. The mock did not synchronize
either operation, allowing ARC to retain a request that the concurrent write
had already released.

This was a test-double race, not evidence of an equivalent production
`URLSessionTask` defect. The SDK already snapshots `currentRequest` within
each callback and does not mutate a live request in place. The mocks now use
private locks, rather than each task's Objective-C monitor, to preserve the
intended callback race without unsafe mock lifetime or state access.

## :bulb: Motivation and Context

The crash only reproduced in the visionOS CI job. Its crash artifact identified
the `resume-setState-race` queue and the test
`SentryNetworkTrackerTests.testResumeConcurrentWithSetState_DoesNotCrash`.

## :green_heart: How did you test it?

- Ran `make format`.
- Ran `make analyze`.
- Ran `make build-ios FOR_AGENTS=true`.
- Ran `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryNetworkTrackerTests`.
- Ran `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryTracePropagationTests`.
- Ran the focused visionOS 26.5 TestCI test 100 times. All iterations passed.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog. This is test infrastructure only.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
