### PR TITLE
test: enable replay integration tests

### DIFF
--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -49,9 +49,14 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             throw XCTSkip("iOS version not supported")
         }
 
-        if #available(iOS 26.0, tvOS 26.0, macCatalyst 26.0, *) {
-            throw XCTSkip("When running the unit tests on iOS 26.0, tvOS 26 or macCatalyst 26.0 with Xcode 26.0, we get warning log messages on the console: 'nw_socket_set_connection_idle [C1.1.1.1:3] setsockopt SO_CONNECTION_IDLE failed [42: Protocol not available]'. This leads to test failures in CI. Therefore, we skip these for now. We are going to fix this with https://github.com/getsentry/sentry-cocoa/issues/6165. Note: Session Replay is also disabled by default on iOS 26 due to Liquid Glass rendering changes.")
+        #if targetEnvironment(macCatalyst)
+        if #available(macCatalyst 26.0, *) {
+            throw XCTSkip(
+                "Creating UIWindow in an unhosted Mac Catalyst test throws "
+                    + "NSInternalInconsistencyException on macOS 26 and later."
+            )
         }
+        #endif
 
         uiApplication = TestSentryUIApplication()
         globalEventProcessor = SentryGlobalEventProcessor()

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -167,7 +167,7 @@ case $PLATFORM in
 
 "tvOS")
     RESOLVED_OS=$(resolve_runtime_version "$PLATFORM" "$OS")
-    DESTINATION="platform=tvOS Simulator,OS=$RESOLVED_OS,name=Apple TV"
+    DESTINATION="platform=tvOS Simulator,OS=$RESOLVED_OS,name=$DEVICE"
     ;;
 
 "visionOS")

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -17,7 +17,7 @@ PLATFORM=""
 OS="latest"
 REF_NAME="HEAD"
 COMMAND="test"
-DEVICE="iPhone 16 Pro"
+DEVICE=""
 CONFIGURATION_OVERRIDE=""
 DERIVED_DATA_PATH=""
 TEST_SCHEME="Sentry"
@@ -40,7 +40,7 @@ OPTIONS:
     -o, --os <os>                    OS version (default: latest)
     -r, --ref <ref>                  Reference name (default: HEAD)
     -c, --command <command>          Command (build/build-for-testing/test-without-building/test)
-    -d, --device <device>            Device name (default: iPhone 16 Pro)
+    -d, --device <device>            Device name (default: platform-specific)
     -C, --configuration <config>     Configuration override
     -D, --derived-data <path>        Derived data path
     -s, --scheme <scheme>            Test scheme (default: Sentry)
@@ -130,6 +130,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [ -z "$DEVICE" ]; then
+    case $PLATFORM in
+        "iOS") DEVICE="iPhone 16 Pro" ;;
+        "tvOS") DEVICE="Apple TV" ;;
+        "visionOS") DEVICE="Apple Vision Pro" ;;
+        "watchOS") DEVICE="Apple Watch SE 3 (44mm)" ;;
+    esac
+fi
+
 # Resolve the actual simulator runtime version from simctl.
 # The display version (e.g., "26.3") may differ from the build version (e.g., "26.3.1")
 # and xcodebuild requires the build version in the destination.
@@ -172,7 +181,7 @@ case $PLATFORM in
 
 "visionOS")
     RESOLVED_OS=$(resolve_runtime_version "$PLATFORM" "$OS")
-    DESTINATION="platform=visionOS Simulator,OS=$RESOLVED_OS,name=Apple Vision Pro"
+    DESTINATION="platform=visionOS Simulator,OS=$RESOLVED_OS,name=$DEVICE"
     ;;
 
 "watchOS")


### PR DESCRIPTION
## :scroll: Description

- Enable all 50 Session Replay integration tests on iOS and tvOS 26+.
- Keep the skip only for Mac Catalyst 26+, where the unhosted test bundle cannot safely create `UIWindow`.
- Use platform-specific simulator defaults while honoring explicit `--device` overrides.

## :bulb: Motivation and Context

Part of #8126.

The suite was disabled in `SentrySessionReplayIntegrationTests.setUpWithError()` by #6136 when xOS 26 CI exposed socket warnings, CoreData/XPC errors, and a Mac Catalyst crash while creating `UIWindow` (#6165).

Current Xcode 26.6 and 27 runs are stable on iOS and tvOS, so the blanket skip now hides valid coverage. The Catalyst failure remains and is kept as a platform-specific skip.

While restoring tvOS coverage, we found that the build helper defaulted every device to an iPhone and ignored visionOS overrides. This was fixed along the way by adding defaults for each simulator platform.

## :green_heart: How did you test it?

- iOS 26.5 and 27, V9/V10: 50 passed per run
- tvOS 26.5 and 27, V9/V10: 50 passed per run
- Mac Catalyst, V9/V10: 50 skipped, 0 failed
- Verified default and overridden destinations for every platform; ShellCheck passed

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
