### PR TITLE
fix: Stabilize SDK log tests

### DIFF
--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -115,6 +115,12 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 
         [self.threadWrapper sleepForTimeInterval:sleepInterval];
 
+        @synchronized(threadLock) {
+            if (state != kSentryANRTrackerRunning) {
+                break;
+            }
+        }
+
         BOOL isInForeground = [self.crashWrapper isApplicationInForeground];
 
         if (!isInForeground) {

--- a/Sources/Swift/Networking/SentryReachability.swift
+++ b/Sources/Swift/Networking/SentryReachability.swift
@@ -41,6 +41,10 @@ public class SentryReachability: NSObject {
     public var pathMonitorIsNil: Bool {
         return pathMonitor == nil
     }
+
+    var currentPathMonitor: NWPathMonitor? {
+        observersLock.synchronized { pathMonitor }
+    }
 #endif // DEBUG || SENTRY_TEST || SENTRY_TEST_CI
     
     @objc(addObserver:)
@@ -72,9 +76,15 @@ public class SentryReachability: NSObject {
 #endif // DEBUG || SENTRY_TEST || SENTRY_TEST_CI
         
         self.currentConnectivity = .none
-        self.pathMonitor = NWPathMonitor()
-        self.pathMonitor?.pathUpdateHandler = self.pathUpdateHandler
-        self.pathMonitor?.start(queue: self.reachabilityQueue)
+        let pathMonitor = NWPathMonitor()
+        pathMonitor.pathUpdateHandler = { [weak self, weak pathMonitor] path in
+            guard let self, let pathMonitor, self.isCurrentPathMonitor(pathMonitor) else {
+                return
+            }
+            self.pathUpdateHandler(path)
+        }
+        self.pathMonitor = pathMonitor
+        pathMonitor.start(queue: self.reachabilityQueue)
     }
     
     @objc(removeObserver:)
@@ -117,6 +127,12 @@ public class SentryReachability: NSObject {
         }
     }
     
+    func isCurrentPathMonitor(_ pathMonitor: NWPathMonitor) -> Bool {
+        observersLock.synchronized {
+            self.pathMonitor === pathMonitor
+        }
+    }
+
     private func pathUpdateHandler(_ path: NWPath) {
         SentrySDKLog.debug("SentryPathUpdateHandler called with path status: \(path.status)")
         

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
@@ -365,6 +365,42 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
     }
     
+    func testClear_WhenWorkerWakesInBackground_DoesNotLogAfterStopping() throws {
+        // -- Arrange --
+        let (sut, _, _, crashWrapper, threadWrapper, _) = try getSut()
+        let oldDebug = SentrySDKLog.isDebug
+        let oldLevel = SentrySDKLog.diagnosticLevel
+        let oldOutput = SentrySDKLog.getLogOutput()
+        let logOutput = TestLogOutput(logsToConsole: false)
+        let sleepStarted = expectation(description: "ANR worker started sleeping")
+        let allowSleepToFinish = DispatchSemaphore(value: 0)
+
+        defer {
+            SentrySDKLogSupport.configure(oldDebug, diagnosticLevel: oldLevel)
+            SentrySDKLog.setOutput(oldOutput)
+        }
+
+        SentrySDKLog.setLogOutput(logOutput)
+        SentrySDKLogSupport.configure(true, diagnosticLevel: .debug)
+        crashWrapper.internalIsApplicationInForeground = false
+        threadWrapper.blockWhenSleeping = {
+            sleepStarted.fulfill()
+            allowSleepToFinish.wait()
+        }
+
+        // -- Act --
+        sut.add(listener: SentryANRTrackerV2TestDelegate())
+        wait(for: [sleepStarted], timeout: waitTimeout)
+        sut.clear()
+        allowSleepToFinish.signal()
+        wait(for: [threadWrapper.threadFinishedExpectation], timeout: waitTimeout)
+
+        // -- Assert --
+        XCTAssertFalse(logOutput.loggedMessages.contains {
+            $0.contains("Ignoring potential app hangs because the app is in the background")
+        })
+    }
+
     func testAppSuspended_NoAppHang() throws {
         let (sut, currentDate, _, _, threadWrapper, _) = try getSut()
         defer { sut.clear() }

--- a/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
+++ b/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
@@ -126,6 +126,22 @@ final class SentryReachabilitySwiftTests: XCTestCase {
         })
     }
 
+    func testRemove_WhenLastObserverIsRemoved_ShouldInvalidatePathMonitor() throws {
+        // -- Arrange --
+        reachability.skipRegisteringActualCallbacks = false
+        let observer = TestSentryReachabilityObserver()
+
+        // -- Act --
+        reachability.add(observer)
+        let pathMonitor = try XCTUnwrap(reachability.currentPathMonitor)
+        let isCurrentBeforeRemovingObserver = reachability.isCurrentPathMonitor(pathMonitor)
+        reachability.remove(observer)
+
+        // -- Assert --
+        XCTAssertTrue(isCurrentBeforeRemovingObserver)
+        XCTAssertFalse(reachability.isCurrentPathMonitor(pathMonitor))
+    }
+
     func testAddingAndRemovingObserversCleanTheMonitor() {
         reachability.skipRegisteringActualCallbacks = false
         reachability.setReachabilityIgnoreActualCallback(false)


### PR DESCRIPTION
Stabilize `SentrySDKLogTests` by preventing stale background work from writing through its process-global log capture.

## Root cause investigation

Observed failures:

- [Unit iOS 26 Sentry, PR #8807](https://github.com/getsentry/sentry-cocoa/actions/runs/31682651212/job/94391514302?pr=8807)
- [Test V10 tvOS, PR #8805](https://github.com/getsentry/sentry-cocoa/actions/runs/31683624220/job/94394574397?pr=8805)

`SentrySDKLogTests` temporarily replaces the SDK-global log output, enables debug logging, and uses a deterministic global date provider. Its assertions require an exact, unfiltered list of messages. Background work from other tests can therefore enter the capture window and be reported as a logger-test failure. The fixed timestamp on the unexpected messages confirmed that those messages passed through this global test fixture.

Two independent producers caused the observed flakes:

- On iOS, `NWPathMonitor` can deliver a queued path update after its final reachability observer has been removed and the monitor has been cancelled. That callback emitted the `SentryPathUpdateHandler` and `SentryConnectivityCallback` debug messages seen in CI.
- On tvOS V10, the V2 ANR worker can be stopped while it is sleeping, then resume and emit the background-state diagnostic before its next loop iteration observes the stopping state.

Runner scheduling can make either race more likely, but both are test-isolation defects rather than runner-specific failures.

This change binds each reachability callback to its originating monitor and discards it once that monitor is no longer current. It also rechecks the ANR worker state immediately after sleep, before reading app state or logging. Regression tests cover both lifecycle boundaries.

Verification:

- `make format`
- `make analyze`
- `make build-ios FOR_AGENTS=true`
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryReachabilitySwiftTests,SentryTests/SentrySDKLogTests,SentryTests/SentryANRTrackerV2Tests`
- `make test-tvos-v10 FOR_AGENTS=true ONLY_TESTING=SentryTestsV10/SentrySDKLogTests,SentryTestsV10/SentryANRTrackerV2Tests`

#skip-changelog
