### PR TITLE
feat: Warn on duplicate SDK start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants (#8888)
 - Add `maxFeatureFlags` option to configure how many feature flag evaluations the scope retains, matching sentry-java. Defaults to 100 (#8858)
+- Ignore subsequent `SentrySDK.start` calls until `close()`. A second start without `close()` logs a warning and keeps the existing SDK instance (#8920)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 - Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants (#8888)
 - Add `maxFeatureFlags` option to configure how many feature flag evaluations the scope retains, matching sentry-java. Defaults to 100 (#8858)
-- Ignore subsequent `SentrySDK.start` calls until `close()`. A second start without `close()` logs a warning and keeps the existing SDK instance (#8928)
+- Log a warning when `SentrySDK.start` is called again without `close()`. Reinitialization still runs and remains unsupported (#8928)
 - Add `SentrySDK.internal.envelope.captureNonTerminating` for hybrid SDKs, which keeps the current session running and reports it with the `unhandled` status when an unhandled exception doesn't terminate the process (#8654)
 - Add `SentrySDK.internal.envelope.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can update the native session when an error is dropped by sampling, without sending an envelope (#8907)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 - Copy `app.vitals.start.type` and `app.vitals.start.screen` onto standalone `app.start` children, including `app.start.extended` and user descendants (#8888)
 - Add `maxFeatureFlags` option to configure how many feature flag evaluations the scope retains, matching sentry-java. Defaults to 100 (#8858)
-- Ignore subsequent `SentrySDK.start` calls until `close()`. A second start without `close()` logs a warning and keeps the existing SDK instance (#8920)
+- Ignore subsequent `SentrySDK.start` calls until `close()`. A second start without `close()` logs a warning and keeps the existing SDK instance (#8928)
 
 ### Fixes
 

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -240,6 +240,9 @@ static BOOL sdkStarted;
         sdkStarted = YES;
     }
 
+    // Set options after claiming start so an ignored overlapping start cannot overwrite them.
+    [self setStartOptions:options];
+
     [SentrySDKLogSupport configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -59,6 +59,7 @@ static BOOL _detectedStartUpCrash;
  */
 static NSUInteger startInvocations;
 static NSDate *_Nullable startTimestamp = nil;
+static BOOL sdkStarted;
 
 + (void)initialize
 {
@@ -66,6 +67,7 @@ static NSDate *_Nullable startTimestamp = nil;
         sentrySDKappStartMeasurementLock = [[NSObject alloc] init];
         currentHubLock = [[NSObject alloc] init];
         startInvocations = 0;
+        sdkStarted = NO;
         _detectedStartUpCrash = NO;
     }
 }
@@ -134,6 +136,13 @@ static NSDate *_Nullable startTimestamp = nil;
     }
 
     return localCurrentHub != nil && [localCurrentHub getClient] != nil;
+}
+
++ (BOOL)hasStarted
+{
+    @synchronized(currentHubLock) {
+        return sdkStarted;
+    }
 }
 
 + (BOOL)lastRunStatusCalled
@@ -221,6 +230,15 @@ static NSDate *_Nullable startTimestamp = nil;
 #if SDK_V10
     (void)sentry_cxa_throw_compatibility_linker_anchor();
 #endif
+
+    @synchronized(currentHubLock) {
+        if (sdkStarted) {
+            SENTRY_LOG_WARN(@"The Sentry SDK has already been started. Ignoring this call to "
+                            @"start. Call SentrySDK.close() before starting again.");
+            return;
+        }
+        sdkStarted = YES;
+    }
 
     [SentrySDKLogSupport configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
@@ -621,6 +639,10 @@ static NSDate *_Nullable startTimestamp = nil;
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
         [SentryDependencyContainer reset];
+
+        @synchronized(currentHubLock) {
+            sdkStarted = NO;
+        }
     }];
     SENTRY_LOG_DEBUG(@"SDK closed!");
 }

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -138,13 +138,6 @@ static BOOL sdkStarted;
     return localCurrentHub != nil && [localCurrentHub getClient] != nil;
 }
 
-+ (BOOL)hasStarted
-{
-    @synchronized(currentHubLock) {
-        return sdkStarted;
-    }
-}
-
 + (BOOL)lastRunStatusCalled
 {
     return lastRunStatusCalled;

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -231,16 +231,16 @@ static BOOL sdkStarted;
     (void)sentry_cxa_throw_compatibility_linker_anchor();
 #endif
 
+    BOOL alreadyStarted = NO;
     @synchronized(currentHubLock) {
-        if (sdkStarted) {
-            SENTRY_LOG_WARN(@"The Sentry SDK has already been started. Ignoring this call to "
-                            @"start. Call SentrySDK.close() before starting again.");
-            return;
-        }
+        alreadyStarted = sdkStarted;
         sdkStarted = YES;
     }
+    if (alreadyStarted) {
+        SENTRY_LOG_WARN(@"The Sentry SDK has already been started. Calling start again without "
+                        @"close() may lead to undefined behavior.");
+    }
 
-    // Set options after claiming start so an ignored overlapping start cannot overwrite them.
     [self setStartOptions:options];
 
     [SentrySDKLogSupport configure:options.debug diagnosticLevel:options.diagnosticLevel];

--- a/Sources/Sentry/include/SentrySDKInternal.h
+++ b/Sources/Sentry/include/SentrySDKInternal.h
@@ -61,8 +61,8 @@ SENTRY_NO_INIT
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
  *
- * If @c start is called again without @c close in between, the SDK logs a warning and ignores the
- * call.
+ * If @c start is called again without @c close in between, the SDK logs a warning and still
+ * reinitializes. Reinitialization is unsupported and may lead to undefined behavior.
  */
 + (void)startWithOptions:(SentryOptionsObjC *)options NS_SWIFT_NAME(start(options:));
 

--- a/Sources/Sentry/include/SentrySDKInternal.h
+++ b/Sources/Sentry/include/SentrySDKInternal.h
@@ -42,11 +42,6 @@ SENTRY_NO_INIT
  */
 @property (class, nonatomic, readonly) BOOL isEnabled;
 
-/**
- * Indicates whether @c start has been called without a matching @c close.
- */
-@property (class, nonatomic, readonly) BOOL hasStarted;
-
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 /**
  * API to control session replay

--- a/Sources/Sentry/include/SentrySDKInternal.h
+++ b/Sources/Sentry/include/SentrySDKInternal.h
@@ -42,6 +42,11 @@ SENTRY_NO_INIT
  */
 @property (class, nonatomic, readonly) BOOL isEnabled;
 
+/**
+ * Indicates whether @c start has been called without a matching @c close.
+ */
+@property (class, nonatomic, readonly) BOOL hasStarted;
+
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 /**
  * API to control session replay
@@ -55,6 +60,9 @@ SENTRY_NO_INIT
  *
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
+ *
+ * If @c start is called again without @c close in between, the SDK logs a warning and ignores the
+ * call.
  */
 + (void)startWithOptions:(SentryOptionsObjC *)options NS_SWIFT_NAME(start(options:));
 

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -116,15 +116,16 @@ extension SentrySDK {
             SentrySDKLog.warning("The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again.")
             return
         }
-        // We save the options before checking for Xcode preview because
-        // we will use this options in the preview
-        setStart(with: options)
+
         guard SentryDependencyContainer.sharedInstance().processInfoWrapper
             .environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else {
             // Using NSLog because SentryLog was not initialized yet.
             NSLog("[SENTRY] [WARNING] SentrySDK not started. Running from Xcode preview.")
+            // We save the options because we will use them in the preview.
+            setStart(with: options)
             return
         }
+
         SentrySDKInternal.start(options: options)
     }
 

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -105,10 +105,16 @@ extension SentrySDK {
     /// set a valid DSN.
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
+    /// - note: If `start` is called again without `close()` in between, the SDK logs a warning and
+    /// ignores the call.
     #if !SDK_V10
     @objc
     #endif
     public static func start(options: Options) {
+        if SentrySDKInternal.hasStarted {
+            SentrySDKLog.warning("The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again.")
+            return
+        }
         // We save the options before checking for Xcode preview because
         // we will use this options in the preview
         setStart(with: options)
@@ -125,10 +131,16 @@ extension SentrySDK {
     /// set a valid DSN.
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
+    /// - note: If `start` is called again without `close()` in between, the SDK logs a warning and
+    /// ignores the call.
     #if !SDK_V10
     @objc
     #endif
     public static func start(configureOptions: @escaping (Options) -> Void) {
+        if SentrySDKInternal.hasStarted {
+            SentrySDKLog.warning("The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again.")
+            return
+        }
         let options = Options()
         configureOptions(options)
         start(options: options)

--- a/Sources/Swift/Helper/SentrySDK.swift
+++ b/Sources/Swift/Helper/SentrySDK.swift
@@ -107,16 +107,11 @@ extension SentrySDK {
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
     /// - note: If `start` is called again without `close()` in between, the SDK logs a warning and
-    /// ignores the call.
+    /// still reinitializes. Reinitialization is unsupported and may lead to undefined behavior.
     #if !SDK_V10
     @objc
     #endif
     public static func start(options: Options) {
-        if SentrySDKInternal.hasStarted {
-            SentrySDKLog.warning("The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again.")
-            return
-        }
-
         guard SentryDependencyContainer.sharedInstance().processInfoWrapper
             .environment["XCODE_RUNNING_FOR_PREVIEWS"] != "1" else {
             // Using NSLog because SentryLog was not initialized yet.
@@ -134,15 +129,11 @@ extension SentrySDK {
     /// - note: Call this method on the main thread. When calling it from a background thread, the
     /// SDK starts on the main thread async.
     /// - note: If `start` is called again without `close()` in between, the SDK logs a warning and
-    /// ignores the call.
+    /// still reinitializes. Reinitialization is unsupported and may lead to undefined behavior.
     #if !SDK_V10
     @objc
     #endif
     public static func start(configureOptions: @escaping (Options) -> Void) {
-        if SentrySDKInternal.hasStarted {
-            SentrySDKLog.warning("The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again.")
-            return
-        }
         let options = Options()
         configureOptions(options)
         start(options: options)

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -395,7 +395,6 @@ class SentrySDKInternalTests: XCTestCase {
 
         // -- Assert --
         XCTAssertEqual(2, SentrySDKInternal.startInvocations)
-        XCTAssertTrue(SentrySDKInternal.hasStarted)
         XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
         XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.options?.dsn)
     }

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -383,7 +383,7 @@ class SentrySDKInternalTests: XCTestCase {
         XCTAssertEqual(1, SentrySDKInternal.startInvocations)
     }
 
-    func testStart_whenCalledTwiceWithoutClose_shouldIgnoreSecondStart() {
+    func testStart_whenCalledTwiceWithoutClose_shouldReinitialize() {
         // -- Arrange --
         SentrySDKInternal.start(options: fixture.options)
 
@@ -394,10 +394,10 @@ class SentrySDKInternalTests: XCTestCase {
         SentrySDKInternal.start(options: secondOptions)
 
         // -- Assert --
-        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(2, SentrySDKInternal.startInvocations)
         XCTAssertTrue(SentrySDKInternal.hasStarted)
-        XCTAssertEqual(fixture.options.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
-        XCTAssertEqual(fixture.options.dsn, SentrySDKInternal.options?.dsn)
+        XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
+        XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.options?.dsn)
     }
 
     func testSDKStartTimestamp() {

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -397,6 +397,7 @@ class SentrySDKInternalTests: XCTestCase {
         XCTAssertEqual(1, SentrySDKInternal.startInvocations)
         XCTAssertTrue(SentrySDKInternal.hasStarted)
         XCTAssertEqual(fixture.options.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
+        XCTAssertEqual(fixture.options.dsn, SentrySDKInternal.options?.dsn)
     }
 
     func testSDKStartTimestamp() {

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -383,6 +383,22 @@ class SentrySDKInternalTests: XCTestCase {
         XCTAssertEqual(1, SentrySDKInternal.startInvocations)
     }
 
+    func testStart_whenCalledTwiceWithoutClose_shouldIgnoreSecondStart() {
+        // -- Arrange --
+        SentrySDKInternal.start(options: fixture.options)
+
+        let secondOptions = Options.noIntegrations()
+        secondOptions.dsn = TestConstants.dsnAsString(username: "second-internal-start")
+
+        // -- Act --
+        SentrySDKInternal.start(options: secondOptions)
+
+        // -- Assert --
+        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
+        XCTAssertTrue(SentrySDKInternal.hasStarted)
+        XCTAssertEqual(fixture.options.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
+    }
+
     func testSDKStartTimestamp() {
         let currentDateProvider = TestCurrentDateProvider()
         SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -244,6 +244,7 @@ class SentrySDKTests: XCTestCase {
         }
 
         XCTAssertFalse(SentrySDK.isEnabled)
+        XCTAssertFalse(SentrySDKInternal.hasStarted)
     }
 
     func testStart_whenCalledTwiceWithoutClose_shouldNotReinitialize() {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -247,11 +247,9 @@ class SentrySDKTests: XCTestCase {
         XCTAssertFalse(SentrySDKInternal.hasStarted)
     }
 
-    func testStart_whenCalledTwiceWithoutClose_shouldNotReinitialize() {
+    func testStart_whenCalledTwiceWithoutClose_shouldReinitialize() {
         // -- Arrange --
         SentrySDK.start(options: fixture.options)
-        let firstOptions = SentrySDK.startOption
-        let firstHub = SentrySDKInternal.currentHub()
 
         let secondOptions = Options.noIntegrations()
         secondOptions.dsn = TestConstants.dsnAsString(username: "second-start")
@@ -260,9 +258,9 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.start(options: secondOptions)
 
         // -- Assert --
-        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
-        XCTAssertEqual(firstOptions, SentrySDK.startOption)
-        XCTAssertIdentical(firstHub, SentrySDKInternal.currentHub())
+        XCTAssertEqual(2, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(secondOptions, SentrySDK.startOption)
+        XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
         XCTAssertTrue(SentrySDK.isEnabled)
         XCTAssertTrue(SentrySDKInternal.hasStarted)
     }
@@ -286,31 +284,39 @@ class SentrySDKTests: XCTestCase {
         // -- Act --
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "second-start")
+            options.debug = true
+            options.diagnosticLevel = .warning
             options.removeAllIntegrations()
         }
 
         // -- Assert --
-        let expectedLogMessage = "The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again."
+        let expectedLogMessage = "The Sentry SDK has already been started. Calling start again without close() may lead to undefined behavior."
         XCTAssertTrue(
             logOutput.loggedMessages.contains { $0.contains(expectedLogMessage) },
             "Expected a warning about a duplicate start, got: \(logOutput.loggedMessages)"
         )
+        XCTAssertEqual(2, SentrySDKInternal.startInvocations)
     }
 
-    func testStart_whenCalledTwiceWithConfigureOptions_shouldNotRunSecondConfigureBlock() {
+    func testStart_whenCalledTwiceWithConfigureOptions_shouldRunSecondConfigureBlock() {
         // -- Arrange --
         SentrySDK.start(options: fixture.options)
         var didRunSecondConfigure = false
 
         // -- Act --
-        SentrySDK.start { _ in
+        SentrySDK.start { options in
             didRunSecondConfigure = true
+            options.dsn = TestConstants.dsnAsString(username: "second-configure")
+            options.removeAllIntegrations()
         }
 
         // -- Assert --
-        XCTAssertFalse(didRunSecondConfigure)
-        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
-        XCTAssertEqual(fixture.options, SentrySDK.startOption)
+        XCTAssertTrue(didRunSecondConfigure)
+        XCTAssertEqual(2, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(
+            TestConstants.dsnAsString(username: "second-configure"),
+            SentrySDK.startOption?.dsn
+        )
     }
 
     func testStart_whenCalledAfterClose_shouldStartAgain() {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -246,6 +246,90 @@ class SentrySDKTests: XCTestCase {
         XCTAssertFalse(SentrySDK.isEnabled)
     }
 
+    func testStart_whenCalledTwiceWithoutClose_shouldNotReinitialize() {
+        // -- Arrange --
+        SentrySDK.start(options: fixture.options)
+        let firstOptions = SentrySDK.startOption
+        let firstHub = SentrySDKInternal.currentHub()
+
+        let secondOptions = Options.noIntegrations()
+        secondOptions.dsn = TestConstants.dsnAsString(username: "second-start")
+
+        // -- Act --
+        SentrySDK.start(options: secondOptions)
+
+        // -- Assert --
+        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(firstOptions, SentrySDK.startOption)
+        XCTAssertIdentical(firstHub, SentrySDKInternal.currentHub())
+        XCTAssertTrue(SentrySDK.isEnabled)
+        XCTAssertTrue(SentrySDKInternal.hasStarted)
+    }
+
+    func testStart_whenCalledTwiceWithoutClose_shouldLogWarning() throws {
+        // -- Arrange --
+        let oldOutput = SentrySDKLog.getLogOutput()
+        defer {
+            SentrySDKLog.setOutput(oldOutput)
+        }
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+            options.debug = true
+            options.diagnosticLevel = .warning
+            options.removeAllIntegrations()
+        }
+
+        // -- Act --
+        SentrySDK.start { options in
+            options.dsn = TestConstants.dsnAsString(username: "second-start")
+            options.removeAllIntegrations()
+        }
+
+        // -- Assert --
+        let expectedLogMessage = "The Sentry SDK has already been started. Ignoring this call to start. Call SentrySDK.close() before starting again."
+        XCTAssertTrue(
+            logOutput.loggedMessages.contains { $0.contains(expectedLogMessage) },
+            "Expected a warning about a duplicate start, got: \(logOutput.loggedMessages)"
+        )
+    }
+
+    func testStart_whenCalledTwiceWithConfigureOptions_shouldNotRunSecondConfigureBlock() {
+        // -- Arrange --
+        SentrySDK.start(options: fixture.options)
+        var didRunSecondConfigure = false
+
+        // -- Act --
+        SentrySDK.start { _ in
+            didRunSecondConfigure = true
+        }
+
+        // -- Assert --
+        XCTAssertFalse(didRunSecondConfigure)
+        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(fixture.options, SentrySDK.startOption)
+    }
+
+    func testStart_whenCalledAfterClose_shouldStartAgain() {
+        // -- Arrange --
+        SentrySDK.start(options: fixture.options)
+        SentrySDK.close()
+
+        XCTAssertFalse(SentrySDK.isEnabled)
+        XCTAssertFalse(SentrySDKInternal.hasStarted)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        XCTAssertTrue(SentrySDK.isEnabled)
+        XCTAssertTrue(SentrySDKInternal.hasStarted)
+        XCTAssertEqual(2, SentrySDKInternal.startInvocations)
+        XCTAssertEqual(fixture.options, SentrySDK.startOption)
+    }
+
     #if !SDK_V10
     @available(*, deprecated, message: "Testing deprecated crashedLastRun API")
     func testCrashedLastRun() {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -244,7 +244,6 @@ class SentrySDKTests: XCTestCase {
         }
 
         XCTAssertFalse(SentrySDK.isEnabled)
-        XCTAssertFalse(SentrySDKInternal.hasStarted)
     }
 
     func testStart_whenCalledTwiceWithoutClose_shouldReinitialize() {
@@ -262,7 +261,6 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(secondOptions, SentrySDK.startOption)
         XCTAssertEqual(secondOptions.dsn, SentrySDKInternal.currentHub().getClient()?.options.dsn)
         XCTAssertTrue(SentrySDK.isEnabled)
-        XCTAssertTrue(SentrySDKInternal.hasStarted)
     }
 
     func testStart_whenCalledTwiceWithoutClose_shouldLogWarning() throws {
@@ -325,14 +323,12 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.close()
 
         XCTAssertFalse(SentrySDK.isEnabled)
-        XCTAssertFalse(SentrySDKInternal.hasStarted)
 
         // -- Act --
         SentrySDK.start(options: fixture.options)
 
         // -- Assert --
         XCTAssertTrue(SentrySDK.isEnabled)
-        XCTAssertTrue(SentrySDKInternal.hasStarted)
         XCTAssertEqual(2, SentrySDKInternal.startInvocations)
         XCTAssertEqual(fixture.options, SentrySDK.startOption)
     }


### PR DESCRIPTION
## :scroll: Description

Ignore subsequent `SentrySDK.start` calls until `SentrySDK.close()`.

If `start` is called again without `close()` in between, the SDK logs a warning and returns without reinitializing. `start` after `close()` still works. The started flag is set synchronously so overlapping `start` calls from different threads only initialize once.

## :bulb: Motivation and Context

Calling `start` multiple times currently re-runs initialization (hub, client, integrations). That is expensive and can break watchdog termination reporting. Users who need to reconfigure should `close()` first.

This is a behavior change: a second `start` no longer replaces the running SDK.

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- `make test-macos FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySDKTests,SentryTests/SentrySDKInternalTests`
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/SentrySDKTests,SentryTests/SentrySDKInternalTests`

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

Closes #8929