### PR TITLE
chore: bump KSCrash to 2.6.0

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -37,4 +37,4 @@
 - Filter sensitive values from selected Session Replay network headers and cookies (#8566)
 - Omit failed-request headers when `options.dataCollection.httpHeaders` is disabled (#8562)
 - Normalize profiling CPU usage to 0–100 percent (#8323)
-- Bump KSCrash to `2.6.0-beta.5`
+- Bump KSCrash to `2.6.0`

--- a/Package.swift
+++ b/Package.swift
@@ -190,7 +190,7 @@ targets += [
 ]
 // END:OBJC_WRAPPER
 
-let packageDependencies: [Package.Dependency] = enableV10 ? [.package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0-beta.5")] : []
+let packageDependencies: [Package.Dependency] = enableV10 ? [.package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0")] : []
 
 let package = Package(
     name: "Sentry",

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -209,7 +209,7 @@ targets += [
 // END:OBJC_WRAPPER
 
 let packageDependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0-beta.5")
+    .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0")
 ]
 
 let package = Package(

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -209,7 +209,7 @@ targets += [
 // END:OBJC_WRAPPER
 
 let packageDependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0-beta.5")
+    .package(url: "https://github.com/kstenerud/KSCrash.git", from: "2.6.0")
 ]
 
 let package = Package(

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -9946,7 +9946,7 @@
 			repositoryURL = "https://github.com/kstenerud/KSCrash.git";
 			requirement = {
 				kind = exactVersion;
-				version = "2.6.0-beta.5";
+				version = "2.6.0";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Bump KSCrash to 2.6.0.

Closes getsentry/sentry-cocoa#8766