### PR TITLE
test: cover session replay renderer v2

### DIFF
--- a/Tests/SentryTests/TestUtils/ImagePixelAssertions.swift
+++ b/Tests/SentryTests/TestUtils/ImagePixelAssertions.swift
@@ -1,0 +1,72 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+import UIKit
+import XCTest
+
+struct ImagePixel {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+func imagePixel(at point: CGPoint, in image: UIImage) -> ImagePixel? {
+    guard let cgImage = image.cgImage,
+          let pixelData = cgImage.dataProvider?.data,
+          let bytes = CFDataGetBytePtr(pixelData) else {
+        return nil
+    }
+
+    let x = Int(point.x * image.scale)
+    let y = Int(point.y * image.scale)
+    guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
+        return nil
+    }
+
+    let offset = y * cgImage.bytesPerRow + x * 4
+    return ImagePixel(
+        red: CGFloat(bytes[offset]) / 255,
+        green: CGFloat(bytes[offset + 1]) / 255,
+        blue: CGFloat(bytes[offset + 2]) / 255,
+        alpha: CGFloat(bytes[offset + 3]) / 255
+    )
+}
+
+func assertImagePixelColor(
+    _ expected: UIColor,
+    at point: CGPoint,
+    in image: UIImage,
+    accuracy: CGFloat = 0.01,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard let actual = imagePixel(at: point, in: image) else {
+        return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
+    }
+
+    var expectedRed: CGFloat = 0
+    var expectedGreen: CGFloat = 0
+    var expectedBlue: CGFloat = 0
+    var expectedAlpha: CGFloat = 0
+    guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
+        return XCTFail("Could not convert expected color to RGB", file: file, line: line)
+    }
+
+    XCTAssertEqual(actual.red, expectedRed, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(actual.green, expectedGreen, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(actual.blue, expectedBlue, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: accuracy, file: file, line: line)
+}
+
+func assertImagePixelsEqual(
+    _ lhs: ImagePixel,
+    _ rhs: ImagePixel,
+    accuracy: CGFloat = 0.01,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    XCTAssertEqual(lhs.red, rhs.red, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(lhs.green, rhs.green, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(lhs.blue, rhs.blue, accuracy: accuracy, file: file, line: line)
+    XCTAssertEqual(lhs.alpha, rhs.alpha, accuracy: accuracy, file: file, line: line)
+}
+#endif

--- a/Tests/SentryTests/ViewCapture/SentryMaskRendererV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryMaskRendererV2Tests.swift
@@ -39,9 +39,9 @@ final class SentryMaskRendererV2Tests: XCTestCase {
         let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: [region])
 
         // -- Assert --
-        assertColor(.red, at: CGPoint(x: 12, y: 10), in: result)
-        assertColor(.blue, at: CGPoint(x: 17, y: 10), in: result)
-        assertColor(.red, at: CGPoint(x: 25, y: 10), in: result)
+        assertImagePixelColor(.red, at: CGPoint(x: 12, y: 10), in: result)
+        assertImagePixelColor(.blue, at: CGPoint(x: 17, y: 10), in: result)
+        assertImagePixelColor(.red, at: CGPoint(x: 25, y: 10), in: result)
     }
 
     func testMaskScreenshot_whenColorIsNotProvided_shouldFillRegionWithAverageColor() throws {
@@ -79,8 +79,8 @@ final class SentryMaskRendererV2Tests: XCTestCase {
         let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: [region])
 
         // -- Assert --
-        let left = try XCTUnwrap(color(at: CGPoint(x: 5, y: 5), in: result))
-        let right = try XCTUnwrap(color(at: CGPoint(x: 15, y: 5), in: result))
+        let left = try XCTUnwrap(imagePixel(at: CGPoint(x: 5, y: 5), in: result))
+        let right = try XCTUnwrap(imagePixel(at: CGPoint(x: 15, y: 5), in: result))
         XCTAssertEqual(left.red, right.red, accuracy: 0.01)
         XCTAssertEqual(left.green, right.green, accuracy: 0.01)
         XCTAssertEqual(left.blue, right.blue, accuracy: 0.01)
@@ -137,9 +137,9 @@ final class SentryMaskRendererV2Tests: XCTestCase {
         let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: regions)
 
         // -- Assert --
-        assertColor(.red, at: CGPoint(x: 5, y: 10), in: result)
-        assertColor(.blue, at: CGPoint(x: 15, y: 10), in: result)
-        assertColor(.red, at: CGPoint(x: 25, y: 10), in: result)
+        assertImagePixelColor(.red, at: CGPoint(x: 5, y: 10), in: result)
+        assertImagePixelColor(.blue, at: CGPoint(x: 15, y: 10), in: result)
+        assertImagePixelColor(.red, at: CGPoint(x: 25, y: 10), in: result)
     }
 
     private func makeImage(size: CGSize, drawing: (CGContext) -> Void) -> UIImage {
@@ -150,51 +150,5 @@ final class SentryMaskRendererV2Tests: XCTestCase {
         }
     }
 
-    private func assertColor(
-        _ expected: UIColor,
-        at point: CGPoint,
-        in image: UIImage,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        guard let actual = color(at: point, in: image) else {
-            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
-        }
-
-        var expectedRed: CGFloat = 0
-        var expectedGreen: CGFloat = 0
-        var expectedBlue: CGFloat = 0
-        var expectedAlpha: CGFloat = 0
-        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
-            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
-        }
-
-        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
-    }
-
-    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
-        guard let cgImage = image.cgImage,
-              let pixelData = cgImage.dataProvider?.data,
-              let bytes = CFDataGetBytePtr(pixelData) else {
-            return nil
-        }
-
-        let x = Int(point.x * image.scale)
-        let y = Int(point.y * image.scale)
-        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
-            return nil
-        }
-
-        let offset = y * cgImage.bytesPerRow + x * 4
-        return (
-            CGFloat(bytes[offset]) / 255,
-            CGFloat(bytes[offset + 1]) / 255,
-            CGFloat(bytes[offset + 2]) / 255,
-            CGFloat(bytes[offset + 3]) / 255
-        )
-    }
 }
 #endif

--- a/Tests/SentryTests/ViewCapture/SentryMaskRendererV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryMaskRendererV2Tests.swift
@@ -1,0 +1,200 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+@testable import Sentry
+import UIKit
+import XCTest
+
+final class SentryMaskRendererV2Tests: XCTestCase {
+
+    func testMaskScreenshot_whenRegionIsTransformed_shouldMaskOnlyTransformedPixels() throws {
+        // -- Arrange --
+        //
+        // Red 30 x 20 image with a rotated blue mask (* = asserted pixel):
+        //
+        //             x=0       x=12  x=15  x=17 x=20  x=25     x=30
+        //  y=0         +-------------------------------------------+
+        //              |                                           |
+        //  y=5         |                +------+                   |
+        //              |                | blue |                   |
+        //  y=10        |       * red    |  *   |     * red         |
+        //              |                |      |                   |
+        //  y=15        |                +------+                   |
+        //              |                                           |
+        //  y=20        +-------------------------------------------+
+        //
+        // The 10 x 5 region is rotated 90 degrees to x=15...20, y=5...15.
+        let image = makeImage(size: CGSize(width: 30, height: 20)) { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 30, height: 20))
+        }
+        let region = SentryRedactRegion(
+            size: CGSize(width: 10, height: 5),
+            transform: CGAffineTransform(a: 0, b: 1, c: -1, d: 0, tx: 20, ty: 5),
+            type: .redact,
+            color: .blue,
+            name: "rotated mask"
+        )
+        let sut = SentryMaskRendererV2()
+
+        // -- Act --
+        let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: [region])
+
+        // -- Assert --
+        assertColor(.red, at: CGPoint(x: 12, y: 10), in: result)
+        assertColor(.blue, at: CGPoint(x: 17, y: 10), in: result)
+        assertColor(.red, at: CGPoint(x: 25, y: 10), in: result)
+    }
+
+    func testMaskScreenshot_whenColorIsNotProvided_shouldFillRegionWithAverageColor() throws {
+        // -- Arrange --
+        //
+        // Source image:
+        //
+        //  x=0              x=10             x=20
+        //   +-----------------+-----------------+
+        //   | black           | white           |
+        //   +-----------------+-----------------+
+        //
+        // Expected masked image (* = asserted pixel, both at y=5):
+        //
+        //  x=0                                  x=20
+        //   +-------------------------------------+
+        //   | average gray                        |
+        //   |        * x=5              * x=15    |
+        //   +-------------------------------------+
+        let image = makeImage(size: CGSize(width: 20, height: 10)) { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+            UIColor.white.setFill()
+            context.fill(CGRect(x: 10, y: 0, width: 10, height: 10))
+        }
+        let region = SentryRedactRegion(
+            size: image.size,
+            transform: .identity,
+            type: .redact,
+            name: "image mask"
+        )
+        let sut = SentryMaskRendererV2()
+
+        // -- Act --
+        let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: [region])
+
+        // -- Assert --
+        let left = try XCTUnwrap(color(at: CGPoint(x: 5, y: 5), in: result))
+        let right = try XCTUnwrap(color(at: CGPoint(x: 15, y: 5), in: result))
+        XCTAssertEqual(left.red, right.red, accuracy: 0.01)
+        XCTAssertEqual(left.green, right.green, accuracy: 0.01)
+        XCTAssertEqual(left.blue, right.blue, accuracy: 0.01)
+        XCTAssertEqual(left.red, 0.5, accuracy: 0.1)
+        XCTAssertEqual(left.green, 0.5, accuracy: 0.1)
+        XCTAssertEqual(left.blue, 0.5, accuracy: 0.1)
+    }
+
+    func testMaskScreenshot_whenMaskIsClipped_shouldPreservePixelsOutsideClip() throws {
+        // -- Arrange --
+        //
+        // Red 30 x 20 image with clip x=10...20, y=5...15:
+        //
+        //             x=0     x=5  x=10     x=15 x=20  x=25    x=30
+        //  y=0         +------------------------------------------+
+        //              | red                                      |
+        //  y=5         |          +-------------+                 |
+        //              |          | blue        |                 |
+        //  y=10        |    * red |      *      |    * red        |
+        //              |          |             |                 |
+        //  y=15        |          +-------------+                 |
+        //              | red                                      |
+        //  y=20        +------------------------------------------+
+        //
+        // The blue mask requests the full image, but only pixels inside the clip change.
+        let image = makeImage(size: CGSize(width: 30, height: 20)) { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 30, height: 20))
+        }
+        let regions = [
+            SentryRedactRegion(
+                size: CGSize(width: 10, height: 10),
+                transform: CGAffineTransform(translationX: 10, y: 5),
+                type: .clipBegin,
+                name: "clip"
+            ),
+            SentryRedactRegion(
+                size: image.size,
+                transform: .identity,
+                type: .redact,
+                color: .blue,
+                name: "clipped mask"
+            ),
+            SentryRedactRegion(
+                size: .zero,
+                transform: .identity,
+                type: .clipEnd,
+                name: "clip end"
+            )
+        ]
+        let sut = SentryMaskRendererV2()
+
+        // -- Act --
+        let result = sut.maskScreenshot(screenshot: image, size: image.size, masking: regions)
+
+        // -- Assert --
+        assertColor(.red, at: CGPoint(x: 5, y: 10), in: result)
+        assertColor(.blue, at: CGPoint(x: 15, y: 10), in: result)
+        assertColor(.red, at: CGPoint(x: 25, y: 10), in: result)
+    }
+
+    private func makeImage(size: CGSize, drawing: (CGContext) -> Void) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            drawing(context.cgContext)
+        }
+    }
+
+    private func assertColor(
+        _ expected: UIColor,
+        at point: CGPoint,
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual = color(at: point, in: image) else {
+            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
+        }
+
+        var expectedRed: CGFloat = 0
+        var expectedGreen: CGFloat = 0
+        var expectedBlue: CGFloat = 0
+        var expectedAlpha: CGFloat = 0
+        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
+            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
+        }
+
+        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
+    }
+
+    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+        guard let cgImage = image.cgImage,
+              let pixelData = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(pixelData) else {
+            return nil
+        }
+
+        let x = Int(point.x * image.scale)
+        let y = Int(point.y * image.scale)
+        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
+            return nil
+        }
+
+        let offset = y * cgImage.bytesPerRow + x * 4
+        return (
+            CGFloat(bytes[offset]) / 255,
+            CGFloat(bytes[offset + 1]) / 255,
+            CGFloat(bytes[offset + 2]) / 255,
+            CGFloat(bytes[offset + 3]) / 255
+        )
+    }
+}
+#endif

--- a/Tests/SentryTests/ViewCapture/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewPhotographerTests.swift
@@ -374,24 +374,11 @@ class SentryViewPhotographerTests: XCTestCase {
     }
     
     private func color(at point: CGPoint, in image: UIImage) -> UIColor {
-        guard let cgImage = image.cgImage,
-              let dataProvider = cgImage.dataProvider,
-              let pixelData = dataProvider.data else {
+        guard let pixel = imagePixel(at: point, in: image) else {
             return .clear
         }
 
-        let data: UnsafePointer<UInt8> = CFDataGetBytePtr(pixelData)
-        
-        let bytesPerPixel = 4
-        let bytesPerRow = cgImage.bytesPerRow
-        let pixelOffset = Int(point.y) * bytesPerRow + Int(point.x) * bytesPerPixel
-        
-        let red = CGFloat(data[pixelOffset]) / 255.0
-        let green = CGFloat(data[pixelOffset + 1]) / 255.0
-        let blue = CGFloat(data[pixelOffset + 2]) / 255.0
-        let alpha = CGFloat(data[pixelOffset + 3]) / 255.0
-        
-        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+        return UIColor(red: pixel.red, green: pixel.green, blue: pixel.blue, alpha: pixel.alpha)
     }
 }
 

--- a/Tests/SentryTests/ViewCapture/SentryViewPhotographerV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewPhotographerV2Tests.swift
@@ -64,19 +64,19 @@ final class SentryViewPhotographerV2Tests: XCTestCase {
         let result = sut.image(view: rootView)
 
         // -- Assert --
-        assertColor(.red, at: CGPoint(x: 2, y: 2), in: result)
-        assertColor(.green, at: CGPoint(x: 22, y: 2), in: result)
+        assertImagePixelColor(.red, at: CGPoint(x: 2, y: 2), in: result)
+        assertImagePixelColor(.green, at: CGPoint(x: 22, y: 2), in: result)
 
-        let imageMaskLeft = try XCTUnwrap(color(at: CGPoint(x: 45, y: 10), in: result))
-        let imageMaskRight = try XCTUnwrap(color(at: CGPoint(x: 55, y: 10), in: result))
-        assertEqual(imageMaskLeft, imageMaskRight)
+        let imageMaskLeft = try XCTUnwrap(imagePixel(at: CGPoint(x: 45, y: 10), in: result))
+        let imageMaskRight = try XCTUnwrap(imagePixel(at: CGPoint(x: 55, y: 10), in: result))
+        assertImagePixelsEqual(imageMaskLeft, imageMaskRight)
         XCTAssertEqual(imageMaskLeft.red, 0.5, accuracy: 0.1)
         XCTAssertEqual(imageMaskLeft.green, 0.5, accuracy: 0.1)
         XCTAssertEqual(imageMaskLeft.blue, 0.5, accuracy: 0.1)
 
-        let explicitMaskLeft = try XCTUnwrap(color(at: CGPoint(x: 65, y: 10), in: result))
-        let explicitMaskRight = try XCTUnwrap(color(at: CGPoint(x: 75, y: 10), in: result))
-        assertEqual(explicitMaskLeft, explicitMaskRight)
+        let explicitMaskLeft = try XCTUnwrap(imagePixel(at: CGPoint(x: 65, y: 10), in: result))
+        let explicitMaskRight = try XCTUnwrap(imagePixel(at: CGPoint(x: 75, y: 10), in: result))
+        assertImagePixelsEqual(explicitMaskLeft, explicitMaskRight)
         XCTAssertEqual(explicitMaskLeft.red, 0.5, accuracy: 0.1)
         XCTAssertEqual(explicitMaskLeft.green, 0.5, accuracy: 0.1)
         XCTAssertEqual(explicitMaskLeft.blue, 1, accuracy: 0.1)
@@ -125,8 +125,8 @@ final class SentryViewPhotographerV2Tests: XCTestCase {
         let result = sut.image(view: rootView)
 
         // -- Assert --
-        assertColor(.black, at: CGPoint(x: 5, y: 10), in: result)
-        assertColor(.green, at: CGPoint(x: 30, y: 10), in: result)
+        assertImagePixelColor(.black, at: CGPoint(x: 5, y: 10), in: result)
+        assertImagePixelColor(.green, at: CGPoint(x: 30, y: 10), in: result)
     }
 
     func testImage_whenTransparentViewCoversText_shouldStillMaskCoveredText() {
@@ -170,8 +170,8 @@ final class SentryViewPhotographerV2Tests: XCTestCase {
         let result = sut.image(view: rootView)
 
         // -- Assert --
-        assertColor(.black, at: CGPoint(x: 5, y: 10), in: result)
-        assertColor(.black, at: CGPoint(x: 30, y: 10), in: result)
+        assertImagePixelColor(.black, at: CGPoint(x: 5, y: 10), in: result)
+        assertImagePixelColor(.black, at: CGPoint(x: 30, y: 10), in: result)
     }
 
     private func makeSplitImage(leftColor: UIColor, rightColor: UIColor) -> UIImage {
@@ -185,63 +185,5 @@ final class SentryViewPhotographerV2Tests: XCTestCase {
         }
     }
 
-    private func assertEqual(
-        _ lhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
-        _ rhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        XCTAssertEqual(lhs.red, rhs.red, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(lhs.green, rhs.green, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(lhs.blue, rhs.blue, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(lhs.alpha, rhs.alpha, accuracy: 0.01, file: file, line: line)
-    }
-
-    private func assertColor(
-        _ expected: UIColor,
-        at point: CGPoint,
-        in image: UIImage,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        guard let actual = color(at: point, in: image) else {
-            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
-        }
-
-        var expectedRed: CGFloat = 0
-        var expectedGreen: CGFloat = 0
-        var expectedBlue: CGFloat = 0
-        var expectedAlpha: CGFloat = 0
-        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
-            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
-        }
-
-        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
-    }
-
-    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
-        guard let cgImage = image.cgImage,
-              let pixelData = cgImage.dataProvider?.data,
-              let bytes = CFDataGetBytePtr(pixelData) else {
-            return nil
-        }
-
-        let x = Int(point.x * image.scale)
-        let y = Int(point.y * image.scale)
-        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
-            return nil
-        }
-
-        let offset = y * cgImage.bytesPerRow + x * 4
-        return (
-            CGFloat(bytes[offset]) / 255,
-            CGFloat(bytes[offset + 1]) / 255,
-            CGFloat(bytes[offset + 2]) / 255,
-            CGFloat(bytes[offset + 3]) / 255
-        )
-    }
 }
 #endif

--- a/Tests/SentryTests/ViewCapture/SentryViewPhotographerV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewPhotographerV2Tests.swift
@@ -1,0 +1,247 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+@_spi(Private) @testable import Sentry
+import UIKit
+import XCTest
+
+final class SentryViewPhotographerV2Tests: XCTestCase {
+
+    func testImage_whenUsingRendererV2_shouldApplyTextImageExplicitMaskAndExplicitUnmaskToFinalPixels() throws {
+        // -- Arrange --
+        //
+        // Root view hierarchy:
+        //
+        //  x=0              x=20             x=40             x=60             x=80
+        //   +-----------------+-----------------+-----------------+-----------------+
+        //   | masked UILabel  | unmasked UILabel| masked image    | masked UIView   |
+        //   | yellow, red text| green, blue text| black / white   | cyan / magenta  |
+        //   +-----------------+-----------------+-----------------+-----------------+
+        //
+        // Expected final pixels (* = asserted pixel, labels at y=2, others at y=10):
+        //
+        //   +-----------------+-----------------+-----------------+-----------------+
+        //   | red mask        | unchanged       | average gray    | average blue    |
+        //   | *2 red          | *22 green       | *45       *55   | *65       *75   |
+        //   +-----------------+-----------------+-----------------+-----------------+
+        //
+        // Each average replaces two different source colors with one uniform mask color.
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 80, height: 20))
+        rootView.backgroundColor = .white
+
+        let maskedLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+        maskedLabel.backgroundColor = .yellow
+        maskedLabel.textColor = .red
+        maskedLabel.text = "Private"
+        rootView.addSubview(maskedLabel)
+
+        let unmaskedLabel = UILabel(frame: CGRect(x: 20, y: 0, width: 20, height: 20))
+        unmaskedLabel.backgroundColor = .green
+        unmaskedLabel.textColor = .blue
+        unmaskedLabel.text = "Visible"
+        SentryRedactViewHelper.unmaskView(unmaskedLabel)
+        rootView.addSubview(unmaskedLabel)
+
+        let imageView = UIImageView(frame: CGRect(x: 40, y: 0, width: 20, height: 20))
+        imageView.image = makeSplitImage(leftColor: .black, rightColor: .white)
+        rootView.addSubview(imageView)
+
+        let explicitlyMaskedView = UIView(frame: CGRect(x: 60, y: 0, width: 20, height: 20))
+        let cyanSubview = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 20))
+        cyanSubview.backgroundColor = .cyan
+        explicitlyMaskedView.addSubview(cyanSubview)
+        let magentaSubview = UIView(frame: CGRect(x: 10, y: 0, width: 10, height: 20))
+        magentaSubview.backgroundColor = .magenta
+        explicitlyMaskedView.addSubview(magentaSubview)
+        SentryRedactViewHelper.maskView(explicitlyMaskedView)
+        rootView.addSubview(explicitlyMaskedView)
+
+        let sut = SentryViewPhotographer(
+            renderer: SentryViewRendererV2(enableFastViewRendering: true),
+            redactOptions: TestRedactOptions(),
+            enableMaskRendererV2: true
+        )
+
+        // -- Act --
+        let result = sut.image(view: rootView)
+
+        // -- Assert --
+        assertColor(.red, at: CGPoint(x: 2, y: 2), in: result)
+        assertColor(.green, at: CGPoint(x: 22, y: 2), in: result)
+
+        let imageMaskLeft = try XCTUnwrap(color(at: CGPoint(x: 45, y: 10), in: result))
+        let imageMaskRight = try XCTUnwrap(color(at: CGPoint(x: 55, y: 10), in: result))
+        assertEqual(imageMaskLeft, imageMaskRight)
+        XCTAssertEqual(imageMaskLeft.red, 0.5, accuracy: 0.1)
+        XCTAssertEqual(imageMaskLeft.green, 0.5, accuracy: 0.1)
+        XCTAssertEqual(imageMaskLeft.blue, 0.5, accuracy: 0.1)
+
+        let explicitMaskLeft = try XCTUnwrap(color(at: CGPoint(x: 65, y: 10), in: result))
+        let explicitMaskRight = try XCTUnwrap(color(at: CGPoint(x: 75, y: 10), in: result))
+        assertEqual(explicitMaskLeft, explicitMaskRight)
+        XCTAssertEqual(explicitMaskLeft.red, 0.5, accuracy: 0.1)
+        XCTAssertEqual(explicitMaskLeft.green, 0.5, accuracy: 0.1)
+        XCTAssertEqual(explicitMaskLeft.blue, 1, accuracy: 0.1)
+    }
+
+    func testImage_whenOpaqueViewCoversText_shouldPreserveOpaquePixels() {
+        // -- Arrange --
+        //
+        // Sibling hierarchy (later siblings are on top):
+        //
+        //  Sensitive UILabel: x=0 +-------------------------------------+ x=40
+        //  Opaque green view:                     x=20 +----------------+ x=40
+        //
+        // Expected final pixels (* = asserted pixel, both at y=10):
+        //
+        //                     x=0              x=20             x=40
+        //                      +-----------------+-----------------+
+        //                      | black mask      | opaque green    |
+        //                      |  * x=5          |          * x=30 |
+        //                      +-----------------+-----------------+
+        //
+        // The opaque sibling clips the label's mask on the covered right half.
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 20))
+        rootView.backgroundColor = .white
+
+        let label = UILabel(frame: rootView.bounds)
+        label.backgroundColor = .yellow
+        label.textColor = .black
+        label.text = "Private"
+        rootView.addSubview(label)
+
+        let opaqueView = UIView(frame: CGRect(x: 20, y: 0, width: 20, height: 20))
+        opaqueView.backgroundColor = .green
+        opaqueView.isOpaque = true
+        opaqueView.layer.isOpaque = true
+        opaqueView.layer.backgroundColor = UIColor.green.cgColor
+        rootView.addSubview(opaqueView)
+
+        let sut = SentryViewPhotographer(
+            renderer: SentryViewRendererV2(enableFastViewRendering: true),
+            redactOptions: TestRedactOptions(),
+            enableMaskRendererV2: true
+        )
+
+        // -- Act --
+        let result = sut.image(view: rootView)
+
+        // -- Assert --
+        assertColor(.black, at: CGPoint(x: 5, y: 10), in: result)
+        assertColor(.green, at: CGPoint(x: 30, y: 10), in: result)
+    }
+
+    func testImage_whenTransparentViewCoversText_shouldStillMaskCoveredText() {
+        // -- Arrange --
+        //
+        // Sibling hierarchy (later siblings are on top):
+        //
+        //  Sensitive UILabel: x=0 +-------------------------------------+ x=40
+        //  50% green view:                        x=20 +----------------+ x=40
+        //
+        // Expected final pixels (* = asserted pixel, both at y=10):
+        //
+        //                     x=0                                  x=40
+        //                      +-------------------------------------+
+        //                      | black mask over both sibling regions|
+        //                      |  * x=5                    * x=30    |
+        //                      +-------------------------------------+
+        //
+        // The transparent sibling must not clip the label's mask.
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 20))
+        rootView.backgroundColor = .white
+
+        let label = UILabel(frame: rootView.bounds)
+        label.backgroundColor = .yellow
+        label.textColor = .black
+        label.text = "Private"
+        rootView.addSubview(label)
+
+        let transparentView = UIView(frame: CGRect(x: 20, y: 0, width: 20, height: 20))
+        transparentView.backgroundColor = .green
+        transparentView.alpha = 0.5
+        rootView.addSubview(transparentView)
+
+        let sut = SentryViewPhotographer(
+            renderer: SentryViewRendererV2(enableFastViewRendering: true),
+            redactOptions: TestRedactOptions(),
+            enableMaskRendererV2: true
+        )
+
+        // -- Act --
+        let result = sut.image(view: rootView)
+
+        // -- Assert --
+        assertColor(.black, at: CGPoint(x: 5, y: 10), in: result)
+        assertColor(.black, at: CGPoint(x: 30, y: 10), in: result)
+    }
+
+    private func makeSplitImage(leftColor: UIColor, rightColor: UIColor) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: CGSize(width: 20, height: 20), format: format).image { context in
+            leftColor.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 20))
+            rightColor.setFill()
+            context.fill(CGRect(x: 10, y: 0, width: 10, height: 20))
+        }
+    }
+
+    private func assertEqual(
+        _ lhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
+        _ rhs: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.red, rhs.red, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(lhs.green, rhs.green, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(lhs.blue, rhs.blue, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(lhs.alpha, rhs.alpha, accuracy: 0.01, file: file, line: line)
+    }
+
+    private func assertColor(
+        _ expected: UIColor,
+        at point: CGPoint,
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual = color(at: point, in: image) else {
+            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
+        }
+
+        var expectedRed: CGFloat = 0
+        var expectedGreen: CGFloat = 0
+        var expectedBlue: CGFloat = 0
+        var expectedAlpha: CGFloat = 0
+        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
+            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
+        }
+
+        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
+    }
+
+    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+        guard let cgImage = image.cgImage,
+              let pixelData = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(pixelData) else {
+            return nil
+        }
+
+        let x = Int(point.x * image.scale)
+        let y = Int(point.y * image.scale)
+        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
+            return nil
+        }
+
+        let offset = y * cgImage.bytesPerRow + x * 4
+        return (
+            CGFloat(bytes[offset]) / 255,
+            CGFloat(bytes[offset + 1]) / 255,
+            CGFloat(bytes[offset + 2]) / 255,
+            CGFloat(bytes[offset + 3]) / 255
+        )
+    }
+}
+#endif

--- a/Tests/SentryTests/ViewCapture/SentryViewRendererV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewRendererV2Tests.swift
@@ -1,0 +1,151 @@
+#if os(iOS) && !targetEnvironment(macCatalyst)
+@testable import Sentry
+import UIKit
+import XCTest
+
+final class SentryViewRendererV2Tests: XCTestCase {
+
+    func testRender_whenUsingDrawHierarchy_shouldUseDrawHierarchyAtScreenScale() throws {
+        // -- Arrange --
+        //
+        // DrawHierarchyView output (* = asserted pixel):
+        //
+        //  x=0              x=20             x=40
+        //   +-----------------+-----------------+
+        //   | red             | blue            |
+        //   |  * x=5          |          * x=30 |
+        //   +-----------------+-----------------+
+        //
+        // The overriding view draws both halves through drawHierarchy.
+        let view = DrawHierarchyView(frame: CGRect(x: 0, y: 0, width: 40, height: 20))
+
+        let window = hostInWindow(view)
+        defer { window.isHidden = true }
+        let sut = SentryViewRendererV2(enableFastViewRendering: false)
+
+        // -- Act --
+        let image = sut.render(view: view)
+
+        // -- Assert --
+        XCTAssertEqual(view.drawnRect, view.bounds)
+        XCTAssertEqual(view.drawnAfterScreenUpdates, false)
+        XCTAssertEqual(image.size, view.bounds.size)
+        XCTAssertEqual(image.scale, window.screen.scale)
+        XCTAssertEqual(try XCTUnwrap(image.cgImage).width, Int(view.bounds.width * window.screen.scale))
+        assertColor(.red, at: CGPoint(x: 5, y: 10), in: image)
+        assertColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
+    }
+
+    func testRender_whenUsingFastRendering_shouldRenderSublayers() {
+        // -- Arrange --
+        //
+        // Layer hierarchy:
+        //
+        //  Red parent:     x=0 +-----------------------------------+ x=40
+        //  Blue subview:                    x=20 +-----------------+ x=40
+        //
+        // Expected composite (* = asserted pixel):
+        //
+        //                    x=0              x=20             x=40
+        //                     +-----------------+-----------------+
+        //                     | red             | blue subview    |
+        //                     |  * x=5          |          * x=30 |
+        //                     +-----------------+-----------------+
+        //
+        // The blue half must come from the subview's layer, not the parent layer.
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 20))
+        view.backgroundColor = .red
+
+        let subview = UIView(frame: CGRect(x: 20, y: 0, width: 20, height: 20))
+        subview.backgroundColor = .blue
+        view.addSubview(subview)
+
+        let window = hostInWindow(view)
+        defer { window.isHidden = true }
+        let sut = SentryViewRendererV2(enableFastViewRendering: true)
+
+        // -- Act --
+        let image = sut.render(view: view)
+
+        // -- Assert --
+        assertColor(.red, at: CGPoint(x: 5, y: 10), in: image)
+        assertColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
+    }
+
+    private final class DrawHierarchyView: UIView {
+        var drawnRect: CGRect?
+        var drawnAfterScreenUpdates: Bool?
+
+        override func drawHierarchy(in rect: CGRect, afterScreenUpdates afterUpdates: Bool) -> Bool {
+            drawnRect = rect
+            drawnAfterScreenUpdates = afterUpdates
+
+            UIColor.red.setFill()
+            UIRectFill(bounds)
+            UIColor.blue.setFill()
+            UIRectFill(CGRect(x: bounds.midX, y: 0, width: bounds.width / 2, height: bounds.height))
+            return true
+        }
+    }
+
+    private func hostInWindow(_ view: UIView) -> UIWindow {
+        let viewController = UIViewController()
+        viewController.view = view
+
+        let window = UIWindow(frame: view.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.01))
+        return window
+    }
+
+    private func assertColor(
+        _ expected: UIColor,
+        at point: CGPoint,
+        in image: UIImage,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual = color(at: point, in: image) else {
+            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
+        }
+
+        var expectedRed: CGFloat = 0
+        var expectedGreen: CGFloat = 0
+        var expectedBlue: CGFloat = 0
+        var expectedAlpha: CGFloat = 0
+        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
+            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
+        }
+
+        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
+        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
+    }
+
+    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+        guard let cgImage = image.cgImage,
+              let pixelData = cgImage.dataProvider?.data,
+              let bytes = CFDataGetBytePtr(pixelData) else {
+            return nil
+        }
+
+        let x = Int(point.x * image.scale)
+        let y = Int(point.y * image.scale)
+        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
+            return nil
+        }
+
+        let offset = y * cgImage.bytesPerRow + x * 4
+        return (
+            CGFloat(bytes[offset]) / 255,
+            CGFloat(bytes[offset + 1]) / 255,
+            CGFloat(bytes[offset + 2]) / 255,
+            CGFloat(bytes[offset + 3]) / 255
+        )
+    }
+}
+#endif

--- a/Tests/SentryTests/ViewCapture/SentryViewRendererV2Tests.swift
+++ b/Tests/SentryTests/ViewCapture/SentryViewRendererV2Tests.swift
@@ -32,8 +32,8 @@ final class SentryViewRendererV2Tests: XCTestCase {
         XCTAssertEqual(image.size, view.bounds.size)
         XCTAssertEqual(image.scale, window.screen.scale)
         XCTAssertEqual(try XCTUnwrap(image.cgImage).width, Int(view.bounds.width * window.screen.scale))
-        assertColor(.red, at: CGPoint(x: 5, y: 10), in: image)
-        assertColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
+        assertImagePixelColor(.red, at: CGPoint(x: 5, y: 10), in: image)
+        assertImagePixelColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
     }
 
     func testRender_whenUsingFastRendering_shouldRenderSublayers() {
@@ -68,8 +68,8 @@ final class SentryViewRendererV2Tests: XCTestCase {
         let image = sut.render(view: view)
 
         // -- Assert --
-        assertColor(.red, at: CGPoint(x: 5, y: 10), in: image)
-        assertColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
+        assertImagePixelColor(.red, at: CGPoint(x: 5, y: 10), in: image)
+        assertImagePixelColor(.blue, at: CGPoint(x: 30, y: 10), in: image)
     }
 
     private final class DrawHierarchyView: UIView {
@@ -101,51 +101,5 @@ final class SentryViewRendererV2Tests: XCTestCase {
         return window
     }
 
-    private func assertColor(
-        _ expected: UIColor,
-        at point: CGPoint,
-        in image: UIImage,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        guard let actual = color(at: point, in: image) else {
-            return XCTFail("Could not read image pixel at \(point)", file: file, line: line)
-        }
-
-        var expectedRed: CGFloat = 0
-        var expectedGreen: CGFloat = 0
-        var expectedBlue: CGFloat = 0
-        var expectedAlpha: CGFloat = 0
-        guard expected.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha) else {
-            return XCTFail("Could not convert expected color to RGB", file: file, line: line)
-        }
-
-        XCTAssertEqual(actual.red, expectedRed, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.green, expectedGreen, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.blue, expectedBlue, accuracy: 0.01, file: file, line: line)
-        XCTAssertEqual(actual.alpha, expectedAlpha, accuracy: 0.01, file: file, line: line)
-    }
-
-    private func color(at point: CGPoint, in image: UIImage) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
-        guard let cgImage = image.cgImage,
-              let pixelData = cgImage.dataProvider?.data,
-              let bytes = CFDataGetBytePtr(pixelData) else {
-            return nil
-        }
-
-        let x = Int(point.x * image.scale)
-        let y = Int(point.y * image.scale)
-        guard x >= 0, x < cgImage.width, y >= 0, y < cgImage.height else {
-            return nil
-        }
-
-        let offset = y * cgImage.bytesPerRow + x * 4
-        return (
-            CGFloat(bytes[offset]) / 255,
-            CGFloat(bytes[offset + 1]) / 255,
-            CGFloat(bytes[offset + 2]) / 255,
-            CGFloat(bytes[offset + 3]) / 255
-        )
-    }
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

- Add deterministic final-pixel tests for `SentryViewRendererV2` and `SentryMaskRendererV2`.
- Cover both `drawHierarchy(in:afterScreenUpdates:)` and fast `CALayer.render(in:)` view-rendering paths.
- Verify text and image masking, explicit masks and unmasks, transforms, clipping, and transparent and opaque overlays through `SentryViewPhotographer`.

## :bulb: Motivation and Context

`SentryViewRendererV2` is the default production renderer, but the existing replay integration tests inject a fake screenshot provider and the existing photographer tests use a custom renderer with mask renderer V1. Those tests can stay green even if production view capture or final masking pixels regress.

This matters across OS and SDK releases because UIKit rendering internals can change. The new tests protect the production rendering pipeline and specifically guard against regressions such as using `CALayer.draw(in:)`, which does not capture sublayers, instead of `CALayer.render(in:)`.

Related to [#8126](https://github.com/getsentry/sentry-cocoa/issues/8126), which tracks Session Replay screenshot and masking validation on xOS 27. This PR addresses the Renderer V2 coverage gap discovered during that validation; it does not close the broader issue because hosted end-to-end and touch-overlay coverage remain separate follow-up work.

#skip-changelog

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- iOS 27 V9 targeted Renderer V2 tests: 8 passed
- iOS 27 V10 targeted Renderer V2 tests: 8 passed
- iOS 18.5 targeted Renderer V2 tests: passed
- SwiftLint on all three new test files

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
