### PR TITLE
fix: strip ObjC binary targets in prepare-package.sh

### DIFF
--- a/scripts/prepare-package.sh
+++ b/scripts/prepare-package.sh
@@ -139,6 +139,8 @@ for PACKAGE_FILE in "${PACKAGE_FILES[@]}"; do
   if is_enabled "$REMOVE_DUPLICATE"; then
     sed -i '' '/Sentry-Dynamic/d' "$PACKAGE_FILE"
     sed -i '' '/Sentry-WithoutUIKitOrAppKit/d' "$PACKAGE_FILE"
+    sed -i '' '/SentryObjC-Dynamic/d' "$PACKAGE_FILE"
+    sed -i '' '/SentryObjC-Static/d' "$PACKAGE_FILE"
     sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;/\n[[:space:]]*),\{0,1\}$/d;}' "$PACKAGE_FILE"
   fi
 


### PR DESCRIPTION
## Summary
- `--remove-duplicate` strips `Sentry-Dynamic` and `Sentry-WithoutUIKitOrAppKit` binary targets but leaves `SentryObjC-Dynamic` and `SentryObjC-Static`
- When combined with `--change-path`, the remaining ObjC binary targets point to local `.xcframework.zip` files that are never built by `build-xcframework-variant.sh`
- This causes SPM resolution failures when running 3rd-party integration tests locally

## Test plan
- [x] Run `./scripts/prepare-package.sh --package-file Package.swift --is-pr true --remove-duplicate true --change-path true`
- [x] Verify no `SentryObjC-Dynamic` or `SentryObjC-Static` lines remain in Package.swift
- [x] Verify the `Sentry` binary target still points to `Sentry.xcframework.zip`
- [x] CI 3rd-party integration tests still pass

#skip-changelog

Closes #8775