### PR TITLE
fix: bypass enableLogs/Metrics for APIs

### DIFF
--- a/3rd-party-integrations/SentryCocoaLumberjack/README.md
+++ b/3rd-party-integrations/SentryCocoaLumberjack/README.md
@@ -26,7 +26,6 @@ import CocoaLumberjackSwift
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
-    options.enableLogs = true
 }
 
 DDLog.add(SentryCocoaLumberjackLogger(), with: .info)

--- a/3rd-party-integrations/SentryPulse/README.md
+++ b/3rd-party-integrations/SentryPulse/README.md
@@ -26,7 +26,6 @@ import SentryPulse
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
-    options.enableLogs = true
 }
 
 SentryPulse.start()

--- a/3rd-party-integrations/SentrySwiftLog/README.md
+++ b/3rd-party-integrations/SentrySwiftLog/README.md
@@ -25,7 +25,6 @@ import Logging
 
 SentrySDK.start { options in
     options.dsn = "YOUR_DSN"
-    options.enableLogs = true
 }
 
 var handler = SentryLogHandler(logLevel: .info)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Install idle Session Replay recovery infrastructure at zero sample rates. (#8865)
+- Do not gate manual log and metrics APIs behind `enableLogs` / `enableMetrics`. Both options remain for compatibility until the next major and are now deprecated; `SentrySDK.logger`, opt-in logging integrations that forward through it, and `SentrySDK.metrics` keep capturing when the flags are `false` (#8918)
 
 ### Features
 
@@ -18,10 +19,6 @@
 ### Internal
 
 - Add visionOS support to internal screen APIs (#8913)
-
-### Improvements
-
-- Do not gate manual log and metrics APIs behind `enableLogs` / `enableMetrics`. Both options remain for compatibility until the next major, but `SentrySDK.logger`, opt-in logging integrations that forward through it, and `SentrySDK.metrics` keep capturing when the flags are `false` (#8906)
 
 ## 9.26.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Add visionOS support to internal screen APIs (#8913)
 
+### Improvements
+
+- Do not gate manual log and metrics APIs behind `enableLogs` / `enableMetrics`. Both options remain for compatibility until the next major, but `SentrySDK.logger`, opt-in logging integrations that forward through it, and `SentrySDK.metrics` keep capturing when the flags are `false` (#8906)
+
 ## 9.26.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+> [!NOTE]
+> `enableLogs` and `enableMetrics` are now deprecated and will be removed in the next major version. Manual log and metric capture is no longer gated by these flags.
+
 ### Improvements
 
 - Install idle Session Replay recovery infrastructure at zero sample rates. (#8865)
-- Do not gate manual log and metrics APIs behind `enableLogs` / `enableMetrics`. Both options remain for compatibility until the next major and are now deprecated; `SentrySDK.logger`, opt-in logging integrations that forward through it, and `SentrySDK.metrics` keep capturing when the flags are `false` (#8918)
+- Manual log and metrics APIs are no longer gated by behind `enableLogs` / `enableMetrics` (#8918)
 
 ### Features
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1301,10 +1301,6 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    // Manual log APIs (SentrySDK.logger and opt-in logging integrations that forward
-    // through it) must not be gated behind options.enableLogs. The option remains for
-    // compatibility until the next major, but is a no-op for capture.
-
     if (![log isKindOfClass:[SentryLog class]]) {
         return;
     }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1301,12 +1301,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-#if !SDK_V10
-    if (self.options.enableLogs == NO) {
-        SENTRY_LOG_DEBUG(@"Dropping log, because the option enableLogs is false.");
-        return;
-    }
-#endif // !SDK_V10
+    // Manual log APIs (SentrySDK.logger and opt-in logging integrations that forward
+    // through it) must not be gated behind options.enableLogs. The option remains for
+    // compatibility until the next major, but is a no-op for capture.
 
     if (![log isKindOfClass:[SentryLog class]]) {
         return;

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -155,10 +155,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if !SDK_V10
 /**
- * When enabled, the SDK sends logs to Sentry. Logs can be captured using the
- * @c SentryObjCSDK.logger API, which provides structured logging with attributes.
+ * Legacy option kept for compatibility until the next major release.
+ *
+ * Manual log capture through @c SentryObjCSDK.logger (and opt-in logging integrations that
+ * forward through it) is not gated by this flag. Setting it to @c NO does not drop those logs.
  * @note Default value is @c NO.
- * @note In v10 and later, logs are always enabled. Remove this option when upgrading.
+ * @note In v10 and later, this option is removed and logs are always enabled.
  */
 @property (nonatomic) BOOL enableLogs;
 #endif // !SDK_V10
@@ -547,7 +549,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SentryObjCExperimentalOptions *experimental;
 
 /**
- * When enabled, the SDK sends metrics to Sentry.
+ * Legacy option kept for compatibility until the next major release.
+ *
+ * Manual metric capture through the metrics API is not gated by this flag. Setting it to
+ * @c NO does not drop those metrics.
  * @note Default value is @c YES.
  */
 @property (nonatomic) BOOL enableMetrics;

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -92,7 +92,8 @@ extension SentrySDK {
     ///
     /// ## Requirements
     ///
-    /// To disable metrics, set ``Options/enableMetrics`` to `false`.
+    /// ``Options/enableMetrics`` is kept for compatibility until the next major release and does
+    /// not gate this manual API.
     ///
     /// - Important: The Metrics API has been designed and optimized for Swift. Objective-C support is
     ///   currently not available. If you need Objective-C support, please see the issue

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsApi.swift
@@ -45,7 +45,7 @@ struct SentryMetricsApi<Dependencies: SentryMetricsApiDependencies>: SentryMetri
             return
         }
         guard let integration = dependencies.metricsIntegration else {
-            SentrySDKLog.warning("Metric '\(name)' was not captured because metrics are disabled. Enable metrics by setting 'options.enableMetrics = true' when starting the SDK.")
+            SentrySDKLog.warning("Metric '\(name)' was not captured because the metrics integration is not installed.")
             return
         }
 

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -12,10 +12,6 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     private let beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
 
     init?(with options: Options, dependencies _: Dependencies) {
-        // Always install so the manual metrics API keeps working even when
-        // options.enableMetrics is false. The option remains for compatibility until the
-        // next major, but is a no-op for capture.
-
 #if SDK_V10
         let shouldAddDefaultUserId = options.dataCollection.userInfo
 #else

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -12,7 +12,9 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
     private let beforeSendMetric: ((SentryMetric) -> SentryMetric?)?
 
     init?(with options: Options, dependencies _: Dependencies) {
-        guard options.enableMetrics else { return nil }
+        // Always install so the manual metrics API keeps working even when
+        // options.enableMetrics is false. The option remains for compatibility until the
+        // next major, but is a no-op for capture.
 
 #if SDK_V10
         let shouldAddDefaultUserId = options.dataCollection.userInfo

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -158,10 +158,14 @@
     @objc public var beforeSendSpan: SentryBeforeSendSpanCallback?
 
     #if !SDK_V10
-    /// When enabled, the SDK sends logs to Sentry. Logs can be captured using the SentrySDK.logger
-    /// API, which provides structured logging with attributes.
-    /// @note Default value is @c false.
-    /// @note In v10 and later, logs are always enabled. Remove this option when upgrading.
+    /// Legacy option kept for compatibility until the next major release.
+    ///
+    /// Manual log capture through ``SentrySDK/logger`` (and opt-in logging integrations that
+    /// forward through it) is not gated by this flag. Setting it to `false` does not drop
+    /// those logs.
+    ///
+    /// - Note: Default value is `false`.
+    /// - Note: In v10 and later, this option is removed and logs are always enabled.
     @objc public var enableLogs: Bool = false
     #endif // !SDK_V10
 
@@ -774,9 +778,12 @@
 
     // MARK: - Integration: Metrics
 
-    /// When enabled, the SDK sends metrics to Sentry. Metrics can be captured using the ``SentrySDK/metrics``
-    /// API, which allows you to send, view and query counters, gauges and measurements.
-    /// @note Default value is @c true.
+    /// Legacy option kept for compatibility until the next major release.
+    ///
+    /// Manual metric capture through ``SentrySDK/metrics`` is not gated by this flag. Setting it
+    /// to `false` does not drop those metrics.
+    ///
+    /// - Note: Default value is `true`.
     @objc public var enableMetrics: Bool = true
 
     /// Use this callback to drop or modify a metric before the SDK sends it to Sentry. Return nil to

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -166,6 +166,7 @@
     ///
     /// - Note: Default value is `false`.
     /// - Note: In v10 and later, this option is removed and logs are always enabled.
+    /// - Warning: Deprecated. This option will be removed in the next major version.
     @objc public var enableLogs: Bool = false
     #endif // !SDK_V10
 
@@ -784,6 +785,7 @@
     /// to `false` does not drop those metrics.
     ///
     /// - Note: Default value is `true`.
+    /// - Warning: Deprecated. This option will be removed in the next major version.
     @objc public var enableMetrics: Bool = true
 
     /// Use this callback to drop or modify a metric before the SDK sends it to Sentry. Return nil to

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsApiE2ETests.swift
@@ -41,15 +41,18 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
-    func testCount_withMetricsDisabled_shouldNotCreateMetric() throws {
+    func testCount_withMetricsDisabled_shouldStillCreateMetric() throws {
         // -- Arrange --
+        // enableMetrics must not gate the manual metrics API.
         let client = try givenSdkWithHub(isMetricsEnabled: false)
 
         // -- Act --
         SentrySDK.metrics.count(key: "test.metric", value: 1)
 
         // -- Assert --
-        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+        let metric = try XCTUnwrap(client.testMetricsBuffer.addInvocations.first)
+        XCTAssertEqual(metric.name, "test.metric")
+        XCTAssertEqual(metric.value, .counter(1))
     }
 
     func testCount_withZeroValue_shouldCreateMetric() throws {
@@ -132,15 +135,18 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
-    func testDistribution_withMetricsDisabled_shouldNotCreateMetric() throws {
+    func testDistribution_withMetricsDisabled_shouldStillCreateMetric() throws {
         // -- Arrange --
+        // enableMetrics must not gate the manual metrics API.
         let client = try givenSdkWithHub(isMetricsEnabled: false)
 
         // -- Act --
         SentrySDK.metrics.distribution(key: "test.metric", value: 1.0)
 
         // -- Assert --
-        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+        let metric = try XCTUnwrap(client.testMetricsBuffer.addInvocations.first)
+        XCTAssertEqual(metric.name, "test.metric")
+        XCTAssertEqual(metric.value, .distribution(1.0))
     }
 
     func testDistribution_withNegativeValue_shouldCreateMetric() throws {
@@ -206,15 +212,18 @@ class SentryMetricsApiE2ETests: XCTestCase {
         XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
     }
 
-    func testGauge_withMetricsDisabled_shouldNotCreateMetric() throws {
+    func testGauge_withMetricsDisabled_shouldStillCreateMetric() throws {
         // -- Arrange --
+        // enableMetrics must not gate the manual metrics API.
         let client = try givenSdkWithHub(isMetricsEnabled: false)
 
         // -- Act --
         SentrySDK.metrics.gauge(key: "test.metric", value: 1.0)
 
         // -- Assert --
-        XCTAssertEqual(client.testMetricsBuffer.addInvocations.count, 0)
+        let metric = try XCTUnwrap(client.testMetricsBuffer.addInvocations.first)
+        XCTAssertEqual(metric.name, "test.metric")
+        XCTAssertEqual(metric.value, .gauge(1.0))
     }
 
     func testGauge_withNegativeValue_shouldCreateMetric() throws {
@@ -274,16 +283,16 @@ class SentryMetricsApiE2ETests: XCTestCase {
         SentrySDK.setStart(with: options)
         SentrySDKInternal.setCurrentHub(hub)
 
-        if isMetricsEnabled {
-            let dependencies = SentryDependencyContainer.sharedInstance()
-            let integration = try XCTUnwrap(
-                SentryMetricsIntegration<SentryDependencyContainer>(
-                    with: options,
-                    dependencies: dependencies
-                ) as Any as? SentryIntegrationProtocol
-            )
-            hub.addInstalledIntegration(integration, name: SentryMetricsIntegration<SentryDependencyContainer>.name)
-        }
+        // Always install the metrics integration. enableMetrics is a legacy option and must
+        // not prevent manual metric capture.
+        let dependencies = SentryDependencyContainer.sharedInstance()
+        let integration = try XCTUnwrap(
+            SentryMetricsIntegration<SentryDependencyContainer>(
+                with: options,
+                dependencies: dependencies
+            ) as Any as? SentryIntegrationProtocol
+        )
+        hub.addInstalledIntegration(integration, name: SentryMetricsIntegration<SentryDependencyContainer>.name)
 
         hub.startSession()
         return client

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -22,7 +22,7 @@ class SentryMetricsIntegrationTests: XCTestCase {
         startSDK(isEnabled: false)
 
         // -- Assert --
-        XCTAssertFalse(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().contains("Metrics"))
+        XCTAssertTrue(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().contains("Metrics"))
     }
 
     func testStartSDK_whenMetricsIsEnabled_shouldInstallMetricsIntegration() {

--- a/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Metrics/SentryMetricsIntegrationTests.swift
@@ -13,9 +13,10 @@ class SentryMetricsIntegrationTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testStartSDK_whenMetricsIsDisabled_shouldNotInstallMetricsIntegration() {
+    func testStartSDK_whenEnableMetricsIsFalse_shouldStillBeInstalled() {
         // -- Arrange --
-        // SDK not enabled in startSDK call
+        // enableMetrics is a legacy compatibility option and must not prevent install so
+        // manual metric APIs keep working.
 
         // -- Act --
         startSDK(isEnabled: false)

--- a/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySwiftIntegrationInstallerTests.swift
@@ -4,11 +4,13 @@ import XCTest
 
 final class SentrySwiftIntegrationInstallerTests: XCTestCase {
 
-    private var expectedReplayIntegrationCount: Int {
+    private var expectedDefaultIntegrationCount: Int {
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-        return 1
+        // Replay + Metrics
+        return 2
 #else
-        return 0
+        // Metrics
+        return 1
 #endif
     }
 
@@ -35,11 +37,12 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         #endif // !SDK_V10
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
-        options.enableMetrics = false
         options.enableCrashHandler = false
         #if canImport(MetricKit) && !os(tvOS)
         options.enableMetricKit = false
         #endif
+        // Metrics stays installed even when enableMetrics is false so manual APIs keep working.
+        options.enableMetrics = false
 
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)
@@ -49,9 +52,10 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
 
         // Assert
         let names = try XCTUnwrap(testHub.installedIntegrationNames())
-        XCTAssertEqual(names.count, expectedReplayIntegrationCount + 1)
+        XCTAssertEqual(names.count, expectedDefaultIntegrationCount + 1)
+        XCTAssertEqual(testHub.installedIntegrations().count, expectedDefaultIntegrationCount + 1)
         XCTAssertTrue(names.contains("SentrySwiftAsyncIntegration"))
-        XCTAssertEqual(testHub.installedIntegrations().count, expectedReplayIntegrationCount + 1)
+        XCTAssertTrue(names.contains("SentryMetricsIntegration"))
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
         XCTAssertTrue(names.contains("SentrySessionReplayIntegration"))
 #endif
@@ -73,11 +77,12 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         #endif // !SDK_V10
         options.enableWatchdogTerminationTracking = false
         options.enableSwizzling = false
-        options.enableMetrics = false
         options.enableCrashHandler = false
         #if canImport(MetricKit) && !os(tvOS)
         options.enableMetricKit = false
         #endif
+        // Metrics remains installed regardless of enableMetrics.
+        options.enableMetrics = false
 
         let testHub = TestHub(client: nil, andScope: nil)
         SentrySDKInternal.setCurrentHub(testHub)
@@ -86,7 +91,7 @@ final class SentrySwiftIntegrationInstallerTests: XCTestCase {
         SentrySwiftIntegrationInstaller.install(with: options)
 
         // Assert
-        XCTAssertEqual(testHub.installedIntegrationNames().count, expectedReplayIntegrationCount)
-        XCTAssertEqual(testHub.installedIntegrations().count, expectedReplayIntegrationCount)
+        XCTAssertEqual(testHub.installedIntegrationNames().count, expectedDefaultIntegrationCount)
+        XCTAssertEqual(testHub.installedIntegrations().count, expectedDefaultIntegrationCount)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -87,7 +87,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0)
 
         let sut = try getSut()
-        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 2) // Metrics and SessionReplay
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         XCTAssertNil(sut.sessionReplay)
         XCTAssertFalse(try XCTUnwrap(sut.getTouchTracker()).isEnabled)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -61,7 +61,12 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     private func getSut() throws -> SentrySessionReplayIntegration {
-        return try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
+        return try XCTUnwrap(sessionReplayIntegration())
+    }
+
+    private func sessionReplayIntegration() -> SentrySessionReplayIntegration? {
+        return SentrySDKInternal.currentHub().installedIntegrations()
+            .first { $0 is SentrySessionReplayIntegration } as? SentrySessionReplayIntegration
     }
     
     private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true, noIntegrations: Bool = false, configure: ((Options) -> Void)? = nil) {
@@ -87,11 +92,11 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertNil(sut.sessionReplay)
         XCTAssertFalse(try XCTUnwrap(sut.getTouchTracker()).isEnabled)
     }
-    
+
     func testInstallFullSessionReplay() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)
-        
-        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
+
+        XCTAssertNotNil(sessionReplayIntegration())
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
 
@@ -187,8 +192,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testInstallNoSwizzlingNoTouchTracker() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0, enableSwizzling: false)
-        guard let integration = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
-        else {
+        guard let integration = sessionReplayIntegration() else {
             XCTFail("Could not find session replay integration")
             return
         }
@@ -204,7 +208,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testInstallFullSessionReplayButDontRunBecauseOfRandom() throws {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
         startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
-        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertNotNil(sessionReplayIntegration())
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
@@ -229,16 +233,16 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.1)
         
         startSDK(sessionSampleRate: 0.3, errorSampleRate: 0)
-        
-        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
+
+        XCTAssertNotNil(sessionReplayIntegration())
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
     }
-    
+
     func testInstallErrorReplay() {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0.1)
-        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertNotNil(sessionReplayIntegration())
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -3059,22 +3059,24 @@ final class SentryClientTests: XCTestCase {
     }
 
     #if !SDK_V10
-    func testCaptureLog_withLogsDisabled_logDropped() {
+    func testCaptureLog_withLogsDisabled_logStillCaptured() {
         // -- Arrange --
+        // enableLogs is a legacy compatibility option and must not gate manual log APIs.
         let sut = fixture.getSut()
         sut.options.enableLogs = false
 
         let testProcessor = TestTelemetryProcessorForClient()
         Dynamic(sut).telemetryProcessor = testProcessor
 
-        let log = SentryLog(level: .info, body: "This log should be dropped")
+        let log = SentryLog(level: .info, body: "This log should still be captured")
         let scope = Scope()
 
         // -- Act --
         sut._swiftCaptureLog(log, with: scope)
 
         // -- Assert --
-        XCTAssertEqual(testProcessor.addLogInvocations.count, 0, "Log should be dropped when enableLogs is false")
+        XCTAssertEqual(testProcessor.addLogInvocations.count, 1, "Manual logs must not be gated by enableLogs")
+        XCTAssertEqual(testProcessor.addLogInvocations.first?.body, "This log should still be captured")
     }
     #endif // !SDK_V10
 

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -448,7 +448,7 @@ class SentrySDKInternalTests: XCTestCase {
         }
 
         let hub = SentrySDKInternal.currentHub()
-        var expectedIntegrationCount = 1
+        var expectedIntegrationCount = 2 // SwiftAsync plus the always-installed Metrics integration.
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
         expectedIntegrationCount += 1
 #endif

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -381,10 +381,12 @@ class SentrySDKTests: XCTestCase {
             options.removeAllIntegrations()
         }
 
+        // Metrics always installs so the manual metrics API keeps working.
+        // Replay is only installed if session replay is supported.
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
-        assertIntegrationsInstalled(integrations: ["SentrySessionReplayIntegration"])
+        assertIntegrationsInstalled(integrations: ["SentryMetricsIntegration", "SentrySessionReplayIntegration"])
 #else
-        assertIntegrationsInstalled(integrations: [])
+        assertIntegrationsInstalled(integrations: ["SentryMetricsIntegration"])
 #endif
     }
 
@@ -689,13 +691,14 @@ extension SentrySDKTests {
         SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
     }
     
-    private func assertIntegrationsInstalled(integrations: [String]) {
-        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
+    private func assertIntegrationsInstalled(integrations: [String], file: StaticString = #file, line: UInt = #line) {
+        let hub = SentrySDKInternal.currentHub()
+        XCTAssertEqual(integrations.count, hub.installedIntegrations().count, file: file, line: line)
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
-                XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
+                XCTAssertTrue(hub.isIntegrationInstalled(integrationClass), "\(integration) not installed", file: file, line: line)
             } else {
-                XCTAssertTrue(SentrySDKInternal.currentHub().hasIntegration(integration), "\(integration) not installed with legacy ObjC API nor Swift")
+                XCTAssertTrue(hub.hasIntegration(integration), "\(integration) not installed with legacy ObjC API nor Swift", file: file, line: line)
             }
         }
     }


### PR DESCRIPTION
Manual `SentrySDK.logger` / opt-in logging integrations and `SentrySDK.metrics` no longer drop data when `enableLogs` or `enableMetrics` is `false`.

Per the cross-SDK decision: keep both options until the next major, do not flip defaults in a minor, and do not gate manual APIs behind either flag. Both options are now deprecated. Metrics integration always installs so the manual metrics API keeps working; `enableMetrics` remains for compatibility telemetry only.

Default flips and flag removal stay on the v10 track (`enableLogs` already removed there; `enableMetrics` tracked in #8873).

Supersedes #8906 with review feedback from @NinjaLikesCheez addressed (removed explanatory comments).

Closes #8771