### PR TITLE
revert: Restore logs and metrics options

### DIFF
--- a/3rd-party-integrations/SentryCocoaLumberjack/README.md
+++ b/3rd-party-integrations/SentryCocoaLumberjack/README.md
@@ -26,6 +26,7 @@ import CocoaLumberjackSwift
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
+    options.enableLogs = true
 }
 
 DDLog.add(SentryCocoaLumberjackLogger(), with: .info)

--- a/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
+++ b/3rd-party-integrations/SentryCocoaLumberjack/Tests/SentryCocoaLumberjackLoggerTests.swift
@@ -18,6 +18,7 @@ final class SentryCocoaLumberjackLoggerTests: XCTestCase {
         capturedLogs = []
         SentrySDK.start { options in
             options.dsn = "https://test@test.ingest.sentry.io/123456"
+            options.enableLogs = true
             options.beforeSendLog = { [weak self] log in
                 self?.capturedLogs.append(log)
                 return nil

--- a/3rd-party-integrations/SentryPulse/README.md
+++ b/3rd-party-integrations/SentryPulse/README.md
@@ -26,6 +26,7 @@ import SentryPulse
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
+    options.enableLogs = true
 }
 
 SentryPulse.start()

--- a/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
+++ b/3rd-party-integrations/SentryPulse/Tests/SentryPulseTests.swift
@@ -24,6 +24,7 @@ final class SentryPulseTests: XCTestCase {
 
         SentrySDK.start { options in
             options.dsn = "https://test@test.ingest.sentry.io/123456"
+            options.enableLogs = true
             options.beforeSendLog = { [weak self] log in
                 self?.capturedLogs.append(log)
                 return nil

--- a/3rd-party-integrations/SentrySwiftLog/README.md
+++ b/3rd-party-integrations/SentrySwiftLog/README.md
@@ -25,6 +25,7 @@ import Logging
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
+    options.enableLogs = true
 }
 
 var handler = SentryLogHandler(logLevel: .info)

--- a/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
+++ b/3rd-party-integrations/SentrySwiftLog/Tests/SentryLogHandlerTests.swift
@@ -16,6 +16,7 @@ final class SentryLogHandlerTests: XCTestCase {
         capturedLogs = []
         SentrySDK.start { options in
             options.dsn = "https://test@test.ingest.sentry.io/123456"
+            options.enableLogs = true
             options.beforeSendLog = { [weak self] log in
                 self?.capturedLogs.append(log)
                 return nil

--- a/3rd-party-integrations/SentrySwiftyBeaver/README.md
+++ b/3rd-party-integrations/SentrySwiftyBeaver/README.md
@@ -25,6 +25,7 @@ import SwiftyBeaver
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
+    options.logsEnabled = true
 }
 
 let log = SwiftyBeaver.self

--- a/3rd-party-integrations/SentrySwiftyBeaver/Sources/SentryDestination.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Sources/SentryDestination.swift
@@ -33,6 +33,7 @@ import SwiftyBeaver
 ///
 /// SentrySDK.start { options in
 ///     options.dsn = "YOUR_DSN"
+///     options.logsEnabled = true
 /// }
 ///
 /// let log = SwiftyBeaver.self

--- a/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
+++ b/3rd-party-integrations/SentrySwiftyBeaver/Tests/SentryDestinationTests.swift
@@ -16,6 +16,7 @@ final class SentryDestinationTests: XCTestCase {
         capturedLogs = []
         SentrySDK.start { options in
             options.dsn = "https://test@test.ingest.sentry.io/123456"
+            options.enableLogs = true
             options.beforeSendLog = { [weak self] log in
                 self?.capturedLogs.append(log)
                 return nil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@
 ## Unreleased
 
 > [!IMPORTANT]
-> This release removes the options `enableLogs` and `enableMetrics` from `Options`. Use `beforeSendLog` or `beforeSendMetric` to drop logs or metrics.
+> This release removes the option `enableLogs` from `Options`. If you need to disable logs, use `beforeSendLog` to drop all logs.
 >
-> We recognize that removing these options in a minor release is disruptive. We made this tradeoff deliberately because enabling Logs and Metrics by default will help most users successfully adopt these features.
+> We recognize that removing this option in a minor release is disruptive. We made this tradeoff deliberately because enabling Logs by default will help most users successfully adopt this feature.
 
 ### Breaking Changes
 
-- Remove `options.enableLogs` to remove explicit opt-in for Logs. If you need to disable logs, use `beforeSendLog` to drop all logs (#8769)
-- Remove `options.enableMetrics` to remove opt-out of Metrics. If you need to disable metrics, use `beforeSendMetric` to drop all metrics (#8785)
+- Remove `options.enableLogs` to remove explicit opt-in for Logs. If you need to disable logs, use `beforeSendLog` to drop all logs (#8783)
 
 ## 9.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,5 @@
 # Changelog
 
-## Unreleased
-
-> [!IMPORTANT]
-> This release removes the option `enableLogs` from `Options`. If you need to disable logs, use `beforeSendLog` to drop all logs.
->
-> We recognize that removing this option in a minor release is disruptive. We made this tradeoff deliberately because enabling Logs by default will help most users successfully adopt this feature.
-
-### Breaking Changes
-
-- Remove `options.enableLogs` to remove explicit opt-in for Logs. If you need to disable logs, use `beforeSendLog` to drop all logs (#8783)
-
 ## 9.26.0
 
 > [!WARNING]

--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -21,6 +21,7 @@
 
 - Enable MetricKit integration by default (#8716)
 - Enable logging by default (#8717)
+- Remove `enableLogs`; logs are always enabled in v10 (#8769)
 - Change the default diagnostic level to warning (#8732)
 - Enable `swiftAsyncStacktraces` by default (#8718)
 - Remove `sendDefaultPii`; use `dataCollection` to configure automatic data collection (#8253)

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -56,6 +56,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case .breadcrumbs: return SentrySDKOverrides.Breadcrumbs.allCases
         case .crash: return SentrySDKOverrides.Crash.allCases
         case .metricKit: return SentrySDKOverrides.MetricKit.allCases
+        case .metrics: return SentrySDKOverrides.Metrics.allCases
         case .spotlight: return SentrySDKOverrides.Spotlight.allCases
         case .swizzling: return SentrySDKOverrides.Swizzling.allCases
         case .swiftAsync: return SentrySDKOverrides.SwiftAsync.allCases
@@ -238,6 +239,11 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case disableRawPayloads = "--io.sentry.metric-kit.disable-raw-payloads"
     }
     case metricKit = "MetricKit"
+
+    public enum Metrics: String, SentrySDKOverride {
+        case enable = "--io.sentry.metrics.enable"
+    }
+    case metrics = "Metrics"
 
     public enum Spotlight: String, SentrySDKOverride {
         case disable = "--io.sentry.spotlight.disable"
@@ -564,6 +570,14 @@ extension SentrySDKOverrides.MetricKit {
     }
 }
 
+extension SentrySDKOverrides.Metrics {
+    public var overrideType: OverrideType {
+        switch self {
+        case .enable: return .boolean
+        }
+    }
+}
+
 extension SentrySDKOverrides.Spotlight {
     public var overrideType: OverrideType {
         switch self {
@@ -768,6 +782,14 @@ extension SentrySDKOverrides.Crash {
 
 extension SentrySDKOverrides.MetricKit {
     public var ignoresDisableEverything: Bool { return false }
+}
+
+extension SentrySDKOverrides.Metrics {
+    public var ignoresDisableEverything: Bool {
+        switch self {
+        case .enable: return true
+        }
+    }
 }
 
 extension SentrySDKOverrides.Spotlight {

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -57,6 +57,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case .crash: return SentrySDKOverrides.Crash.allCases
         case .metricKit: return SentrySDKOverrides.MetricKit.allCases
         case .metrics: return SentrySDKOverrides.Metrics.allCases
+        case .logs: return SentrySDKOverrides.Logs.allCases
         case .spotlight: return SentrySDKOverrides.Spotlight.allCases
         case .swizzling: return SentrySDKOverrides.Swizzling.allCases
         case .swiftAsync: return SentrySDKOverrides.SwiftAsync.allCases
@@ -244,6 +245,11 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case enable = "--io.sentry.metrics.enable"
     }
     case metrics = "Metrics"
+
+    public enum Logs: String, SentrySDKOverride {
+        case disable = "--io.sentry.logs.disable"
+    }
+    case logs = "Logs"
 
     public enum Spotlight: String, SentrySDKOverride {
         case disable = "--io.sentry.spotlight.disable"
@@ -578,6 +584,14 @@ extension SentrySDKOverrides.Metrics {
     }
 }
 
+extension SentrySDKOverrides.Logs {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disable: return .boolean
+        }
+    }
+}
+
 extension SentrySDKOverrides.Spotlight {
     public var overrideType: OverrideType {
         switch self {
@@ -790,6 +804,10 @@ extension SentrySDKOverrides.Metrics {
         case .enable: return true
         }
     }
+}
+
+extension SentrySDKOverrides.Logs {
+    public var ignoresDisableEverything: Bool { return false }
 }
 
 extension SentrySDKOverrides.Spotlight {

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -268,6 +268,7 @@ public struct SentrySDKWrapper {
 #endif // !os(macOS) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
         // Integration: Metrics
+        options.enableMetrics = SentrySDKOverrides.Metrics.enable.boolValue
         options.beforeSendMetric = { metric in
             // Modify the metric in the callback
             var modifiedMetric = metric

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -29,7 +29,7 @@ public struct SentrySDKWrapper {
             print("SentrySDK already enabled, closing it")
             SentrySDK.close()
         }
-
+        
         if !SentrySDKOverrides.Special.skipSDKInit.boolValue {
             print("[Sentry] lastRunStatus before start: \(SentrySDK.lastRunStatus)")
             SentrySDK.start(configureOptions: configureSentryOptions(options:))
@@ -147,12 +147,12 @@ public struct SentrySDKWrapper {
                 // Disable the fast view rendering, because we noticed parts (like the tab bar) are not rendered correctly
                 enableFastViewRendering: SentrySDKOverrides.Replay.enableFastViewRendering.boolValue
             )
-
+            
             // Configure network detail capture for testing
             options.sessionReplay.networkDetailAllowUrls = [
                 "httpbin.org"
             ]
-
+            
             do {
                 let sentryDomainRegex = try NSRegularExpression(pattern: ".*\\.sentry\\.io.*", options: [])
                 options.sessionReplay.networkDetailDenyUrls = [sentryDomainRegex]
@@ -267,6 +267,11 @@ public struct SentrySDKWrapper {
         options.configureUserFeedback = configureFeedback(config:)
 #endif // !os(macOS) && !os(tvOS) && !os(watchOS) && !os(visionOS)
 
+        // Integration: Logs
+        #if !SDK_V10
+        options.enableLogs = !SentrySDKOverrides.Logs.disable.boolValue
+        #endif // !SDK_V10
+
         // Integration: Metrics
         options.enableMetrics = SentrySDKOverrides.Metrics.enable.boolValue
         options.beforeSendMetric = { metric in
@@ -281,7 +286,7 @@ public struct SentrySDKWrapper {
             // Add a custom attribute to the metric
             modifiedMetric.attributes["custom-attribute"] = .string("some-value")
             modifiedMetric.attributes["custom-attribute-2"] = "some-value-2"
-
+            
             return modifiedMetric
         }
 
@@ -346,7 +351,7 @@ public struct SentrySDKWrapper {
         }
         let data = Data("hello".utf8)
         scope.addAttachment(Attachment(data: data, filename: "log.txt"))
-
+        
         scope.setAttribute(value: "\(Bundle.main.bundleIdentifier ?? "")-custom-attribute", key: "custom-attribute-text")
         scope.setAttribute(value: Date().timeIntervalSince1970, key: "custom-attribute-numeric")
         scope.setAttribute(value: true, key: "custom-attribute-boolean")
@@ -375,7 +380,7 @@ public struct SentrySDKWrapper {
         for overrideCategory in SentrySDKOverrides.allCases {
             for flag in overrideCategory.featureFlags {
                 let tagKey = cleanTagKey(from: flag.rawValue)
-
+                
                 switch flag.overrideType {
                 case .boolean:
                     if flag.boolValue {
@@ -393,7 +398,7 @@ public struct SentrySDKWrapper {
             }
         }
     }
-
+    
     private func cleanTagKey(from rawValue: String) -> String {
         return rawValue
             .replacingOccurrences(of: "--io.sentry.", with: "")
@@ -626,7 +631,7 @@ extension SentrySDKWrapper {
         }
         return nil
     }
-
+    
     /// Whether or not profiling benchmarks are being run; this requires disabling certain other features for proper functionality.
     var isBenchmarking: Bool { args.contains("--io.sentry.test.benchmarking") }
     var isUITest: Bool { env[SentrySDKOverrides.Scope.environment.rawValue] == "ui-tests" }

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -110,6 +110,9 @@ schemeTemplates:
         # metrics
         "--io.sentry.metrics.enable": true
 
+        # logs
+        "--io.sentry.logs.disable": false
+
         # spotlight
         "--io.sentry.spotlight.disable": true
         "--io.sentry.spotlight.enable": false

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -107,6 +107,9 @@ schemeTemplates:
         "--io.sentry.metric-kit.disable": false
         "--io.sentry.metric-kit.disable-raw-payloads": false
 
+        # metrics
+        "--io.sentry.metrics.enable": true
+
         # spotlight
         "--io.sentry.spotlight.disable": true
         "--io.sentry.spotlight.enable": false

--- a/Samples/iOS-SwiftUI-SPM/Sources/MainApp.swift
+++ b/Samples/iOS-SwiftUI-SPM/Sources/MainApp.swift
@@ -14,6 +14,9 @@ struct MainApp: App {
             options.enableTimeToFullDisplayTracing = true
             options.attachScreenshot = true
             options.enableMetricKit = true
+            #if !SDK_V10
+            options.enableLogs = true
+            #endif // !SDK_V10
 
             #if targetEnvironment(simulator)
             options.enableSpotlight = true

--- a/SentryTestUtils/Sources/TestOptions.swift
+++ b/SentryTestUtils/Sources/TestOptions.swift
@@ -2,7 +2,7 @@ import Foundation
 import Sentry
 
 public extension Options {
-
+    
     func removeAllIntegrations() {
         enableAutoSessionTracking = false
         enableWatchdogTerminationTracking = false
@@ -21,6 +21,7 @@ public extension Options {
         attachViewHierarchy = false
         enableUIViewControllerTracing = false
         #endif
+        enableMetrics = false
         beforeSendMetric = { metric in metric }
         #if canImport(MetricKit) && !os(tvOS)
         enableMetricKit = false

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1188,6 +1188,13 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
+#if !SDK_V10
+    if (self.options.enableLogs == NO) {
+        SENTRY_LOG_DEBUG(@"Dropping log, because the option enableLogs is false.");
+        return;
+    }
+#endif // !SDK_V10
+
     if (![log isKindOfClass:[SentryLog class]]) {
         return;
     }

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -40,6 +40,15 @@
     return options.environment;
 }
 
++ (BOOL)enableLogs:(SentryOptions *)options
+{
+#if SDK_V10
+    return YES;
+#else
+    return options.enableLogs;
+#endif // SDK_V10
+}
+
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptions *)options
 {
     return [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:options];

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *_Nullable)release:(SentryOptionsObjC *)options;
 + (NSString *)environment:(SentryOptionsObjC *)options;
 + (NSObject *_Nullable)beforeSendLog:(NSObject *)beforeSendLog options:(SentryOptionsObjC *)options;
++ (BOOL)enableLogs:(SentryOptionsObjC *)options;
 + (NSArray<NSString *> *)enabledFeatures:(SentryOptionsObjC *)options;
 
 + (SentryDispatchQueueWrapper *)dispatchQueueWrapper;

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -142,6 +142,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) SentryObjCSpan *_Nullable (^beforeSendSpan)(SentryObjCSpan *);
 
+#if !SDK_V10
+/**
+ * When enabled, the SDK sends logs to Sentry. Logs can be captured using the
+ * @c SentryObjCSDK.logger API, which provides structured logging with attributes.
+ * @note Default value is @c NO.
+ * @note In v10 and later, logs are always enabled. Remove this option when upgrading.
+ */
+@property (nonatomic) BOOL enableLogs;
+#endif // !SDK_V10
+
 /// This block can be used to modify the breadcrumb before it will be serialized and sent.
 @property (nonatomic, copy, nullable) SentryObjCBreadcrumb *_Nullable (^beforeBreadcrumb)
     (SentryObjCBreadcrumb *);

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -523,6 +523,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// Options for experimental features that are subject to change.
 @property (nonatomic, strong) SentryObjCExperimentalOptions *experimental;
 
+/**
+ * When enabled, the SDK sends metrics to Sentry.
+ * @note Default value is @c YES.
+ */
+@property (nonatomic) BOOL enableMetrics;
+
 #if (TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION) && SENTRY_OBJC_HAS_UIKIT
 
 /**

--- a/Sources/SentryObjCCompat/SentryObjCOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCOptions.swift
@@ -139,6 +139,13 @@ import Foundation
         }
     }
 
+    #if !SDK_V10
+    @objc public var enableLogs: Bool {
+        get { wrapped.enableLogs }
+        set { wrapped.enableLogs = newValue }
+    }
+    #endif // !SDK_V10
+
     @objc public var beforeBreadcrumb: ((SentryObjCBreadcrumb) -> SentryObjCBreadcrumb?)? {
         didSet {
             if let beforeBreadcrumb = beforeBreadcrumb {

--- a/Sources/SentryObjCCompat/SentryObjCOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCOptions.swift
@@ -558,5 +558,10 @@ import Foundation
         get { SentryObjCExperimentalOptions(wrapped.experimental) }
         set { wrapped.experimental = newValue.wrapped }
     }
+
+    @objc public var enableMetrics: Bool {
+        get { wrapped.enableMetrics }
+        set { wrapped.enableMetrics = newValue }
+    }
 }
 // swiftlint:enable file_length missing_docs type_body_length

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -10,19 +10,19 @@ import Foundation
             return []
         }
         var features: [String] = []
-
+        
         if options.enableCaptureFailedRequests {
             features.append("captureFailedRequests")
         }
-
+        
         if options.enableTimeToFullDisplayTracing {
             features.append("timeToFullDisplayTracing")
         }
-
+        
         if options.swiftAsyncStacktraces {
             features.append("swiftAsyncStacktraces")
         }
-
+        
         if options.enablePersistingTracesWhenCrashing {
             features.append("persistingTracesWhenCrashing")
         }
@@ -49,7 +49,9 @@ import Foundation
         if options.experimental.enableUnhandledCPPExceptionsV2 {
             features.append("unhandledCPPExceptionsV2")
         }
-        features.append("metrics")
+        if options.enableMetrics {
+            features.append("metrics")
+        }
         #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         #if SDK_V10
         features.append("standaloneAppStartTracing")

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -92,8 +92,7 @@ extension SentrySDK {
     ///
     /// ## Requirements
     ///
-    /// To disable metrics, set ``Options/beforeSendMetric`` to return `nil`.
-
+    /// To disable metrics, set ``Options/enableMetrics`` to `false`.
     ///
     /// - Important: The Metrics API has been designed and optimized for Swift. Objective-C support is
     ///   currently not available. If you need Objective-C support, please see the issue

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
@@ -8,7 +8,7 @@ protocol SentryMetricsApiDependencies {
     var scope: Scope { get }
     var dateProvider: SentryCurrentDateProvider { get }
 
-    /// The integration is nullable as it might not be installed on the hub as expected.
+    /// The integration is nullable, meaning if it's not installed or not enabled, it will return nil
     var metricsIntegration: Integration? { get }
 }
 
@@ -44,7 +44,7 @@ struct SentryMetricsApi<Dependencies: SentryMetricsApiDependencies>: SentryMetri
             return
         }
         guard let integration = dependencies.metricsIntegration else {
-            SentrySDKLog.fatal("Metric '\(name)' was not captured because metrics integrations is not available. This is a bug, please create an issue at https://github.com/getsentry/sentry-cocoa/issues")
+            SentrySDKLog.warning("Metric '\(name)' was not captured because metrics are disabled. Enable metrics by setting 'options.enableMetrics = true' when starting the SDK.")
             return
         }
 

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -11,7 +11,9 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     private let scopeMetaData: SentryDefaultScopeApplyingMetadata
     private let beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
 
-    init(with options: Options, dependencies _: Dependencies) {
+    init?(with options: Options, dependencies _: Dependencies) {
+        guard options.enableMetrics else { return nil }
+
 #if SDK_V10
         let shouldAddDefaultUserId = options.dataCollection.userInfo
 #else
@@ -60,7 +62,7 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
         scope.addAttributesToItem(&mutableMetric, metadata: self.scopeMetaData)
 
         if let beforeSendMetric = beforeSendMetric {
-            // Create a non-mutated copy of the metric, because it could be modified by the SDK user's `beforeSendMetric`
+            // Create a non-mutated copy of the metric, because it could be modified by the SDK user's `beforeSendMetric` 
             let metricToSend = mutableMetric
             guard let processedItem = beforeSendMetric(mutableMetric) else {
                 SentrySDKLog.debug("Metric dropped by beforeSendMetric callback.")

--- a/Sources/Swift/Options+Dictionary.swift
+++ b/Sources/Swift/Options+Dictionary.swift
@@ -77,6 +77,12 @@ extension Options {
             self.maxBreadcrumbs = maxBreadcrumbs.uintValue
         }
 
+        #if !SDK_V10
+        if let enableLogs = boolValue(dictionary["enableLogs"]) {
+            self.enableLogs = enableLogs
+        }
+        #endif // !SDK_V10
+
         if let enableMetrics = boolValue(dictionary["enableMetrics"]) {
             self.enableMetrics = enableMetrics
         }

--- a/Sources/Swift/Options+Dictionary.swift
+++ b/Sources/Swift/Options+Dictionary.swift
@@ -77,6 +77,10 @@ extension Options {
             self.maxBreadcrumbs = maxBreadcrumbs.uintValue
         }
 
+        if let enableMetrics = boolValue(dictionary["enableMetrics"]) {
+            self.enableMetrics = enableMetrics
+        }
+
         if let enableNetworkBreadcrumbs = boolValue(dictionary["enableNetworkBreadcrumbs"]) {
             self.enableNetworkBreadcrumbs = enableNetworkBreadcrumbs
         }

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -752,6 +752,11 @@
 
     // MARK: - Integration: Metrics
 
+    /// When enabled, the SDK sends metrics to Sentry. Metrics can be captured using the ``SentrySDK/metrics``
+    /// API, which allows you to send, view and query counters, gauges and measurements.
+    /// @note Default value is @c true.
+    @objc public var enableMetrics: Bool = true
+
     /// Use this callback to drop or modify a metric before the SDK sends it to Sentry. Return nil to
     /// drop the metric.
     public var beforeSendMetric: ((SentryMetric) -> SentryMetric?)?

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -147,6 +147,14 @@
     /// drop the span.
     @objc public var beforeSendSpan: SentryBeforeSendSpanCallback?
 
+    #if !SDK_V10
+    /// When enabled, the SDK sends logs to Sentry. Logs can be captured using the SentrySDK.logger
+    /// API, which provides structured logging with attributes.
+    /// @note Default value is @c false.
+    /// @note In v10 and later, logs are always enabled. Remove this option when upgrading.
+    @objc public var enableLogs: Bool = false
+    #endif // !SDK_V10
+
     /// Use this callback to drop or modify a log before the SDK sends it to Sentry. Return nil to
     /// drop the log.
     @objc public var beforeSendLog: ((SentryLog) -> SentryLog?)?

--- a/Tests/SentryObjCTests/SentryObjCLoggerTests.m
+++ b/Tests/SentryObjCTests/SentryObjCLoggerTests.m
@@ -14,6 +14,9 @@
     [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
         options.dsn = @"https://key@sentry.io/123";
         options.enableCrashHandler = NO;
+#if !SDK_V10
+        options.enableLogs = YES;
+#endif // !SDK_V10
         options.beforeSendLog = ^SentryObjCLog *(SentryObjCLog *log) {
             weakSelf.capturedLog = log;
             return log;
@@ -856,5 +859,25 @@
     XCTAssertNotNil(self.capturedLog.body);
     XCTAssertNil(self.capturedLog.attributes[@"sentry.message.template"]);
 }
+
+#if !SDK_V10
+#    pragma mark - logs disabled
+
+- (void)testLoggerMethod_whenLogsDisabled_shouldNotCrash
+{
+    // -- Arrange --
+    [SentryObjCSDK close];
+    [SentryObjCSDK startWithConfigureOptions:^(SentryObjCOptions *options) {
+        options.dsn = @"https://key@sentry.io/123";
+        options.enableCrashHandler = NO;
+        options.enableLogs = NO;
+    }];
+
+    // -- Act & Assert (no crash) --
+    [SentryObjCSDK.logger info:@"should not crash"];
+    [SentryObjCSDK.logger debugWithFormat:@"User %@ count %d", @"test", 5];
+    [SentryObjCSDK.logger debugWithAttributes:@{ @"k" : @"v" } format:@"Val: %f", 1.0];
+}
+#endif // !SDK_V10
 
 @end

--- a/Tests/SentryObjCTests/SentryObjCOptionsTests.m
+++ b/Tests/SentryObjCTests/SentryObjCOptionsTests.m
@@ -519,6 +519,18 @@
     XCTAssertTrue(options.strictTraceContinuation);
 }
 
+- (void)testEnableMetrics_whenSetToYes_shouldReturnYes
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+
+    // -- Act --
+    options.enableMetrics = YES;
+
+    // -- Assert --
+    XCTAssertTrue(options.enableMetrics);
+}
+
 #pragma mark - Numeric properties
 
 - (void)testShutdownTimeInterval_whenSet_shouldReturnValue

--- a/Tests/SentryObjCTests/SentryObjCOptionsTests.m
+++ b/Tests/SentryObjCTests/SentryObjCOptionsTests.m
@@ -241,6 +241,20 @@
     XCTAssertTrue(options.enableNetworkBreadcrumbs);
 }
 
+#if !SDK_V10
+- (void)testEnableLogs_whenSetToYes_shouldReturnYes
+{
+    // -- Arrange --
+    SentryObjCOptions *options = [[SentryObjCOptions alloc] init];
+
+    // -- Act --
+    options.enableLogs = YES;
+
+    // -- Assert --
+    XCTAssertTrue(options.enableLogs);
+}
+#endif // !SDK_V10
+
 - (void)testEnableAutoSessionTracking_whenSetToYes_shouldReturnYes
 {
     // -- Arrange --

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -291,6 +291,30 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         XCTAssertFalse(features.contains("unhandledCPPExceptionsV2"))
     }
 
+    func testEnableMetrics_isEnabled_shouldAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+        options.enableMetrics = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertTrue(features.contains("metrics"))
+    }
+
+    func testEnableMetrics_isDisabled_shouldNotAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+        options.enableMetrics = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("metrics"))
+    }
+
     func testEnableStandaloneAppStartTracing_isEnabled_shouldAddFeature() throws {
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         // -- Arrange --

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -41,6 +41,17 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
+    func testCount_withMetricsDisabled_shouldNotCreateMetric() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub(isMetricsEnabled: false)
+
+        // -- Act --
+        SentrySDK.metrics.count(key: "test.metric", value: 1)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+    }
+
     func testCount_withZeroValue_shouldCreateMetric() throws {
         // -- Arrange --
         let client = try givenSdkWithHub()
@@ -121,6 +132,17 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
+    func testDistribution_withMetricsDisabled_shouldNotCreateMetric() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub(isMetricsEnabled: false)
+
+        // -- Act --
+        SentrySDK.metrics.distribution(key: "test.metric", value: 1.0)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+    }
+
     func testDistribution_withNegativeValue_shouldCreateMetric() throws {
         // -- Arrange --
         let client = try givenSdkWithHub()
@@ -184,6 +206,17 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
+    func testGauge_withMetricsDisabled_shouldNotCreateMetric() throws {
+        // -- Arrange --
+        let client = try givenSdkWithHub(isMetricsEnabled: false)
+
+        // -- Act --
+        SentrySDK.metrics.gauge(key: "test.metric", value: 1.0)
+
+        // -- Assert --
+        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+    }
+
     func testGauge_withNegativeValue_shouldCreateMetric() throws {
         // -- Arrange --
         let client = try givenSdkWithHub()
@@ -224,10 +257,11 @@ class SentryMetricsApiE2ETests: XCTestCase {
     // MARK: - Helpers
 
     @discardableResult
-    private func givenSdkWithHub() throws -> E2EMetricsTestClient {
+    private func givenSdkWithHub(isMetricsEnabled: Bool = true) throws -> E2EMetricsTestClient {
         let options = Options()
         options.dsn = TestConstants.dsnForTestCase(type: Self.self)
         options.removeAllIntegrations()
+        options.enableMetrics = isMetricsEnabled
 
         let client = try XCTUnwrap(E2EMetricsTestClient(options: options))
         let hub = SentryHubInternal(
@@ -240,14 +274,16 @@ class SentryMetricsApiE2ETests: XCTestCase {
         SentrySDK.setStart(with: options)
         SentrySDKInternal.setCurrentHub(hub)
 
-        let dependencies = SentryDependencyContainer.sharedInstance()
-        let integration = try XCTUnwrap(
-            SentryMetricsIntegration<SentryDependencyContainer>(
-                with: options,
-                dependencies: dependencies
-            ) as Any as? SentryIntegrationProtocol
-        )
-        hub.addInstalledIntegration(integration, name: SentryMetricsIntegration<SentryDependencyContainer>.name)
+        if isMetricsEnabled {
+            let dependencies = SentryDependencyContainer.sharedInstance()
+            let integration = try XCTUnwrap(
+                SentryMetricsIntegration<SentryDependencyContainer>(
+                    with: options,
+                    dependencies: dependencies
+                ) as Any as? SentryIntegrationProtocol
+            )
+            hub.addInstalledIntegration(integration, name: SentryMetricsIntegration<SentryDependencyContainer>.name)
+        }
 
         hub.startSession()
         return client

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -13,6 +13,28 @@ class SentryMetricsIntegrationTests: XCTestCase {
 
     // MARK: - Tests
 
+    func testStartSDK_whenIntegrationIsNotEnabled_shouldNotBeInstalled() {
+        // -- Arrange --
+        // SDK not enabled in startSDK call
+
+        // -- Act --
+        startSDK(isEnabled: false)
+
+        // -- Assert --
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 0)
+    }
+
+    func testStartSDK_whenIntegrationIsEnabled_shouldBeInstalled() {
+        // -- Arrange --
+        // SDK enabled in startSDK call
+
+        // -- Act --
+        startSDK(isEnabled: true)
+
+        // -- Assert --
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().first, "Metrics")
+    }
+
     func testAddMetric_whenMetricAdded_shouldForwardToTelemetryProcessor() throws {
         // -- Arrange --
         let client = try givenSdkWithHub()
@@ -449,10 +471,12 @@ class SentryMetricsIntegrationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func startSDK(configure: ((Options) -> Void)? = nil) {
+    private func startSDK(isEnabled: Bool, configure: ((Options) -> Void)? = nil) {
         SentrySDK.start {
             $0.dsn = TestConstants.dsnForTestCase(type: Self.self)
             $0.removeAllIntegrations()
+
+            $0.enableMetrics = isEnabled
 
             configure?($0)
         }
@@ -463,6 +487,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         let options = Options()
         options.dsn = TestConstants.dsnForTestCase(type: Self.self)
         options.removeAllIntegrations()
+        options.enableMetrics = true
 
         configure?(options)
 

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -25,6 +25,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableAppHangTracking = false
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
+        options.enableMetrics = false
         options.enableCrashHandler = false
         #if canImport(MetricKit) && !os(tvOS)
         options.enableMetricKit = false
@@ -41,15 +42,13 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
 #if SENTRY_DISABLE_SENTRYCRASH_V10
         // KSCRASH_TODO(GH-8725): V10 temporarily omits the Swift async integration.
         // Acceptance: SCV10-011 in SENTRYCRASH_V10_MIGRATION_LEDGER.md.
-        XCTAssertEqual(names.count, 1)
+        XCTAssertEqual(names.count, 0)
         XCTAssertFalse(names.contains("SentrySwiftAsyncIntegration"))
-        XCTAssertTrue(names.contains("SentryMetricsIntegration"))
-        XCTAssertEqual(testHub.installedIntegrations().count, 1)
+        XCTAssertEqual(testHub.installedIntegrations().count, 0)
 #else
-        XCTAssertEqual(names.count, 2)
+        XCTAssertEqual(names.count, 1)
         XCTAssertTrue(names.contains("SentrySwiftAsyncIntegration"))
-        XCTAssertTrue(names.contains("SentryMetricsIntegration"))
-        XCTAssertEqual(testHub.installedIntegrations().count, 2)
+        XCTAssertEqual(testHub.installedIntegrations().count, 1)
 #endif
     }
 
@@ -67,6 +66,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         options.enableAppHangTracking = false
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
+        options.enableMetrics = false
         options.enableCrashHandler = false
         #if canImport(MetricKit) && !os(tvOS)
         options.enableMetricKit = false
@@ -79,10 +79,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         SentrySwiftIntegrationInstaller.install(with: options)
 
         // Assert
-        let names = testHub.installedIntegrationNames()
-        XCTAssertEqual(names.count, 1)
-        XCTAssertFalse(names.contains("SentrySwiftAsyncIntegration"))
-        XCTAssertTrue(names.contains("SentryMetricsIntegration"))
-        XCTAssertEqual(testHub.installedIntegrations().count, 1)
+        XCTAssertEqual(testHub.installedIntegrationNames().count, 0)
+        XCTAssertEqual(testHub.installedIntegrations().count, 0)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -61,12 +61,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     private func getSut() throws -> SentrySessionReplayIntegration {
-        return try XCTUnwrap(sessionReplayIntegration())
-    }
-
-    private func sessionReplayIntegration() -> SentrySessionReplayIntegration? {
-        return SentrySDKInternal.currentHub().installedIntegrations()
-            .first { $0 is SentrySessionReplayIntegration } as? SentrySessionReplayIntegration
+        return try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
     
     private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true, noIntegrations: Bool = false, configure: ((Options) -> Void)? = nil) {
@@ -85,15 +80,15 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testNoInstall() {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0)
-
-        XCTAssertNil(sessionReplayIntegration())
+        
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 0)
         XCTAssertEqual(globalEventProcessor.processors.count, 0)
     }
-
+    
     func testInstallFullSessionReplay() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)
-
-        XCTAssertNotNil(sessionReplayIntegration())
+        
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
 
@@ -116,7 +111,8 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testInstallNoSwizzlingNoTouchTracker() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0, enableSwizzling: false)
-        guard let integration = sessionReplayIntegration() else {
+        guard let integration = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
+        else {
             XCTFail("Could not find session replay integration")
             return
         }
@@ -132,7 +128,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testInstallFullSessionReplayButDontRunBecauseOfRandom() throws {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
         startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
-        XCTAssertNotNil(sessionReplayIntegration())
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
@@ -157,8 +153,8 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.1)
         
         startSDK(sessionSampleRate: 0.3, errorSampleRate: 0)
-
-        XCTAssertNotNil(sessionReplayIntegration())
+        
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
@@ -166,7 +162,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testInstallErrorReplay() {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0.1)
-        XCTAssertNotNil(sessionReplayIntegration())
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     
@@ -591,7 +587,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testStartWithNoSessionReplay() throws {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0, noIntegrations: true)
-        var sut = sessionReplayIntegration()
+        var sut = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
         XCTAssertNil(sut)
         SentrySDK.replay.start()
         sut = try getSut()

--- a/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
+++ b/Tests/SentryTests/OptionsInSyncWithDocs/SentryOptionsDocumentationSyncTests.swift
@@ -21,6 +21,7 @@ final class SentryOptionsDocumentationSyncTests: XCTestCase {
             "strictTraceContinuation", // Docs PR: https://github.com/getsentry/sentry-docs/pull/16983
             "orgId", // Docs PR: https://github.com/getsentry/sentry-docs/pull/16983
             "effectiveOrgId", // @_spi(Private) - internal computed property, not a user-facing option
+            "enableMetrics", // Promoted to GA in https://github.com/getsentry/sentry-cocoa/pull/7843; docs update pending
             "beforeSendMetric" // Promoted to GA in https://github.com/getsentry/sentry-cocoa/pull/7843; docs update pending
         ]
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -115,6 +115,9 @@ final class SentryClientTests: XCTestCase {
             let options = Options()
             options.dsn = SentryClientTests.dsn
             options.removeAllIntegrations()
+            #if !SDK_V10
+            options.enableLogs = true
+            #endif // !SDK_V10
             configureOptions(options)
 
             return SentryClientInternal(
@@ -3056,6 +3059,26 @@ final class SentryClientTests: XCTestCase {
 
         XCTAssertEqual(testProcessor.forwardTelemetryDataInvocations.count, 1)
     }
+
+    #if !SDK_V10
+    func testCaptureLog_withLogsDisabled_logDropped() {
+        // -- Arrange --
+        let sut = fixture.getSut()
+        sut.options.enableLogs = false
+
+        let testProcessor = TestTelemetryProcessorForClient()
+        Dynamic(sut).telemetryProcessor = testProcessor
+
+        let log = SentryLog(level: .info, body: "This log should be dropped")
+        let scope = Scope()
+
+        // -- Act --
+        sut._swiftCaptureLog(log, with: scope)
+
+        // -- Assert --
+        XCTAssertEqual(testProcessor.addLogInvocations.count, 0, "Log should be dropped when enableLogs is false")
+    }
+    #endif // !SDK_V10
 
     func testCaptureLog_whenClientDisabled_logDropped() {
         // The full isDisabled logic is covered elsewhere; this just verifies _swiftCaptureLog

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -211,6 +211,11 @@
     [self testBooleanField:@"enableNetworkBreadcrumbs"];
 }
 
+- (void)testEnableMetrics
+{
+    [self testBooleanField:@"enableMetrics" defaultValue:YES];
+}
+
 - (void)testEnableAutoBreadcrumbTracking
 {
     [self testBooleanField:@"enableAutoBreadcrumbTracking"];

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -211,6 +211,13 @@
     [self testBooleanField:@"enableNetworkBreadcrumbs"];
 }
 
+#if !SDK_V10
+- (void)testEnableLogs
+{
+    [self testBooleanField:@"enableLogs" defaultValue:NO];
+}
+#endif // !SDK_V10
+
 - (void)testEnableMetrics
 {
     [self testBooleanField:@"enableMetrics" defaultValue:YES];

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -447,9 +447,9 @@ class SentrySDKInternalTests: XCTestCase {
 #if SENTRY_DISABLE_SENTRYCRASH_V10
         // KSCRASH_TODO(GH-8725): V10 temporarily omits the Swift async integration.
         // Acceptance: SCV10-011 in SENTRYCRASH_V10_MIGRATION_LEDGER.md.
-        XCTAssertEqual(1, hub.installedIntegrations().count)
+        XCTAssertEqual(0, hub.installedIntegrations().count)
 #else
-        XCTAssertEqual(2, hub.installedIntegrations().count)
+        XCTAssertEqual(1, hub.installedIntegrations().count)
 #endif
         SentrySDK.close()
         XCTAssertEqual(0, hub.installedIntegrations().count)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -381,7 +381,7 @@ class SentrySDKTests: XCTestCase {
             options.removeAllIntegrations()
         }
 
-        assertIntegrationsInstalled(integrations: ["SentryMetricsIntegration"])
+        assertIntegrationsInstalled(integrations: [])
     }
 
     func testGlobalOptions() {
@@ -685,14 +685,13 @@ extension SentrySDKTests {
         SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
     }
 
-    private func assertIntegrationsInstalled(integrations: [String], file: StaticString = #file, line: UInt = #line) {
-        let hub = SentrySDKInternal.currentHub()
-        XCTAssertEqual(integrations.count, hub.installedIntegrations().count, file: file, line: line)
+    private func assertIntegrationsInstalled(integrations: [String]) {
+        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
-                XCTAssertTrue(hub.isIntegrationInstalled(integrationClass), "\(integration) not installed", file: file, line: line)
+                XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
             } else {
-                XCTAssertTrue(hub.hasIntegration(integration), "\(integration) not installed with legacy ObjC API nor Swift", file: file, line: line)
+                XCTAssertTrue(SentrySDKInternal.currentHub().hasIntegration(integration), "\(integration) not installed with legacy ObjC API nor Swift")
             }
         }
     }

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -3,11 +3,11 @@
 import XCTest
 
 class SentrySDKTests: XCTestCase {
-
+    
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySDKTests")
-
+    
     private class Fixture {
-
+    
         let options: Options = {
             let options = Options.noIntegrations()
             options.dsn = SentrySDKTests.dsnAsString
@@ -59,7 +59,7 @@ class SentrySDKTests: XCTestCase {
             hub = SentryHubInternal(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper(processInfoWrapper: ProcessInfo.processInfo), andDispatchQueue: SentryDispatchQueueWrapper())
 
             feedback = SentryFeedback(message: "Again really?", name: "Tim Apple", email: "tim@apple.com")
-
+            
 #if os(iOS) || os(tvOS)
             options.dsn = SentrySDKTests.dsnAsString
 
@@ -85,7 +85,7 @@ class SentrySDKTests: XCTestCase {
         try super.setUpWithError()
         fixture = try Fixture()
     }
-
+    
     override func tearDown() {
         super.tearDown()
 
@@ -107,7 +107,7 @@ class SentrySDKTests: XCTestCase {
         let breadcrumbs = Dynamic(SentrySDKInternal.currentHub().scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(0, breadcrumbs?.count)
     }
-
+    
     func testStartWithConfigureOptions() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
@@ -375,7 +375,7 @@ class SentrySDKTests: XCTestCase {
     func testDetectedStartUpCrash_DefaultValue() {
         XCTAssertFalse(SentrySDK.detectedStartUpCrash)
     }
-
+    
     func testInstallIntegrations_NoIntegrations() {
         SentrySDK.start { options in
             options.removeAllIntegrations()
@@ -409,15 +409,15 @@ class SentrySDKTests: XCTestCase {
 
         let scope = Scope()
         SentrySDK.capture(event: fixture.event, scope: scope)
-
+    
         assertEventCaptured(expectedScope: scope)
     }
-
+       
     func testCaptureEventWithScopeBlock_ScopePassedToHub() {
         givenSdkWithHub()
 
         SentrySDK.capture(event: fixture.event, block: fixture.scopeBlock)
-
+    
         assertEventCaptured(expectedScope: fixture.scopeWithBlockApplied)
     }
 
@@ -425,7 +425,7 @@ class SentrySDKTests: XCTestCase {
         givenSdkWithHub()
 
         SentrySDK.capture(event: fixture.event, block: fixture.scopeBlock)
-
+    
         assertHubScopeNotChanged()
     }
 
@@ -602,38 +602,44 @@ class SentrySDKTests: XCTestCase {
     }
 
     // MARK: - Logger Flush Tests
-
+    
     func testFlush_CallsLoggerCaptureLogs() {
+        #if !SDK_V10
+        fixture.client.options.enableLogs = true
+        #endif // !SDK_V10
         SentrySDKInternal.setCurrentHub(fixture.hub)
         SentrySDK.setStart(with: fixture.client.options)
-
+        
         // Add a log to ensure there's something to flush
         SentrySDK.logger.info("Test log message")
-
+        
         // Verify the log was captured
         XCTAssertEqual(fixture.client.captureLogInvocations.count, 1)
         XCTAssertEqual(fixture.client.captureLogInvocations.first?.log.body, "Test log message")
-
+        
         // Flush the SDK - this should trigger the log buffer to flush
         SentrySDK.flush(timeout: 1.0)
-
+        
         // The log should still be captured (flush doesn't clear the invocations)
         XCTAssertEqual(fixture.client.captureLogInvocations.count, 1)
     }
-
+    
     func testClose_CallsLoggerCaptureLogs() {
+        #if !SDK_V10
+        fixture.client.options.enableLogs = true
+        #endif // !SDK_V10
         SentrySDKInternal.setCurrentHub(fixture.hub)
         SentrySDK.setStart(with: fixture.client.options)
-
+        
         // Add a log to ensure there's something to flush
         SentrySDK.logger.info("Test log message")
-
+        
         // Verify the log was captured
         XCTAssertEqual(fixture.client.captureLogInvocations.count, 1)
-
+        
         // Close the SDK
         SentrySDK.close()
-
+        
         // The log should still be captured
         XCTAssertEqual(fixture.client.captureLogInvocations.count, 1)
     }
@@ -646,28 +652,28 @@ extension SentrySDKTests {
         XCTAssertEqual(fixture.event, client.captureEventWithScopeInvocations.first?.event)
         XCTAssertEqual(expectedScope, client.captureEventWithScopeInvocations.first?.scope)
     }
-
+    
     private func assertErrorCaptured(expectedScope: Scope) {
         let client = fixture.client
         XCTAssertEqual(1, client.captureErrorWithScopeInvocations.count)
         XCTAssertEqual(fixture.error.localizedDescription, client.captureErrorWithScopeInvocations.first?.error.localizedDescription)
         XCTAssertEqual(expectedScope, client.captureErrorWithScopeInvocations.first?.scope)
     }
-
+    
     private func assertExceptionCaptured(expectedScope: Scope) {
         let client = fixture.client
         XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
         XCTAssertEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
         XCTAssertEqual(expectedScope, client.captureExceptionWithScopeInvocations.first?.scope)
     }
-
+    
     private func assertMessageCaptured(expectedScope: Scope) {
         let client = fixture.client
         XCTAssertEqual(1, client.captureMessageWithScopeInvocations.count)
         XCTAssertEqual(fixture.message, client.captureMessageWithScopeInvocations.first?.message)
         XCTAssertEqual(expectedScope, client.captureMessageWithScopeInvocations.first?.scope)
     }
-
+    
     private func assertHubScopeNotChanged() {
         let hubScope = SentrySDKInternal.currentHub().scope
         XCTAssertEqual(fixture.scope, hubScope)
@@ -678,13 +684,13 @@ extension SentrySDKTests {
         let flags = try XCTUnwrap(context["flags"] as? [String: Any])
         return try XCTUnwrap(flags["values"] as? [[String: Any]])
     }
-
+    
     private func startprocessInfoWrapperForPreview() {
         let testProcessInfoWrapper = MockSentryProcessInfo()
         testProcessInfoWrapper.overrides.environment = ["XCODE_RUNNING_FOR_PREVIEWS": "1"]
         SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
     }
-
+    
     private func assertIntegrationsInstalled(integrations: [String]) {
         XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
         integrations.forEach { integration in

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -23424,6 +23424,82 @@
                 "declKind": "Accessor",
                 "implicit": true,
                 "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC10enableLogsSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableLogs"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC10enableLogsSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableLogs:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC10enableLogsSbvp",
+            "moduleName": "Sentry",
+            "name": "enableLogs",
+            "printedName": "enableLogs",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableLogs"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC25enableMemoryIntrospectionSbvg",
                 "moduleName": "Sentry",
                 "name": "Get",

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -23652,6 +23652,82 @@
                 "declKind": "Accessor",
                 "implicit": true,
                 "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableMetrics"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableMetrics:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvp",
+            "moduleName": "Sentry",
+            "name": "enableMetrics",
+            "printedName": "enableMetrics",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableMetrics"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC24enableNetworkBreadcrumbsSbvg",
                 "moduleName": "Sentry",
                 "name": "Get",

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2005,6 +2005,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "enableLogs",
+    "parent": "SentryObjCOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "enableMemoryIntrospection",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -5904,6 +5911,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setEnableLogs:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setEnableMemoryIntrospection:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9197,6 +9211,12 @@
   {
     "kind": "ObjCPropertyDecl",
     "name": "enableGraphQLOperationTracking",
+    "parent": "SentryObjCOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "enableLogs",
     "parent": "SentryObjCOptions",
     "type": "BOOL"
   },

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -2026,6 +2026,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "enableMetrics",
+    "parent": "SentryObjCOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "enableNetworkBreadcrumbs",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -5918,6 +5925,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setEnableMetrics:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setEnableNetworkBreadcrumbs:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9201,6 +9215,12 @@
   {
     "kind": "ObjCPropertyDecl",
     "name": "enableMetricKitRawPayload",
+    "parent": "SentryObjCOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "enableMetrics",
     "parent": "SentryObjCOptions",
     "type": "BOOL"
   },

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -2126,6 +2126,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "enableMetrics",
+    "parent": "SentryObjCOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "enableNetworkBreadcrumbs",
     "parent": "SentryObjCOptions",
     "returnType": "BOOL",
@@ -6095,6 +6102,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setEnableMetrics:",
+    "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setEnableNetworkBreadcrumbs:",
     "parent": "SentryObjCOptions",
     "returnType": "void",
@@ -9419,6 +9433,12 @@
   {
     "kind": "ObjCPropertyDecl",
     "name": "enableMetricKitRawPayload",
+    "parent": "SentryObjCOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "enableMetrics",
     "parent": "SentryObjCOptions",
     "type": "BOOL"
   },

--- a/sdk_api_v10.json
+++ b/sdk_api_v10.json
@@ -23846,6 +23846,82 @@
                 "declKind": "Accessor",
                 "implicit": true,
                 "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvg",
+                "moduleName": "Sentry",
+                "name": "Get",
+                "printedName": "Get()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)enableMetrics"
+              },
+              {
+                "accessorKind": "set",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
+                "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvs",
+                "moduleName": "Sentry",
+                "name": "Set",
+                "printedName": "Set()",
+                "usr": "c:@M@Sentry@objc(cs)SentryOptions(im)setEnableMetrics:"
+              }
+            ],
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Bool",
+                "printedName": "Swift.Bool",
+                "usr": "s:Sb"
+              }
+            ],
+            "declAttributes": [
+              "Final",
+              "HasStorage",
+              "ObjC"
+            ],
+            "declKind": "Var",
+            "hasStorage": true,
+            "kind": "Var",
+            "mangledName": "$s6Sentry7OptionsC13enableMetricsSbvp",
+            "moduleName": "Sentry",
+            "name": "enableMetrics",
+            "printedName": "enableMetrics",
+            "usr": "c:@M@Sentry@objc(cs)SentryOptions(py)enableMetrics"
+          },
+          {
+            "accessors": [
+              {
+                "accessorKind": "get",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Bool",
+                    "printedName": "Swift.Bool",
+                    "usr": "s:Sb"
+                  }
+                ],
+                "declAttributes": [
+                  "Final",
+                  "ObjC"
+                ],
+                "declKind": "Accessor",
+                "implicit": true,
+                "kind": "Accessor",
                 "mangledName": "$s6Sentry7OptionsC24enableNetworkBreadcrumbsSbvg",
                 "moduleName": "Sentry",
                 "name": "Get",


### PR DESCRIPTION
Restore the `enableLogs` and `enableMetrics` options instead of shipping their removal as breaking changes.

This reverts #8783 and #8785, including their API surface, runtime behavior, tests, samples, and changelog entries. Logs remain opt-in through `enableLogs` on v9, while metrics can again be disabled through `enableMetrics`.

Validated with formatting, static analysis, public API generation, iOS and macOS builds, and focused option, logging, metrics, SDK, client, and ObjC tests. The full iOS suite encountered one pre-existing concurrent logging assertion caused by unrelated reachability output.

#skip-changelog
