### PR TITLE
ref: remove frames tracker from app start in V10

### DIFF
--- a/CHANGELOG_V10.md
+++ b/CHANGELOG_V10.md
@@ -44,3 +44,4 @@
 - Normalize profiling CPU usage to 0–100 percent (#8323)
 - Bump KSCrash to `2.6.0`
 - Restore memory metrics and initial OS, device, app, and runtime contexts in `SentryV10` (#8836)
+- Remove unused `SentryFramesTracker` dependency from `SentryAppStartTracker` in V10 (#8859)

--- a/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
+++ b/Sources/Swift/Integrations/AppStartTracking/SentryAppStartTracker.swift
@@ -15,7 +15,7 @@ extension SentryAppStartTrackerHelper: AppStartInfoProvider {}
 /// After reboot of the device, the app is not in memory and no process exists. Warm start: When the
 /// app recently terminated, the app is partially in memory and no process exists.
 @_spi(Private) @objc
-public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener {
+public final class SentryAppStartTracker: NSObject {
 
     // MARK: - Static Properties
 
@@ -32,7 +32,9 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
 
     let dispatchQueue: SentryDispatchQueueWrapper
     let appStateManager: SentryAppStateManager
+    #if !SDK_V10
     private let framesTracker: SentryFramesTracker
+    #endif
     private let enablePreWarmedAppStartTracing: Bool
     private let reportingStrategy: AppStartReportingStrategy
     let extendedAppLaunchManager: SentryExtendedAppLaunchManager
@@ -55,7 +57,6 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
     init(
         dispatchQueueWrapper: SentryDispatchQueueWrapper,
         appStateManager: SentryAppStateManager,
-        framesTracker: SentryFramesTracker,
         enablePreWarmedAppStartTracing: Bool,
         dateProvider: SentryCurrentDateProvider,
         sysctlWrapper: SentrySysctl,
@@ -64,7 +65,6 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
     ) {
         self.dispatchQueue = dispatchQueueWrapper
         self.appStateManager = appStateManager
-        self.framesTracker = framesTracker
         self.enablePreWarmedAppStartTracing = enablePreWarmedAppStartTracing
         self.extendedAppLaunchManager = extendedAppLaunchManager
         self.reportingStrategy = StandaloneTransactionStrategy(extendedAppLaunchManager: extendedAppLaunchManager)
@@ -172,15 +172,18 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
             object: nil
         )
 
+        #if !SDK_V10
         if !(reportingStrategy is StandaloneTransactionStrategy) {
             framesTracker.removeListener(self)
         }
+        #endif
 
         #if SENTRY_TEST || SENTRY_TEST_CI || DEBUG
         isRunning = false
         #endif
     }
 
+    #if !SDK_V10
     // MARK: - SentryFramesTrackerListener
 
     /// This is when the first frame is drawn.
@@ -188,6 +191,7 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
     public func framesTrackerHasNewFrame(_ newFrameDate: Date) {
         buildAppStartMeasurement(newFrameDate)
     }
+    #endif
 
     // MARK: - Private Methods
     // swiftlint:disable function_body_length
@@ -354,5 +358,9 @@ public final class SentryAppStartTracker: NSObject, SentryFramesTrackerListener 
         SentryAppStartMeasurementProvider.setAppStartTrace(nil)
     }
 }
+
+#if !SDK_V10
+extension SentryAppStartTracker: SentryFramesTrackerListener {}
+#endif
 
 #endif // (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -400,7 +400,6 @@ extension SentryFileManager: SentryFileManagerProtocol { }
         return SentryAppStartTracker(
             dispatchQueueWrapper: SentryDispatchQueueWrapper(),
             appStateManager: appStateManager,
-            framesTracker: framesTracker,
             enablePreWarmedAppStartTracing: options.enablePreWarmedAppStartTracing,
             dateProvider: dateProvider,
             sysctlWrapper: sysctlWrapper,

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -92,7 +92,6 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             let sut = SentryAppStartTracker(
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper(),
                 appStateManager: appStateManager,
-                framesTracker: framesTracker,
                 enablePreWarmedAppStartTracing: enablePreWarmedAppStartTracing,
                 dateProvider: SentryDependencyContainer.sharedInstance().dateProvider,
                 sysctlWrapper: SentryDependencyContainer.sharedInstance().sysctlWrapper,


### PR DESCRIPTION
## Summary

- Remove unused `SentryFramesTracker` dependency from `SentryAppStartTracker` in the V10 code path
- In V10, standalone app start mode ends the measurement at `didFinishLaunching`, never via the frames tracker listener — the dependency was injected but functionally dead
- Guard the `framesTracker` property, listener conformance, and cleanup behind `#if !SDK_V10`

## Test plan

- [x] `make build-ios FOR_AGENTS=true` passes
- [x] `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryAppStartTrackerTests` — 25 tests, 0 failures

#skip-changelog

Closes #8860