### PR TITLE
test: fix macOS-Swift sample UI tests

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -547,6 +547,7 @@ run_ui_tests_for_prs: &run_ui_tests_for_prs
   - "Samples/iOS-SwiftUI/**"
   - "Samples/iOS-Swift/**"
   - "Samples/iOS-Swift6/**"
+  - "Samples/macOS-Swift/**"
   - "Samples/SentrySampleShared/**"
   - "Samples/Shared/**"
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -147,6 +147,25 @@ jobs:
       platform: iOS
       files_suffix: _swift6_
 
+  ui-tests-macos-swift:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_ui_tests_for_prs == 'true'
+    needs: files-changed
+    name: Test macOS Swift V1 # Up the version with every change to keep track of flaky tests
+    runs-on: ["bitrise_pool_name:tahoe"]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          version: "26"
+      - run: make init-ci-build
+      - name: Run macOS UI tests
+        run: make test-sample-macOS-Swift-ui
+      - name: Run CI Diagnostics
+        uses: ./.github/actions/ci-diagnostics
+        if: failure()
+
   # This check validates that either UI tests passed or were skipped, which allows us
   # to make UI tests a required check with only running the UI tests when required.
   # So, we don't have to run UI tests, for example, for unrelated changes.
@@ -158,6 +177,7 @@ jobs:
         ui-tests-swift-ui,
         ui-tests-swift,
         ui-tests-swift6,
+        ui-tests-macos-swift,
         run-full-ci-gate,
       ]
     name: UI Tests - Check

--- a/Makefile
+++ b/Makefile
@@ -1188,8 +1188,8 @@ test-sample-iOS-ObjectiveC-ui: xcode-ci-iOS-ObjectiveC
 # Unlike the simulator based UI tests, these run natively on the host, where AMFI
 # kills any bundle whose signature doesn't match its contents. Skipping code signing
 # leaves the XCTest runner with the stale seal it ships with, so macOS refuses to
-# launch it ("... is damaged and can't be opened"). Ad-hoc signing keeps the bundles
-# valid without requiring a certificate on CI.
+# launch it ("... is damaged and can't be opened"). The "-" identity selects ad-hoc
+# signing, which keeps the bundles valid without requiring a certificate on CI.
 .PHONY: test-sample-macOS-Swift-ui
 test-sample-macOS-Swift-ui: xcode-ci-macOS-Swift
 	@echo "--> Running macOS-Swift UI tests"

--- a/Makefile
+++ b/Makefile
@@ -1184,6 +1184,12 @@ test-sample-iOS-ObjectiveC-ui: xcode-ci-iOS-ObjectiveC
 ## Run macOS-Swift sample UI tests
 #
 # Generates the macOS-Swift project and runs its UI tests.
+#
+# Unlike the simulator based UI tests, these run natively on the host, where AMFI
+# kills any bundle whose signature doesn't match its contents. Skipping code signing
+# leaves the XCTest runner with the stale seal it ships with, so macOS refuses to
+# launch it ("... is damaged and can't be opened"). Ad-hoc signing keeps the bundles
+# valid without requiring a certificate on CI.
 .PHONY: test-sample-macOS-Swift-ui
 test-sample-macOS-Swift-ui: xcode-ci-macOS-Swift
 	@echo "--> Running macOS-Swift UI tests"
@@ -1191,7 +1197,11 @@ test-sample-macOS-Swift-ui: xcode-ci-macOS-Swift
 		-workspace Sentry.xcworkspace \
 		-scheme macOS-Swift \
 		-testPlan macOS-Swift_Base \
-		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+		CODE_SIGNING_ALLOWED="YES" \
+		CODE_SIGNING_REQUIRED="YES" \
+		CODE_SIGN_STYLE="Manual" \
+		CODE_SIGN_IDENTITY="-" \
+		DEVELOPMENT_TEAM="" 2>&1 | xcbeautify --preserve-unbeautified
 
 ## Run tvOS-Swift sample UI tests
 #

--- a/Samples/macOS-Swift/App/Resources/Base.lproj/Main.storyboard
+++ b/Samples/macOS-Swift/App/Resources/Base.lproj/Main.storyboard
@@ -910,7 +910,7 @@
                                                                     <action selector="startProfile:" target="XfG-lQ-9wD" id="dhO-rC-e2o"/>
                                                                 </connections>
                                                             </buttonCell>
-                                                            <accessibility identifier="io.sentry.ios-swift.ui-test.button.stop-continuous-profiler"/>
+                                                            <accessibility identifier="io.sentry.ios-swift.ui-tests.button.start-continuous-profiler"/>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="g56-6u-NUj">
                                                             <rect key="frame" x="251" y="110" width="95" height="24"/>

--- a/Samples/macOS-Swift/UITests/Sources/MacOSSwiftUITests.swift
+++ b/Samples/macOS-Swift/UITests/Sources/MacOSSwiftUITests.swift
@@ -167,15 +167,15 @@ private extension MacOSSwiftUITests {
     }
 
     func retrieveFirstProfileChunkData(app: XCUIApplication) {
-        app.buttons["io.sentry.ui-tests.view-first-continuous-profile-chunk"].afterWaitingForExistence("Couldn't find button to view first profile chunk").tap()
+        app.buttons["io.sentry.ui-tests.view-first-continuous-profile-chunk"].afterWaitingForExistence("Couldn't find button to view first profile chunk").click()
     }
 
     func stopContinuousProfiler(app: XCUIApplication) {
-        app.buttons["io.sentry.ios-swift.ui-test.button.stop-continuous-profiler"].afterWaitingForExistence("Couldn't find button to stop continuous profiler").tap()
+        app.buttons["io.sentry.ios-swift.ui-test.button.stop-continuous-profiler"].afterWaitingForExistence("Couldn't find button to stop continuous profiler").click()
     }
 
     func checkLaunchProfileMarkerFileExistence(app: XCUIApplication) throws -> Bool {
-        app.buttons["io.sentry.ui-tests.app-launch-profile-marker-file-button"].afterWaitingForExistence("Couldn't find app launch profile marker file check button").tap()
+        app.buttons["io.sentry.ui-tests.app-launch-profile-marker-file-button"].afterWaitingForExistence("Couldn't find app launch profile marker file check button").click()
         let string = try XCTUnwrap(app.textFields["io.sentry.ui-tests.profile-marshaling-text-field"].afterWaitingForExistence("Couldn't find data marshaling text field.").value as? NSString)
         return string == "<exists>"
     }


### PR DESCRIPTION
## :scroll: Description

The macOS-Swift sample UI tests could not run on a macOS host, so three defects had gone unnoticed.

### 1. `make test-sample-macOS-Swift-ui` passed `CODE_SIGNING_ALLOWED=NO`

Unlike the simulator-based UI tests, these run natively on the host, where AMFI kills any bundle whose signature doesn't match its contents. Skipping code signing leaves the XCTest runner with the `com.apple.XCTRunner` template seal it ships with, which no longer matches once the test plugin is embedded, so macOS refuses to launch it:

> "macOS-Swift-UITests-Runner.app" is damaged and can't be opened. You should move it to the Trash.

Ad-hoc signing (`CODE_SIGN_IDENTITY="-"`) keeps the bundles valid without requiring a certificate or provisioning profile, so it works on CI and for the App Sandbox variants too.

### 2. Duplicate accessibility identifier in `Main.storyboard`

The "Start profile" button carried the Stop button's identifier (`io.sentry.ios-swift.ui-test.button.stop-continuous-profiler`), making the two indistinguishable to XCUITest.

### 3. `tap()` instead of `click()` in the profiling helpers

`tap()` synthesizes a touch gesture that AppKit controls ignore, so the clicks silently did nothing and the marshaling text field stayed empty. From the test log:

```
t =  3.29s Click "Main" Tab
t =  3.92s     Wait for io.sentry.macOS-Swift to idle    <- 0.5s, worked
t =  9.70s Tap "io.sentry.ui-tests.app-launch-profile-marker-file-button" Button
t = 14.85s     Wait for io.sentry.macOS-Swift to idle    <- 5s stall, no effect
```

The surrounding tab helpers (`returnToMainTab`, `verifyIsSandboxed`) already used `click()`; that asymmetry was the bug. The profiling helpers now match.

## :bulb: Motivation and Context

Found while validating the SDK on macOS 27 Beta for #8124. None of these are macOS 27 regressions — they are pre-existing sample/CI bugs that only surfaced because these UI tests had never actually been executed on a macOS host.

Without these fixes `make test-sample-macOS-Swift-ui` cannot pass at all, so the launch-profiling coverage for macOS (sandboxed and non-sandboxed) was effectively dead.

## :green_heart: How did you test it?

Ran on a macOS 27.0 host (build 26A5425a) with Xcode 27.0 Beta 6 (27A5252f), after deleting the built test products so the bundles were genuinely re-signed rather than reused:

- `make build-sample-macOS-Swift` — succeeds, no actionable Xcode 27 warnings
- `make test-sample-macOS-Swift-ui` — 2 tests, 0 failures (135.8s)
  - `testMacAppsDontEnableLaunchProfilingForEachOther_Nonsandboxed`
  - `testMacAppsDontEnableLaunchProfilingForEachOther_Sandboxed`
- `make format` and `make analyze` — clean

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog
