### PR TITLE
fix: synchronize network tracker feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Prevent duplicate automatic HTTP spans and breadcrumbs for URLSession task wrappers (#8846)
 - Prevent breadcrumb persistence for watchdog termination events from blocking the calling thread (#8653)
+- Fix data races when reading and updating network tracker feature flags (#8832)
 
 ## 9.26.0
 

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -40,12 +40,17 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     private let hub: Hub
     private let threadInspector: SentryThreadInspector
 
-    // We accept races when toggling these flags to avoid acquiring locks for many parallel HTTP
-    // requests. This matches the Objective-C implementation's deliberate performance tradeoff.
-    private(set) var isNetworkTrackingEnabled = false
-    private(set) var isNetworkBreadcrumbEnabled = false
-    private(set) var isCaptureFailedRequestsEnabled = false
-    private(set) var isGraphQLOperationTrackingEnabled = false
+    // All network tracker feature flags share a single synchronization boundary so that hot paths
+    // observing several flags read one consistent snapshot, and disable() resets the whole set
+    // atomically. See https://github.com/getsentry/sentry-cocoa/issues/8592.
+    private struct NetworkTrackerState {
+        var isNetworkTrackingEnabled = false
+        var isNetworkBreadcrumbEnabled = false
+        var isCaptureFailedRequestsEnabled = false
+        var isGraphQLOperationTrackingEnabled = false
+    }
+
+    private let state = SentryMutex(NetworkTrackerState())
 
     // MARK: - Initializers
 
@@ -58,26 +63,44 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     // MARK: - Public API
 
     func enableNetworkTracking() {
-        isNetworkTrackingEnabled = true
+        state.withLock { $0.isNetworkTrackingEnabled = true }
     }
 
     func enableNetworkBreadcrumbs() {
-        isNetworkBreadcrumbEnabled = true
+        state.withLock { $0.isNetworkBreadcrumbEnabled = true }
     }
 
     func enableCaptureFailedRequests() {
-        isCaptureFailedRequestsEnabled = true
+        state.withLock { $0.isCaptureFailedRequestsEnabled = true }
     }
 
     func enableGraphQLOperationTracking() {
-        isGraphQLOperationTrackingEnabled = true
+        state.withLock { $0.isGraphQLOperationTrackingEnabled = true }
     }
 
     func disable() {
-        isNetworkTrackingEnabled = false
-        isNetworkBreadcrumbEnabled = false
-        isCaptureFailedRequestsEnabled = false
-        isGraphQLOperationTrackingEnabled = false
+        state.withLock { state in
+            state.isNetworkTrackingEnabled = false
+            state.isNetworkBreadcrumbEnabled = false
+            state.isCaptureFailedRequestsEnabled = false
+            state.isGraphQLOperationTrackingEnabled = false
+        }
+    }
+
+    var isNetworkTrackingEnabled: Bool {
+        state.withLock { $0.isNetworkTrackingEnabled }
+    }
+
+    var isNetworkBreadcrumbEnabled: Bool {
+        state.withLock { $0.isNetworkBreadcrumbEnabled }
+    }
+
+    var isCaptureFailedRequestsEnabled: Bool {
+        state.withLock { $0.isCaptureFailedRequestsEnabled }
+    }
+
+    var isGraphQLOperationTrackingEnabled: Bool {
+        state.withLock { $0.isGraphQLOperationTrackingEnabled }
     }
 
     // MARK: - URL Session Handling
@@ -110,6 +133,8 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             return
         }
 
+        let featureState = state.withLock { $0 }
+
         let isUntracked = sessionTask.withNetworkTrackerState { state in
             guard case .idle = state.spanState else {
                 return false
@@ -125,7 +150,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         }
 
         // Register the request start date only on first resume so suspend/resume cycles preserve it.
-        if isNetworkBreadcrumbEnabled {
+        if featureState.isNetworkBreadcrumbEnabled {
             let startDate = dateProvider.date()
             sessionTask.withNetworkTrackerState {
                 if $0.startDate == nil {
@@ -134,7 +159,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             }
         }
 
-        guard isNetworkTrackingEnabled else {
+        guard featureState.isNetworkTrackingEnabled else {
             addTraceWithoutTransaction(to: sessionTask)
             return
         }
@@ -235,7 +260,10 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     }
 
     func urlSessionTask(_ sessionTask: URLSessionTask, setState newState: URLSessionTask.State) {
-        if !isNetworkTrackingEnabled && !isNetworkBreadcrumbEnabled && !isCaptureFailedRequestsEnabled {
+        let featureState = state.withLock { $0 }
+        if !featureState.isNetworkTrackingEnabled
+            && !featureState.isNetworkBreadcrumbEnabled
+            && !featureState.isCaptureFailedRequestsEnabled {
             return
         }
 
@@ -301,8 +329,8 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         //   - running → completed/canceling (normal completion or cancellation)
         //   - suspended → canceling (task cancelled while suspended)
         if sessionTask.state == .running || sessionTask.state == .suspended {
-            captureFailedRequest(for: sessionTask, currentRequest: currentRequest, options: options)
-            addBreadcrumb(for: sessionTask, currentRequest: currentRequest, options: options)
+            captureFailedRequest(for: sessionTask, currentRequest: currentRequest, options: options, featureState: featureState)
+            addBreadcrumb(for: sessionTask, currentRequest: currentRequest, options: options, featureState: featureState)
 
         }
 
@@ -351,8 +379,13 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
 
     // MARK: - Failed requests
 
-    private func captureFailedRequest(for sessionTask: URLSessionTask, currentRequest: URLRequest, options: Options) {
-        guard isCaptureFailedRequestsEnabled else {
+    private func captureFailedRequest(
+        for sessionTask: URLSessionTask,
+        currentRequest: URLRequest,
+        options: Options,
+        featureState: NetworkTrackerState
+    ) {
+        guard featureState.isCaptureFailedRequestsEnabled else {
             SentrySDKLog.debug("captureFailedRequestsEnabled is disabled, not capturing HTTP Client errors.")
             return
         }
@@ -451,7 +484,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         }
 
         var context: [String: [String: Any]] = ["response": responseContext]
-        if isGraphQLOperationTrackingEnabled,
+        if featureState.isGraphQLOperationTrackingEnabled,
            let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: sessionTask) {
             context["graphql"] = ["operation_name": operationName]
         }
@@ -469,8 +502,13 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     // MARK: - Breadcrumbs
 
     // swiftlint:disable:next function_body_length
-    private func addBreadcrumb(for sessionTask: URLSessionTask, currentRequest: URLRequest, options: Options) {
-        guard isNetworkBreadcrumbEnabled else {
+    private func addBreadcrumb(
+        for sessionTask: URLSessionTask,
+        currentRequest: URLRequest,
+        options: Options,
+        featureState: NetworkTrackerState
+    ) {
+        guard featureState.isNetworkBreadcrumbEnabled else {
             return
         }
 
@@ -513,7 +551,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             data["status_code"] = responseStatusCode
             data["reason"] = HTTPURLResponse.localizedString(forStatusCode: responseStatusCode)
 
-            if isGraphQLOperationTrackingEnabled,
+            if featureState.isGraphQLOperationTrackingEnabled,
                let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: sessionTask) {
                 data["graphql_operation_name"] = operationName
             }

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -40,12 +40,17 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     private let hub: Hub
     private let threadInspector: SentryThreadInspector
 
-    // We accept races when toggling these flags to avoid acquiring locks for many parallel HTTP
-    // requests. This matches the Objective-C implementation's deliberate performance tradeoff.
-    private(set) var isNetworkTrackingEnabled = false
-    private(set) var isNetworkBreadcrumbEnabled = false
-    private(set) var isCaptureFailedRequestsEnabled = false
-    private(set) var isGraphQLOperationTrackingEnabled = false
+    // All network tracker feature flags share a single synchronization boundary so that hot paths
+    // observing several flags read one consistent snapshot, and disable() resets the whole set
+    // atomically. See https://github.com/getsentry/sentry-cocoa/issues/8592.
+    private struct NetworkTrackerState {
+        var isNetworkTrackingEnabled = false
+        var isNetworkBreadcrumbEnabled = false
+        var isCaptureFailedRequestsEnabled = false
+        var isGraphQLOperationTrackingEnabled = false
+    }
+
+    private let state = SentryMutex(NetworkTrackerState())
 
     // MARK: - Initializers
 
@@ -58,26 +63,44 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     // MARK: - Public API
 
     func enableNetworkTracking() {
-        isNetworkTrackingEnabled = true
+        state.withLock { $0.isNetworkTrackingEnabled = true }
     }
 
     func enableNetworkBreadcrumbs() {
-        isNetworkBreadcrumbEnabled = true
+        state.withLock { $0.isNetworkBreadcrumbEnabled = true }
     }
 
     func enableCaptureFailedRequests() {
-        isCaptureFailedRequestsEnabled = true
+        state.withLock { $0.isCaptureFailedRequestsEnabled = true }
     }
 
     func enableGraphQLOperationTracking() {
-        isGraphQLOperationTrackingEnabled = true
+        state.withLock { $0.isGraphQLOperationTrackingEnabled = true }
     }
 
     func disable() {
-        isNetworkTrackingEnabled = false
-        isNetworkBreadcrumbEnabled = false
-        isCaptureFailedRequestsEnabled = false
-        isGraphQLOperationTrackingEnabled = false
+        state.withLock { state in
+            state.isNetworkTrackingEnabled = false
+            state.isNetworkBreadcrumbEnabled = false
+            state.isCaptureFailedRequestsEnabled = false
+            state.isGraphQLOperationTrackingEnabled = false
+        }
+    }
+
+    var isNetworkTrackingEnabled: Bool {
+        state.withLock { $0.isNetworkTrackingEnabled }
+    }
+
+    var isNetworkBreadcrumbEnabled: Bool {
+        state.withLock { $0.isNetworkBreadcrumbEnabled }
+    }
+
+    var isCaptureFailedRequestsEnabled: Bool {
+        state.withLock { $0.isCaptureFailedRequestsEnabled }
+    }
+
+    var isGraphQLOperationTrackingEnabled: Bool {
+        state.withLock { $0.isGraphQLOperationTrackingEnabled }
     }
 
     // MARK: - URL Session Handling
@@ -110,8 +133,10 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             return
         }
 
+        let featureState = state.withLock { $0 }
+
         // Register the request start date only on first resume so suspend/resume cycles preserve it.
-        if isNetworkBreadcrumbEnabled {
+        if featureState.isNetworkBreadcrumbEnabled {
             let startDate = dateProvider.date()
             sessionTask.withNetworkTrackerState {
                 if $0.startDate == nil {
@@ -120,7 +145,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             }
         }
 
-        guard isNetworkTrackingEnabled else {
+        guard featureState.isNetworkTrackingEnabled else {
             addTraceWithoutTransaction(to: sessionTask)
             return
         }
@@ -221,7 +246,10 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     }
 
     func urlSessionTask(_ sessionTask: URLSessionTask, setState newState: URLSessionTask.State) {
-        if !isNetworkTrackingEnabled && !isNetworkBreadcrumbEnabled && !isCaptureFailedRequestsEnabled {
+        let featureState = state.withLock { $0 }
+        if !featureState.isNetworkTrackingEnabled
+            && !featureState.isNetworkBreadcrumbEnabled
+            && !featureState.isCaptureFailedRequestsEnabled {
             return
         }
 
@@ -283,8 +311,8 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         //   - running → completed/canceling (normal completion or cancellation)
         //   - suspended → canceling (task cancelled while suspended)
         if sessionTask.state == .running || sessionTask.state == .suspended {
-            captureFailedRequest(for: sessionTask, currentRequest: currentRequest, options: options)
-            addBreadcrumb(for: sessionTask, currentRequest: currentRequest, options: options)
+            captureFailedRequest(for: sessionTask, currentRequest: currentRequest, options: options, featureState: featureState)
+            addBreadcrumb(for: sessionTask, currentRequest: currentRequest, options: options, featureState: featureState)
 
         }
 
@@ -333,8 +361,13 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
 
     // MARK: - Failed requests
 
-    private func captureFailedRequest(for sessionTask: URLSessionTask, currentRequest: URLRequest, options: Options) {
-        guard isCaptureFailedRequestsEnabled else {
+    private func captureFailedRequest(
+        for sessionTask: URLSessionTask,
+        currentRequest: URLRequest,
+        options: Options,
+        featureState: NetworkTrackerState
+    ) {
+        guard featureState.isCaptureFailedRequestsEnabled else {
             SentrySDKLog.debug("captureFailedRequestsEnabled is disabled, not capturing HTTP Client errors.")
             return
         }
@@ -433,7 +466,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         }
 
         var context: [String: [String: Any]] = ["response": responseContext]
-        if isGraphQLOperationTrackingEnabled,
+        if featureState.isGraphQLOperationTrackingEnabled,
            let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: sessionTask) {
             context["graphql"] = ["operation_name": operationName]
         }
@@ -451,8 +484,13 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
     // MARK: - Breadcrumbs
 
     // swiftlint:disable:next function_body_length
-    private func addBreadcrumb(for sessionTask: URLSessionTask, currentRequest: URLRequest, options: Options) {
-        guard isNetworkBreadcrumbEnabled else {
+    private func addBreadcrumb(
+        for sessionTask: URLSessionTask,
+        currentRequest: URLRequest,
+        options: Options,
+        featureState: NetworkTrackerState
+    ) {
+        guard featureState.isNetworkBreadcrumbEnabled else {
             return
         }
 
@@ -495,7 +533,7 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
             data["status_code"] = responseStatusCode
             data["reason"] = HTTPURLResponse.localizedString(forStatusCode: responseStatusCode)
 
-            if isGraphQLOperationTrackingEnabled,
+            if featureState.isGraphQLOperationTrackingEnabled,
                let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: sessionTask) {
                 data["graphql_operation_name"] = operationName
             }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -196,6 +196,50 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertTrue(breadcrumbs?.isEmpty ?? true)
     }
 
+    func testDisableDisablesAllFeatureFlags() {
+        let sut = fixture.getSut()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertTrue(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertTrue(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertTrue(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.disable()
+
+        XCTAssertFalse(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+    }
+
+    func testFeatureFlagsCanBeEnabledIndependently() {
+        let sut = TestNetworkTracker(
+            options: fixture.options,
+            dependencies: SentryDependencyContainer.sharedInstance()
+        )
+
+        XCTAssertFalse(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.enableNetworkTracking()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.enableNetworkBreadcrumbs()
+        sut.enableCaptureFailedRequests()
+        sut.enableGraphQLOperationTracking()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertTrue(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertTrue(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertTrue(sut.isGraphQLOperationTrackingEnabled)
+    }
+
     func testDisabledTracker() throws {
         let sut = fixture.getSut()
         sut.disable()

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -176,6 +176,50 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertTrue(breadcrumbs?.isEmpty ?? true)
     }
 
+    func testDisableDisablesAllFeatureFlags() {
+        let sut = fixture.getSut()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertTrue(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertTrue(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertTrue(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.disable()
+
+        XCTAssertFalse(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+    }
+
+    func testFeatureFlagsCanBeEnabledIndependently() {
+        let sut = TestNetworkTracker(
+            options: fixture.options,
+            dependencies: SentryDependencyContainer.sharedInstance()
+        )
+
+        XCTAssertFalse(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.enableNetworkTracking()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertFalse(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertFalse(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertFalse(sut.isGraphQLOperationTrackingEnabled)
+
+        sut.enableNetworkBreadcrumbs()
+        sut.enableCaptureFailedRequests()
+        sut.enableGraphQLOperationTracking()
+
+        XCTAssertTrue(sut.isNetworkTrackingEnabled)
+        XCTAssertTrue(sut.isNetworkBreadcrumbEnabled)
+        XCTAssertTrue(sut.isCaptureFailedRequestsEnabled)
+        XCTAssertTrue(sut.isGraphQLOperationTrackingEnabled)
+    }
+
     func testDisabledTracker() throws {
         let sut = fixture.getSut()
         sut.disable()


### PR DESCRIPTION
## 📜 Description

Synchronize `SentryDefaultNetworkTracker` feature flags using a single `SentryMutex`-protected state.

The four network tracker feature flags now share one synchronization boundary, and URL session hot paths take a single snapshot of that state instead of repeatedly locking for individual reads.

`disable()` also resets all feature flags under the same lock.

## 💡 Motivation and Context

`SentryDefaultNetworkTracker` previously used unsynchronized `Bool` properties for its feature flags and intentionally accepted races to avoid locking on parallel HTTP requests.

This change removes those unsynchronized reads and writes while keeping the hot path lightweight by reusing one state snapshot per callback.

It addresses the **Synchronize network tracker feature flags** task from getsentry/sentry-cocoa#8592.

Refs getsentry/sentry-cocoa#8592

## 💚 How did you test it?

* **Functional tests:** added `testDisableDisablesAllFeatureFlags` and<br>`testFeatureFlagsCanBeEnabledIndependently` to `SentryNetworkTrackerTests`,<br>verifying `disable()` resets all flags and each `enable*()` toggles only its<br>own flag. These are behavior-preservation tests for the synchronization<br>refactor, not race tests. Full `SentryNetworkTrackerTests` suite passes<br>(96 tests, 0 failures).
* **Thread Sanitizer:** ran the network tracker tests (including the concurrent<br>resume/setState race test) with `-enableThreadSanitizer YES` on the branch —<br>no ThreadSanitizer warnings observed. (A prior stress test did not reproduce<br>a TSAN race on the old implementation either, so this is additional<br>validation, not a claim of a reproduced-then-fixed race.)
* **Parallel throughput A/B benchmark:** built a temporary harness measuring<br>the disabled-feature early-return hot path of `urlSessionTask(_:setState:)`<br>(worst case: the callback does little beyond acquiring the snapshot). Same<br>machine, same Xcode 26.6 / Swift 6.3.3, same `Test` config, TSAN off, one<br>task per worker reused across 100,000 iterations/worker, 5 samples + warm-up,<br>median reported. Baseline (`main`, unsynchronized Bools) vs synchronized<br>branch (`SentryMutex<NetworkTrackerState>`):

  <!-- linear:table-colwidths:200,200,200,200 -->
  | Workers | Baseline ops/s | Synchronized ops/s | Delta |
  | -- | -- | -- | -- |
  |  | 6,866,070 | 6,197,364 | 9.7% |
  |  | 2,547,070 | 2,173,274 | 4.7% |
  |  | 1,192,982 | 1,699,008 | 2.4% |
  |  | 1,407,834 | 1,695,412 | 0.4% |

  (w2 omitted from the table: the baseline median there is dominated by<br>outliers spanning 4.5M–11.7M ops/s and is not a stable comparison point.)

  Added per-call cost in the worst-case disabled path is \~16 ns (\~10% at a<br>single worker). The synchronized results are stable to \~3% run-to-run at<br>every worker count, while the baseline swings up to 2×. Under parallel load<br>(w8/w16) the single-mutex design is both faster and far less noisy than the<br>unsynchronized reads. Real network processing (span/breadcrumb/event work)<br>dilutes the snapshot cost to a negligible fraction. The benchmark was<br>temporary and is not included in this PR.

<details><summary>Throughput benchmark (not committed — run locally to reproduce A/B)</summary>

This is a temporary harness used to measure synchronization overhead on the worst-case hot path. It is not part of the PR. To reproduce the measurements, paste it into `SentryNetworkTrackerTests`, run it on `main` and on this branch with identical settings, then remove it.

### Methodology

* All feature flags are disabled, so the callback hits the early-return path and does almost nothing except obtain the feature-state snapshot. This makes synchronization overhead intentionally visible rather than diluting it with span, breadcrumb, or event processing.
* One task is created per worker and reused within that worker. This avoids allocation noise without introducing contention on a single shared task.
* Thread Sanitizer is disabled for performance measurements.
* Five measured samples are collected for each worker count, with an additional warm-up before each sample.
* The median throughput is reported.
* Both `main` and this branch are measured on the same machine, with the same Xcode/Swift versions and `Test` configuration.

### Temporary benchmark

```swift
// MARK: - TEMPORARY benchmark (#8592)
// Measures the disabled-feature early-return hot path of urlSessionTask(_:setState:).
// Worst case: the callback does little beyond acquiring the state snapshot, so the
// synchronization cost is not diluted by span/breadcrumb/event work.

private func benchmarkDisabledTracker(
    workers: Int,
    iterationsPerWorker: Int,
    sut: TestNetworkTracker
) -> Double {
    // One task per worker, reused within the worker: avoids allocation noise while
    // avoiding unrelated shared-task contention across workers.
    let tasks = (0..<workers).map { _ in createDataTask() }

    // Warm-up sample (discarded).
    DispatchQueue.concurrentPerform(iterations: workers) { worker in
        let task = tasks[worker]
        for _ in 0..<(iterationsPerWorker / 10) {
            sut.urlSessionTask(task, setState: .completed)
        }
    }

    let start = CFAbsoluteTimeGetCurrent()

    DispatchQueue.concurrentPerform(iterations: workers) { worker in
        let task = tasks[worker]
        for _ in 0..<iterationsPerWorker {
            sut.urlSessionTask(task, setState: .completed)
        }
    }

    let elapsed = CFAbsoluteTimeGetCurrent() - start

    return Double(workers * iterationsPerWorker) / elapsed
}

func testBENCHMARK_DisabledTrackerThroughput() {
    let workersList = [1, 2, 4, 8, 16]
    let iterationsPerWorker = 100_000
    let sampleCount = 5

    // Fresh SUT — all four flags disabled by default (no enable calls).
    let sut = TestNetworkTracker(
        options: fixture.options,
        dependencies: SentryDependencyContainer.sharedInstance()
    )

    var report = "\n=== BENCHMARK: disabled tracker early-return path ===\n"
    report += "workers | samples(ops/s) | median\n"

    for workers in workersList {
        var samples: [Double] = []

        for _ in 0..<sampleCount {
            samples.append(
                benchmarkDisabledTracker(
                    workers: workers,
                    iterationsPerWorker: iterationsPerWorker,
                    sut: sut
                )
            )
        }

        samples.sort()

        let median = samples[samples.count / 2]
        let minV = samples.first ?? 0
        let maxV = samples.last ?? 0

        report += String(
            format: "%d | min=%.0f med=%.0f max=%.0f | med=%.0f\n",
            workers,
            minV,
            median,
            maxV,
            median
        )
    }

    report += "=== END BENCHMARK ===\n"

    print(report)
    XCTAssertTrue(true)
}
```

</details>

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] If I added a new public API, I also added it to the [SentryObjC wrapper](<../develop-docs/SENTRY-OBJC.md>).