### PR TITLE
ci: Test local SDK integration variants

### DIFF
--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -109,6 +109,9 @@ jobs:
         run: |
           unzip -q Sentry.xcframework.zip
           ./scripts/prepare-package.sh --is-pr true --remove-duplicate true --change-path true
+          sed -i '' '/\.library(name: "SentryObjC-/d' Package*.swift
+          sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;N;N;/SentryObjC-Dynamic/d;}' Package*.swift
+          sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;N;N;/SentryObjC-Static/d;}' Package*.swift
           sed -i '' 's|path: "Sentry.xcframework.zip"|path: "Sentry.xcframework"|' Package*.swift
       - name: Use local sentry-cocoa
         working-directory: 3rd-party-integrations/${{matrix.integration_dir}}

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -108,8 +108,8 @@ jobs:
       - name: Modify Package.swift to use local xcframeworks
         run: |
           unzip -q Sentry.xcframework.zip
-          ./scripts/prepare-package.sh --package-file Package.swift --is-pr true --remove-duplicate true --change-path true
-          sed -i '' 's|path: "Sentry.xcframework.zip"|path: "Sentry.xcframework"|' Package.swift
+          ./scripts/prepare-package.sh --is-pr true --remove-duplicate true --change-path true
+          sed -i '' 's|path: "Sentry.xcframework.zip"|path: "Sentry.xcframework"|' Package*.swift
       - name: Use local sentry-cocoa
         working-directory: 3rd-party-integrations/${{matrix.integration_dir}}
         run: |

--- a/.github/workflows/test-3rd-party-integrations.yml
+++ b/.github/workflows/test-3rd-party-integrations.yml
@@ -106,14 +106,22 @@ jobs:
         with:
           name: xcframeworks-for-3rd-party-integration-tests
       - name: Modify Package.swift to use local xcframeworks
-        run: ./scripts/prepare-package.sh --package-file Package.swift --is-pr true --remove-duplicate true --change-path true
+        run: |
+          unzip -q Sentry.xcframework.zip
+          ./scripts/prepare-package.sh --package-file Package.swift --is-pr true --remove-duplicate true --change-path true
+          sed -i '' 's|path: "Sentry.xcframework.zip"|path: "Sentry.xcframework"|' Package.swift
       - name: Use local sentry-cocoa
         working-directory: 3rd-party-integrations/${{matrix.integration_dir}}
         run: |
           sed -i '' 's|\.package(url: "https://github\.com/getsentry/sentry-cocoa", from: "[^"]*")|.package(name: "sentry-cocoa", path: "../..")|g' Package.swift
-      - name: Run SPM Tests
+      - name: Run SPM Binary Tests
         working-directory: 3rd-party-integrations/${{matrix.integration_dir}}
         run: swift test
+      - name: Run SPM Source Tests
+        working-directory: 3rd-party-integrations/${{matrix.integration_dir}}
+        run: swift test
+        env:
+          SENTRY_COCOA_SOURCE_BUILD: "1"
       - name: Archiving Raw Logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() || cancelled() }}

--- a/3rd-party-integrations/SentryCocoaLumberjack/Package.swift
+++ b/3rd-party-integrations/SentryCocoaLumberjack/Package.swift
@@ -1,5 +1,20 @@
 // swift-tools-version:6.0
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
 import PackageDescription
+
+func envFlag(_ name: String) -> Bool {
+    getenv(name).map { String(cString: $0) == "1" } ?? false
+}
+
+let sentryProductName = envFlag("SENTRY_COCOA_SOURCE_BUILD") ? "SentrySPM" : "Sentry"
 
 let package = Package(
     name: "SentryCocoaLumberjack",
@@ -19,7 +34,7 @@ let package = Package(
             name: "SentryCocoaLumberjack",
             dependencies: [
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
         ),
         .testTarget(
@@ -27,7 +42,7 @@ let package = Package(
             dependencies: [
                 "SentryCocoaLumberjack",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
         )
     ]

--- a/3rd-party-integrations/SentryCocoaLumberjack/Sources/SentryCocoaLumberjackLogger.swift
+++ b/3rd-party-integrations/SentryCocoaLumberjack/Sources/SentryCocoaLumberjackLogger.swift
@@ -1,5 +1,9 @@
 import CocoaLumberjackSwift
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 
 /// A CocoaLumberjack logger that forwards log entries to Sentry's structured logging system.
 ///

--- a/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
+++ b/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
@@ -1,6 +1,10 @@
 @_spi(Private) @testable import SentryCocoaLumberjack
 import CocoaLumberjackSwift
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 import XCTest
 
 // swiftlint:disable cyclomatic_complexity file_length type_body_length

--- a/3rd-party-integrations/SentryPulse/Package.swift
+++ b/3rd-party-integrations/SentryPulse/Package.swift
@@ -1,5 +1,20 @@
 // swift-tools-version:6.0
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
 import PackageDescription
+
+func envFlag(_ name: String) -> Bool {
+    getenv(name).map { String(cString: $0) == "1" } ?? false
+}
+
+let sentryProductName = envFlag("SENTRY_COCOA_SOURCE_BUILD") ? "SentrySPM" : "Sentry"
 
 let package = Package(
     name: "SentryPulse",
@@ -19,7 +34,7 @@ let package = Package(
             name: "SentryPulse",
             dependencies: [
                 .product(name: "Pulse", package: "Pulse"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
         ),
         .testTarget(
@@ -27,8 +42,8 @@ let package = Package(
             dependencies: [
                 "SentryPulse",
                 .product(name: "Pulse", package: "Pulse"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
-        ) 
+        )
     ]
 )

--- a/3rd-party-integrations/SentryPulse/Sources/SentryPulse.swift
+++ b/3rd-party-integrations/SentryPulse/Sources/SentryPulse.swift
@@ -1,6 +1,10 @@
 import Combine
 import Pulse
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 
 /// Automatically forwards Pulse log messages to Sentry's structured logging system.
 ///

--- a/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
+++ b/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
@@ -1,6 +1,10 @@
 @testable import SentryPulse
 import Pulse
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 import XCTest
 
 // swiftlint:disable cyclomatic_complexity

--- a/3rd-party-integrations/SentrySwiftLog/Package.swift
+++ b/3rd-party-integrations/SentrySwiftLog/Package.swift
@@ -1,5 +1,20 @@
 // swift-tools-version:6.0
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
 import PackageDescription
+
+func envFlag(_ name: String) -> Bool {
+    getenv(name).map { String(cString: $0) == "1" } ?? false
+}
+
+let sentryProductName = envFlag("SENTRY_COCOA_SOURCE_BUILD") ? "SentrySPM" : "Sentry"
 
 let package = Package(
     name: "SentrySwiftLog",
@@ -19,7 +34,7 @@ let package = Package(
             name: "SentrySwiftLog",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
         ),
         .testTarget(
@@ -27,7 +42,7 @@ let package = Package(
             dependencies: [
                 "SentrySwiftLog",
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Sentry", package: "sentry-cocoa")
+                .product(name: sentryProductName, package: "sentry-cocoa")
             ]
         )
     ]

--- a/3rd-party-integrations/SentrySwiftLog/Sources/SentryLogHandler.swift
+++ b/3rd-party-integrations/SentrySwiftLog/Sources/SentryLogHandler.swift
@@ -1,5 +1,9 @@
 import Logging
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 
 /// A `swift-log` handler that forwards log entries to Sentry's structured logging system.
 ///

--- a/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
+++ b/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
@@ -1,6 +1,10 @@
 @testable import SentrySwiftLog
 import Logging
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 import XCTest
 
 final class SentryLogHandlerTests: XCTestCase {

--- a/3rd-party-integrations/SentrySwiftyBeaver/Package.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Package.swift
@@ -1,5 +1,20 @@
 // swift-tools-version:6.0
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
 import PackageDescription
+
+func envFlag(_ name: String) -> Bool {
+    getenv(name).map { String(cString: $0) == "1" } ?? false
+}
+
+let sentryProductName = envFlag("SENTRY_COCOA_SOURCE_BUILD") ? "SentrySPM" : "Sentry"
 
 let package = Package(
     name: "SentrySwiftyBeaver",
@@ -18,7 +33,7 @@ let package = Package(
         .target(
             name: "SentrySwiftyBeaver",
             dependencies: [
-                .product(name: "Sentry", package: "sentry-cocoa"),
+                .product(name: sentryProductName, package: "sentry-cocoa"),
                 .product(name: "SwiftyBeaver", package: "SwiftyBeaver")
             ]
         ),
@@ -26,7 +41,7 @@ let package = Package(
             name: "SentrySwiftyBeaverTests",
             dependencies: [
                 "SentrySwiftyBeaver",
-                .product(name: "Sentry", package: "sentry-cocoa"),
+                .product(name: sentryProductName, package: "sentry-cocoa"),
                 .product(name: "SwiftyBeaver", package: "SwiftyBeaver")
             ]
         )

--- a/3rd-party-integrations/SentrySwiftyBeaver/Sources/SentryDestination.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Sources/SentryDestination.swift
@@ -1,4 +1,8 @@
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 import SwiftyBeaver
 
 /// A SwiftyBeaver destination that forwards log entries to Sentry's structured logging system.

--- a/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
@@ -1,5 +1,9 @@
 @testable import SentrySwiftyBeaver
+#if canImport(Sentry)
 import Sentry
+#else
+import SentrySwift
+#endif
 import SwiftyBeaver
 import XCTest
 


### PR DESCRIPTION
Test third-party integrations against both local SDK delivery modes in CI.

The binary run downloads the CI-built `Sentry.xcframework`, unpacks it, and patches the local SDK manifest to reference the extracted framework directory. The source run uses the same local package dependency but selects its `SentrySPM` product through `SENTRY_COCOA_SOURCE_BUILD=1`. Integration sources import the public binary module when available and fall back to `SentrySwift` for the source-built product.

SwiftPM selects versioned manifests based on the toolchain. The CI rewrite must therefore patch `Package.swift`, `Package@swift-6.1.swift`, and `Package@swift-6.2.swift`. Patching only `Package.swift` allowed Xcode 16.4 to select an unmodified versioned manifest and download the published 9.25.0 SDK artifacts instead.

This remains a draft to confirm that neither test variant resolves `sentry-cocoa` from GitHub releases.

#skip-changelog

Closes #8790