### PR TITLE
feat: Set app start vitals on standalone children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants
+- Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants (#8888)
 
 ## 9.26.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants
+
 ## 9.26.1
 
 ### Fixes

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -804,14 +804,23 @@ static const NSTimeInterval SENTRY_AUTO_TRANSACTION_DEADLINE = 30.0;
                 ? [NSString stringWithFormat:@"%@.prewarmed", appContextType]
                 : appContextType;
             if (isStandalone) {
+                NSString *screen = [SentryAppStartMeasurementProvider consumeAppStartScreen];
                 [self setDataValue:durationMs forKey:vitalsType];
                 [self setDataValue:durationMs forKey:SentrySpanDataKeyAppVitalsStartValue];
                 [self setDataValue:appStartType forKey:SentrySpanDataKeyAppVitalsStartType];
                 [self setDataValue:@(appStartMeasurement.isPreWarmed)
                             forKey:SentrySpanDataKeyAppVitalsStartPrewarmed];
-                [self setDataValue:[SentryAppStartMeasurementProvider consumeAppStartScreen]
-                            forKey:SentrySpanDataKeyAppVitalsStartScreen];
+                if (screen != nil) {
+                    [self setDataValue:screen forKey:SentrySpanDataKeyAppVitalsStartScreen];
+                }
                 [self setDataValue:@"launch" forKey:SentrySpanDataKeyAppVitalsStartReason];
+
+                for (id<SentrySpan> span in transaction.spans) {
+                    [span setDataValue:appStartType forKey:SentrySpanDataKeyAppVitalsStartType];
+                    if (screen != nil) {
+                        [span setDataValue:screen forKey:SentrySpanDataKeyAppVitalsStartScreen];
+                    }
+                }
             } else {
                 [self setMeasurement:legacyType value:durationMs];
             }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/AppStartReportingStrategyTests.swift
@@ -259,6 +259,30 @@ class AppStartReportingStrategyTests: XCTestCase {
         XCTAssertNil(extra?["app.vitals.start.screen"])
     }
 
+    func testReport_whenScreenNameSet_shouldCopyTypeAndScreenOntoChildSpans() throws {
+        let hub = setUpIntegrationHub()
+        let measurement = createMeasurement(type: .cold)
+        SentryAppStartMeasurementProvider.setAppStartScreen("MainViewController")
+        addTeardownBlock { SentryAppStartMeasurementProvider.reset() }
+
+        StandaloneTransactionStrategy(extendedAppLaunchManager: SentryExtendedAppLaunchManager()).report(measurement, traceId: SentryId())
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let spans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+        try assertAppStartVitals(on: spans, type: "cold", screen: "MainViewController")
+    }
+
+    func testReport_whenNoScreenNameSet_shouldCopyTypeButNotScreenOntoChildSpans() throws {
+        let hub = setUpIntegrationHub()
+        let measurement = createMeasurement(type: .warm)
+
+        StandaloneTransactionStrategy(extendedAppLaunchManager: SentryExtendedAppLaunchManager()).report(measurement, traceId: SentryId())
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let spans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+        try assertAppStartVitals(on: spans, type: "warm", screen: nil)
+    }
+
     func testReport_shouldSetStartReasonToLaunch() throws {
 
         let hub = setUpIntegrationHub()
@@ -447,6 +471,43 @@ class AppStartReportingStrategyTests: XCTestCase {
         let end = span["timestamp"] as? TimeInterval ?? 0
         XCTAssertEqual(start, expectedStart, accuracy: 0.001, file: file, line: line)
         XCTAssertEqual(end, expectedEnd, accuracy: 0.001, file: file, line: line)
+    }
+
+    private func assertAppStartVitals(
+        on spans: [[String: Any]],
+        type: String,
+        screen: String?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws {
+        XCTAssertFalse(spans.isEmpty, "Expected child spans", file: file, line: line)
+        for span in spans {
+            let data = span["data"] as? [String: Any]
+            let op = span["op"] as? String ?? ""
+            XCTAssertEqual(
+                data?["app.vitals.start.type"] as? String,
+                type,
+                "Missing or wrong type on \(op)",
+                file: file,
+                line: line
+            )
+            if let screen {
+                XCTAssertEqual(
+                    data?["app.vitals.start.screen"] as? String,
+                    screen,
+                    "Missing or wrong screen on \(op)",
+                    file: file,
+                    line: line
+                )
+            } else {
+                XCTAssertNil(
+                    data?["app.vitals.start.screen"],
+                    "Screen should be omitted on \(op)",
+                    file: file,
+                    line: line
+                )
+            }
+        }
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryExtendedAppLaunchTests.swift
@@ -295,6 +295,39 @@ class SentryExtendedAppLaunchTests: XCTestCase {
         XCTAssertEqual(childSpan["op"] as? String, "app.init")
     }
 
+    func testFinish_whenScreenSet_extendedAndUserDescendantsHaveVitals() throws {
+        let hub = setUpIntegrationHub()
+        let manager = SentryExtendedAppLaunchManager()
+        manager.extend()
+        let extendedSpan = try XCTUnwrap(manager.extendedAppStartSpan())
+
+        SentryAppStartMeasurementProvider.setAppStartScreen("MainViewController")
+        addTeardownBlock { SentryAppStartMeasurementProvider.reset() }
+
+        let measurement = createMeasurement(type: .cold, duration: 0.5)
+        StandaloneTransactionStrategy(extendedAppLaunchManager: manager).report(measurement, traceId: SentryId())
+
+        let child = extendedSpan.startChild(operation: "app.init", description: "fetch remote config")
+        let grandchild = child.startChild(operation: "app.init.db", description: "load cache")
+        grandchild.finish()
+        child.finish()
+        manager.finish()
+
+        let serialized = try XCTUnwrap(hub.capturedTransactionsWithScope.invocations.first?.transaction)
+        let spans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+
+        let descriptions = ["Extended App Start", "fetch remote config", "load cache"]
+        for description in descriptions {
+            let match = try XCTUnwrap(
+                spans.first { ($0["description"] as? String) == description },
+                "Missing span \(description)"
+            )
+            let data = match["data"] as? [String: Any]
+            XCTAssertEqual(data?["app.vitals.start.type"] as? String, "cold", description)
+            XCTAssertEqual(data?["app.vitals.start.screen"] as? String, "MainViewController", description)
+        }
+    }
+
     func testExtend_finishingReturnedSpan_capturesTransaction() throws {
         let hub = setUpIntegrationHub()
         let manager = SentryExtendedAppLaunchManager()

--- a/Tests/SentryTests/Transaction/SentryBuildAppStartSpansTests.swift
+++ b/Tests/SentryTests/Transaction/SentryBuildAppStartSpansTests.swift
@@ -151,6 +151,10 @@ class SentryBuildAppStartSpansTests: XCTestCase {
             expectedEndTimestamp: Date(timeIntervalSince1970: 1_935),
             expectedSampled: tracer.sampled
         )
+        for span in result {
+            XCTAssertNil(span.data["app.vitals.start.type"])
+            XCTAssertNil(span.data["app.vitals.start.screen"])
+        }
     }
 
     func testSentryBuildAppStartSpans_appStartMeasurementIsWarmAndNotPrewarmed_shouldNotIncludePreRuntimeSpans() {
@@ -298,6 +302,10 @@ class SentryBuildAppStartSpansTests: XCTestCase {
             expectedEndTimestamp: Date(timeIntervalSince1970: 1_600),
             expectedSampled: tracer.sampled
         )
+        for span in result {
+            XCTAssertEqual("cold", span.data["app.vitals.start.type"] as? String)
+            XCTAssertNil(span.data["app.vitals.start.screen"])
+        }
     }
 
     func testBuildStandaloneAppStartSpans_whenPrewarmed_shouldNotIncludeGroupingSpan() {


### PR DESCRIPTION
## :scroll: Description

Set `app.vitals.start.type` and `app.vitals.start.screen` on standalone `app.start` children — including `app.start.extended` and user descendants. The `ui.load`-attached app start path is unchanged.

## :bulb: Motivation and Context

Mobile vitals app start breakdown groups `app.start` children using these attributes. They were only on the root, so child spans did not group. Matches Android ([getsentry/sentry-java#6005](https://github.com/getsentry/sentry-java/pull/6005)) and Flutter ([getsentry/sentry-dart#3988](https://github.com/getsentry/sentry-dart/pull/3988)).

Related to https://github.com/getsentry/sentry/pull/122577
Closes https://github.com/getsentry/sentry-cocoa/issues/8889

## :green_heart: How did you test it?

Unit tests covering foreground and headless standalone children (`AppStartReportingStrategyTests`), user descendants under `app.start.extended` (`SentryExtendedAppLaunchTests`), and the nested `ui.load` path not receiving these attributes (`SentryBuildAppStartSpansTests`). Also ran `SentryTracerTests`.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).