### PR TITLE
chore: use internal KSCrash imports

### DIFF
--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -1,7 +1,6 @@
 #if SDK_V10
-// swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
+internal import KSCrashRecording
 import Foundation
 
 extension SentryKSCrash {

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
@@ -1,7 +1,6 @@
 #if SDK_V10
-// swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
+internal import KSCrashRecording
 import Foundation
 
 // MARK: - Integration

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ReportFilter.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ReportFilter.swift
@@ -1,7 +1,6 @@
 #if SDK_V10
-// swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
+internal import KSCrashRecording
 import Foundation
 
 extension SentryKSCrash {

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+ScopeObserver.swift
@@ -1,7 +1,6 @@
 #if SDK_V10
-// swiftlint:disable:next no_implementation_only_import
-@_implementationOnly import KSCrashRecording
 internal import _SentryPrivate
+internal import KSCrashRecording
 
 extension SentryKSCrash.Scope {
     class Observer: NSObject, SentryScopeObserver {


### PR DESCRIPTION
Replacement for incorrectly auto-merged #8780.

Restores the intended second layer of the KSCrash V10 stack.

#skip-changelog