### PR TITLE
ref: type KSCrash installer monitors

### DIFF
--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Installer.swift
@@ -14,7 +14,7 @@ extension SentryKSCrash {
         /// - Throws: Any error from `KSCrash.installWithConfiguration(_:error:)`.
         func install(
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         ) throws
@@ -53,13 +53,13 @@ extension SentryKSCrash {
 
         func install(
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         ) throws {
             let config = KSCrashConfiguration()
             config.installPath = installPath
-            config.monitors = MonitorType(rawValue: monitors)
+            config.monitors = monitors
             config.enableMemoryIntrospection = enableMemoryIntrospection
             config.enableSwapCxaThrow = enableSwapCxaThrow
             config.reportStoreConfiguration.reportCleanupPolicy = .onSuccess

--- a/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
+++ b/Sources/Swift/Integrations/KSCrash/SentryKSCrash+Integration.swift
@@ -11,12 +11,12 @@ extension SentryKSCrash {
     /// Mach exceptions, signals, C++ exceptions, and NSExceptions.
     /// KSCrash unconditionally adds its required infrastructure monitors on top of
     /// the crash detectors passed here.
-    static let productionSafeMonitors: UInt = MonitorType([
+    static let productionSafeMonitors: MonitorType = [
         .machException,
         .signal,
         .cppException,
         .nsException
-    ]).rawValue
+    ]
 
     final class Integration<Dependencies: DependencyProvider>: NSObject, SwiftIntegration {
         private weak var options: Options?

--- a/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
+++ b/Tests/SentryTests/Integrations/KSCrash/MockKSCrashInstaller.swift
@@ -1,6 +1,7 @@
 #if SDK_V10
 @_spi(Private) import SentryTestUtils
 @_spi(Private) @testable import Sentry
+internal import KSCrashRecording
 
 final class MockKSCrashDependencies: SentryKSCrash.DependencyProvider {
     typealias Installing = MockKSCrashInstaller
@@ -32,7 +33,7 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
     public var installCalls: [
         (
             installPath: String,
-            monitors: UInt,
+            monitors: MonitorType,
             enableMemoryIntrospection: Bool,
             enableSwapCxaThrow: Bool
         )
@@ -52,7 +53,7 @@ final class MockKSCrashInstaller: SentryKSCrash.Installing {
 
     public func install(
         installPath: String,
-        monitors: UInt,
+        monitors: MonitorType,
         enableMemoryIntrospection: Bool,
         enableSwapCxaThrow: Bool
     ) throws {


### PR DESCRIPTION
Replacement for incorrectly auto-merged #8787.

Restores the intended top layer of the KSCrash V10 stack.

#skip-changelog