### PR TITLE
test: Add watchOS network snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -802,10 +802,9 @@ build-sample-SDK-Size:
 ## Run all platform tests
 #
 # Convenience target that invokes all platform test targets.
-# Note: test-watchos is excluded as watchOS does not support XCTest.
-# See test-ios, test-macos, test-catalyst, test-tvos, test-visionos for more details.
+# See test-ios, test-macos, test-catalyst, test-tvos, test-visionos, test-watchos for more details.
 .PHONY: test
-test: test-ios test-macos test-catalyst test-tvos test-visionos
+test: test-ios test-macos test-catalyst test-tvos test-visionos test-watchos
 
 ## Run iOS tests
 #
@@ -934,15 +933,36 @@ test-visionos:
 		$(if $(TEST_PLAN),--test-plan "$(TEST_PLAN)") \
 		--only-testing "$(ONLY_TESTING)"
 
-# Note: test-watchos target is not available because watchOS does not support XCTest.
-# Tests cannot be run on watchOS as the XCTest framework is not available on that platform.
+## Run watchOS tests
+#
+# Runs unit tests for watchOS Simulator.
+# Outputs logs and uses xcbeautify for formatted output.
+#
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Optional: TEST_SCHEME=SchemeName to override the default Xcode scheme (default: Sentry)
+# Examples:
+#   make test-watchos
+#   make test-watchos ONLY_TESTING=SentryTests/SentryHttpTransportTests
+#   make test-watchos TEST_PLAN=Sentry_TestServer   # needs `make -C test-server start-debug`
+.PHONY: test-watchos
+test-watchos:
+	@echo "--> Running watchOS tests"
+	./scripts/sentry-xcodebuild.sh \
+		--platform watchOS \
+		--os $(WATCHOS_SIMULATOR_OS) \
+		--device "$(WATCHOS_DEVICE_NAME)" \
+		--ref $(GIT-REF) \
+		--command test \
+		--configuration Test \
+		$(if $(TEST_SCHEME),--scheme "$(TEST_SCHEME)") \
+		$(if $(TEST_PLAN),--test-plan "$(TEST_PLAN)") \
+		--only-testing "$(ONLY_TESTING)"
 
 ## Run all platform tests with SDK_V10 flag
 #
 # Convenience target that invokes all V10 platform test targets.
-# Note: test-watchos-v10 is excluded as watchOS does not support XCTest.
 .PHONY: test-v10
-test-v10: test-ios-v10 test-macos-v10 test-catalyst-v10 test-tvos-v10 test-visionos-v10
+test-v10: test-ios-v10 test-macos-v10 test-catalyst-v10 test-tvos-v10 test-visionos-v10 test-watchos-v10
 
 ## Run iOS tests with SDK_V10 flag
 #
@@ -1050,6 +1070,29 @@ test-visionos-v10:
 		--platform visionOS \
 		--os $(VISIONOS_SIMULATOR_OS) \
 		--device "$(VISIONOS_DEVICE_NAME)" \
+		--ref $(GIT-REF) \
+		--command test \
+		--scheme SentryV10 \
+		--configuration TestV10 \
+		$(if $(TEST_PLAN),--test-plan "$(TEST_PLAN)") \
+		--only-testing "$(ONLY_TESTING)"
+
+## Run watchOS tests with SDK_V10 flag
+#
+# Runs unit tests for watchOS Simulator using the SentryV10 scheme.
+#
+# Optional: ONLY_TESTING=Target/ClassName to run specific test class(es)
+# Examples:
+#   make test-watchos-v10
+#   make test-watchos-v10 ONLY_TESTING=SentryTestsV10/SentryHttpTransportTests
+#   make test-watchos-v10 TEST_PLAN=SentryV10_TestServer   # needs `make -C test-server start-debug`
+.PHONY: test-watchos-v10
+test-watchos-v10:
+	@echo "--> Running V10 watchOS tests"
+	./scripts/sentry-xcodebuild.sh \
+		--platform watchOS \
+		--os $(WATCHOS_SIMULATOR_OS) \
+		--device "$(WATCHOS_DEVICE_NAME)" \
 		--ref $(GIT-REF) \
 		--command test \
 		--scheme SentryV10 \

--- a/Tests/Resources/NetworkEnvelopeSnapshots/failed-request-event-watchos-v10.json
+++ b/Tests/Resources/NetworkEnvelopeSnapshots/failed-request-event-watchos-v10.json
@@ -1,0 +1,135 @@
+{
+  "header": {
+    "event_id": "<event-id>",
+    "sdk": {
+      "features": "<features>",
+      "integrations": "<integrations>",
+      "name": "sentry.cocoa",
+      "packages": [],
+      "settings": {
+        "infer_ip": "auto"
+      },
+      "version": "<sdk-version>"
+    },
+    "trace": {
+      "environment": "test",
+      "public_key": "SentryNetworkTrackerIntegrationTestServerTests.testFailedRequest_whenCaptureEnabled_shouldMatchEnvelopeSnapshot()",
+      "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+      "trace_id": "<trace-id>"
+    }
+  },
+  "items": [
+    {
+      "header": {
+        "length": "<length>",
+        "type": "event"
+      },
+      "payload": {
+        "contexts": {
+          "app": {
+            "app_build": "<runtime-value>",
+            "app_id": "<runtime-value>",
+            "app_identifier": "<runtime-value>",
+            "app_memory": "<runtime-value>",
+            "app_name": "<runtime-value>",
+            "app_start_time": "<runtime-value>",
+            "app_version": "<runtime-value>",
+            "build_type": "<runtime-value>",
+            "device_app_hash": "<runtime-value>"
+          },
+          "culture": {
+            "calendar": "<runtime-value>",
+            "display_name": "<runtime-value>",
+            "is_24_hour_format": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "timezone": "<runtime-value>"
+          },
+          "device": {
+            "arch": "<runtime-value>",
+            "family": "<runtime-value>",
+            "free_memory": "<runtime-value>",
+            "low_power_mode": "<runtime-value>",
+            "memory_size": "<runtime-value>",
+            "model": "<runtime-value>",
+            "model_id": "<runtime-value>",
+            "processor_count": "<runtime-value>",
+            "simulator": "<runtime-value>",
+            "thermal_state": "<runtime-value>",
+            "usable_memory": "<runtime-value>"
+          },
+          "os": {
+            "build": "<runtime-value>",
+            "kernel_version": "<runtime-value>",
+            "name": "<runtime-value>",
+            "rooted": "<runtime-value>",
+            "version": "<runtime-value>"
+          },
+          "response": {
+            "body_size": 37,
+            "cookies": {},
+            "headers": {
+              "Connection": "keep-alive",
+              "Content-Length": "37",
+              "Content-Type": "application/json; charset=utf-8",
+              "Date": "<timestamp>"
+            },
+            "status_code": 400
+          },
+          "trace": {
+            "span_id": "<span-id>",
+            "trace_id": "<trace-id>"
+          }
+        },
+        "debug_meta": "<debug-meta>",
+        "dist": "<runtime-value>",
+        "environment": "test",
+        "event_id": "<event-id>",
+        "exception": {
+          "values": [
+            {
+              "mechanism": {
+                "type": "HTTPClientError"
+              },
+              "stacktrace": "<stacktrace>",
+              "type": "HTTPClientError",
+              "value": "HTTP Client Error with status code: 400"
+            }
+          ]
+        },
+        "extra": {},
+        "level": "error",
+        "platform": "cocoa",
+        "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+        "request": {
+          "cookies": {},
+          "headers": {
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "<accept-language>",
+            "baggage": "<baggage>",
+            "sentry-trace": "<sentry-trace>",
+            "User-Agent": "<user-agent>"
+          },
+          "method": "GET",
+          "url": "http://localhost:8081/http-client-error"
+        },
+        "sdk": {
+          "features": "<features>",
+          "integrations": "<integrations>",
+          "name": "sentry.cocoa",
+          "packages": [],
+          "settings": {
+            "infer_ip": "auto"
+          },
+          "version": "<sdk-version>"
+        },
+        "tags": {},
+        "threads": "<threads>",
+        "timestamp": "<timestamp>",
+        "user": {
+          "id": "<id>"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Resources/NetworkEnvelopeSnapshots/failed-request-event-watchos.json
+++ b/Tests/Resources/NetworkEnvelopeSnapshots/failed-request-event-watchos.json
@@ -1,0 +1,134 @@
+{
+  "header": {
+    "event_id": "<event-id>",
+    "sdk": {
+      "features": "<features>",
+      "integrations": "<integrations>",
+      "name": "sentry.cocoa",
+      "packages": [],
+      "settings": {
+        "infer_ip": "never"
+      },
+      "version": "<sdk-version>"
+    },
+    "trace": {
+      "environment": "test",
+      "public_key": "SentryNetworkTrackerIntegrationTestServerTests.testFailedRequest_whenCaptureEnabled_shouldMatchEnvelopeSnapshot()",
+      "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+      "trace_id": "<trace-id>"
+    }
+  },
+  "items": [
+    {
+      "header": {
+        "length": "<length>",
+        "type": "event"
+      },
+      "payload": {
+        "contexts": {
+          "app": {
+            "app_build": "<runtime-value>",
+            "app_id": "<runtime-value>",
+            "app_identifier": "<runtime-value>",
+            "app_memory": "<runtime-value>",
+            "app_name": "<runtime-value>",
+            "app_start_time": "<runtime-value>",
+            "app_version": "<runtime-value>",
+            "build_type": "<runtime-value>",
+            "device_app_hash": "<runtime-value>"
+          },
+          "culture": {
+            "calendar": "<runtime-value>",
+            "display_name": "<runtime-value>",
+            "is_24_hour_format": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "timezone": "<runtime-value>"
+          },
+          "device": {
+            "arch": "<runtime-value>",
+            "family": "<runtime-value>",
+            "free_memory": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "low_power_mode": "<runtime-value>",
+            "memory_size": "<runtime-value>",
+            "model": "<runtime-value>",
+            "model_id": "<runtime-value>",
+            "processor_count": "<runtime-value>",
+            "simulator": "<runtime-value>",
+            "thermal_state": "<runtime-value>",
+            "usable_memory": "<runtime-value>"
+          },
+          "os": {
+            "build": "<runtime-value>",
+            "kernel_version": "<runtime-value>",
+            "name": "<runtime-value>",
+            "rooted": "<runtime-value>",
+            "version": "<runtime-value>"
+          },
+          "response": {
+            "body_size": 37,
+            "headers": {
+              "Connection": "keep-alive",
+              "Content-Length": "37",
+              "Content-Type": "application/json; charset=utf-8",
+              "Date": "<timestamp>"
+            },
+            "status_code": 400
+          },
+          "trace": {
+            "span_id": "<span-id>",
+            "trace_id": "<trace-id>"
+          }
+        },
+        "debug_meta": "<debug-meta>",
+        "dist": "<runtime-value>",
+        "environment": "test",
+        "event_id": "<event-id>",
+        "exception": {
+          "values": [
+            {
+              "mechanism": {
+                "type": "HTTPClientError"
+              },
+              "stacktrace": "<stacktrace>",
+              "type": "HTTPClientError",
+              "value": "HTTP Client Error with status code: 400"
+            }
+          ]
+        },
+        "extra": {},
+        "level": "error",
+        "platform": "cocoa",
+        "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+        "request": {
+          "headers": {
+            "Accept": "*/*",
+            "Accept-Encoding": "gzip, deflate",
+            "Accept-Language": "<accept-language>",
+            "baggage": "<baggage>",
+            "sentry-trace": "<sentry-trace>",
+            "User-Agent": "<user-agent>"
+          },
+          "method": "GET",
+          "url": "http://localhost:8081/http-client-error"
+        },
+        "sdk": {
+          "features": "<features>",
+          "integrations": "<integrations>",
+          "name": "sentry.cocoa",
+          "packages": [],
+          "settings": {
+            "infer_ip": "never"
+          },
+          "version": "<sdk-version>"
+        },
+        "tags": {},
+        "threads": "<threads>",
+        "timestamp": "<timestamp>",
+        "user": {
+          "id": "<id>"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Resources/NetworkEnvelopeSnapshots/successful-request-transaction-watchos-v10.json
+++ b/Tests/Resources/NetworkEnvelopeSnapshots/successful-request-transaction-watchos-v10.json
@@ -1,0 +1,182 @@
+{
+  "header": {
+    "event_id": "<event-id>",
+    "sdk": {
+      "features": "<features>",
+      "integrations": "<integrations>",
+      "name": "sentry.cocoa",
+      "packages": [],
+      "settings": {
+        "infer_ip": "auto"
+      },
+      "version": "<sdk-version>"
+    },
+    "trace": {
+      "environment": "test",
+      "public_key": "SentryNetworkTrackerIntegrationTestServerTests.testSuccessfulRequest_whenTransactionFinishes_shouldMatchEnvelopeSnapshot()",
+      "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+      "sample_rand": "<sample-rand>",
+      "sample_rate": "1.000000",
+      "sampled": "true",
+      "trace_id": "<trace-id>",
+      "transaction": "Network Envelope Snapshot"
+    }
+  },
+  "items": [
+    {
+      "header": {
+        "length": "<length>",
+        "type": "transaction"
+      },
+      "payload": {
+        "contexts": {
+          "app": {
+            "app_build": "<runtime-value>",
+            "app_id": "<runtime-value>",
+            "app_identifier": "<runtime-value>",
+            "app_memory": "<runtime-value>",
+            "app_name": "<runtime-value>",
+            "app_start_time": "<runtime-value>",
+            "app_version": "<runtime-value>",
+            "build_type": "<runtime-value>",
+            "device_app_hash": "<runtime-value>"
+          },
+          "culture": {
+            "calendar": "<runtime-value>",
+            "display_name": "<runtime-value>",
+            "is_24_hour_format": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "timezone": "<runtime-value>"
+          },
+          "device": {
+            "arch": "<runtime-value>",
+            "family": "<runtime-value>",
+            "free_memory": "<runtime-value>",
+            "low_power_mode": "<runtime-value>",
+            "memory_size": "<runtime-value>",
+            "model": "<runtime-value>",
+            "model_id": "<runtime-value>",
+            "processor_count": "<runtime-value>",
+            "simulator": "<runtime-value>",
+            "thermal_state": "<runtime-value>",
+            "usable_memory": "<runtime-value>"
+          },
+          "os": {
+            "build": "<runtime-value>",
+            "kernel_version": "<runtime-value>",
+            "name": "<runtime-value>",
+            "rooted": "<runtime-value>",
+            "version": "<runtime-value>"
+          },
+          "trace": {
+            "data": {
+              "thread.id": "<thread-id>",
+              "thread.name": "main"
+            },
+            "op": "test.network",
+            "origin": "manual",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          }
+        },
+        "dist": "<runtime-value>",
+        "environment": "test",
+        "event_id": "<event-id>",
+        "extra": {
+          "thread.id": "<thread-id>",
+          "thread.name": "main"
+        },
+        "platform": "cocoa",
+        "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+        "sdk": {
+          "features": "<features>",
+          "integrations": "<integrations>",
+          "name": "sentry.cocoa",
+          "packages": [],
+          "settings": {
+            "infer_ip": "auto"
+          },
+          "version": "<sdk-version>"
+        },
+        "spans": [
+          {
+            "data": {
+              "http.request.method": "GET",
+              "http.response.status_code": 200,
+              "thread.id": "<thread-id>",
+              "thread.name": "main",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          },
+          {
+            "data": {
+              "http.request.method": "GET",
+              "thread.id": "<thread-id>",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "unknown_error",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          },
+          {
+            "data": {
+              "http.request.method": "GET",
+              "http.response.status_code": 200,
+              "thread.id": "<thread-id>",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          }
+        ],
+        "start_timestamp": "<timestamp>",
+        "tags": {},
+        "timestamp": "<timestamp>",
+        "transaction": "Network Envelope Snapshot",
+        "transaction_info": {
+          "source": "custom"
+        },
+        "type": "transaction",
+        "user": {
+          "id": "<id>"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/Resources/NetworkEnvelopeSnapshots/successful-request-transaction-watchos.json
+++ b/Tests/Resources/NetworkEnvelopeSnapshots/successful-request-transaction-watchos.json
@@ -1,0 +1,183 @@
+{
+  "header": {
+    "event_id": "<event-id>",
+    "sdk": {
+      "features": "<features>",
+      "integrations": "<integrations>",
+      "name": "sentry.cocoa",
+      "packages": [],
+      "settings": {
+        "infer_ip": "never"
+      },
+      "version": "<sdk-version>"
+    },
+    "trace": {
+      "environment": "test",
+      "public_key": "SentryNetworkTrackerIntegrationTestServerTests.testSuccessfulRequest_whenTransactionFinishes_shouldMatchEnvelopeSnapshot()",
+      "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+      "sample_rand": "<sample-rand>",
+      "sample_rate": "1.000000",
+      "sampled": "true",
+      "trace_id": "<trace-id>",
+      "transaction": "Network Envelope Snapshot"
+    }
+  },
+  "items": [
+    {
+      "header": {
+        "length": "<length>",
+        "type": "transaction"
+      },
+      "payload": {
+        "contexts": {
+          "app": {
+            "app_build": "<runtime-value>",
+            "app_id": "<runtime-value>",
+            "app_identifier": "<runtime-value>",
+            "app_memory": "<runtime-value>",
+            "app_name": "<runtime-value>",
+            "app_start_time": "<runtime-value>",
+            "app_version": "<runtime-value>",
+            "build_type": "<runtime-value>",
+            "device_app_hash": "<runtime-value>"
+          },
+          "culture": {
+            "calendar": "<runtime-value>",
+            "display_name": "<runtime-value>",
+            "is_24_hour_format": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "timezone": "<runtime-value>"
+          },
+          "device": {
+            "arch": "<runtime-value>",
+            "family": "<runtime-value>",
+            "free_memory": "<runtime-value>",
+            "locale": "<runtime-value>",
+            "low_power_mode": "<runtime-value>",
+            "memory_size": "<runtime-value>",
+            "model": "<runtime-value>",
+            "model_id": "<runtime-value>",
+            "processor_count": "<runtime-value>",
+            "simulator": "<runtime-value>",
+            "thermal_state": "<runtime-value>",
+            "usable_memory": "<runtime-value>"
+          },
+          "os": {
+            "build": "<runtime-value>",
+            "kernel_version": "<runtime-value>",
+            "name": "<runtime-value>",
+            "rooted": "<runtime-value>",
+            "version": "<runtime-value>"
+          },
+          "trace": {
+            "data": {
+              "thread.id": "<thread-id>",
+              "thread.name": "main"
+            },
+            "op": "test.network",
+            "origin": "manual",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          }
+        },
+        "dist": "<runtime-value>",
+        "environment": "test",
+        "event_id": "<event-id>",
+        "extra": {
+          "thread.id": "<thread-id>",
+          "thread.name": "main"
+        },
+        "platform": "cocoa",
+        "release": "io.sentry.network-envelope-snapshot@1.0.0+1",
+        "sdk": {
+          "features": "<features>",
+          "integrations": "<integrations>",
+          "name": "sentry.cocoa",
+          "packages": [],
+          "settings": {
+            "infer_ip": "never"
+          },
+          "version": "<sdk-version>"
+        },
+        "spans": [
+          {
+            "data": {
+              "http.request.method": "GET",
+              "http.response.status_code": 200,
+              "thread.id": "<thread-id>",
+              "thread.name": "main",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          },
+          {
+            "data": {
+              "http.request.method": "GET",
+              "thread.id": "<thread-id>",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "unknown_error",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          },
+          {
+            "data": {
+              "http.request.method": "GET",
+              "http.response.status_code": 200,
+              "thread.id": "<thread-id>",
+              "type": "fetch",
+              "url": "http://localhost:8081/echo-sentry-trace"
+            },
+            "description": "GET http://localhost:8081/echo-sentry-trace",
+            "op": "http.client",
+            "origin": "auto.http.ns_url_session",
+            "parent_span_id": "<span-id>",
+            "sampled": true,
+            "span_id": "<span-id>",
+            "start_timestamp": "<timestamp>",
+            "status": "ok",
+            "timestamp": "<timestamp>",
+            "trace_id": "<trace-id>",
+            "type": "trace"
+          }
+        ],
+        "start_timestamp": "<timestamp>",
+        "tags": {},
+        "timestamp": "<timestamp>",
+        "transaction": "Network Envelope Snapshot",
+        "transaction_info": {
+          "source": "custom"
+        },
+        "type": "transaction",
+        "user": {
+          "id": "<id>"
+        }
+      }
+    }
+  ]
+}

--- a/Tests/SentryTests/Integrations/Performance/Network/NetworkEnvelopeSnapshot.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/NetworkEnvelopeSnapshot.swift
@@ -51,6 +51,8 @@ struct NetworkEnvelopeSnapshot {
         let platformResource = "\(resource)-ios"
 #elseif os(tvOS)
         let platformResource = "\(resource)-tvos"
+#elseif os(watchOS)
+        let platformResource = "\(resource)-watchos"
 #elseif os(visionOS)
         let platformResource = "\(resource)-visionos"
 #elseif os(macOS)


### PR DESCRIPTION
Add watchOS-specific network-envelope snapshots for the v9 and V10 test configurations, and select them when compiling the snapshot helper for watchOS.

The nightly watchOS job failed while compiling `SentryTests` because snapshot selection had no `os(watchOS)` branch. The new snapshots capture the observed watchOS envelope differences, and the Makefile now provides watchOS test targets alongside the existing platform targets.

Resolves the nightly failure: https://github.com/getsentry/sentry-cocoa/actions/runs/31662131873/job/94328919460

#skip-changelog


Closes #8808