### PR TITLE
ref: type KSCrash installer monitors

### DIFF
--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -14,7 +14,7 @@ extension SentryKSCrash {
         /// - Throws: Any error from `KSCrash.installWithConfiguration(_:error:)`.
         func install(
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         ) throws
@@ -53,13 +53,13 @@ extension SentryKSCrash {
 
         func install(
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         ) throws {
             let config = KSCrashConfiguration()
             config.installPath = installPath
-            config.monitors = MonitorType(rawValue: monitors)
+            config.monitors = monitors
             config.enableMemoryIntrospection = enableMemoryIntrospection
             config.enableSwapCxaThrow = enableSwapCxaThrow
             config.reportStoreConfiguration.reportCleanupPolicy = .onSuccess

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
@@ -11,12 +11,12 @@ extension SentryKSCrash {
     /// Mach exceptions, signals, C++ exceptions, and NSExceptions.
     /// KSCrash unconditionally adds its required infrastructure monitors on top of
     /// the crash detectors passed here.
-    static let productionSafeMonitors: UInt = MonitorType([
+    static let productionSafeMonitors: MonitorType = [
         .machException,
         .signal,
         .cppException,
         .nsException
-    ]).rawValue
+    ]
 
     final class Integration<Dependencies: DependencyProvider>: NSObject, SwiftIntegration {
         private weak var options: Options?

--- a/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
@@ -1,6 +1,7 @@
 #if SDK_V10
 @_spi(Private) import SentryTestUtils
 @_spi(Private) @testable import Sentry
+internal import KSCrashRecording
 
 final class MockKSCrashDependencies: SentryKSCrash.DependencyProvider {
     typealias Installing = MockKSCrashInstaller
@@ -32,7 +33,7 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
     public var installCalls: [
         (
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         )
@@ -52,7 +53,7 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
 
     public func install(
         installPath: String,
-        monitors: UInt,
+        monitors: MonitorType,
         enableMemoryIntrospection: Bool,
         enableSwapCxaThrow: Bool
     ) throws {


### PR DESCRIPTION
## :scroll: Description

Use KSCrash's `MonitorType` through the KSCrash installer interface rather than converting it to a `UInt` bit mask. Update the production monitor set and test installer mock to preserve the typed value end-to-end.

## :bulb: Motivation and Context

The V10 test targets now import `KSCrashRecording`, so the installer and its tests can depend directly on KSCrash's monitor type. This removes an unnecessary raw-value conversion at the configuration boundary.

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- `make test-ios-v10 FOR_AGENTS=true ONLY_TESTING=SentryTestsV10/SentryKSCrashIntegrationTests`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
