### PR TITLE
test: Stabilize profiling integration tests

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -101,10 +101,12 @@ class SentryFileManagerTests: XCTestCase {
     
     private var fixture: Fixture!
     private var sut: SentryFileManager!
+    private var originalDateProvider: SentryCurrentDateProvider!
     
     override func setUpWithError() throws {
         try super.setUpWithError()
         fixture = try Fixture()
+        originalDateProvider = SentryDependencyContainer.sharedInstance().dateProvider
         SentryDependencyContainer.sharedInstance().dateProvider = fixture.currentDateProvider
         
         sut = try fixture.getSut()
@@ -124,6 +126,7 @@ class SentryFileManagerTests: XCTestCase {
         #if !SDK_V10
         sut.deleteAbnormalSession()
         #endif // !SDK_V10
+        SentryDependencyContainer.sharedInstance().dateProvider = originalDateProvider
     }
     
     func testInitDoesNotOverrideDirectories() throws {

--- a/Tests/SentryTests/HybridSDK/SentryInternalProfilingApiIntegrationTests.swift
+++ b/Tests/SentryTests/HybridSDK/SentryInternalProfilingApiIntegrationTests.swift
@@ -29,6 +29,36 @@ class SentryInternalProfilingApiIntegrationTests: XCTestCase {
         }
     }
 
+    // CPU-constrained CI runners can delay the sampling thread beyond any fixed sleep, so wait for
+    // the samples the serializer actually requires. A short polling interval avoids busy-spinning
+    // and is used instead of XCTNSPredicateExpectation, which was observed to add about one second
+    // to every profiling test before reevaluating its predicate.
+    private func waitForProfilerSamples() -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 5
+        repeat {
+            if let profiler = SentryTraceProfiler.getCurrentProfiler(),
+               let profile = profiler.state.copyProfilingData()["profile"] as? [String: Any],
+               let samples = profile["samples"] as? [Any],
+               samples.count >= 2 {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        } while ProcessInfo.processInfo.systemUptime < deadline
+
+        XCTFail("Profiler did not collect at least two samples")
+        return false
+    }
+
+    private func collectProfile(startTime: UInt64, traceId: SentryId) -> [String: Any]? {
+        guard waitForProfilerSamples() else {
+            return nil
+        }
+        let endTime = SentryDependencyContainer.sharedInstance().dateProvider.systemTime()
+        return SentrySDK.internal.profiling.collect(
+            between: startTime, and: endTime, for: traceId
+        )
+    }
+
     // MARK: - Accessor
 
     func testProfiling_shouldBeAccessible() {
@@ -82,12 +112,9 @@ class SentryInternalProfilingApiIntegrationTests: XCTestCase {
         // -- Arrange --
         let traceId = SentryId()
         let startTime = SentrySDK.internal.profiling.start(for: traceId)
-        Thread.sleep(forTimeInterval: 0.2)
 
         // -- Act --
-        let payload = SentrySDK.internal.profiling.collect(
-            between: startTime, and: startTime + 200_000_000, for: traceId
-        )
+        let payload = collectProfile(startTime: startTime, traceId: traceId)
 
         // -- Assert --
         XCTAssertNotNil(payload)
@@ -101,12 +128,9 @@ class SentryInternalProfilingApiIntegrationTests: XCTestCase {
         // -- Arrange --
         let traceId = SentryId()
         let startTime = SentrySDK.internal.profiling.start(for: traceId)
-        Thread.sleep(forTimeInterval: 0.2)
 
         // -- Act --
-        let payload = SentrySDK.internal.profiling.collect(
-            between: startTime, and: startTime + 200_000_000, for: traceId
-        )
+        let payload = collectProfile(startTime: startTime, traceId: traceId)
 
         // -- Assert --
         XCTAssertNotNil(payload?["profile_id"])
@@ -125,12 +149,9 @@ class SentryInternalProfilingApiIntegrationTests: XCTestCase {
         // -- Arrange --
         let traceId = SentryId()
         let startTime = SentrySDK.internal.profiling.start(for: traceId)
-        Thread.sleep(forTimeInterval: 0.2)
 
         // -- Act --
-        let payload = SentrySDK.internal.profiling.collect(
-            between: startTime, and: startTime + 200_000_000, for: traceId
-        )
+        let payload = collectProfile(startTime: startTime, traceId: traceId)
 
         // -- Assert --
         let transaction = try XCTUnwrap(payload?["transaction"] as? NSDictionary)
@@ -144,12 +165,9 @@ class SentryInternalProfilingApiIntegrationTests: XCTestCase {
         // -- Arrange --
         let traceId = SentryId()
         let startTime = SentrySDK.internal.profiling.start(for: traceId)
-        Thread.sleep(forTimeInterval: 0.2)
 
         // -- Act --
-        let payload = SentrySDK.internal.profiling.collect(
-            between: startTime, and: startTime + 200_000_000, for: traceId
-        )
+        let payload = collectProfile(startTime: startTime, traceId: traceId)
 
         // -- Assert --
         let debugMeta = try XCTUnwrap(payload?["debug_meta"] as? [String: Any])

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -15,6 +15,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         SentryExtraPackages.clear()
     }
 
+    #if !os(tvOS) && !os(watchOS) && !os(visionOS)
     // CPU-constrained CI runners can delay the sampling thread beyond any fixed sleep, so wait for
     // the samples the serializer actually requires. A short polling interval avoids busy-spinning
     // and is used instead of XCTNSPredicateExpectation, which was observed to add about one second
@@ -34,6 +35,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTFail("Profiler did not collect at least two samples")
         return false
     }
+    #endif
 
     func testStoreEnvelope() {
         let client = TestClient(options: Options())

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -15,6 +15,26 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         SentryExtraPackages.clear()
     }
 
+    // CPU-constrained CI runners can delay the sampling thread beyond any fixed sleep, so wait for
+    // the samples the serializer actually requires. A short polling interval avoids busy-spinning
+    // and is used instead of XCTNSPredicateExpectation, which was observed to add about one second
+    // to every profiling test before reevaluating its predicate.
+    private func waitForProfilerSamples() -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 5
+        repeat {
+            if let profiler = SentryTraceProfiler.getCurrentProfiler(),
+               let profile = profiler.state.copyProfilingData()["profile"] as? [String: Any],
+               let samples = profile["samples"] as? [Any],
+               samples.count >= 2 {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        } while ProcessInfo.processInfo.systemUptime < deadline
+
+        XCTFail("Profiler did not collect at least two samples")
+        return false
+    }
+
     func testStoreEnvelope() {
         let client = TestClient(options: Options())
         SentrySDKInternal.setCurrentHub(TestHub(client: client, andScope: nil))
@@ -272,8 +292,11 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
 
         let startTime = PrivateSentrySDKOnly.startProfiler(forTrace: traceIdA)
         XCTAssertGreaterThan(startTime, 0)
-        Thread.sleep(forTimeInterval: 0.2)
-        let payload = PrivateSentrySDKOnly.collectProfileBetween(startTime, and: startTime + 200_000_000, forTrace: traceIdA)
+        guard waitForProfilerSamples() else {
+            return
+        }
+        let endTime = SentryDependencyContainer.sharedInstance().dateProvider.systemTime()
+        let payload = PrivateSentrySDKOnly.collectProfileBetween(startTime, and: endTime, forTrace: traceIdA)
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?["platform"] as? String, "cocoa")
         


### PR DESCRIPTION
Make profiling integration tests wait for the samples required by serialization instead of assuming the sampler runs within a fixed 200 ms window. Restore the shared date provider after file manager tests so randomized test ordering cannot leak a zero system timestamp.

**Why**

CPU-constrained CI runners delayed profiling tests to more than one second, leaving too few samples inside the hard-coded collection window. Separately, file manager tests left a zero-valued test date provider installed globally, causing profiling start times to fail depending on test order.

**Verification**

- Reproduced the zero profiling start time with the macOS flaky plan before the fix
- Passed the macOS flaky plan after the fix
- Passed 10 macOS flaky-plan iterations with 150 tests and no failures
- Passed all 9 iOS profiling integration tests
- Passed 50 iOS transaction profiling iterations
- Passed `make format`
- Passed `make analyze`

#skip-changelog


Closes #8932