### PR TITLE
fix: Synchronize trace profiler getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 - Silence spurious ERROR log in `SentryCrashCxaThrowSwapper` for empty sections (#8915)
 - Stop recording touch events while Session Replay is paused. (#8887)
+- Synchronize access to the current trace profiler in debug and test builds. (#8936)
 
 ### Internal
 

--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -114,6 +114,7 @@ SentryProfiler *_Nullable _threadUnsafe_gTraceProfiler;
 #    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 + (SentryProfiler *_Nullable)getCurrentProfiler
 {
+    std::lock_guard<std::mutex> l(_threadUnsafe_gTraceProfilerLock);
     return _threadUnsafe_gTraceProfiler;
 }
 

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -2,6 +2,18 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
+#if !os(tvOS) && !os(watchOS) && !os(visionOS)
+private final class BlockingMetricProfiler: SentryMetricProfiler {
+    let recordMetricsStarted = DispatchSemaphore(value: 0)
+    let continueRecordingMetrics = DispatchSemaphore(value: 0)
+
+    override func recordMetrics() {
+        recordMetricsStarted.signal()
+        continueRecordingMetrics.wait()
+    }
+}
+#endif
+
 class PrivateSentrySDKOnlyTests: XCTestCase {
 
     override func tearDown() {
@@ -34,6 +46,35 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
 
         XCTFail("Profiler did not collect at least two samples")
         return false
+    }
+    #endif
+
+    #if !os(tvOS) && !os(watchOS) && !os(visionOS)
+    func testGetCurrentProfiler_whenProfilerLockHeld_shouldWaitForLock() throws {
+        // -- Arrange --
+        XCTAssertTrue(SentryTraceProfiler.start(withTracer: SentryId()))
+        let profiler = try XCTUnwrap(SentryTraceProfiler.getCurrentProfiler())
+        let blockingMetricProfiler = BlockingMetricProfiler(mode: .trace)
+        profiler.metricProfiler = blockingMetricProfiler
+
+        let getCurrentProfilerFinished = DispatchSemaphore(value: 0)
+
+        // -- Act --
+        DispatchQueue.global().async {
+            SentryTraceProfiler.recordMetrics()
+        }
+        XCTAssertEqual(blockingMetricProfiler.recordMetricsStarted.wait(timeout: .now() + 1), .success)
+
+        DispatchQueue.global().async {
+            _ = SentryTraceProfiler.getCurrentProfiler()
+            getCurrentProfilerFinished.signal()
+        }
+
+        // -- Assert --
+        XCTAssertEqual(getCurrentProfilerFinished.wait(timeout: .now() + 0.1), .timedOut)
+
+        blockingMetricProfiler.continueRecordingMetrics.signal()
+        XCTAssertEqual(getCurrentProfilerFinished.wait(timeout: .now() + 1), .success)
     }
     #endif
 

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -57,6 +57,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         let blockingMetricProfiler = BlockingMetricProfiler(mode: .trace)
         profiler.metricProfiler = blockingMetricProfiler
 
+        let getCurrentProfilerStarted = DispatchSemaphore(value: 0)
         let getCurrentProfilerFinished = DispatchSemaphore(value: 0)
 
         // -- Act --
@@ -66,15 +67,24 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(blockingMetricProfiler.recordMetricsStarted.wait(timeout: .now() + 1), .success)
 
         DispatchQueue.global().async {
+            getCurrentProfilerStarted.signal()
             _ = SentryTraceProfiler.getCurrentProfiler()
             getCurrentProfilerFinished.signal()
         }
+        // Confirm the worker is scheduled before using a short timeout to detect lock blocking.
+        // Otherwise, an unscheduled worker could make an unlocked getter appear blocked.
+        XCTAssertEqual(getCurrentProfilerStarted.wait(timeout: .now() + 1), .success)
+
+        let getCurrentProfilerWhileLocked = getCurrentProfilerFinished.wait(timeout: .now() + 0.1)
+        blockingMetricProfiler.continueRecordingMetrics.signal()
 
         // -- Assert --
-        XCTAssertEqual(getCurrentProfilerFinished.wait(timeout: .now() + 0.1), .timedOut)
-
-        blockingMetricProfiler.continueRecordingMetrics.signal()
-        XCTAssertEqual(getCurrentProfilerFinished.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(getCurrentProfilerWhileLocked, .timedOut)
+        // An early return consumes the semaphore signal and already fails the assertion above.
+        // Only wait again when the getter was blocked to avoid a second misleading failure.
+        if getCurrentProfilerWhileLocked == .timedOut {
+            XCTAssertEqual(getCurrentProfilerFinished.wait(timeout: .now() + 1), .success)
+        }
     }
     #endif
 


### PR DESCRIPTION
Synchronize the trace-profiler test getter with the mutex that protects the global profiler. This prevents the getter from racing with profiler startup and other synchronized profiler operations.

The regression test holds the profiler mutex through metric recording and verifies that the getter waits until the lock is released. This follows up on the concurrency concern deferred from #8931.

**Testing**

- `make format`
- `make analyze`
- `make build-ios FOR_AGENTS=true`
- `make build-macos FOR_AGENTS=true`
- `make test-macos FOR_AGENTS=true ONLY_TESTING=SentryTests/PrivateSentrySDKOnlyTests`
- `make test-ios FOR_AGENTS=true ONLY_TESTING=SentryTests/PrivateSentrySDKOnlyTests/testGetCurrentProfiler_whenProfilerLockHeld_shouldWaitForLock`
- `make test-ios FOR_AGENTS=true`
