### PR TITLE
feat(visionOS): enable view hierarchy capture

### DIFF
--- a/Sources/SentryObjC/Public/SentryObjCInternalApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCInternalApi.h
@@ -20,9 +20,9 @@
 #if SENTRY_OBJC_HAS_UIKIT
 @class SentryObjCInternalPerformanceApi;
 @class SentryObjCInternalScreenApi;
+@class SentryObjCInternalViewHierarchyApi;
 #    if !TARGET_OS_VISION
 @class SentryObjCInternalScreenshotApi;
-@class SentryObjCInternalViewHierarchyApi;
 #    endif
 #endif
 #if SENTRY_OBJC_REPLAY_SUPPORTED
@@ -78,12 +78,12 @@ SENTRY_NO_INIT
 /// Screen name tracking.
 @property (nonatomic, readonly) SentryObjCInternalScreenApi *screen;
 
+/// View hierarchy capture.
+@property (nonatomic, readonly) SentryObjCInternalViewHierarchyApi *viewHierarchy;
+
 #    if !TARGET_OS_VISION
 /// Screenshot capture.
 @property (nonatomic, readonly) SentryObjCInternalScreenshotApi *screenshot;
-
-/// View hierarchy capture.
-@property (nonatomic, readonly) SentryObjCInternalViewHierarchyApi *viewHierarchy;
 #    endif
 #endif
 

--- a/Sources/SentryObjC/Public/SentryObjCInternalViewHierarchyApi.h
+++ b/Sources/SentryObjC/Public/SentryObjCInternalViewHierarchyApi.h
@@ -5,7 +5,7 @@
 #    import <SentryObjC/SentryObjCDefines.h>
 #endif
 
-#if SENTRY_OBJC_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_OBJC_HAS_UIKIT
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SentryObjCCompat/SentryObjCInternalApi.swift
+++ b/Sources/SentryObjCCompat/SentryObjCInternalApi.swift
@@ -58,13 +58,13 @@ import Foundation
         SentryObjCInternalScreenApi(wrapped.value.screen)
     }
 
+    @objc public var viewHierarchy: SentryObjCInternalViewHierarchyApi {
+        SentryObjCInternalViewHierarchyApi(wrapped.value.viewHierarchy)
+    }
+
     #if (os(iOS) || os(tvOS))
     @objc public var screenshot: SentryObjCInternalScreenshotApi {
         SentryObjCInternalScreenshotApi(wrapped.value.screenshot)
-    }
-
-    @objc public var viewHierarchy: SentryObjCInternalViewHierarchyApi {
-        SentryObjCInternalViewHierarchyApi(wrapped.value.viewHierarchy)
     }
 
     @objc public var replay: SentryObjCInternalReplayApi {

--- a/Sources/SentryObjCCompat/SentryObjCInternalViewHierarchyApi.swift
+++ b/Sources/SentryObjCCompat/SentryObjCInternalViewHierarchyApi.swift
@@ -6,7 +6,7 @@ internal import Sentry
 #endif
 import Foundation
 
-#if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS))
+#if canImport(UIKit) && !SENTRY_NO_UI_FRAMEWORK && (os(iOS) || os(tvOS) || os(visionOS))
 
 @objc(SentryObjCInternalViewHierarchyApi) public final class SentryObjCInternalViewHierarchyApi: NSObject {
     internal let wrapped: Box<SentryInternalViewHierarchyApi>

--- a/Sources/Swift/Core/Integrations/Integrations.swift
+++ b/Sources/Swift/Core/Integrations/Integrations.swift
@@ -89,6 +89,9 @@ private struct AnyIntegration {
 
         #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
         integrations.append(.init(SentryScreenshotIntegration.self))
+        #endif
+
+        #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         integrations.append(.init(SentryViewHierarchyIntegration.self))
         #endif
 

--- a/Sources/Swift/HybridSDK/SentryInternalApi.swift
+++ b/Sources/Swift/HybridSDK/SentryInternalApi.swift
@@ -22,10 +22,10 @@ public struct SentryInternalApi {
     typealias UIDependencies = BaseDependencies
         & SentryInternalPerformanceApi.Dependencies
         & SentryInternalScreenApi.Dependencies
+        & SentryInternalViewHierarchyApi.Dependencies
     #if (os(iOS) || os(tvOS))
     typealias Dependencies = UIDependencies
         & SentryInternalScreenshotApi.Dependencies
-        & SentryInternalViewHierarchyApi.Dependencies
         & SentryInternalReplayApi.Dependencies
     #else
     typealias Dependencies = UIDependencies
@@ -71,12 +71,12 @@ public struct SentryInternalApi {
     /// Screen name tracking for hybrid SDKs.
     public let screen: SentryInternalScreenApi
 
+    /// View hierarchy capture for hybrid SDKs.
+    public let viewHierarchy: SentryInternalViewHierarchyApi
+
     #if (os(iOS) || os(tvOS))
     /// Screenshot capture for hybrid SDKs.
     public let screenshot: SentryInternalScreenshotApi
-
-    /// View hierarchy capture for hybrid SDKs.
-    public let viewHierarchy: SentryInternalViewHierarchyApi
 
     /// Session replay for hybrid SDKs.
     public let replay: SentryInternalReplayApi
@@ -135,9 +135,9 @@ public struct SentryInternalApi {
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         self.performance = SentryInternalPerformanceApi(dependencies: dependencies)
         self.screen = SentryInternalScreenApi(dependencies: dependencies)
+        self.viewHierarchy = SentryInternalViewHierarchyApi(dependencies: dependencies)
         #if (os(iOS) || os(tvOS))
         self.screenshot = SentryInternalScreenshotApi(dependencies: dependencies)
-        self.viewHierarchy = SentryInternalViewHierarchyApi(dependencies: dependencies)
         self.replay = SentryInternalReplayApi(dependencies: dependencies)
         #endif
 #endif

--- a/Sources/Swift/HybridSDK/SentryInternalViewHierarchyApi.swift
+++ b/Sources/Swift/HybridSDK/SentryInternalViewHierarchyApi.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable missing_docs
 import Foundation
 
-#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
 /// Provides view hierarchy capture for hybrid SDKs.
 public struct SentryInternalViewHierarchyApi {

--- a/Sources/Swift/Integrations/Screenshot/SentryScreenshotIntegration.swift
+++ b/Sources/Swift/Integrations/Screenshot/SentryScreenshotIntegration.swift
@@ -72,7 +72,7 @@ final class SentryScreenshotIntegration<Dependencies: ScreenshotIntegrationProvi
             return attachments
         }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if event.isMetricKitEvent() {
             return attachments
         }

--- a/Sources/Swift/Integrations/ViewHierarchy/SentryViewHierarchyIntegration.swift
+++ b/Sources/Swift/Integrations/ViewHierarchy/SentryViewHierarchyIntegration.swift
@@ -71,7 +71,7 @@ final class SentryViewHierarchyIntegration<Dependencies: SentryViewHierarchyInte
             return attachments
         }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if event.isMetricKitEvent() {
             return attachments
         }

--- a/Sources/Swift/Integrations/ViewHierarchy/SentryViewHierarchyIntegration.swift
+++ b/Sources/Swift/Integrations/ViewHierarchy/SentryViewHierarchyIntegration.swift
@@ -1,6 +1,6 @@
 internal import _SentryPrivate
 
-#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
 typealias SentryViewHierarchyIntegrationProvider = ViewHierarchyProviderProvider & ClientProvider
 

--- a/Sources/Swift/Options.swift
+++ b/Sources/Swift/Options.swift
@@ -330,6 +330,8 @@
     /// @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
     /// configurations even when targeting iOS or tvOS platforms.
     /// @note Default value is @c false.
+    /// - Note: On visionOS, only the UIKit window hierarchy (2D Scenes) is captured. Views in
+    ///   immersive spaces or volumetric windows rendered via RealityKit are not included.
     @objc public var attachViewHierarchy: Bool = false
 
     /// @brief If enabled, view hierarchy attachment will contain view `accessibilityIdentifier`.

--- a/Sources/Swift/SentryDependencyContainer.swift
+++ b/Sources/Swift/SentryDependencyContainer.swift
@@ -736,18 +736,20 @@ protocol FramesTrackingProvider {
 extension SentryDependencyContainer: FramesTrackingProvider { }
 #endif
 
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
+protocol ViewHierarchyProviderProvider {
+    var viewHierarchyProvider: SentryViewHierarchyProvider? { get }
+}
+
+extension SentryDependencyContainer: ViewHierarchyProviderProvider { }
+#endif
+
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
 protocol ScreenshotIntegrationProvider {
     var screenshotSource: SentryScreenshotSource? { get }
 }
 
 extension SentryDependencyContainer: ScreenshotIntegrationProvider { }
-
-protocol ViewHierarchyProviderProvider {
-    var viewHierarchyProvider: SentryViewHierarchyProvider? { get }
-}
-
-extension SentryDependencyContainer: ViewHierarchyProviderProvider { }
 
 protocol SessionReplayCaptureSchedulerProvider {
     var sessionReplayCaptureScheduler: SentrySessionReplayRunLoopCaptureScheduler { get }

--- a/Tests/SentryObjCTests/SentryObjCInternalViewHierarchyApiIntegrationTests.m
+++ b/Tests/SentryObjCTests/SentryObjCInternalViewHierarchyApiIntegrationTests.m
@@ -1,7 +1,7 @@
 @import SentryObjC;
 @import XCTest;
 
-#if SENTRY_OBJC_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_OBJC_HAS_UIKIT
 
 @interface SentryObjCInternalViewHierarchyApiIntegrationTests : XCTestCase
 @end

--- a/Tests/SentryTests/HybridSDK/SentryInternalViewHierarchyApiIntegrationTests.swift
+++ b/Tests/SentryTests/HybridSDK/SentryInternalViewHierarchyApiIntegrationTests.swift
@@ -2,7 +2,7 @@
 import SentryTestUtils
 import XCTest
 
-#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
 class SentryInternalViewHierarchyApiIntegrationTests: XCTestCase {
 

--- a/Tests/SentryTests/HybridSDK/SentryInternalViewHierarchyApiTests.swift
+++ b/Tests/SentryTests/HybridSDK/SentryInternalViewHierarchyApiTests.swift
@@ -1,7 +1,7 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
-#if (os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
 
 class SentryInternalViewHierarchyApiTests: XCTestCase {
 

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTestHelper.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTestHelper.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
 @_spi(Private) import Sentry
 
@@ -16,4 +16,4 @@ public func saveViewHierarchy(_ reportDirectoryPath: UnsafePointer<CChar>?) {
     SentryDependencyContainer.sharedInstance().viewHierarchyProvider?.saveViewHierarchy(filePath)
 }
 
-#endif // os(iOS) || os(tvOS)
+#endif // os(iOS) || os(tvOS) || os(visionOS)

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
 @_spi(Private) @testable import Sentry
 @_spi(Private) @testable import SentryTestUtils

--- a/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.swift
@@ -1,6 +1,6 @@
 @_spi(Private) @testable import Sentry
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 
 class TestSentryViewHierarchyProvider: SentryViewHierarchyProvider {
 
@@ -23,4 +23,4 @@ class TestSentryViewHierarchyProvider: SentryViewHierarchyProvider {
     }
 }
 
-#endif // os(iOS) || os(tvOS)
+#endif // os(iOS) || os(tvOS) || os(visionOS)

--- a/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
@@ -2,7 +2,7 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 class SentryViewHierarchyProviderTests: XCTestCase {
     private static let mockWindowScene: UIWindowScene = MockUIWindowScene()
     private static let viewHierarchyMaxDepth = 90


### PR DESCRIPTION
## Summary
- Wire up the existing `SentryViewHierarchyProvider` — which already compiled on visionOS — through the integration, registration, hybrid SDK, and ObjC layers so that `attachViewHierarchy` works on visionOS
- On visionOS only the UIKit window hierarchy (2D Scenes) is captured; views in immersive spaces or volumetric windows rendered via RealityKit are not included

#skip-changelog

Closes #8925