### PR TITLE
fix: skip setCurrentRequest: on canceling/completed tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - Silence spurious ERROR log in `SentryCrashCxaThrowSwapper` for empty sections (#8915)
 - Stop recording touch events while Session Replay is paused. (#8887)
+- Fix crash in `[NSURLSessionTask cancel]` when cancelling an in-flight task with swizzling enabled (#8921)
 
 ### Internal
 

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -38,6 +38,15 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
         }
     }
 
+    // setCurrentRequest: is a private API without concurrency guarantees. Calling it
+    // on a task that is canceling or completed races with [NSURLSessionTask cancel]
+    // and can cause EXC_BAD_ACCESS (see #8917).
+    NSURLSessionTaskState taskState = sessionTask.state;
+    if (taskState == NSURLSessionTaskStateCanceling
+        || taskState == NSURLSessionTaskStateCompleted) {
+        return;
+    }
+
     // CFNetwork may read currentRequest concurrently, so never mutate it in place.
     SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
     if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
@@ -195,6 +195,58 @@ final class SentryTracePropagationTests: XCTestCase {
         XCTAssertEqual(task.currentRequest?.value(forHTTPHeaderField: "sentry-trace"), traceHeader.value())
     }
 
+    // MARK: - setCurrentRequest: must not be called on canceling or completed tasks (issue #8917)
+
+    func testAddBaggageHeader_whenTaskIsCanceling_shouldNotCallSetCurrentRequest() throws {
+        // -- Arrange --
+        let request = URLRequest(url: try XCTUnwrap(URL(string: "https://www.domain.com/api")))
+        let task = MutableRequestTaskMock(request: request)
+        task.state = .canceling
+
+        let traceHeader = TraceHeader(
+            trace: SentryId(),
+            spanId: SpanId(),
+            sampled: .yes
+        )
+
+        // -- Act --
+        SentryTracePropagation.addBaggageHeader(
+            Baggage(),
+            traceHeader: traceHeader,
+            propagateTraceparent: true,
+            tracePropagationTargets: [try XCTUnwrap(NSRegularExpression(pattern: ".*"))],
+            toRequest: task
+        )
+
+        // -- Assert --
+        XCTAssertEqual(task.setCurrentRequestCallCount, 0, "setCurrentRequest: must not be called on a canceling task — it races with [NSURLSessionTask cancel] and can cause EXC_BAD_ACCESS")
+    }
+
+    func testAddBaggageHeader_whenTaskIsCompleted_shouldNotCallSetCurrentRequest() throws {
+        // -- Arrange --
+        let request = URLRequest(url: try XCTUnwrap(URL(string: "https://www.domain.com/api")))
+        let task = MutableRequestTaskMock(request: request)
+        task.state = .completed
+
+        let traceHeader = TraceHeader(
+            trace: SentryId(),
+            spanId: SpanId(),
+            sampled: .yes
+        )
+
+        // -- Act --
+        SentryTracePropagation.addBaggageHeader(
+            Baggage(),
+            traceHeader: traceHeader,
+            propagateTraceparent: true,
+            tracePropagationTargets: [try XCTUnwrap(NSRegularExpression(pattern: ".*"))],
+            toRequest: task
+        )
+
+        // -- Assert --
+        XCTAssertEqual(task.setCurrentRequestCallCount, 0, "setCurrentRequest: must not be called on a completed task")
+    }
+
     // MARK: - Trace propagation for download and upload tasks (issue #8519)
 
     func testAddBaggageHeader_DownloadTask_AddsTraceHeaders() throws {


### PR DESCRIPTION
## Summary

- Guard `addBaggageHeader:toRequest:` against calling the private `setCurrentRequest:` API when the task is already in `.canceling` or `.completed` state
- Add two unit tests that verify `setCurrentRequest:` is not called on terminal-state tasks

## Root Cause

`setCurrentRequest:` is a private API with no concurrency guarantees. When Sentry's swizzled `resume()` calls it to inject trace headers, it replaces the task's internal `_currentRequest` pointer. CFNetwork's internal structures can retain stale references to the old request. When `cancel()` later runs cleanup through these stale pointers → `EXC_BAD_ACCESS (SIGSEGV)` at address `0x10`.

The crash reproduces on both 8.55.1 and 9.26.0 because both versions use the `setCurrentRequest:` code path for immutable requests (common on modern iOS). Disabling swizzling prevents the crash because `resume()` never fires and `setCurrentRequest:` is never called.

## Fix

Add a task state check before calling `setCurrentRequest:`. If the task is already `.canceling` or `.completed`, skip the header injection entirely — the request is no longer useful for trace propagation at that point.

This is a TOCTOU narrowing (not a full elimination) of the race window, but it covers the reported scenario where `cancel` transitions the task state before our `resume` swizzle reaches `setCurrentRequest:`.

A more complete long-term fix would move trace header injection to task creation time (swizzling `URLSession`'s factory methods), eliminating `setCurrentRequest:` entirely.

Fixes #8917

## Test plan

- [x] New tests `testAddBaggageHeader_whenTaskIsCanceling_shouldNotCallSetCurrentRequest` and `testAddBaggageHeader_whenTaskIsCompleted_shouldNotCallSetCurrentRequest` — both fail before the fix, pass after
- [x] All 16 `SentryTracePropagationTests` pass
- [x] All 92 `SentryNetworkTrackerTests` pass (0 regressions)
- [x] `make analyze` passes