### PR TITLE
fix(network): Stabilize envelope snapshots

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -312,7 +312,8 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         let envelopeCaptured = expectationAllowingOverFulfill(description: "Envelope captured")
         let transport = startSDK(
             envelopeCaptured: envelopeCaptured,
-            expectedEnvelopeItemType: SentryEnvelopeItemTypes.transaction
+            expectedEnvelopeItemType: SentryEnvelopeItemTypes.transaction,
+            disableFramesTracking: true
         ) {
             self.configureEnvelopeSnapshotOptions($0)
             $0.enableNetworkBreadcrumbs = false
@@ -352,7 +353,8 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         let envelopeCaptured = expectationAllowingOverFulfill(description: "Envelope captured")
         let transport = startSDK(
             envelopeCaptured: envelopeCaptured,
-            expectedEnvelopeItemType: SentryEnvelopeItemTypes.event
+            expectedEnvelopeItemType: SentryEnvelopeItemTypes.event,
+            disableFramesTracking: true
         ) {
             self.configureEnvelopeSnapshotOptions($0)
             $0.enableNetworkBreadcrumbs = false
@@ -458,6 +460,7 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         function: String = #function,
         envelopeCaptured: XCTestExpectation? = nil,
         expectedEnvelopeItemType: String? = nil,
+        disableFramesTracking: Bool = false,
         _ configureOptions: ((Options) -> Void)? = nil
     ) -> EnvelopeCapturingTransport {
         let options = Options()
@@ -467,6 +470,11 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
         configureOptions?(options)
 
         SentrySDK.start(options: options)
+
+        if disableFramesTracking {
+            // The display-link callback makes frames.delay nondeterministic in strict snapshots.
+            SentryDependencyContainer.sharedInstance().framesTracker.stop()
+        }
 
         let transport = EnvelopeCapturingTransport(
             expectation: envelopeCaptured,

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTestServerTests.swift
@@ -471,10 +471,12 @@ class SentryNetworkTrackerIntegrationTestServerTests: XCTestCase {
 
         SentrySDK.start(options: options)
 
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         if disableFramesTracking {
             // The display-link callback makes frames.delay nondeterministic in strict snapshots.
             SentryDependencyContainer.sharedInstance().framesTracker.stop()
         }
+#endif
 
         let transport = EnvelopeCapturingTransport(
             expectation: envelopeCaptured,


### PR DESCRIPTION
## :scroll: Description

Stops the frames tracker after SDK startup in the two strict network-envelope snapshot tests.

## :bulb: Motivation and Context

`CADisplayLink` can fire before a short network transaction finishes, causing `frames.delay` to be added to the transaction payload intermittently. The strict snapshots correctly reject that nondeterministic field. Stopping only the frames tracker preserves the URLSession network-tracking integration and the behavior covered by these tests.

## :green_heart: How did you test it?

- `make test-catalyst-v10 FOR_AGENTS=true TEST_PLAN=SentryV10_TestServer`
- `make test-catalyst FOR_AGENTS=true TEST_PLAN=Sentry_TestServer`

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog


Closes #8806