### PR TITLE
KSCrash: Scope Sync

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Sync scope data to KSCrash crash reports in `SentryV10` (#8759)
 - Process pending KSCrash reports into fatal Sentry events in `SentryV10` (#8515)
 - Install KSCrash crash handler in `SentryV10` with production-safe monitors matching SentryCrash's existing monitor set (#8469)
   - Respect `options.enableMemoryIntrospection` when configuring KSCrash

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		3C0B2C89E044195F8220E78E /* SentrySamplingProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03F84D3027DD4191008FE43F /* SentrySamplingProfiler.cpp */; };
 		3C1AF6C3902531610F3E87CA /* SentryANRStoppedResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FAAB96492EA688CB0030A2DB /* SentryANRStoppedResultInternal.h */; };
 		3C9D00BF77D6097384B42D19 /* SentryANRStoppedResultInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = FAAB964B2EA688E40030A2DB /* SentryANRStoppedResultInternal.m */; };
+		3CB64C903029D35800ED9B67 /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = 3CB64C8F3029D35800ED9B67 /* Recording */; };
 		3CFC66E52FF50342004005B4 /* libSentryTestUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8431F00A29B284F200D8DC56 /* libSentryTestUtils.a */; };
 		3CFC66E72FF50342004005B4 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0787B53CA34AC1B3CF256F35 /* Sentry.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		3CFC66E92FF50342004005B4 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 630C01951EC341D600C52CEF /* Resources */; };
@@ -801,7 +802,6 @@
 		D8BD2E6829361A0F00D96C6A /* PrivatesHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = D8BD2E67293619F600D96C6A /* PrivatesHeader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8BFE37229A3782F002E73F3 /* SentryTimeToDisplayTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = D8BFE37029A3782F002E73F3 /* SentryTimeToDisplayTracker.h */; };
 		D8BFE37329A3782F002E73F3 /* SentryTimeToDisplayTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = D8BFE37129A3782F002E73F3 /* SentryTimeToDisplayTracker.m */; };
-		D9342A3A2155489C8CD87D27 /* Installations in Frameworks */ = {isa = PBXBuildFile; productRef = 2AC7A1A6EA2F466E8F99247D /* Installations */; };
 		D9856A3B7F5A85C34DCBCE10 /* SentryCrashMach-O.h in Headers */ = {isa = PBXBuildFile; fileRef = 6292585C2DAFA8290049388F /* SentryCrashMach-O.h */; };
 		D9D5E3FBC7A0E78A8AC858EF /* NSMutableDictionary+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B0DC72D288698F70039995F /* NSMutableDictionary+Sentry.h */; };
 		DB06D59EFC3F10A3A4702B82 /* SentryEventSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */; };
@@ -1849,8 +1849,8 @@
 			files = (
 				5E97D595C205DFAA28813138 /* SystemConfiguration.framework in Frameworks */,
 				1D39B749E2C0B09067076027 /* CoreData.framework in Frameworks */,
+				3CB64C903029D35800ED9B67 /* Recording in Frameworks */,
 				B3418ABC1AC38F349A9E2CE6 /* libz.tbd in Frameworks */,
-				D9342A3A2155489C8CD87D27 /* Installations in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3762,7 +3762,7 @@
 			);
 			name = "SentryV10";
 			packageProductDependencies = (
-				2AC7A1A6EA2F466E8F99247D /* Installations */,
+				3CB64C8F3029D35800ED9B67 /* Recording */,
 			);
 			productName = "SentryV10";
 			productReference = 0787B53CA34AC1B3CF256F35 /* Sentry.framework */;
@@ -9952,10 +9952,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		2AC7A1A6EA2F466E8F99247D /* Installations */ = {
+		3CB64C8F3029D35800ED9B67 /* Recording */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 7D3AA95A0088413F8CF3F65A /* XCRemoteSwiftPackageReference "KSCrash" */;
-			productName = Installations;
+			productName = Recording;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -27,6 +27,7 @@
 #import "SentryObjCExceptionHelper.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
+#import "SentryScopeSyncC.h"
 #import "SentrySessionReplaySyncC.h"
 #import "SentrySwizzleWrapperHelper.h"
 #import "SentryTime.h"

--- a/Sources/Sentry/include/SentryScopeSyncC.h
+++ b/Sources/Sentry/include/SentryScopeSyncC.h
@@ -2,22 +2,22 @@
 #define SentryScopeSyncC_h
 
 typedef struct {
-    char *user;
-    char *dist;
-    char *context;
-    char *traceContext;
-    char *environment;
-    char *tags;
-    char *extras;
-    char *fingerprint;
-    char *level;
-    char **breadcrumbs; // dynamic array of char arrays
+    char *_Nullable user;
+    char *_Nullable dist;
+    char *_Nullable context;
+    char *_Nullable traceContext;
+    char *_Nullable environment;
+    char *_Nullable tags;
+    char *_Nullable extras;
+    char *_Nullable fingerprint;
+    char *_Nullable level;
+    char *_Nullable *_Nullable breadcrumbs; // dynamic array of char arrays
     long maxCrumbs;
     long currentCrumb;
 
 } SentryCrashScope;
 
-SentryCrashScope *sentrycrash_scopesync_getScope(void);
+SentryCrashScope *_Nonnull sentrycrash_scopesync_getScope(void);
 
 /**
  * Needs to be called before adding or clearing breadcrumbs to initialize the storage of the
@@ -25,25 +25,25 @@ SentryCrashScope *sentrycrash_scopesync_getScope(void);
  */
 void sentrycrash_scopesync_configureBreadcrumbs(long maxBreadcrumbs);
 
-void sentrycrash_scopesync_setUser(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setUser(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setDist(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setDist(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setContext(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setContext(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setTraceContext(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setTraceContext(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setEnvironment(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setEnvironment(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setTags(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setTags(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setExtras(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setExtras(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setFingerprint(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setFingerprint(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_setLevel(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_setLevel(const char *_Nullable const jsonEncodedCString);
 
-void sentrycrash_scopesync_addBreadcrumb(const char *const jsonEncodedCString);
+void sentrycrash_scopesync_addBreadcrumb(const char *_Nullable const jsonEncodedCString);
 
 void sentrycrash_scopesync_clearBreadcrumbs(void);
 

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -1,6 +1,6 @@
 #if SDK_V10
 // swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashInstallations
+@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
 import Foundation
 
@@ -141,6 +141,33 @@ extension SentryKSCrash {
 
         var crashedLastLaunch: Bool { KSCrash.shared.crashedLastLaunch }
         var activeDurationSinceLastCrash: TimeInterval { KSCrash.shared.activeDurationSinceLastCrash }
+
+        // KSCRASH_TODO(GH-8756): We need to support dictionary types here... KSCrash's new KV store
+        // doesn't support them... we will need to either: work around this OR
+        // upstream support for it.
+        // Tracked in https://github.com/getsentry/sentry-cocoa/issues/8756
+        func setUserInfo(_ userInfo: [String: Any]) {
+            precondition(installed, "KSCrash must be installed before setUserInfo(_:forKey:) can be used")
+
+            for (key, value) in userInfo {
+                switch value {
+                case let value as String:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                case let value as Int:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                case let value as UInt:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                case let value as Double:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                case let value as Bool:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                case let value as Date:
+                    KSCrash.shared.setUserInfo(value, forKey: key)
+                default:
+                    SentrySDKLog.debug("Dropping '\(key): \(value) as it's not a supported type")
+                }
+            }
+        }
     }
 }
 #endif

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -150,7 +150,10 @@ extension SentryKSCrash {
         // upstream support for it.
         // Tracked in https://github.com/getsentry/sentry-cocoa/issues/8756
         func setUserInfo(_ userInfo: [String: Any]) {
-            precondition(installed, "KSCrash must be installed before setUserInfo(_:forKey:) can be used")
+            guard installed else {
+                SentrySDKLog.debug("KSCrash must be installed before calling setUserInfo(_:)")
+                return
+            }
 
             for (key, value) in userInfo {
                 switch value {

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -41,6 +41,9 @@ extension SentryKSCrash {
 
         /// Total active time elapsed since the previous crash.
         var activeDurationSinceLastCrash: TimeInterval { get }
+
+        /// Adds additional user information to the crash handler
+        func setUserInfo(_ userInfo: [String: Any])
     }
 
     /// Configures and installs a crash handler.

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
@@ -1,6 +1,6 @@
 #if SDK_V10
 // swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashInstallations
+@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
 import Foundation
 

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ReportFilter.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ReportFilter.swift
@@ -1,6 +1,6 @@
 #if SDK_V10
 // swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashInstallations
+@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
 import Foundation
 

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
@@ -8,11 +8,11 @@ extension SentryKSCrash {
 extension SentryKSCrash.Scope {
     class Configuration {
         private let options: Options
-        private let installer: SentryKSCrash.Installer
+        private let installer: SentryKSCrash.Installing
 
         private let observer: SentryKSCrash.Scope.Observer
 
-        init(installer: SentryKSCrash.Installer, options: Options) {
+        init(installer: SentryKSCrash.Installing, options: Options) {
             self.installer = installer
             self.options = options
             self.observer = .init(maxBreadcrumbs: options.maxBreadcrumbs)

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
@@ -10,11 +10,12 @@ extension SentryKSCrash.Scope {
         private let options: Options
         private let installer: SentryKSCrash.Installer
 
-        private let observer = SentryKSCrash.Scope.Observer()
+        private let observer: SentryKSCrash.Scope.Observer
 
         init(installer: SentryKSCrash.Installer, options: Options) {
             self.installer = installer
             self.options = options
+            self.observer = .init(maxBreadcrumbs: options.maxBreadcrumbs)
 
             configure()
         }

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
@@ -1,4 +1,4 @@
-#if ENABLE_KSCRASH
+#if SDK_V10
 internal import _SentryPrivate
 
 extension SentryKSCrash {

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Scope.swift
@@ -1,0 +1,82 @@
+#if ENABLE_KSCRASH
+internal import _SentryPrivate
+
+extension SentryKSCrash {
+    enum Scope {}
+}
+
+extension SentryKSCrash.Scope {
+    class Configuration {
+        private let options: Options
+        private let installer: SentryKSCrash.Installer
+
+        private let observer = SentryKSCrash.Scope.Observer()
+
+        init(installer: SentryKSCrash.Installer, options: Options) {
+            self.installer = installer
+            self.options = options
+
+            configure()
+        }
+
+        private func configure() {
+            configureScope()
+            configurePowerStateNotifications()
+        }
+
+        private func configureScope() {
+            SentrySDKInternal.currentHub().configureScope { [weak self] outerScope in
+                guard let self else { return }
+
+                var userInfo = outerScope.serialize()
+
+                // SentryCrashReportConverter.convertReportToEvent needs the release name, dist, and
+                // environment of the SentryOptions in the UserInfo. When SentryCrash records a crash it
+                // writes the UserInfo into SentryCrashField_User of the report.
+                // SentryCrashReportConverter.initWithReport loads the contents of SentryCrashField_User
+                // into self.userContext and convertReportToEvent can map the release name, dist, and
+                // environment to the SentryEvent. Fixes GH-581 and GH-5260.
+                userInfo["release"] = options.releaseName
+                userInfo["dist"] = options.dist
+                if userInfo["environment"] == nil {
+                    userInfo["environment"] = options.environment
+                }
+
+                // Crashes don't use the attributes field, we remove them to avoid uploading them
+                // unnecessarily.
+                userInfo.removeValue(forKey: "attributes")
+                installer.setUserInfo(userInfo)
+
+                outerScope.add(observer)
+            }
+        }
+
+        private func configurePowerStateNotifications() {
+            updateLowPowerModeScopeContext(ProcessInfo.processInfo)
+
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(powerStateDidChange(_:)),
+                name: NSNotification.Name.NSProcessInfoPowerStateDidChange,
+                object: nil
+            )
+        }
+
+        @objc private func powerStateDidChange(_ notification: Notification) {
+            updateLowPowerModeScopeContext((notification.object as? ProcessInfo) ?? .processInfo)
+        }
+
+        private func updateLowPowerModeScopeContext(_ processInfo: ProcessInfo) {
+            let isLowPowerModeEnabled = processInfo.isLowPowerModeEnabled
+
+            SentrySDKInternal.currentHub().configureScope { scope in
+                let existing = scope.contextDictionary[SENTRY_CONTEXT_DEVICE_KEY] as? [String: Any]
+                var device = existing ?? [:]
+
+                device["low_power_mode"] = isLowPowerModeEnabled
+                scope.setContext(value: device, key: SENTRY_CONTEXT_DEVICE_KEY)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
@@ -1,3 +1,136 @@
+// swiftlint:disable:next no_implementation_only_import
+@_implementationOnly import KSCrashRecording
+internal import _SentryPrivate
+
 extension SentryKSCrash.Scope {
-    struct Observer {}
+    class Observer: NSObject, SentryScopeObserver {
+        private func sync<K: Hashable, V>(
+            dictionary: [K: V]?,
+            syncToSentryCrash: (UnsafePointer<CChar>?) -> Void
+        ) {
+            sync(
+                object: dictionary,
+                serialize: { $0.isEmpty ? nil : $0 },
+                syncToSentryCrash: syncToSentryCrash
+            )
+        }
+
+        private func sync<T>(
+            object: T?,
+            serialize: (T) -> Any? = { $0 },
+            syncToSentryCrash: (UnsafePointer<CChar>?) -> Void
+        ) {
+            guard
+                let object,
+                let serialized = serialize(object)
+            else {
+                syncToSentryCrash(nil)
+                return
+            }
+
+            if let data = jsonEncodedCString(serialized) {
+                syncToSentryCrash((data as NSData).bytes.assumingMemoryBound(to: CChar.self))
+            }
+        }
+
+        private func jsonEncodedCString(_ serialized: Any) -> Data? {
+            do {
+                let data = try KSJSONCodec.encode(serialized, options: .sorted)
+
+                return sentry_nullTerminated(data)
+            } catch {
+                SentrySDKLog.debug("Failed to encode object (\(serialized)) as JSON C-String with error: \(error)")
+                return nil
+            }
+        }
+
+        init(maxBreadcrumbs: UInt) {
+            super.init()
+
+            sentrycrash_scopesync_configureBreadcrumbs(Int(maxBreadcrumbs))
+        }
+
+        func setUser(_ user: User?) {
+            sync(object: user) {
+                $0.serialize()
+            } syncToSentryCrash: {
+                sentrycrash_scopesync_setUser($0)
+            }
+        }
+        
+        func setTags(_ tags: [String: String]?) {
+            sync(dictionary: tags) {
+                sentrycrash_scopesync_setTags($0)
+            }
+        }
+        
+        func setExtras(_ extras: [String: Any]?) {
+            sync(dictionary: extras) {
+                sentrycrash_scopesync_setExtras($0)
+            }
+        }
+        
+        func setContext(_ context: [String: [String: Any]]?) {
+            sync(dictionary: context) {
+                sentrycrash_scopesync_setContext($0)
+            }
+        }
+        
+        func setTraceContext(_ traceContext: [String: Any]?) {
+            sync(dictionary: traceContext) {
+                sentrycrash_scopesync_setTraceContext($0)
+            }
+        }
+        
+        func setDist(_ dist: String?) {
+            sync(object: dist) {
+                sentrycrash_scopesync_setDist($0)
+            }
+        }
+        
+        func setEnvironment(_ environment: String?) {
+            sync(object: environment) {
+                sentrycrash_scopesync_setEnvironment($0)
+            }
+        }
+
+        func setFingerprint(_ fingerprint: [String]?) {
+            sync(object: fingerprint) {
+                $0.isEmpty ? nil : $0
+            } syncToSentryCrash: {
+                sentrycrash_scopesync_setFingerprint($0)
+            }
+        }
+        
+        func setLevel(_ level: SentryLevel) {
+            sync(object: level) { level in
+                if level == .none {
+                    return nil
+                }
+
+                return level.description
+            } syncToSentryCrash: {
+                sentrycrash_scopesync_setLevel($0)
+            }
+        }
+        
+        func setAttributes(_ attributes: [String: Any]?) {
+            // NOP - crash events don't support attributes
+        }
+        
+        func addSerializedBreadcrumb(_ serializedBreadcrumb: [String: Any]) {
+            sync(object: serializedBreadcrumb) {
+                sentrycrash_scopesync_addBreadcrumb($0)
+            }
+        }
+        
+        func clearBreadcrumbs() {
+            sentrycrash_scopesync_clearBreadcrumbs()
+        }
+        
+        func clear() {
+            sentrycrash_scopesync_clear()
+        }
+        
+    }
 }

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
@@ -1,0 +1,3 @@
+extension SentryKSCrash.Scope {
+    struct Observer {}
+}

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
@@ -1,3 +1,4 @@
+#if SDK_V10
 // swiftlint:disable:next no_implementation_only_import
 @_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
@@ -134,3 +135,4 @@ extension SentryKSCrash.Scope {
         
     }
 }
+#endif

--- a/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
@@ -46,6 +46,7 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
     public var sendAllReportsDispatchQueues: [SentryDispatchQueueWrapper] = []
     public var sendAllReportsProcessingSessions: [SentryKSCrash.ReportProcessingSession] = []
     public var onSendAllReports: (() -> Void)?
+    public var setUserInfoInvocations: [[String: Any]] = []
 
     public init() {}
 
@@ -70,6 +71,10 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
     public func uninstall() {
         uninstallCallCount += 1
         installed = false
+    }
+
+    public func setUserInfo(_ userInfo: [String: Any]) {
+        setUserInfoInvocations.append(userInfo)
     }
 
     public func sendAllReports(

--- a/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeConfigurationTests.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeConfigurationTests.swift
@@ -1,0 +1,116 @@
+#if ENABLE_KSCRASH
+@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import Sentry
+import XCTest
+
+final class SentryKSCrashScopeConfigurationTests: XCTestCase {
+    private var originalHub: SentryHubInternal!
+
+    override func setUp() {
+        super.setUp()
+        originalHub = SentrySDKInternal.currentHub()
+    }
+
+    override func tearDown() {
+        sentrycrash_scopesync_clear()
+        SentrySDKInternal.setCurrentHub(originalHub)
+        super.tearDown()
+    }
+
+    func testInit_shouldConfigureInstallerFromScopeAndOptions() throws {
+        // -- Arrange --
+        let scope = Scope()
+        scope.setTag(value: "value", key: "tag")
+        scope.setEnvironment("scope-environment")
+        scope.setAttribute(value: "unused", key: "attribute")
+        setCurrentHub(scope: scope)
+
+        let options = Options()
+        options.releaseName = "release"
+        options.dist = "dist"
+        options.environment = "options-environment"
+        let installer = MockKSCrashInstaller()
+
+        // -- Act --
+        _ = SentryKSCrash.Scope.Configuration(installer: installer, options: options)
+
+        // -- Assert --
+        let userInfo = try XCTUnwrap(installer.setUserInfoInvocations.first)
+        XCTAssertEqual(installer.setUserInfoInvocations.count, 1)
+        XCTAssertEqual(userInfo["release"] as? String, "release")
+        XCTAssertEqual(userInfo["dist"] as? String, "dist")
+        XCTAssertEqual(userInfo["environment"] as? String, "scope-environment")
+        XCTAssertEqual((userInfo["tags"] as? [String: String])?["tag"], "value")
+        XCTAssertNil(userInfo["attributes"])
+    }
+
+    func testInit_whenScopeHasNoEnvironment_shouldUseOptionsEnvironment() throws {
+        // -- Arrange --
+        setCurrentHub(scope: Scope())
+        let options = Options()
+        options.environment = "options-environment"
+        let installer = MockKSCrashInstaller()
+
+        // -- Act --
+        _ = SentryKSCrash.Scope.Configuration(installer: installer, options: options)
+
+        // -- Assert --
+        let userInfo = try XCTUnwrap(installer.setUserInfoInvocations.first)
+        XCTAssertEqual(userInfo["environment"] as? String, "options-environment")
+    }
+
+    func testInit_shouldAddObserverToScope() {
+        // -- Arrange --
+        let scope = Scope()
+        setCurrentHub(scope: scope)
+        let installer = MockKSCrashInstaller()
+
+        // -- Act --
+        let sut = SentryKSCrash.Scope.Configuration(installer: installer, options: Options())
+        scope.setDist("updated-dist")
+
+        // -- Assert --
+        withExtendedLifetime(sut) {
+            XCTAssertEqual("\"updated-dist\"", getScopeJson { $0.dist })
+        }
+    }
+
+    func testInit_shouldPreserveDeviceContextAndAddLowPowerMode() throws {
+        // -- Arrange --
+        let scope = Scope()
+        setCurrentHub(scope: scope)
+        scope.setContext(value: ["custom": "preserved"], key: SENTRY_CONTEXT_DEVICE_KEY)
+
+        // -- Act --
+        _ = SentryKSCrash.Scope.Configuration(
+            installer: MockKSCrashInstaller(),
+            options: Options()
+        )
+
+        // -- Assert --
+        let device = try XCTUnwrap(
+            scope.contextDictionary[SENTRY_CONTEXT_DEVICE_KEY] as? [String: Any]
+        )
+        XCTAssertEqual(device["custom"] as? String, "preserved")
+        XCTAssertEqual(
+            device["low_power_mode"] as? Bool,
+            ProcessInfo.processInfo.isLowPowerModeEnabled
+        )
+    }
+
+    private func setCurrentHub(scope: Scope) {
+        SentrySDKInternal.setCurrentHub(
+            SentryHubInternal(client: TestClient(options: Options()), andScope: scope)
+        )
+    }
+
+    private func getScopeJson(
+        getField: (SentryCrashScope) -> UnsafeMutablePointer<CChar>?
+    ) -> String? {
+        guard let charPointer = getField(sentrycrash_scopesync_getScope().pointee) else {
+            return nil
+        }
+        return String(cString: charPointer)
+    }
+}
+#endif

--- a/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeConfigurationTests.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeConfigurationTests.swift
@@ -1,4 +1,4 @@
-#if ENABLE_KSCRASH
+#if SDK_V10
 @_spi(Private) import SentryTestUtils
 @_spi(Private) @testable import Sentry
 import XCTest

--- a/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
@@ -1,3 +1,4 @@
+#if SDK_V10
 @_spi(Private) @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -469,3 +470,4 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
@@ -1,0 +1,365 @@
+@_spi(Private) @testable import Sentry
+import SentryTestUtils
+import XCTest
+
+class SentryKSCrashScopeObserverTests: XCTestCase {
+
+    private class Fixture {
+        let dist = "dist"
+        let environment = "environment"
+        let tags = ["tag": "tag", "tag1": "tag1"]
+        let extras = ["extra": [1, 2], "extra2": "tag1"] as [String: Any]
+        let fingerprint = ["a", "b", "c"]
+        let maxBreadcrumbs: UInt = 10
+
+        var sut: SentryKSCrash.Scope.Observer {
+            return .init(maxBreadcrumbs: maxBreadcrumbs)
+        }
+    }
+
+    private let fixture = Fixture()
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testUser() throws {
+        let sut = fixture.sut
+        let user = TestData.user
+        sut.setUser(user)
+
+        let expected = try serialize(object: user.serialize())
+
+        XCTAssertEqual(expected, getScopeJson { $0.user })
+    }
+
+    func testUser_setToNil() {
+        let sut = fixture.sut
+        sut.setUser(TestData.user)
+        sut.setUser(nil)
+
+        XCTAssertNil(getScopeJson { $0.user })
+    }
+
+    func testLevel() {
+        let sut = fixture.sut
+        let level = SentryLevel.fatal
+        sut.setLevel(level)
+
+        XCTAssertEqual("\"fatal\"", getScopeJson { $0.level })
+    }
+
+    func testLevel_setToNone() {
+        let sut = fixture.sut
+        sut.setLevel(SentryLevel.fatal)
+        sut.setLevel(SentryLevel.none)
+
+        XCTAssertNil(getScopeJson { $0.level })
+    }
+
+    func testDist() throws {
+        let sut = fixture.sut
+        sut.setDist(fixture.dist)
+
+        let expected = try serialize(object: fixture.dist)
+
+        XCTAssertEqual(expected, getScopeJson { $0.dist })
+    }
+
+    func testDist_setToNil() {
+        let sut = fixture.sut
+        sut.setDist(fixture.dist)
+        sut.setDist(nil)
+
+        XCTAssertNil(getScopeJson { $0.dist })
+    }
+
+    func testEnvironment() throws {
+        let sut = fixture.sut
+        sut.setEnvironment(fixture.environment)
+
+        let expected = try serialize(object: fixture.environment)
+
+        XCTAssertEqual(expected, getScopeJson { $0.environment })
+    }
+
+    func testEnvironment_setToNil() {
+        let sut = fixture.sut
+        sut.setEnvironment(fixture.environment)
+        sut.setEnvironment(nil)
+
+        XCTAssertNil(getScopeJson { $0.environment })
+    }
+
+    func testContext() throws {
+        let sut = fixture.sut
+        sut.setContext(TestData.context)
+
+        let expected = try serialize(object: TestData.context)
+
+        XCTAssertEqual(expected, getScopeJson { $0.context })
+    }
+
+    func testContext_setToNil() {
+        let scope = Scope()
+        let sut = fixture.sut
+        scope.add(sut)
+        TestData.setContext(scope)
+        sut.setContext(nil)
+
+        XCTAssertNil(getScopeJson { $0.context })
+    }
+
+    func testContext_setEmptyDict() {
+        let scope = Scope()
+        let sut = fixture.sut
+        scope.add(sut)
+        TestData.setContext(scope)
+        sut.setContext([:])
+
+        XCTAssertNil(getScopeJson { $0.context })
+    }
+
+    func testTraceContext() throws {
+        let sut = fixture.sut
+        sut.setTraceContext(TestData.traceContext)
+
+        let expected = try serialize(object: TestData.traceContext)
+
+        XCTAssertEqual(expected, getScopeJson { $0.traceContext })
+    }
+
+    func testTraceContext_setToNil() {
+        let sut = fixture.sut
+        sut.setTraceContext(TestData.traceContext)
+        sut.setTraceContext(nil)
+
+        XCTAssertNil(getScopeJson { $0.traceContext })
+    }
+
+    func testTraceContext_setEmptyDict() {
+        let sut = fixture.sut
+        sut.setTraceContext(TestData.traceContext)
+        sut.setTraceContext([:])
+
+        XCTAssertNil(getScopeJson { $0.traceContext })
+    }
+
+    func testFingerprint() throws {
+        let sut = fixture.sut
+        sut.setFingerprint(fixture.fingerprint)
+
+        let expected = try serialize(object: fixture.fingerprint)
+
+        XCTAssertEqual(expected, getScopeJson { $0.fingerprint })
+    }
+
+    func testFingerprint_SetToNil() {
+        let sut = fixture.sut
+        sut.setFingerprint(fixture.fingerprint)
+        sut.setFingerprint(nil)
+
+        XCTAssertNil(getScopeJson { $0.fingerprint })
+    }
+
+    func testFingerprint_SetToEmptyArray() {
+        let sut = fixture.sut
+        sut.setFingerprint(fixture.fingerprint)
+        sut.setFingerprint([])
+
+        XCTAssertNil(getScopeJson { $0.fingerprint })
+    }
+
+    func testExtra() throws {
+        let sut = fixture.sut
+        sut.setExtras(fixture.extras)
+
+        let expected = try serialize(object: fixture.extras)
+
+        XCTAssertEqual(expected, getScopeJson { $0.extras })
+    }
+
+    func testExtra_SetToNil() {
+        let sut = fixture.sut
+        sut.setExtras(fixture.extras)
+        sut.setExtras(nil)
+
+        XCTAssertNil(getScopeJson { $0.extras })
+    }
+
+    func testExtra_SetToEmptyDict() {
+        let sut = fixture.sut
+        sut.setExtras(fixture.extras)
+        sut.setExtras([:])
+
+        XCTAssertNil(getScopeJson { $0.extras })
+    }
+
+    func testTags() throws {
+        let sut = fixture.sut
+        sut.setTags(fixture.tags)
+
+        let expected = try serialize(object: fixture.tags)
+
+        XCTAssertEqual(expected, getScopeJson { $0.tags })
+    }
+
+    func testTags_SetToNil() {
+        let sut = fixture.sut
+        sut.setTags(fixture.tags)
+        sut.setTags(nil)
+
+        XCTAssertNil(getScopeJson { $0.tags })
+    }
+
+    func testTags_SetToEmptyDict() {
+        let sut = fixture.sut
+        sut.setTags(fixture.tags)
+        sut.setTags([:])
+
+        XCTAssertNil(getScopeJson { $0.tags })
+    }
+
+    func testAddCrumb() throws {
+        let sut = fixture.sut
+        let crumb = TestData.crumb
+        sut.addSerializedBreadcrumb(crumb.serialize())
+
+        try assertOneCrumbSetToScope(crumb: crumb)
+    }
+
+    func testAddCrumbWithoutConfigure_DoesNotCrash() {
+        sentrycrash_scopesync_addBreadcrumb("")
+    }
+
+    func testCallConfigureCrumbTwice() throws {
+        let sut = fixture.sut
+        let crumb = TestData.crumb
+        sut.addSerializedBreadcrumb(crumb.serialize())
+
+        sentrycrash_scopesync_configureBreadcrumbs(Int(fixture.maxBreadcrumbs))
+
+        let scope = sentrycrash_scopesync_getScope()
+        XCTAssertEqual(0, scope.pointee.currentCrumb)
+
+        sut.addSerializedBreadcrumb(crumb.serialize())
+        try assertOneCrumbSetToScope(crumb: crumb)
+    }
+
+    func testAddCrumb_MoreThanMaxBreadcrumbs() throws {
+        let sut = fixture.sut
+
+        var crumbs: [Breadcrumb] = []
+        for i in 0...fixture.maxBreadcrumbs {
+            let crumb = TestData.crumb
+            crumb.message = "\(i)"
+            sut.addSerializedBreadcrumb(crumb.serialize())
+            crumbs.append(crumb)
+        }
+        crumbs.removeFirst()
+
+        let scope = sentrycrash_scopesync_getScope()
+
+        XCTAssertEqual(1, scope.pointee.currentCrumb)
+
+        guard let breadcrumbs = scope.pointee.breadcrumbs else {
+            XCTFail("Pointer to breadcrumbs is nil.")
+            return
+        }
+
+        // Breadcrumbs are stored with a ring buffer. Therefore,
+        // we need to start where the current crumb is
+        var i = scope.pointee.currentCrumb
+        var crumbPointer = breadcrumbs[i]
+        for crumb in crumbs {
+            let scopeCrumbJSON = String(cString: crumbPointer ?? UnsafeMutablePointer<CChar>.allocate(capacity: 0))
+
+            XCTAssertEqual(try serialize(object: crumb.serialize()), scopeCrumbJSON)
+
+            i = (i + 1) % Int(fixture.maxBreadcrumbs)
+            crumbPointer = breadcrumbs[i]
+        }
+    }
+
+    func testClear() {
+        let sut = fixture.sut
+        let user = TestData.user
+        sut.setUser(user)
+        sut.setDist(fixture.dist)
+        sut.setContext(TestData.context)
+        sut.setEnvironment(fixture.environment)
+        sut.setTags(fixture.tags)
+        sut.setExtras(fixture.extras)
+        sut.setFingerprint(fixture.fingerprint)
+        sut.setLevel(SentryLevel.fatal)
+        sut.addSerializedBreadcrumb(TestData.crumb.serialize())
+
+        sut.clear()
+
+        assertEmptyScope()
+    }
+
+    func testEmptyScope() {
+        // First, we need to configure the CScope
+        XCTAssertNotNil(fixture.sut)
+
+        assertEmptyScope()
+    }
+
+    private func serialize(object: Any) throws -> String {
+        let serialized = try XCTUnwrap(SentryCrashJSONCodec.encode(object, options: SentryCrashJSONEncodeOptionSorted))
+        return String(data: serialized, encoding: .utf8) ?? ""
+    }
+
+    private func getCrashScope() -> SentryCrashScope {
+        let jsonPointer = sentrycrash_scopesync_getScope()
+        return jsonPointer.pointee
+    }
+
+    private func getScopeJson(getField: (SentryCrashScope) -> UnsafeMutablePointer<CChar>?) -> String? {
+        let scopePointer = sentrycrash_scopesync_getScope()
+
+        guard let charPointer = getField(scopePointer.pointee) else {
+            return nil
+        }
+
+        return String(cString: charPointer)
+    }
+
+    private func assertOneCrumbSetToScope(crumb: Breadcrumb) throws {
+        let expected = try serialize(object: crumb.serialize())
+
+        let scope = sentrycrash_scopesync_getScope()
+
+        XCTAssertEqual(1, scope.pointee.currentCrumb)
+
+        let breadcrumbs = scope.pointee.breadcrumbs
+        let breadcrumbJSON = String(cString: breadcrumbs?.pointee ?? UnsafeMutablePointer<CChar>.allocate(capacity: 0))
+
+        XCTAssertEqual(expected, breadcrumbJSON)
+    }
+
+    private func assertEmptyScope() {
+        let scope = getCrashScope()
+        XCTAssertNil(scope.user)
+        XCTAssertNil(scope.dist)
+        XCTAssertNil(scope.context)
+        XCTAssertNil(scope.environment)
+        XCTAssertNil(scope.tags)
+        XCTAssertNil(scope.extras)
+        XCTAssertNil(scope.fingerprint)
+        XCTAssertNil(scope.level)
+
+        XCTAssertEqual(0, scope.currentCrumb)
+        XCTAssertEqual(fixture.maxBreadcrumbs, UInt(scope.maxCrumbs))
+
+        guard let breadcrumbs = scope.breadcrumbs else {
+            XCTFail("Pointer to breadcrumbs is nil.")
+            return
+        }
+
+        for i in 0..<Int(fixture.maxBreadcrumbs) {
+            XCTAssertNil(breadcrumbs[i])
+        }
+    }
+}

--- a/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/SentryKSCrash+ScopeObserverTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class SentryKSCrashScopeObserverTests: XCTestCase {
 
-    private class Fixture {
+    private struct Fixture {
         let dist = "dist"
         let environment = "environment"
         let tags = ["tag": "tag", "tag1": "tag1"]
@@ -19,226 +19,322 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
 
     private let fixture = Fixture()
 
-    override func tearDown() {
-        super.tearDown()
-    }
-
-    func testUser() throws {
+    func testSetUser_whenUserIsDefined_shouldSerializeUser() throws {
+        // -- Arrange --
         let sut = fixture.sut
         let user = TestData.user
+
+        // -- Act --
         sut.setUser(user)
 
         let expected = try serialize(object: user.serialize())
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.user })
     }
 
-    func testUser_setToNil() {
+    func testSetUser_whenUserIsNil_shouldClearUser() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setUser(TestData.user)
+
+        // -- Act --
         sut.setUser(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.user })
     }
 
-    func testLevel() {
+    func testSetLevel_whenLevelIsFatal_shouldSerializeLevel() {
+        // -- Arrange --
         let sut = fixture.sut
         let level = SentryLevel.fatal
+
+        // -- Act --
         sut.setLevel(level)
 
+        // -- Assert --
         XCTAssertEqual("\"fatal\"", getScopeJson { $0.level })
     }
 
-    func testLevel_setToNone() {
+    func testSetLevel_whenLevelIsNone_shouldClearLevel() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setLevel(SentryLevel.fatal)
+
+        // -- Act --
         sut.setLevel(SentryLevel.none)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.level })
     }
 
-    func testDist() throws {
+    func testSetDist_whenDistIsDefined_shouldSerializeDist() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setDist(fixture.dist)
 
         let expected = try serialize(object: fixture.dist)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.dist })
     }
 
-    func testDist_setToNil() {
+    func testSetDist_whenDistIsNil_shouldClearDist() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setDist(fixture.dist)
+
+        // -- Act --
         sut.setDist(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.dist })
     }
 
-    func testEnvironment() throws {
+    func testSetEnvironment_whenEnvironmentIsDefined_shouldSerializeEnvironment() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setEnvironment(fixture.environment)
 
         let expected = try serialize(object: fixture.environment)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.environment })
     }
 
-    func testEnvironment_setToNil() {
+    func testSetEnvironment_whenEnvironmentIsNil_shouldClearEnvironment() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setEnvironment(fixture.environment)
+
+        // -- Act --
         sut.setEnvironment(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.environment })
     }
 
-    func testContext() throws {
+    func testSetContext_whenContextIsDefined_shouldSerializeContext() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setContext(TestData.context)
 
         let expected = try serialize(object: TestData.context)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.context })
     }
 
-    func testContext_setToNil() {
+    func testSetContext_whenContextIsNil_shouldClearContext() {
+        // -- Arrange --
         let scope = Scope()
         let sut = fixture.sut
         scope.add(sut)
         TestData.setContext(scope)
+
+        // -- Act --
         sut.setContext(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.context })
     }
 
-    func testContext_setEmptyDict() {
+    func testSetContext_whenContextIsEmpty_shouldClearContext() {
+        // -- Arrange --
         let scope = Scope()
         let sut = fixture.sut
         scope.add(sut)
         TestData.setContext(scope)
+
+        // -- Act --
         sut.setContext([:])
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.context })
     }
 
-    func testTraceContext() throws {
+    func testSetTraceContext_whenTraceContextIsDefined_shouldSerializeTraceContext() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setTraceContext(TestData.traceContext)
 
         let expected = try serialize(object: TestData.traceContext)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.traceContext })
     }
 
-    func testTraceContext_setToNil() {
+    func testSetTraceContext_whenTraceContextIsNil_shouldClearTraceContext() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setTraceContext(TestData.traceContext)
+
+        // -- Act --
         sut.setTraceContext(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.traceContext })
     }
 
-    func testTraceContext_setEmptyDict() {
+    func testSetTraceContext_whenTraceContextIsEmpty_shouldClearTraceContext() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setTraceContext(TestData.traceContext)
+
+        // -- Act --
         sut.setTraceContext([:])
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.traceContext })
     }
 
-    func testFingerprint() throws {
+    func testSetFingerprint_whenFingerprintIsDefined_shouldSerializeFingerprint() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setFingerprint(fixture.fingerprint)
 
         let expected = try serialize(object: fixture.fingerprint)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.fingerprint })
     }
 
-    func testFingerprint_SetToNil() {
+    func testSetFingerprint_whenFingerprintIsNil_shouldClearFingerprint() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setFingerprint(fixture.fingerprint)
+
+        // -- Act --
         sut.setFingerprint(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.fingerprint })
     }
 
-    func testFingerprint_SetToEmptyArray() {
+    func testSetFingerprint_whenFingerprintIsEmpty_shouldClearFingerprint() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setFingerprint(fixture.fingerprint)
+
+        // -- Act --
         sut.setFingerprint([])
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.fingerprint })
     }
 
-    func testExtra() throws {
+    func testSetExtras_whenExtrasAreDefined_shouldSerializeExtras() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setExtras(fixture.extras)
 
         let expected = try serialize(object: fixture.extras)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.extras })
     }
 
-    func testExtra_SetToNil() {
+    func testSetExtras_whenExtrasAreNil_shouldClearExtras() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setExtras(fixture.extras)
+
+        // -- Act --
         sut.setExtras(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.extras })
     }
 
-    func testExtra_SetToEmptyDict() {
+    func testSetExtras_whenExtrasAreEmpty_shouldClearExtras() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setExtras(fixture.extras)
+
+        // -- Act --
         sut.setExtras([:])
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.extras })
     }
 
-    func testTags() throws {
+    func testSetTags_whenTagsAreDefined_shouldSerializeTags() throws {
+        // -- Arrange --
         let sut = fixture.sut
+
+        // -- Act --
         sut.setTags(fixture.tags)
 
         let expected = try serialize(object: fixture.tags)
 
+        // -- Assert --
         XCTAssertEqual(expected, getScopeJson { $0.tags })
     }
 
-    func testTags_SetToNil() {
+    func testSetTags_whenTagsAreNil_shouldClearTags() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setTags(fixture.tags)
+
+        // -- Act --
         sut.setTags(nil)
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.tags })
     }
 
-    func testTags_SetToEmptyDict() {
+    func testSetTags_whenTagsAreEmpty_shouldClearTags() {
+        // -- Arrange --
         let sut = fixture.sut
         sut.setTags(fixture.tags)
+
+        // -- Act --
         sut.setTags([:])
 
+        // -- Assert --
         XCTAssertNil(getScopeJson { $0.tags })
     }
 
-    func testAddCrumb() throws {
+    func testAddSerializedBreadcrumb_whenBreadcrumbIsDefined_shouldSerializeBreadcrumb() throws {
+        // -- Arrange --
         let sut = fixture.sut
         let crumb = TestData.crumb
+
+        // -- Act --
         sut.addSerializedBreadcrumb(crumb.serialize())
 
+        // -- Assert --
         try assertOneCrumbSetToScope(crumb: crumb)
     }
 
-    func testAddCrumbWithoutConfigure_DoesNotCrash() {
+    func testAddBreadcrumb_whenScopeIsNotConfigured_shouldNotCrash() {
+        // -- Act & Assert --
         sentrycrash_scopesync_addBreadcrumb("")
     }
 
-    func testCallConfigureCrumbTwice() throws {
+    func testConfigureBreadcrumbs_whenCalledTwice_shouldResetBreadcrumbs() throws {
+        // -- Arrange --
         let sut = fixture.sut
         let crumb = TestData.crumb
         sut.addSerializedBreadcrumb(crumb.serialize())
 
+        // -- Act --
         sentrycrash_scopesync_configureBreadcrumbs(Int(fixture.maxBreadcrumbs))
 
+        // -- Assert --
         let scope = sentrycrash_scopesync_getScope()
         XCTAssertEqual(0, scope.pointee.currentCrumb)
 
@@ -246,10 +342,13 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
         try assertOneCrumbSetToScope(crumb: crumb)
     }
 
-    func testAddCrumb_MoreThanMaxBreadcrumbs() throws {
+    func testAddSerializedBreadcrumb_whenExceedingMaximum_shouldOverwriteOldestBreadcrumb() throws {
+        // -- Arrange --
         let sut = fixture.sut
 
         var crumbs: [Breadcrumb] = []
+
+        // -- Act --
         for i in 0...fixture.maxBreadcrumbs {
             let crumb = TestData.crumb
             crumb.message = "\(i)"
@@ -258,6 +357,7 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
         }
         crumbs.removeFirst()
 
+        // -- Assert --
         let scope = sentrycrash_scopesync_getScope()
 
         XCTAssertEqual(1, scope.pointee.currentCrumb)
@@ -281,7 +381,8 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
         }
     }
 
-    func testClear() {
+    func testClear_whenScopeHasValues_shouldClearScope() {
+        // -- Arrange --
         let sut = fixture.sut
         let user = TestData.user
         sut.setUser(user)
@@ -294,15 +395,20 @@ class SentryKSCrashScopeObserverTests: XCTestCase {
         sut.setLevel(SentryLevel.fatal)
         sut.addSerializedBreadcrumb(TestData.crumb.serialize())
 
+        // -- Act --
         sut.clear()
 
+        // -- Assert --
         assertEmptyScope()
     }
 
-    func testEmptyScope() {
-        // First, we need to configure the CScope
-        XCTAssertNotNil(fixture.sut)
+    func testInit_whenScopeIsConfigured_shouldCreateEmptyScope() {
 
+        // -- Act --
+        let sut = fixture.sut
+
+        // -- Assert --
+        XCTAssertNotNil(sut)
         assertEmptyScope()
     }
 

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashScopeObserverTests.swift
@@ -242,7 +242,7 @@ class SentryCrashScopeObserverTests: XCTestCase {
         sentrycrash_scopesync_configureBreadcrumbs(fixture.maxBreadcrumbs)
         
         let scope = sentrycrash_scopesync_getScope()
-        XCTAssertEqual(0, scope?.pointee.currentCrumb)
+        XCTAssertEqual(0, scope.pointee.currentCrumb)
         
         sut.addSerializedBreadcrumb(crumb.serialize())
         try assertOneCrumbSetToScope(crumb: crumb)
@@ -262,16 +262,16 @@ class SentryCrashScopeObserverTests: XCTestCase {
 
         let scope = sentrycrash_scopesync_getScope()
         
-        XCTAssertEqual(1, scope?.pointee.currentCrumb)
+        XCTAssertEqual(1, scope.pointee.currentCrumb)
         
-        guard let breadcrumbs = scope?.pointee.breadcrumbs else {
+        guard let breadcrumbs = scope.pointee.breadcrumbs else {
             XCTFail("Pointer to breadcrumbs is nil.")
             return
         }
         
         // Breadcrumbs are stored with a ring buffer. Therefore,
         // we need to start where the current crumb is
-        var i = scope?.pointee.currentCrumb ?? 0
+        var i = scope.pointee.currentCrumb
         var crumbPointer = breadcrumbs[i]
         for crumb in crumbs {
             let scopeCrumbJSON = String(cString: crumbPointer ?? UnsafeMutablePointer<CChar>.allocate(capacity: 0))
@@ -315,13 +315,11 @@ class SentryCrashScopeObserverTests: XCTestCase {
     
     private func getCrashScope() -> SentryCrashScope {
         let jsonPointer = sentrycrash_scopesync_getScope()
-        return jsonPointer!.pointee
+        return jsonPointer.pointee
     }
     
     private func getScopeJson(getField: (SentryCrashScope) -> UnsafeMutablePointer<CChar>?) -> String? {
-        guard let scopePointer = sentrycrash_scopesync_getScope() else {
-            return nil
-        }
+        let scopePointer = sentrycrash_scopesync_getScope()
 
         guard let charPointer = getField(scopePointer.pointee) else {
             return nil
@@ -335,9 +333,9 @@ class SentryCrashScopeObserverTests: XCTestCase {
 
         let scope = sentrycrash_scopesync_getScope()
         
-        XCTAssertEqual(1, scope?.pointee.currentCrumb)
+        XCTAssertEqual(1, scope.pointee.currentCrumb)
         
-        let breadcrumbs = scope?.pointee.breadcrumbs
+        let breadcrumbs = scope.pointee.breadcrumbs
         let breadcrumbJSON = String(cString: breadcrumbs?.pointee ?? UnsafeMutablePointer<CChar>.allocate(capacity: 0))
         
         XCTAssertEqual(expected, breadcrumbJSON)


### PR DESCRIPTION
## :scroll: Description

This change integrates the existing Sentry Scope Sync APIs into the KSCrash integration. **It does not** yet plumb it in fully, that will happen in a follow up PR (8758).

This change also moves from KSCrash's Installation module to the Reporting module (which pulls in Installation) and gives us greater access to parts of KSCrash

## :bulb: Motivation and Context

This lays the groundwork for future KSCrash report by surfacing the information we will need for parts of the crash report

## :green_heart: How did you test it?

- Tests
- CI

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog (v10 only)


Closes #8760