### PR TITLE
ref: Refactor MetricKit diagnostics

### DIFF
--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -104,7 +104,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
 
     private func process(crashDiagnostic diagnostic: MXCrashDiagnostic, timestamp: Date) {
         guard enabledDiagnostics.contains(.crashDiagnostics) else {
-            SentrySDK.logger.debug("Crash diagnostic are not enabled, skipping payload")
+            SentrySDKLog.debug("Crash diagnostic are not enabled, skipping payload")
             return
         }
 
@@ -124,7 +124,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
 
     private func process(diskWriteExceptionDiagnostic diagnostic: MXDiskWriteExceptionDiagnostic, timestamp: Date) {
         guard enabledDiagnostics.contains(.diskWriteException) else {
-            SentrySDK.logger.debug("Disk write exception diagnostics are not enabled, skipping payload")
+            SentrySDKLog.debug("Disk write exception diagnostics are not enabled, skipping payload")
             return
         }
 
@@ -142,7 +142,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
 
     private func process(cpuExceptionDiagnostic diagnostic: MXCPUExceptionDiagnostic, timestamp: Date) {
         guard enabledDiagnostics.contains(.cpuException) else {
-            SentrySDK.logger.debug("CPU exception diagnostics are not enabled, skipping payload")
+            SentrySDKLog.debug("CPU exception diagnostics are not enabled, skipping payload")
             return
         }
 
@@ -161,7 +161,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
 
     private func process(hangDiagnostic diagnostic: MXHangDiagnostic, timestamp: Date) {
         guard enabledDiagnostics.contains(.hang) else {
-            SentrySDK.logger.debug("Hang diagnostics are not enabled, skipping payload")
+            SentrySDKLog.debug("Hang diagnostics are not enabled, skipping payload")
             return
         }
 
@@ -184,7 +184,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
             let data = diagnostic.callStackTree.jsonRepresentation()
             callStackTree = try SentryMXCallStackTree.from(data: data)
         } catch {
-            SentrySDK.logger.error("Failed to create SentryMXCallStackTree from MXDiagnostic: \(error)")
+            SentrySDKLog.error("Failed to create SentryMXCallStackTree from MXDiagnostic: \(error)")
             return
         }
 

--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -18,81 +18,196 @@ extension MXDiskWriteExceptionDiagnostic: CallStackTreeProviding { }
 extension MXCPUExceptionDiagnostic: CallStackTreeProviding { }
 extension MXHangDiagnostic: CallStackTreeProviding { }
 
+#if SENTRY_TEST || SENTRY_TEST_CI || DEBUG
+protocol SentryMetricManager {
+    func add(_ subscriber: MXMetricManagerSubscriber)
+    func remove(_ subscriber: MXMetricManagerSubscriber)
+}
+extension MXMetricManager: SentryMetricManager {}
+#else
+typealias SentryMetricManager = MXMetricManager
+#endif
+
 final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
-    
-    let disableCrashDiagnostics: Bool
-    let measurementFormatter: MeasurementFormatter
+
+    // MARK: - Types
+
+    enum DiagnosticMetric: CaseIterable {
+        case crashDiagnostics
+        case diskWriteException
+        case cpuException
+        case hang
+
+        static var all: Set<DiagnosticMetric> {
+            .init(allCases)
+        }
+    }
+
+    private enum ExceptionType {
+        fileprivate static let crashDiagnostic = "MXCrashDiagnostic"
+        fileprivate static let diskWriteException = "MXDiskWriteException"
+        fileprivate static let cpuException = "MXCPUException"
+        fileprivate static let hangDiagnostic = "MXHangDiagnostic"
+    }
+
+    // MARK: - Properties
+
+    private let metricManager: SentryMetricManager
+    private let measurementFormatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.unitOptions = .providedUnit
+        return formatter
+    }()
+
     let inAppLogic: SentryInAppLogic
     let attachDiagnosticAsAttachment: Bool
-    
-    init(inAppLogic: SentryInAppLogic, attachDiagnosticAsAttachment: Bool, disableCrashDiagnostics: Bool = true) {
-        self.disableCrashDiagnostics = disableCrashDiagnostics
+    let enabledDiagnostics: Set<DiagnosticMetric>
+
+    init(
+        metricManager: SentryMetricManager = MXMetricManager.shared,
+        inAppLogic: SentryInAppLogic,
+        attachDiagnosticAsAttachment: Bool,
+        enabledDiagnostics: Set<DiagnosticMetric> = DiagnosticMetric.all.subtracting([.crashDiagnostics])
+    ) {
+        self.metricManager = metricManager
         self.inAppLogic = inAppLogic
         self.attachDiagnosticAsAttachment = attachDiagnosticAsAttachment
-        measurementFormatter = MeasurementFormatter()
-        measurementFormatter.locale = Locale(identifier: "en_US")
-        measurementFormatter.unitOptions = .providedUnit
+        self.enabledDiagnostics = enabledDiagnostics
         super.init()
     }
-    
+
     func receiveReports() {
-        let shared = MXMetricManager.shared
-        shared.add(self)
+        metricManager.add(self)
     }
-    
+
     func pauseReports() {
-        let shared = MXMetricManager.shared
-        shared.remove(self)
+        metricManager.remove(self)
     }
-    
+
     func didReceive(_ payloads: [MXDiagnosticPayload]) {
         payloads.forEach { payload in
-            
             payload.crashDiagnostics?.forEach { diagnostic in
-                
-                if disableCrashDiagnostics {
-                    return
-                }
-                let exceptionValue = "MachException Type:\(String(describing: diagnostic.exceptionType)) Code:\(String(describing: diagnostic.exceptionCode)) Signal:\(String(describing: diagnostic.signal))"
-                captureEvent(handled: false, exceptionValue: exceptionValue, exceptionType: "MXCrashDiagnostic", exceptionMechanism: crashMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
+                process(crashDiagnostic: diagnostic, timestamp: payload.timeStampBegin)
             }
-            
             payload.diskWriteExceptionDiagnostics?.forEach { diagnostic in
-                let totalWritesCaused = measurementFormatter.string(from: diagnostic.totalWritesCaused)
-                let exceptionValue = "MXDiskWriteException totalWritesCaused:\(totalWritesCaused)"
-                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXDiskWriteException", exceptionMechanism: diskWriteMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
+                process(diskWriteExceptionDiagnostic: diagnostic, timestamp: payload.timeStampBegin)
             }
-            
             payload.cpuExceptionDiagnostics?.forEach { diagnostic in
-                let totalCPUTime = measurementFormatter.string(from: diagnostic.totalCPUTime)
-                let totalSampledTime = measurementFormatter.string(from: diagnostic.totalSampledTime)
-
-                let exceptionValue = "MXCPUException totalCPUTime:\(totalCPUTime) totalSampledTime:\(totalSampledTime)"
-                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXCPUException", exceptionMechanism: cpuExceptionMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic)
+                process(cpuExceptionDiagnostic: diagnostic, timestamp: payload.timeStampBegin)
             }
-            
             payload.hangDiagnostics?.forEach { diagnostic in
-                let hangDuration = measurementFormatter.string(from: diagnostic.hangDuration)
-                let exceptionValue = "MXHangDiagnostic hangDuration:\(hangDuration)"
-                captureEvent(handled: true, exceptionValue: exceptionValue, exceptionType: "MXHangDiagnostic", exceptionMechanism: hangDiagnosticMechanism, timeStampBegin: payload.timeStampBegin, diagnostic: diagnostic, useFullCallStackTree: true)
+                process(hangDiagnostic: diagnostic, timestamp: payload.timeStampBegin)
             }
         }
     }
-    
-    func captureEvent(handled: Bool, exceptionValue: String, exceptionType: String, exceptionMechanism: String, timeStampBegin: Date, diagnostic: MXDiagnostic & CallStackTreeProviding, useFullCallStackTree: Bool = false) {
-        if let callStackTree = try? SentryMXCallStackTree.from(data: diagnostic.callStackTree.jsonRepresentation()) {
-            let event = Event(level: handled ? .warning : .error)
-            event.timestamp = timeStampBegin
-            let exception = Exception(value: exceptionValue, type: exceptionType)
-            let mechanism = Mechanism(type: exceptionMechanism)
-            mechanism.handled = NSNumber(value: handled)
-            mechanism.synthetic = true
-            exception.mechanism = mechanism
-            event.exceptions = [exception]
-            capture(event: event, handled: handled, callStackTree: callStackTree, diagnosticJSON: diagnostic.jsonRepresentation(), useFullCallStackTree: useFullCallStackTree)
+
+    private func process(crashDiagnostic diagnostic: MXCrashDiagnostic, timestamp: Date) {
+        guard enabledDiagnostics.contains(.crashDiagnostics) else {
+            SentrySDK.logger.debug("Crash diagnostic are not enabled, skipping payload")
+            return
         }
+
+        let exceptionType = String(describing: diagnostic.exceptionType)
+        let code = String(describing: diagnostic.exceptionCode)
+        let signal = String(describing: diagnostic.signal)
+
+        captureEvent(
+            handled: false,
+            exceptionValue: "MachException Type:\(exceptionType) Code:\(code) Signal:\(signal)",
+            exceptionType: ExceptionType.crashDiagnostic,
+            exceptionMechanism: crashMechanism,
+            timeStampBegin: timestamp,
+            diagnostic: diagnostic
+        )
     }
-    
+
+    private func process(diskWriteExceptionDiagnostic diagnostic: MXDiskWriteExceptionDiagnostic, timestamp: Date) {
+        guard enabledDiagnostics.contains(.diskWriteException) else {
+            SentrySDK.logger.debug("Disk write exception diagnostics are not enabled, skipping payload")
+            return
+        }
+
+        let totalWritesCaused = measurementFormatter.string(from: diagnostic.totalWritesCaused)
+
+        captureEvent(
+            handled: true,
+            exceptionValue: "MXDiskWriteException totalWritesCaused:\(totalWritesCaused)",
+            exceptionType: ExceptionType.diskWriteException,
+            exceptionMechanism: diskWriteMechanism,
+            timeStampBegin: timestamp,
+            diagnostic: diagnostic
+        )
+    }
+
+    private func process(cpuExceptionDiagnostic diagnostic: MXCPUExceptionDiagnostic, timestamp: Date) {
+        guard enabledDiagnostics.contains(.cpuException) else {
+            SentrySDK.logger.debug("CPU exception diagnostics are not enabled, skipping payload")
+            return
+        }
+
+        let totalCPUTime = measurementFormatter.string(from: diagnostic.totalCPUTime)
+        let totalSampledTime = measurementFormatter.string(from: diagnostic.totalSampledTime)
+
+        captureEvent(
+            handled: true,
+            exceptionValue: "MXCPUException totalCPUTime:\(totalCPUTime) totalSampledTime:\(totalSampledTime)",
+            exceptionType: ExceptionType.cpuException,
+            exceptionMechanism: cpuExceptionMechanism,
+            timeStampBegin: timestamp,
+            diagnostic: diagnostic
+        )
+    }
+
+    private func process(hangDiagnostic diagnostic: MXHangDiagnostic, timestamp: Date) {
+        guard enabledDiagnostics.contains(.hang) else {
+            SentrySDK.logger.debug("Hang diagnostics are not enabled, skipping payload")
+            return
+        }
+
+        let hangDuration = measurementFormatter.string(from: diagnostic.hangDuration)
+
+        captureEvent(
+            handled: true,
+            exceptionValue: "MXHangDiagnostic hangDuration:\(hangDuration)",
+            exceptionType: ExceptionType.hangDiagnostic,
+            exceptionMechanism: hangDiagnosticMechanism,
+            timeStampBegin: timestamp,
+            diagnostic: diagnostic,
+            useFullCallStackTree: true
+        )
+    }
+
+    func captureEvent(handled: Bool, exceptionValue: String, exceptionType: String, exceptionMechanism: String, timeStampBegin: Date, diagnostic: MXDiagnostic & CallStackTreeProviding, useFullCallStackTree: Bool = false) {
+        let callStackTree: SentryMXCallStackTree
+        do {
+            let data = diagnostic.callStackTree.jsonRepresentation()
+            callStackTree = try SentryMXCallStackTree.from(data: data)
+        } catch {
+            SentrySDK.logger.error("Failed to create SentryMXCallStackTree from MXDiagnostic: \(error)")
+            return
+        }
+
+        let event = Event(level: handled ? .warning : .error)
+        event.timestamp = timeStampBegin
+
+        let mechanism = Mechanism(type: exceptionMechanism)
+        mechanism.handled = NSNumber(value: handled)
+        mechanism.synthetic = true
+
+        let exception = Exception(value: exceptionValue, type: exceptionType)
+        exception.mechanism = mechanism
+        event.exceptions = [exception]
+
+        capture(
+            event: event,
+            handled: handled,
+            callStackTree: callStackTree,
+            diagnosticJSON: diagnostic.jsonRepresentation(),
+            useFullCallStackTree: useFullCallStackTree
+        )
+    }
+
     func capture(event: Event, handled: Bool, callStackTree: SentryMXCallStackTree, diagnosticJSON: Data, useFullCallStackTree: Bool = false) {
         let debugMeta = callStackTree.toDebugMeta()
         let threads: [SentryThread]
@@ -116,7 +231,7 @@ final class SentryMXManager: NSObject, MXMetricManagerSubscriber {
         // Therefore we don't call captureFatalEvent.
         capture(event: event, diagnosticJSON: diagnosticJSON)
     }
-    
+
     func capture(event: Event, diagnosticJSON: Data) {
         if attachDiagnosticAsAttachment {
             SentrySDK.capture(event: event) { scope in
@@ -134,7 +249,7 @@ extension Event {
         guard let mechanism = exceptions?.first?.mechanism, exceptions?.count == 1 else {
             return false
         }
-        
+
         return [crashMechanism, diskWriteMechanism, cpuExceptionMechanism, hangDiagnosticMechanism].contains(mechanism.type)
     }
 }

--- a/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMetricKitIntegration.swift
@@ -10,7 +10,11 @@ final class SentryMetricKitIntegration<Dependencies>: NSObject, SwiftIntegration
             return nil
         }
 
-        mxManager = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: options.inAppIncludes), attachDiagnosticAsAttachment: options.enableMetricKitRawPayload)
+        mxManager = SentryMXManager(
+            inAppLogic: SentryInAppLogic(inAppIncludes: options.inAppIncludes),
+            attachDiagnosticAsAttachment: options.enableMetricKitRawPayload,
+            enabledDiagnostics: [.cpuException, .diskWriteException, .hang]
+        )
         super.init()
 
         mxManager.receiveReports()

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
@@ -15,8 +15,13 @@ final class SentryMXManagerTests: XCTestCase {
     }
     
     private func givenSut(disableCrashDiagnostics: Bool = true) -> SentryMXManager {
-        let sut = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: []), attachDiagnosticAsAttachment: false, disableCrashDiagnostics: disableCrashDiagnostics)
-        
+        let sut = SentryMXManager(
+            inAppLogic: SentryInAppLogic(inAppIncludes: []),
+            attachDiagnosticAsAttachment: false,
+            enabledDiagnostics: SentryMXManager.DiagnosticMetric.all
+                .subtracting(disableCrashDiagnostics ? [.crashDiagnostics] : [])
+        )
+
         return sut
     }
     

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -3,32 +3,26 @@
 import XCTest
 
 #if os(iOS) || os(macOS) || os(visionOS)
-
-/**
- * We need to check if MetricKit is available for compatibility on iOS 12 and below. As there are no compiler directives for iOS versions we use canImport.
- */
-#if canImport(MetricKit)
 import MetricKit
-#endif // canImport(MetricKit)
 
 final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
-    
+
     var callStackTreePerThread: SentryMXCallStackTree!
     var callStackTreeNotPerThread: SentryMXCallStackTree!
     var timeStampBegin: Date!
-    
+
     override func setUpWithError() throws {
         try super.setUpWithError()
-        
+
         let contentsPerThread = try contentsOfResource("MetricKitCallstacks/per-thread")
         callStackTreePerThread = try SentryMXCallStackTree.from(data: contentsPerThread)
-        
+
         let contentsNotPerThread = try contentsOfResource("MetricKitCallstacks/not-per-thread")
         callStackTreeNotPerThread = try SentryMXCallStackTree.from(data: contentsNotPerThread)
-        
+
         timeStampBegin = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(21.23)
     }
-    
+
     override func tearDown() {
         super.tearDown()
         // swiftlint:disable:next avoid_clear_test_state - just disabled to allow adding the SwiftLint rule. Please double check if you can remove this when touching this.
@@ -41,20 +35,24 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
           let sut = SentryMetricKitIntegration(with: options, dependencies: ())
           XCTAssertNotNil(sut)
     }
-    
+
     func testOptionDisabled_MetricKitManagerNotInitialized() {
           let options = Options()
           options.enableMetricKit = false
           let sut = SentryMetricKitIntegration(with: options, dependencies: ())
           XCTAssertNil(sut)
     }
-    
+
     func testMXCrashPayloadReceived() throws {
             givenSDKWithHubWithScope()
-            
+
         let options = Options()
         options.enableMetricKit = true
-        let sut = SentryMXManager(inAppLogic: SentryInAppLogic(inAppIncludes: []), attachDiagnosticAsAttachment: false, disableCrashDiagnostics: false)
+        let sut = SentryMXManager(
+            inAppLogic: SentryInAppLogic(inAppIncludes: []),
+            attachDiagnosticAsAttachment: false,
+            enabledDiagnostics: [.crashDiagnostics]
+        )
 
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
@@ -64,18 +62,40 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.crashDiagnostics = [crashDiagnostic]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.didReceive([payload])
-            
+
         try assertPerThread(exceptionType: "MXCrashDiagnostic", exceptionValue: "MachException Type:nil Code:nil Signal:nil", exceptionMechanism: "MXCrashDiagnostic", handled: false)
     }
-    
+
+    func testDidReceive_whenHangDiagnosticsDisabled_shouldNotCaptureEvent() throws {
+        // -- Arrange --
+        givenSDKWithHubWithScope()
+        let sut = SentryMXManager(
+            inAppLogic: SentryInAppLogic(inAppIncludes: []),
+            attachDiagnosticAsAttachment: false,
+            enabledDiagnostics: [.crashDiagnostics]
+        )
+        let payload = TestMXDiagnosticPayload()
+        let callStackTree = TestMXCallStackTree()
+        callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/per-thread")
+        let hangDiagnostic = TestMXHangDiagnostic()
+        hangDiagnostic.overrides.callStackTree = callStackTree
+        payload.overrides.hangDiagnostic = [hangDiagnostic]
+
+        // -- Act --
+        sut.didReceive([payload])
+
+        // -- Assert --
+        assertNothingCaptured()
+    }
+
     func testAttachDiagnosticAsAttachment() throws {
             givenSDKWithHubWithScope()
-            
+
         let options = Options()
         options.enableMetricKit = true
         options.enableMetricKitRawPayload = true
         let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/per-thread")
@@ -84,21 +104,21 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.hangDiagnostic = [hangDiagnostic]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertEventWithScopeCaptured { _, scope, _ in
                 let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
-                
+
                 XCTAssertEqual(diagnosticAttachment?.data, hangDiagnostic.jsonRepresentation())
             }
     }
-    
+
     func testDontAttachDiagnosticAsAttachment() throws {
             givenSDKWithHubWithScope()
-            
+
         let options = Options()
         options.enableMetricKit = true
         let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/per-thread")
@@ -107,22 +127,22 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.hangDiagnostic = [hangDiagnostic]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertEventWithScopeCaptured { _, scope, _ in
                 let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
-                
+
                 XCTAssertNil(diagnosticAttachment)
             }
     }
-    
+
     func testSetInAppIncludes_AppliesInAppToStackTrace() throws {
             givenSDKWithHubWithScope()
-            
+
         let options = Options()
         options.enableMetricKit = true
         options.add(inAppInclude: "iOS-Swift")
         let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/per-thread")
@@ -131,23 +151,23 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.hangDiagnostic = [hangDiagnostic]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertEventWithScopeCaptured { event, _, _ in
                 let stacktrace = try XCTUnwrap( event?.threads?.first?.stacktrace)
-                
+
                 let inAppFramesCount = stacktrace.frames.filter { $0.inApp as? Bool ?? false }.count
-                
+
                 XCTAssertEqual(2, inAppFramesCount)
             }
     }
-    
+
     func testCPUExceptionDiagnostic_NotPerThread() throws {
             givenSDKWithHubWithScope()
-            
+
             let options = Options()
             options.enableMetricKit = true
             let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/not-per-thread")
@@ -156,17 +176,17 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.cpuDiagnostic = [cpuException]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertNotPerThread(exceptionType: "MXCPUException", exceptionValue: "MXCPUException totalCPUTime:2.2 ms totalSampledTime:5.5 ms", exceptionMechanism: "mx_cpu_exception")
     }
-    
+
     func testCPUExceptionDiagnostic_OnlyOneFrame() throws {
             givenSDKWithHubWithScope()
-            
+
             let options = Options()
             options.enableMetricKit = true
             let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/not-per-thread-only-one-frame")
@@ -175,20 +195,20 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.cpuDiagnostic = [cpuException]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
                 XCTFail("Hub Client is not a `TestClient`")
                 return
             }
-            
+
             let invocations = client.captureEventWithScopeInvocations.invocations
             XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
-            
+
             try assertEvent(event: try XCTUnwrap(invocations.first).event)
-            
+
             func assertEvent(event: Event) throws {
                 let sentryFrames = try XCTUnwrap(event.threads?.first?.stacktrace?.frames, "Event has no frames.")
-                
+
                 XCTAssertEqual(1, sentryFrames.count)
                 let frame = sentryFrames.first
                 XCTAssertEqual("0x000000021f1a0001", frame?.imageAddress)
@@ -196,14 +216,14 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
                 XCTAssertFalse(frame?.inApp?.boolValue ?? true)
             }
     }
-    
+
     func testDiskWriteExceptionDiagnostic() throws {
             givenSDKWithHubWithScope()
-            
+
             let options = Options()
             options.enableMetricKit = true
             let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/not-per-thread-only-one-frame")
@@ -212,17 +232,17 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.diskWriteDiagnostic = [diskWriteException]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertNotPerThread(exceptionType: "MXDiskWriteException", exceptionValue: "MXDiskWriteException totalWritesCaused:5.5 Mib", exceptionMechanism: "mx_disk_write_exception")
     }
-    
+
     func testHangDiagnostic() throws {
             givenSDKWithHubWithScope()
-            
+
             let options = Options()
             options.enableMetricKit = true
             let sut = try XCTUnwrap(SentryMetricKitIntegration(with: options, dependencies: ()))
-            
+
         let payload = TestMXDiagnosticPayload()
         let callStackTree = TestMXCallStackTree()
         callStackTree.overrides.jsonRepresentation = try contentsOfResource("MetricKitCallstacks/not-per-thread-only-one-frame")
@@ -231,52 +251,52 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         payload.overrides.hangDiagnostic = [hangDiagnostic]
         payload.overrides.timeStampBegin = timeStampBegin
         sut.mxManager.didReceive([payload])
-            
+
             try assertNotPerThread(exceptionType: "MXHangDiagnostic", exceptionValue: "MXHangDiagnostic hangDuration:6.6 sec", exceptionMechanism: "mx_hang_diagnostic")
     }
-    
+
     private func givenSDKWithHubWithScope() {
         let scope = Scope()
         scope.addBreadcrumb(TestData.crumb)
         scope.addAttachment(TestData.dataAttachment)
-        
+
         givenSdkWithHub(scope: scope)
     }
-    
+
     private func assertPerThread(exceptionType: String, exceptionValue: String, exceptionMechanism: String, handled: Bool = true) throws {
         try assertEventWithScopeCaptured { event, scope, _ in
             XCTAssertEqual(1, scope?.attachments.count)
-            
+
             XCTAssertEqual(callStackTreePerThread.callStacks.count, event?.threads?.count)
             XCTAssertEqual(timeStampBegin, event?.timestamp)
-            
+
             try assertFrames(event: event, exceptionType, exceptionValue, exceptionMechanism, framesCount: 3, handled: handled)
         }
     }
-    
+
     private func assertNothingCaptured() {
         guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
-        
+
         XCTAssertEqual(0, client.captureEventWithScopeInvocations.count, "No events should be captured")
     }
-    
+
     private func assertNotPerThread(exceptionType: String, exceptionValue: String, exceptionMechanism: String) throws {
         guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
-        
+
         let invocations = client.captureEventWithScopeInvocations.invocations
         XCTAssertEqual(1, invocations.count, "Client expected to capture 1 event.")
     }
-    
+
     private func assertFrames(event: Event?, _ exceptionType: String, _ exceptionValue: String, _ exceptionMechanism: String, framesCount: Int, handled: Bool = true, debugMetaCount: Int = 2) throws {
         let sentryFrames = try XCTUnwrap(event?.threads?.first?.stacktrace?.frames, "Event has no frames.")
         XCTAssertEqual(framesCount, sentryFrames.count)
-        
+
         XCTAssertEqual(1, event?.exceptions?.count)
         let exception = try XCTUnwrap(event?.exceptions?.first, "Event has exception.")
 
@@ -286,37 +306,37 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertEqual(handled, exception.mechanism?.handled?.boolValue)
         XCTAssertEqual(true, exception.mechanism?.synthetic)
         XCTAssertEqual(event?.threads?.first?.threadId, exception.threadId)
-        
+
         XCTAssertEqual(debugMetaCount, event?.debugMeta?.count)
         guard let debugMeta = event?.debugMeta else {
             XCTFail("Event has no debugMeta.")
             return
         }
-        
+
         XCTAssertEqual("macho", try XCTUnwrap(debugMeta.first).type)
         XCTAssertEqual("9E8D8DE6-EEC1-3199-8720-9ED68EE3F967", try XCTUnwrap(debugMeta.first).debugID)
         XCTAssertEqual("0x000000010109c000", try XCTUnwrap(debugMeta.first).imageAddress)
         XCTAssertEqual("Sentry", try XCTUnwrap(debugMeta.first).codeFile)
-        
+
         XCTAssertEqual("macho", try XCTUnwrap(debugMeta.element(at: 1)).type)
         XCTAssertEqual("CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF", try XCTUnwrap(debugMeta.element(at: 1)).debugID)
         XCTAssertEqual("0x0000000100f3c000", try XCTUnwrap(debugMeta.element(at: 1)).imageAddress)
         XCTAssertEqual("iOS-Swift", try XCTUnwrap(debugMeta.element(at: 1)).codeFile)
     }
-    
+
     private func assertFrame(mxFrame: SentryMXFrame, sentryFrame: Frame) {
         XCTAssertEqual(mxFrame.binaryName, sentryFrame.package)
-        
+
         let lastRootFrameAddress = formatHexAddress(value: mxFrame.address)
         XCTAssertEqual(lastRootFrameAddress, sentryFrame.instructionAddress)
-        
+
         XCTAssertEqual(mxFrame.binaryName, sentryFrame.package)
         let lastRootFrameImageAddress = formatHexAddress(value: mxFrame.address - UInt64(mxFrame.offsetIntoBinaryTextSegment))
         XCTAssertEqual(lastRootFrameImageAddress, sentryFrame.imageAddress)
-        
+
         XCTAssertFalse(sentryFrame.inApp as? Bool ?? true)
     }
-  
+
 }
 
 @available(tvOS, unavailable)
@@ -325,9 +345,9 @@ class TestMXCallStackTree: MXCallStackTree {
     struct Override {
         var jsonRepresentation = Data()
     }
-    
+
     public var overrides = Override()
-    
+
     override func jsonRepresentation() -> Data {
         return overrides.jsonRepresentation
     }
@@ -339,9 +359,9 @@ class TestMXCrashDiagnostic: MXCrashDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
     }
-    
+
     public var overrides = Override()
-    
+
     override var callStackTree: MXCallStackTree {
         return overrides.callStackTree
     }
@@ -353,17 +373,17 @@ class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
     }
-    
+
     public var overrides = Override()
-    
+
     override var callStackTree: MXCallStackTree {
         return overrides.callStackTree
     }
-    
+
     override var totalCPUTime: Measurement<UnitDuration> {
         return Measurement(value: 2.2, unit: .milliseconds)
     }
-    
+
     override var totalSampledTime: Measurement<UnitDuration> {
         return Measurement(value: 5.5, unit: .milliseconds)
     }
@@ -375,13 +395,13 @@ class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
     }
-    
+
     public var overrides = Override()
-    
+
     override var callStackTree: MXCallStackTree {
         return overrides.callStackTree
     }
-    
+
     override var totalWritesCaused: Measurement<UnitInformationStorage> {
         return Measurement(value: 5.5, unit: .mebibits)
     }
@@ -393,13 +413,13 @@ class TestMXHangDiagnostic: MXHangDiagnostic {
     struct Override {
         var callStackTree = TestMXCallStackTree()
     }
-    
+
     public var overrides = Override()
-    
+
     override var callStackTree: MXCallStackTree {
         return overrides.callStackTree
     }
-    
+
     override var hangDuration: Measurement<UnitDuration> {
         return Measurement(value: 6.6, unit: .seconds)
     }


### PR DESCRIPTION
## :scroll: Description

Refactor MetricKit diagnostic handling into type-specific processors and make the metric manager and enabled diagnostic set injectable. The production integration continues to capture CPU, disk-write, and hang diagnostics while leaving crash diagnostics disabled.

Parsing failures are now logged, and every diagnostic type consistently honors the enabled set.

## :bulb: Motivation and Context

Separating diagnostic processing and subscription dependencies makes the MetricKit manager easier to test and configure without changing the production defaults.

## :green_heart: How did you test it?

- `make format`
- `make analyze`
- iOS, macOS, and visionOS builds
- Targeted iOS MetricKit tests: 25 passed

Targeted macOS tests are currently blocked before execution by unrelated `SentryTestUtils/Sources/TestSentrySystemWrapper.swift` compilation errors against `SentrySystemWrapper`.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] If I added a new public API, I also added it to the SentryObjC wrapper.

#skip-changelog


Closes #8935