### PR TITLE
fix: false app hangs when app stops rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 - Remove `options.enableLogs` to remove explicit opt-in for Logs. If you need to disable logs, use `beforeSendLog` to drop all logs (#8769)
 - Remove `options.enableMetrics` to remove opt-out of Metrics. If you need to disable metrics, use `beforeSendMetric` to drop all metrics (#8785)
 
+### Fixes
+
+- Fix false fully-blocking app hang reports when the app stops rendering while staying active, e.g. a CarPlay scene keeping the app alive while the phone is locked, or the proximity sensor blanking the screen during a call (#8840)
+- Exclude time without frame delay data and app suspension time from reported app hang durations (#8840)
+
 ## 9.26.0
 
 > [!WARNING]

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -34,6 +34,37 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     SentryANRTrackerState state;
 }
 
+/**
+ * Returns the frames delay to trust for hang classification, and via @c trustedFramesCount the
+ * matching frames count when passed non NULL.
+ *
+ * When the main thread drains its queue, the run loop turns, and an active display link fires
+ * within roughly one frame duration afterwards. So when the main thread is responsive, an ongoing
+ * frame gap larger than the @c sleepInterval means the app isn't rendering although the main
+ * thread isn't blocked, and the ongoing frame's delay must be ignored. Recorded delayed frames
+ * stay trusted because they actually rendered. The ongoing frame always contributes one frame to
+ * @c framesContributingToDelayCount (see @c getFramesDelayObjC), so ignoring its delay also
+ * removes it from the trusted frames count.
+ */
+static CFTimeInterval
+getTrustedFramesDelayDuration(SentryFramesDelayResultSPI *framesDelay,
+    BOOL isMainThreadUnresponsive, NSTimeInterval sleepInterval,
+    NSUInteger *_Nullable trustedFramesCount)
+{
+    CFTimeInterval delayDuration = framesDelay.delayDuration;
+    NSUInteger framesCount = framesDelay.framesContributingToDelayCount;
+
+    if (!isMainThreadUnresponsive && framesDelay.ongoingFrameDelayDuration > sleepInterval) {
+        delayDuration -= framesDelay.ongoingFrameDelayDuration;
+        framesCount -= 1;
+    }
+
+    if (trustedFramesCount != NULL) {
+        *trustedFramesCount = framesCount;
+    }
+    return delayDuration;
+}
+
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
 {
     return [self
@@ -84,6 +115,10 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 
     BOOL reported = NO;
 
+    // Ticks since the main thread last drained the main queue. When the ticks reach the
+    // reportThreshold the main thread is treated as unresponsive; see the heartbeat block below.
+    __block atomic_int ticksSinceLastMainQueueDrain = 0;
+
     NSInteger reportThreshold = 5;
     NSTimeInterval sleepInterval = self.timeoutInterval / reportThreshold;
     uint64_t sleepIntervalInNanos = timeIntervalToNanoseconds(sleepInterval);
@@ -96,12 +131,12 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     uint64_t lastAppHangStoppedSystemTime = dateProvider.systemTime - timeoutIntervalInNanos;
     uint64_t lastAppHangStartedSystemTime = 0;
 
-    // Track background time to exclude from hang duration calculation.
-    // When the app goes to background during a hang, we don't want to include
-    // the background time in the reported duration.
-    BOOL wasInBackground = NO;
-    uint64_t wentToBackgroundSystemTime = 0;
-    uint64_t accumulatedBackgroundTime = 0;
+    // Track time to exclude from the hang duration calculation. While the app is in the
+    // background, the frames tracker can't provide frame delay data, e.g. because it's paused, or
+    // the OS suspends the app, the app can't be hanging, but the system time keeps ticking.
+    BOOL isExcludingTime = NO;
+    uint64_t excludedTimeStartSystemTime = 0;
+    uint64_t accumulatedExcludedTime = 0;
 
     // Canceling the thread can take up to sleepInterval.
     while (YES) {
@@ -112,6 +147,16 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         }
 
         NSDate *sleepDeadline = [[dateProvider date] dateByAddingTimeInterval:self.timeoutInterval];
+
+        // Frame delay data alone can't distinguish a blocked main thread from an app that
+        // legitimately stopped rendering while staying active, e.g. a CarPlay scene keeping the
+        // app alive while the phone is locked, or the proximity sensor blanking the screen; see
+        // https://github.com/getsentry/sentry-cocoa/issues/8317. This heartbeat provides the
+        // missing signal: when the main thread drains its queue, it isn't blocked.
+        atomic_fetch_add_explicit(&ticksSinceLastMainQueueDrain, 1, memory_order_relaxed);
+        [self.dispatchQueueWrapper dispatchAsyncOnMainQueueIfNotMainThread:^{
+            atomic_store_explicit(&ticksSinceLastMainQueueDrain, 0, memory_order_relaxed);
+        }];
 
         [self.threadWrapper sleepForTimeInterval:sleepInterval];
 
@@ -126,22 +171,14 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         if (!isInForeground) {
             SENTRY_LOG_DEBUG(@"Ignoring potential app hangs because the app is in the background");
 
-            // Track when the app goes to background during an ongoing hang.
-            // This is needed to exclude background time from the hang duration.
-            if (reported && !wasInBackground) {
-                wasInBackground = YES;
-                wentToBackgroundSystemTime = dateProvider.systemTime;
+            // Start excluding time from the hang duration. Background time is one of three
+            // exclusion causes; see the declaration of isExcludingTime.
+            if (reported && !isExcludingTime) {
+                isExcludingTime = YES;
+                excludedTimeStartSystemTime = dateProvider.systemTime;
             }
 
             continue;
-        }
-
-        // App is in foreground - check if we're returning from background during a hang.
-        // Accumulate the time spent in background so we can exclude it from the duration.
-        if (reported && wasInBackground) {
-            uint64_t backgroundTime = dateProvider.systemTime - wentToBackgroundSystemTime;
-            accumulatedBackgroundTime += backgroundTime;
-            wasInBackground = NO;
         }
 
         // The sleepDeadline should be roughly executed after the timeoutInterval even if there is
@@ -153,10 +190,22 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         if (deltaFromNowToSleepDeadline >= self.timeoutInterval) {
             SENTRY_LOG_DEBUG(@"Ignoring App Hang because the delta is too big: %f.",
                 deltaFromNowToSleepDeadline);
+
+            // The thread slept way longer than expected, e.g. because the OS suspended the app.
+            // Exclude the extra sleep time from the hang duration. When already excluding time,
+            // the ongoing excluded time span covers the extra sleep time.
+            if (reported && !isExcludingTime) {
+                accumulatedExcludedTime += timeIntervalToNanoseconds(
+                    deltaFromNowToSleepDeadline + self.timeoutInterval - sleepInterval);
+            }
             continue;
         }
 
         uint64_t nowSystemTime = dateProvider.systemTime;
+
+        int mainQueueDrainTicks
+            = atomic_load_explicit(&ticksSinceLastMainQueueDrain, memory_order_relaxed);
+        BOOL isMainThreadUnresponsive = mainQueueDrainTicks >= reportThreshold;
 
         if (reported) {
 
@@ -167,10 +216,25 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
                                    endSystemTimestamp:nowSystemTime];
 
             if (framesDelay.delayDuration == -1) {
+                // Without frame delay data, e.g. because the frames tracker is paused after the
+                // app resigned active, the app can't be hanging. Exclude that time from the hang
+                // duration.
+                if (!isExcludingTime) {
+                    isExcludingTime = YES;
+                    excludedTimeStartSystemTime = nowSystemTime;
+                }
                 continue;
             }
 
-            BOOL appHangStopped = framesDelay.delayDuration < appHangStoppedFrameDelayThreshold;
+            if (isExcludingTime) {
+                accumulatedExcludedTime += nowSystemTime - excludedTimeStartSystemTime;
+                isExcludingTime = NO;
+            }
+
+            CFTimeInterval framesDelayDuration = getTrustedFramesDelayDuration(
+                framesDelay, isMainThreadUnresponsive, sleepInterval, NULL);
+
+            BOOL appHangStopped = framesDelayDuration < appHangStoppedFrameDelayThreshold;
 
             if (appHangStopped) {
                 SENTRY_LOG_DEBUG(@"App hang stopped.");
@@ -179,14 +243,15 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
                 // hanging for almost the sleepInterval until we detect it and it could already
                 // stopped hanging almost a sleepInterval until we again detect it's not.
                 //
-                // Subtract any time spent in background during the hang.
-                // When the app goes to background during a hang, the system time continues
-                // to tick, but we don't want to include that time in the reported duration.
+                // Subtract any time during which the app couldn't have been hanging, such as
+                // time in background, without frame delay data, or while the OS suspended the
+                // app. The system time continues to tick during that time, but we don't want to
+                // include it in the reported duration.
                 uint64_t elapsedSystemTime = nowSystemTime - lastAppHangStartedSystemTime;
-                uint64_t foregroundElapsedTime = elapsedSystemTime > accumulatedBackgroundTime
-                    ? elapsedSystemTime - accumulatedBackgroundTime
+                uint64_t observedElapsedTime = elapsedSystemTime > accumulatedExcludedTime
+                    ? elapsedSystemTime - accumulatedExcludedTime
                     : 0;
-                uint64_t appHangDurationNanos = timeoutIntervalInNanos + foregroundElapsedTime;
+                uint64_t appHangDurationNanos = timeoutIntervalInNanos + observedElapsedTime;
 
                 NSTimeInterval appHangDurationMinimum
                     = nanosecondsToTimeInterval(appHangDurationNanos - sleepIntervalInNanos);
@@ -195,8 +260,8 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 
                 lastAppHangStoppedSystemTime = nowSystemTime;
                 reported = NO;
-                wasInBackground = NO;
-                accumulatedBackgroundTime = 0;
+                isExcludingTime = NO;
+                accumulatedExcludedTime = 0;
 
                 // The App Hang stopped, don't block the App Hangs thread or the main thread with
                 // calling ANRStopped listeners.
@@ -226,10 +291,13 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
             continue;
         }
 
-        uint64_t framesDelayForTimeIntervalInNanos
-            = timeIntervalToNanoseconds(framesDelayForTimeInterval.delayDuration);
+        NSUInteger framesContributingToDelayCount;
+        CFTimeInterval delayDuration = getTrustedFramesDelayDuration(framesDelayForTimeInterval,
+            isMainThreadUnresponsive, sleepInterval, &framesContributingToDelayCount);
 
-        BOOL isFullyBlocking = framesDelayForTimeInterval.framesContributingToDelayCount == 1;
+        uint64_t framesDelayForTimeIntervalInNanos = timeIntervalToNanoseconds(delayDuration);
+
+        BOOL isFullyBlocking = framesContributingToDelayCount == 1;
 
         if (isFullyBlocking && framesDelayForTimeIntervalInNanos >= timeoutIntervalInNanos) {
             SENTRY_LOG_WARN(@"App Hang detected: fully-blocking.");
@@ -240,8 +308,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         }
 
         NSTimeInterval nonFullyBlockingFramesDelayThreshold = self.timeoutInterval * 0.99;
-        if (!isFullyBlocking
-            && framesDelayForTimeInterval.delayDuration > nonFullyBlockingFramesDelayThreshold) {
+        if (!isFullyBlocking && delayDuration > nonFullyBlockingFramesDelayThreshold) {
 
             SENTRY_LOG_WARN(@"App Hang detected: non-fully-blocking.");
 

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -14,10 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDelayDuration:(CFTimeInterval)delayDuration
        framesContributingToDelayCount:(NSUInteger)frames
+            ongoingFrameDelayDuration:(CFTimeInterval)ongoingFrameDelayDuration
 {
     if (self = [super init]) {
         _delayDuration = delayDuration;
         _framesContributingToDelayCount = frames;
+        _ongoingFrameDelayDuration = ongoingFrameDelayDuration;
         return self;
     }
     return nil;
@@ -145,7 +147,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryFramesDelayResultObjC *cantCalculateFrameDelayReturnValue =
         [[SentryFramesDelayResultObjC alloc] initWithDelayDuration:-1.0
-                                    framesContributingToDelayCount:0];
+                                    framesContributingToDelayCount:0
+                                         ongoingFrameDelayDuration:-1.0];
 
     if (isRunning == NO) {
         SENTRY_LOG_DEBUG(@"Not calculating frames delay because frames tracker isn't running.");
@@ -216,6 +219,9 @@ NS_ASSUME_NONNULL_BEGIN
     NSDateInterval *queryDateInterval = [[NSDateInterval alloc] initWithStartDate:startDate
                                                                           endDate:endDate];
 
+    CFTimeInterval ongoingFrameDelay = [self calculateDelay:currentFrameDelay
+                                          queryDateInterval:queryDateInterval];
+
     CFTimeInterval delay = 0.0;
     NSUInteger framesCount = 0;
 
@@ -235,7 +241,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     SentryFramesDelayResultObjC *data =
         [[SentryFramesDelayResultObjC alloc] initWithDelayDuration:delay
-                                    framesContributingToDelayCount:framesCount];
+                                    framesContributingToDelayCount:framesCount
+                                         ongoingFrameDelayDuration:ongoingFrameDelay];
 
     return data;
 }

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -11,6 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CFTimeInterval delayDuration;
 @property (nonatomic, readonly) NSUInteger framesContributingToDelayCount;
 
+/**
+ * The part of @c delayDuration stemming from the ongoing, not yet recorded frame. This is only an
+ * assumption, because the app may not be rendering at all, e.g. when the screen is off. The
+ * ongoing frame always contributes one frame to @c framesContributingToDelayCount. This is -1
+ * when the frames delay can't be calculated; check @c delayDuration first.
+ */
+@property (nonatomic, readonly) CFTimeInterval ongoingFrameDelayDuration;
+
 @end
 
 @interface SentryDelayedFramesTracker : NSObject

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesDelayResult.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesDelayResult.swift
@@ -5,10 +5,16 @@ final class SentryFramesDelayResult {
     /// The frames delay for the passed time period. If frame delay can't be calculated this is -1.
     let delayDuration: CFTimeInterval
     let framesContributingToDelayCount: UInt
+    /// The part of `delayDuration` stemming from the ongoing, not yet recorded frame. This is only
+    /// an assumption, because the app may not be rendering at all, e.g. when the screen is off.
+    /// The ongoing frame always contributes one frame to `framesContributingToDelayCount`. This is
+    /// -1 when the frames delay can't be calculated; check `delayDuration` first.
+    let ongoingFrameDelayDuration: CFTimeInterval
 
-    init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt) {
+    init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt, ongoingFrameDelayDuration: CFTimeInterval) {
         self.delayDuration = delayDuration
         self.framesContributingToDelayCount = framesContributingToDelayCount
+        self.ongoingFrameDelayDuration = ongoingFrameDelayDuration
     }
 }
 
@@ -18,10 +24,12 @@ final class SentryFramesDelayResult {
 @_spi(Private) public final class SentryFramesDelayResultSPI: NSObject {
     @objc public let delayDuration: CFTimeInterval
     @objc public let framesContributingToDelayCount: UInt
+    @objc public let ongoingFrameDelayDuration: CFTimeInterval
 
-    init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt) {
+    init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt, ongoingFrameDelayDuration: CFTimeInterval) {
         self.delayDuration = delayDuration
         self.framesContributingToDelayCount = framesContributingToDelayCount
+        self.ongoingFrameDelayDuration = ongoingFrameDelayDuration
     }
 }
 // swiftlint:enable missing_docs

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesTracker.swift
@@ -189,7 +189,7 @@ public class SentryFramesTracker: NSObject {
         endSystemTimestamp: UInt64
     ) -> SentryFramesDelayResultSPI {
         let result = getFramesDelay(startSystemTimestamp, endSystemTimestamp: endSystemTimestamp)
-        return .init(delayDuration: result.delayDuration, framesContributingToDelayCount: result.framesContributingToDelayCount)
+        return .init(delayDuration: result.delayDuration, framesContributingToDelayCount: result.framesContributingToDelayCount, ongoingFrameDelayDuration: result.ongoingFrameDelayDuration)
     }
 
     // The add/remove pair below is shaped so the dispatched closures never

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -28,7 +28,7 @@ extension SentryFileManager: SentryFileManagerProtocol { }
 @_spi(Private) extension SentryDelayedFramesTracker: SentryDelayedFramesTrackerWrapper {
     func getFramesDelay(_ startSystemTimestamp: UInt64, endSystemTimestamp: UInt64, isRunning: Bool, slowFrameThreshold: CFTimeInterval) -> SentryFramesDelayResult {
         let objcResult = getFramesDelayObjC(startSystemTimestamp, endSystemTimestamp: endSystemTimestamp, isRunning: isRunning, slowFrameThreshold: slowFrameThreshold)
-        return .init(delayDuration: objcResult.delayDuration, framesContributingToDelayCount: objcResult.framesContributingToDelayCount)
+        return .init(delayDuration: objcResult.delayDuration, framesContributingToDelayCount: objcResult.framesContributingToDelayCount, ongoingFrameDelayDuration: objcResult.ongoingFrameDelayDuration)
     }
 }
 #endif

--- a/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/AppHangTracking/SentryANRTrackerV2Tests.swift
@@ -2,19 +2,23 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
+// swiftlint:disable file_length
+
 #if os(iOS) || os(tvOS)
 
 final class SentryANRTrackerV2Tests: XCTestCase {
     
     private let waitTimeout: TimeInterval = 10.0
     private var timeoutInterval: TimeInterval = 2
-        
+    private var dispatchQueue: TestSentryDispatchQueueWrapper!
+
     private func getSut() throws -> (SentryANRTracker, TestCurrentDateProvider, TestDisplayLinkWrapper, TestSentryApplicationStateProvider, SentryTestThreadWrapper, SentryFramesTracker) {
-        
+
         let currentDate = TestCurrentDateProvider()
-        
+
         let applicationStateProvider = TestSentryApplicationStateProvider()
         let dispatchQueue = TestSentryDispatchQueueWrapper()
+        self.dispatchQueue = dispatchQueue
         let threadWrapper = SentryTestThreadWrapper()
         
         let displayLinkWrapper = TestDisplayLinkWrapper(dateProvider: currentDate)
@@ -47,7 +51,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testFullyBlockingAppHang_Reported() throws {
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: listener)
         
@@ -78,7 +84,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         timeoutInterval = 5.0
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: listener)
         
@@ -109,7 +117,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         timeoutInterval = 0.5
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: listener)
         
@@ -144,7 +154,10 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testNonFullyBlockingAppHang_Reported() throws {
         let (sut, _, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        // This test intentionally keeps the main thread responsive: recorded slow frames
+        // must trigger a non fully blocking app hang even when the heartbeat is alive.
+
         let listener = SentryANRTrackerV2TestDelegate()
         
         sut.add(listener: listener)
@@ -194,7 +207,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testAlmostFullyBlockingAppHang_NoneReported() throws {
         let (sut, dateProvider, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         sut.add(listener: listener)
@@ -220,7 +235,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testFullyBlockingFollowedByNonFullyBlocking_OnlyFirstReported() throws {
         let (sut, dateProvider, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         
         sut.add(listener: listener)
@@ -249,7 +266,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testFullyBlockingFollowedByFullyBlocking_BothReported() throws {
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         // We use multiple listeners here, because we can't reset the XCTestExpectation
         let secondHangDuration = timeoutInterval + 0.1
         let firstListener = SentryANRTrackerV2TestDelegate(blockOnFirstANRStopped: { [currentDate, secondHangDuration] in
@@ -294,7 +313,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testFullyBlockingFollowedByNormalFrames_OneReported() throws {
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let firstListener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: firstListener)
         
@@ -331,7 +352,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testTwoListeners_FullyBlocking_ReportedToBothListeners() throws {
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let firstListener = SentryANRTrackerV2TestDelegate()
         
         sut.add(listener: firstListener)
@@ -353,18 +376,40 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         defer { sut.clear() }
         
         applicationStateProvider.isApplicationInForeground = false
-        
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
-        
+
         sut.add(listener: listener)
-        
+
         triggerFullyBlockingAppHang(currentDate)
-        
+
         renderNormalFramesToStopAppHang(displayLinkWrapper)
 
         wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
     }
     
+    /// When the app stops rendering but the main thread stays responsive, e.g. a CarPlay
+    /// scene keeping the app alive while the phone is locked, it's not an app hang (#8317).
+    ///
+    /// [||||--------------]
+    /// - means no frame rendered
+    /// | means a rendered frame
+    func testNoFramesRendered_whenMainThreadResponsive_shouldNotReportAppHang() throws {
+        let (sut, currentDate, _, _, _, _) = try getSut()
+        defer { sut.clear() }
+
+        // The test dispatch queue wrapper executes main queue blocks,
+        // keeping the main thread heartbeat responsive.
+        let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
+
+        sut.add(listener: listener)
+
+        triggerFullyBlockingAppHang(currentDate)
+
+        wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
+    }
+
     func testClear_WhenWorkerWakesInBackground_DoesNotLogAfterStopping() throws {
         // -- Arrange --
         let (sut, _, _, applicationStateProvider, threadWrapper, _) = try getSut()
@@ -404,7 +449,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testAppSuspended_NoAppHang() throws {
         let (sut, currentDate, _, _, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         // When the app is suspended the thread sleep can take way longer
@@ -431,7 +478,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         timeoutInterval = 0.5
         let (sut, currentDate, displayLinkWrapper, applicationStateProvider, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: listener)
         
@@ -482,7 +531,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         timeoutInterval = 0.5
         let (sut, currentDate, displayLinkWrapper, applicationStateProvider, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate()
         sut.add(listener: listener)
         
@@ -540,7 +591,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         timeoutInterval = 0.5
         let (sut, currentDate, displayLinkWrapper, applicationStateProvider, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let firstListener = SentryANRTrackerV2TestDelegate()
         firstListener.anrDetectedExpectation.assertForOverFulfill = false
         firstListener.anrStoppedExpectation.assertForOverFulfill = false
@@ -618,11 +671,166 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         let secondHangDuration = try XCTUnwrap(secondListener.anrStoppedResults.last)
         XCTAssertLessThan(secondHangDuration.maxDuration, firstHangBackgroundDuration)
     }
-    
+
+    /// Time without frame delay data, e.g. while the frames tracker is paused because the app
+    /// resigned active, should be excluded from the hang duration.
+    ///
+    /// [||||---NO FRAME DELAY DATA---||||]
+    /// | means a rendered frame
+    /// - means no frame rendered
+    func testFullyBlockingAppHang_whenNoFrameDelayDataDuringHang_shouldNotIncludeThatTimeInDuration() throws {
+        timeoutInterval = 0.5
+        let (sut, currentDate, displayLinkWrapper, _, threadWrapper, framesTracker) = try getSut()
+        defer { sut.clear() }
+
+        simulateBlockedMainThread()
+
+        let listener = SentryANRTrackerV2TestDelegate()
+        sut.add(listener: listener)
+
+        let noFrameDelayDataDuration = 3.0
+        var iteration = 0
+        let iterationsWithoutData = 15
+        let noDataIterationsCompleted = expectation(description: "No frame delay data iterations completed")
+
+        threadWrapper.blockWhenSleeping = {
+            guard listener.anrsDetected.count > 0 else { return }
+
+            switch iteration {
+            case 0:
+                // Resetting the frames deletes all frame delay data, the same as pausing
+                // the frames tracker does, so getting the frames delay returns -1.
+                framesTracker.resetFrames()
+                fallthrough
+            case 1..<iterationsWithoutData:
+                currentDate.advance(by: noFrameDelayDataDuration / Double(iterationsWithoutData))
+                iteration += 1
+            case iterationsWithoutData:
+                iteration += 1
+                noDataIterationsCompleted.fulfill()
+            default:
+                break
+            }
+        }
+
+        triggerFullyBlockingAppHang(currentDate)
+        wait(for: [listener.anrDetectedExpectation], timeout: waitTimeout)
+
+        wait(for: [noDataIterationsCompleted], timeout: waitTimeout)
+        threadWrapper.blockWhenSleeping = {}
+
+        renderNormalFramesToStopAppHang(displayLinkWrapper)
+        wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
+
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
+        XCTAssertLessThan(actual.maxDuration, noFrameDelayDataDuration)
+    }
+
+    /// When a slow frame is followed by the app not rendering at all while the main thread
+    /// stays responsive, the frame gap must not turn the slow frame into a hang (#8317).
+    ///
+    /// [||||--|----------]
+    /// - means no frame rendered
+    /// | means a rendered frame
+    func testSlowFrameThenNoRendering_whenMainThreadResponsive_shouldNotReportAppHang() throws {
+        let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
+        defer { sut.clear() }
+
+        let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
+
+        sut.add(listener: listener)
+
+        displayLinkWrapper.frameWith(delay: 1.0)
+
+        // The app stops rendering, but the main thread keeps servicing its queue.
+        currentDate.advance(by: 1.2)
+
+        wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
+    }
+
+    /// A hang stops when the main thread becomes responsive again, even when the app isn't
+    /// rendering frames, e.g. because the screen turned off during the hang.
+    ///
+    /// [||||----------------]
+    /// - means no frame rendered
+    /// | means a rendered frame
+    func testFullyBlockingAppHang_whenMainThreadRecoversWithoutRendering_shouldReportStopped() throws {
+        let (sut, currentDate, _, _, _, _) = try getSut()
+        defer { sut.clear() }
+
+        simulateBlockedMainThread()
+
+        let listener = SentryANRTrackerV2TestDelegate()
+        sut.add(listener: listener)
+
+        triggerFullyBlockingAppHang(currentDate)
+        wait(for: [listener.anrDetectedExpectation], timeout: waitTimeout)
+
+        // The main thread becomes responsive again, but no frames get rendered.
+        dispatchQueue.blockBeforeMainBlock = { true }
+
+        wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
+
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
+        XCTAssertLessThanOrEqual(actual.maxDuration, 4.0)
+        XCTAssertEqual(0.8, actual.maxDuration - actual.minDuration, accuracy: 0.01)
+    }
+
+    /// When the OS suspends the app, the ANR thread sleeps way longer than expected. The
+    /// extra sleep time should be excluded from the hang duration.
+    ///
+    /// [||||---SUSPENDED---||||]
+    /// | means a rendered frame
+    /// - means no frame rendered
+    func testFullyBlockingAppHang_whenAppSuspendedDuringHang_shouldNotIncludeSuspensionTimeInDuration() throws {
+        timeoutInterval = 0.5
+        let (sut, currentDate, displayLinkWrapper, _, threadWrapper, _) = try getSut()
+        defer { sut.clear() }
+
+        simulateBlockedMainThread()
+
+        let listener = SentryANRTrackerV2TestDelegate()
+        sut.add(listener: listener)
+
+        let suspensionIterations = 3
+        let suspensionDurationPerIteration = 1.0
+        let suspensionDuration = suspensionDurationPerIteration * Double(suspensionIterations)
+        var iteration = 0
+        let suspensionCompleted = expectation(description: "Suspension iterations completed")
+
+        threadWrapper.blockWhenSleeping = {
+            guard listener.anrsDetected.count > 0 else { return }
+            guard iteration <= suspensionIterations else { return }
+
+            if iteration < suspensionIterations {
+                // Sleeping way longer than the sleep interval simulates the OS
+                // suspending the app.
+                currentDate.advance(by: suspensionDurationPerIteration)
+            } else {
+                suspensionCompleted.fulfill()
+            }
+            iteration += 1
+        }
+
+        triggerFullyBlockingAppHang(currentDate)
+        wait(for: [listener.anrDetectedExpectation], timeout: waitTimeout)
+
+        wait(for: [suspensionCompleted], timeout: waitTimeout)
+        threadWrapper.blockWhenSleeping = {}
+
+        renderNormalFramesToStopAppHang(displayLinkWrapper)
+        wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
+
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
+        XCTAssertLessThan(actual.maxDuration, suspensionDuration)
+    }
+
     func testRemoveListener_StopsReporting() throws {
         let (sut, currentDate, _, _, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         let mainBlockExpectation = expectation(description: "Main Block")
@@ -642,7 +850,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testClear_StopsReporting() throws {
         let (sut, currentDate, _, _, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let firstListener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         let secondListener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
@@ -667,7 +877,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testNotRemovingDeallocatedListener_DoesNotRetainListener_AndStopsTracking() throws {
         let (sut, currentDate, _, _, _, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         // So ARC deallocates SentryANRTrackerTestDelegate
@@ -705,7 +917,9 @@ final class SentryANRTrackerV2Tests: XCTestCase {
     func testClearDirectlyAfterStart_FullyBlocking_NotReported() throws {
         let (sut, currentDate, _, _, threadWrapper, _) = try getSut()
         defer { sut.clear() }
-        
+
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         let invocations = 10
@@ -729,7 +943,8 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         defer { sut.clear() }
         
         framesTracker.stop()
-        
+        simulateBlockedMainThread()
+
         let listener = SentryANRTrackerV2TestDelegate(shouldANRBeDetected: false, shouldStoppedBeCalled: false)
         
         sut.add(listener: listener)
@@ -739,6 +954,12 @@ final class SentryANRTrackerV2Tests: XCTestCase {
         wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
     }
     
+    /// Stops the test dispatch queue wrapper from executing main queue blocks, so the
+    /// tracker's heartbeat treats the main thread as blocked.
+    private func simulateBlockedMainThread() {
+        dispatchQueue.blockBeforeMainBlock = { false }
+    }
+
     private func renderNormalFramesToStopAppHang(_ displayLinkWrapper: TestDisplayLinkWrapper) {
         
         // We need to render normal frames until we reach the
@@ -814,3 +1035,5 @@ class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
 }
 
 #endif
+
+// swiftlint:enable file_length


### PR DESCRIPTION
## :scroll: Description
V2 infers a blocked main thread purely from missing frames, so any interval where the app is `.active` but not rendering (CarPlay with the phone locked, a proximity-blanked screen during a call, a missed `willResignActive`) gets reported as a fully-blocking hang. That's all four fingerprints in #8317, each with idle main-thread stacks.

The fix adds the signal V1 already has: a main-queue heartbeat with an atomic tick counter. Only the synthesized ongoing-frame delay is gated on it... if the main thread is draining its queue and the frame gap exceeds the tracker's sleep interval, the run loop is turning but the display link isn't, so the app isn't rendering and that gap is ignored (for detection and the hang-stop check, via one shared helper). Recorded delayed frames stay fully trusted since they actually rendered, so genuine non-fully-blocking detection is unaffected.

Durations get the same treatment as the existing background exclusion: time without frame delay data (frames tracker paused) and oversleep from OS suspension no longer count toward the reported duration.

Two notes:
- Error direction is under-report. A main thread genuinely blocked by the OS with the display off (`CAMetalLayer nextDrawable`... 1 of our 22 original events) still reports, because it really is blocked.
- Only `@_spi(Private)` surface changed (`SentryFramesDelayResultSPI.ongoingFrameDelayDuration`), which isn't in the committed `sdk_api*.json`... no regen diff.

## :bulb: Motivation and Context
Fixes #8317: thousands of false `App Hang Fully Blocked` events across four independent fingerprints, durations up to ~24 min matching the non-rendering interval, with no workaround short of disabling hang tracking.

## :green_heart: How did you test it?
Unit tests in `SentryANRTrackerV2Tests` using the existing display link / date provider / dispatch queue doubles (`blockBeforeMainBlock`, same pattern as the V1 tests). New: the no-rendering repro (responsive main thread + stalled display link → no report), the mixed slow-frame-then-gap variant, hang-stop when the main thread recovers without rendering, and duration exclusion for both no-frame-delay-data and suspension oversleep. Existing genuine-hang tests now block the main thread explicitly; the non-fully-blocking test keeps the heartbeat responsive to guard the jank path. Each new test was run against the unfixed path first and failed for the expected reason.

27/27 in the class, plus V1, FramesTracker, HangTrackingIntegration, Span, and TimeToDisplay (187 tests). `make analyze`, `build-ios`, `build-macos` clean. Our CarPlay fingerprint reproduces on every drive, so we can pin this branch in production and confirm within a day or two.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).