### PR TITLE
feat(objc): expose profiling on SentryObjCOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Add `maxFeatureFlags` option to configure how many feature flag evaluations the scope retains, matching sentry-java. Defaults to 100 (#8858)
 - Add `SentrySDK.internal.envelope.captureNonTerminating` for hybrid SDKs, which keeps the current session running and reports it with the `unhandled` status when an unhandled exception doesn't terminate the process (#8654)
 - Add `SentrySDK.internal.envelope.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can update the native session when an error is dropped by sampling, without sending an envelope (#8907)
-- Expose continuous profiling configuration on `SentryObjCOptions` via `configureProfiling` and `SentryObjCProfileOptions`
+- Expose continuous profiling configuration on `SentryObjCOptions` via `configureProfiling` and `SentryObjCProfileOptions` (#8937)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add `maxFeatureFlags` option to configure how many feature flag evaluations the scope retains, matching sentry-java. Defaults to 100 (#8858)
 - Add `SentrySDK.internal.envelope.captureNonTerminating` for hybrid SDKs, which keeps the current session running and reports it with the `unhandled` status when an unhandled exception doesn't terminate the process (#8654)
 - Add `SentrySDK.internal.envelope.updateSessionForDroppedEventNonTerminating` so hybrid SDKs can update the native session when an error is dropped by sampling, without sending an envelope (#8907)
+- Expose continuous profiling configuration on `SentryObjCOptions` via `configureProfiling` and `SentryObjCProfileOptions`
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1951,6 +1951,8 @@
 				Public/SentryObjCNSError.h,
 				Public/SentryObjCOptions.h,
 				Public/SentryObjCPrivateSDKOnly.h,
+				Public/SentryObjCProfileLifecycle.h,
+				Public/SentryObjCProfileOptions.h,
 				Public/SentryObjCRedactRegionType.h,
 				Public/SentryObjCReplayApi.h,
 				Public/SentryObjCReplayOptions.h,
@@ -2046,6 +2048,8 @@
 				Public/SentryObjCNSError.h,
 				Public/SentryObjCOptions.h,
 				Public/SentryObjCPrivateSDKOnly.h,
+				Public/SentryObjCProfileLifecycle.h,
+				Public/SentryObjCProfileOptions.h,
 				Public/SentryObjCRedactRegionType.h,
 				Public/SentryObjCReplayApi.h,
 				Public/SentryObjCReplayOptions.h,
@@ -5591,7 +5595,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -5631,7 +5634,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -5760,7 +5762,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -6030,7 +6031,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -6543,7 +6543,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -7057,7 +7056,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -12753,7 +12751,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -13323,7 +13320,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -13693,7 +13689,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -5595,6 +5595,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -5634,6 +5635,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -5762,6 +5764,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -6031,6 +6034,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -6543,6 +6547,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -7056,6 +7061,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -12751,6 +12757,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -13320,6 +13327,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";
@@ -13689,6 +13697,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULEMAP_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryObjC;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				PUBLIC_HEADERS_FOLDER_PATH = "$(CONTENTS_FOLDER_PATH)/Headers";

--- a/Sources/SentryObjC/Public/SentryObjC.h
+++ b/Sources/SentryObjC/Public/SentryObjC.h
@@ -14,6 +14,7 @@
 #    import "SentryObjCLastRunStatus.h"
 #    import "SentryObjCLevel.h"
 #    import "SentryObjCLogLevel.h"
+#    import "SentryObjCProfileLifecycle.h"
 #    import "SentryObjCReplayQuality.h"
 #    import "SentryObjCSampleDecision.h"
 #    import "SentryObjCSpanStatus.h"
@@ -24,6 +25,7 @@
 #    import <SentryObjC/SentryObjCLastRunStatus.h>
 #    import <SentryObjC/SentryObjCLevel.h>
 #    import <SentryObjC/SentryObjCLogLevel.h>
+#    import <SentryObjC/SentryObjCProfileLifecycle.h>
 #    import <SentryObjC/SentryObjCReplayQuality.h>
 #    import <SentryObjC/SentryObjCSampleDecision.h>
 #    import <SentryObjC/SentryObjCSpanStatus.h>
@@ -155,6 +157,7 @@
 #if !__has_include(<SentryObjC/SentryObjCDefines.h>)
 #    import "SentryObjCExperimentalOptions.h"
 #    import "SentryObjCOptions.h"
+#    import "SentryObjCProfileOptions.h"
 #    import "SentryObjCReplayOptions.h"
 #    import "SentryObjCUserFeedbackConfiguration.h"
 #    import "SentryObjCUserFeedbackFormConfiguration.h"
@@ -163,6 +166,7 @@
 #else
 #    import <SentryObjC/SentryObjCExperimentalOptions.h>
 #    import <SentryObjC/SentryObjCOptions.h>
+#    import <SentryObjC/SentryObjCProfileOptions.h>
 #    import <SentryObjC/SentryObjCReplayOptions.h>
 #    import <SentryObjC/SentryObjCUserFeedbackConfiguration.h>
 #    import <SentryObjC/SentryObjCUserFeedbackFormConfiguration.h>

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -156,10 +156,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if !SDK_V10
 /**
- * When enabled, the SDK sends logs to Sentry. Logs can be captured using the
- * @c SentryObjCSDK.logger API, which provides structured logging with attributes.
+ * Legacy option kept for compatibility until the next major release.
+ *
+ * Manual log capture through @c SentryObjCSDK.logger (and opt-in logging integrations that
+ * forward through it) is not gated by this flag. Setting it to @c NO does not drop those logs.
  * @note Default value is @c NO.
- * @note In v10 and later, logs are always enabled. Remove this option when upgrading.
+ * @note In v10 and later, this option is removed and logs are always enabled.
  */
 @property (nonatomic) BOOL enableLogs;
 #endif // !SDK_V10
@@ -558,7 +560,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SentryObjCExperimentalOptions *experimental;
 
 /**
- * When enabled, the SDK sends metrics to Sentry.
+ * Legacy option kept for compatibility until the next major release.
+ *
+ * Manual metric capture through the metrics API is not gated by this flag. Setting it to
+ * @c NO does not drop those metrics.
  * @note Default value is @c YES.
  */
 @property (nonatomic) BOOL enableMetrics;

--- a/Sources/SentryObjC/Public/SentryObjCOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCOptions.h
@@ -21,6 +21,7 @@
 @class SentryObjCHttpStatusCodeRange;
 @class SentryObjCLog;
 @class SentryObjCMetric;
+@class SentryObjCProfileOptions;
 @class SentryObjCReplayOptions;
 @class SentryObjCSamplingContext;
 @class SentryObjCScope;
@@ -155,12 +156,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if !SDK_V10
 /**
- * Legacy option kept for compatibility until the next major release.
- *
- * Manual log capture through @c SentryObjCSDK.logger (and opt-in logging integrations that
- * forward through it) is not gated by this flag. Setting it to @c NO does not drop those logs.
+ * When enabled, the SDK sends logs to Sentry. Logs can be captured using the
+ * @c SentryObjCSDK.logger API, which provides structured logging with attributes.
  * @note Default value is @c NO.
- * @note In v10 and later, this option is removed and logs are always enabled.
+ * @note In v10 and later, logs are always enabled. Remove this option when upgrading.
  */
 @property (nonatomic) BOOL enableLogs;
 #endif // !SDK_V10
@@ -300,6 +299,16 @@ NS_ASSUME_NONNULL_BEGIN
  * @note The default is @c NO.
  */
 @property (nonatomic) BOOL enablePersistingTracesWhenCrashing;
+
+#if SENTRY_OBJC_PROFILING_SUPPORTED
+/**
+ * A block that configures continuous profiling.
+ * @warning Continuous profiling is an experimental feature and may still contain bugs.
+ * @note Profiling is automatically disabled if a thread sanitizer is attached.
+ */
+@property (nonatomic, copy, nullable) void (^configureProfiling)
+    (SentryObjCProfileOptions *profiling);
+#endif
 
 /**
  * A block that configures the initial scope when starting the SDK.
@@ -549,10 +558,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SentryObjCExperimentalOptions *experimental;
 
 /**
- * Legacy option kept for compatibility until the next major release.
- *
- * Manual metric capture through the metrics API is not gated by this flag. Setting it to
- * @c NO does not drop those metrics.
+ * When enabled, the SDK sends metrics to Sentry.
  * @note Default value is @c YES.
  */
 @property (nonatomic) BOOL enableMetrics;

--- a/Sources/SentryObjC/Public/SentryObjCProfileLifecycle.h
+++ b/Sources/SentryObjC/Public/SentryObjCProfileLifecycle.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
+#    import "SentryObjCDefines.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#endif
+
+#if SENTRY_OBJC_PROFILING_SUPPORTED
+
+/// Different modes for starting and stopping the profiler.
+typedef NS_ENUM(NSInteger, SentryObjCProfileLifecycle) {
+    /// Profiling is controlled manually with startProfiler/stopProfiler.
+    SentryObjCProfileLifecycleManual = 0,
+    /// Profiling starts with an active root span and stops when there are none.
+    SentryObjCProfileLifecycleTrace
+};
+
+#endif

--- a/Sources/SentryObjC/Public/SentryObjCProfileOptions.h
+++ b/Sources/SentryObjC/Public/SentryObjCProfileOptions.h
@@ -1,0 +1,37 @@
+#import <Foundation/Foundation.h>
+#if !__has_include(<SentryObjC/SentryObjCDefines.h>)
+#    import "SentryObjCDefines.h"
+#    import "SentryObjCProfileLifecycle.h"
+#else
+#    import <SentryObjC/SentryObjCDefines.h>
+#    import <SentryObjC/SentryObjCProfileLifecycle.h>
+#endif
+
+#if SENTRY_OBJC_PROFILING_SUPPORTED
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Configuration for the Sentry profiler.
+/// @warning Continuous profiling is an experimental feature and may still contain bugs.
+/// @note Profiling is automatically disabled if a thread sanitizer is attached.
+@interface SentryObjCProfileOptions : NSObject
+
+/// The mode to use for starting and stopping the profiler.
+/// @note Default: @c SentryObjCProfileLifecycleManual.
+@property (nonatomic) SentryObjCProfileLifecycle lifecycle;
+
+/// The percentage of user sessions in which to enable profiling.
+/// @note Default: @c 0.
+@property (nonatomic) float sessionSampleRate;
+
+/// Start the profiler as early as possible during the app lifecycle.
+/// @note Default: @c NO.
+@property (nonatomic) BOOL profileAppStarts;
+
+- (instancetype)init;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Sources/SentryObjCCompat/SentryObjCOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCOptions.swift
@@ -299,6 +299,20 @@ import Foundation
         set { wrapped.enablePersistingTracesWhenCrashing = newValue }
     }
 
+#if os(iOS) || os(macOS)
+    @objc public var configureProfiling: ((SentryObjCProfileOptions) -> Void)? {
+        didSet {
+            if let configureProfiling {
+                wrapped.configureProfiling = { profiling in
+                    configureProfiling(SentryObjCProfileOptions(profiling))
+                }
+            } else {
+                wrapped.configureProfiling = nil
+            }
+        }
+    }
+#endif // os(iOS) || os(macOS)
+
     @objc public var initialScope: ((SentryObjCScope) -> SentryObjCScope) = { return $0 } {
         didSet {
             let initialScope = initialScope

--- a/Sources/SentryObjCCompat/SentryObjCProfileLifecycle.swift
+++ b/Sources/SentryObjCCompat/SentryObjCProfileLifecycle.swift
@@ -1,0 +1,26 @@
+// swiftlint:disable missing_docs
+#if os(iOS) || os(macOS)
+#if SWIFT_PACKAGE
+internal import SentrySwift
+#else
+internal import Sentry
+#endif
+import Foundation
+
+@objc public enum SentryObjCProfileLifecycle: Int {
+    case manual = 0
+    case trace = 1
+}
+
+extension SentryObjCProfileLifecycle {
+    init(_ underlying: SentryProfileOptions.SentryProfileLifecycle) {
+        self = SentryObjCProfileLifecycle(rawValue: underlying.rawValue) ?? .manual
+    }
+
+    var underlying: SentryProfileOptions.SentryProfileLifecycle {
+        SentryProfileOptions.SentryProfileLifecycle(rawValue: rawValue) ?? .manual
+    }
+}
+
+#endif // os(iOS) || os(macOS)
+// swiftlint:enable missing_docs

--- a/Sources/SentryObjCCompat/SentryObjCProfileOptions.swift
+++ b/Sources/SentryObjCCompat/SentryObjCProfileOptions.swift
@@ -1,0 +1,38 @@
+// swiftlint:disable missing_docs
+#if os(iOS) || os(macOS)
+#if SWIFT_PACKAGE
+internal import SentrySwift
+#else
+internal import Sentry
+#endif
+import Foundation
+
+@objc(SentryObjCProfileOptions) public final class SentryObjCProfileOptions: NSObject {
+    internal let wrapped: SentryProfileOptions
+
+    internal init(_ wrapped: SentryProfileOptions) {
+        self.wrapped = wrapped
+    }
+
+    @objc public override init() {
+        self.wrapped = SentryProfileOptions()
+    }
+
+    @objc public var lifecycle: SentryObjCProfileLifecycle {
+        get { SentryObjCProfileLifecycle(wrapped.lifecycle) }
+        set { wrapped.lifecycle = newValue.underlying }
+    }
+
+    @objc public var sessionSampleRate: Float {
+        get { wrapped.sessionSampleRate }
+        set { wrapped.sessionSampleRate = newValue }
+    }
+
+    @objc public var profileAppStarts: Bool {
+        get { wrapped.profileAppStarts }
+        set { wrapped.profileAppStarts = newValue }
+    }
+}
+
+#endif // os(iOS) || os(macOS)
+// swiftlint:enable missing_docs

--- a/sdk_api_objc.diff.json
+++ b/sdk_api_objc.diff.json
@@ -121,6 +121,13 @@
     },
     {
       "kind": "ObjCMethodDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "returnType": "SentryObjCProfileLifecycle",
+      "instance": true
+    },
+    {
+      "kind": "ObjCMethodDecl",
       "name": "nameSource",
       "parent": "SentryObjCTransactionContext",
       "returnType": "SentryObjCTransactionNameSource",
@@ -245,6 +252,12 @@
       "name": "level",
       "parent": "SentryObjCLog",
       "type": "SentryObjCLogLevel"
+    },
+    {
+      "kind": "ObjCPropertyDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "type": "SentryObjCProfileLifecycle"
     },
     {
       "kind": "ObjCPropertyDecl",
@@ -511,6 +524,13 @@
     },
     {
       "kind": "ObjCMethodDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "returnType": "enum SentryObjCProfileLifecycle",
+      "instance": true
+    },
+    {
+      "kind": "ObjCMethodDecl",
       "name": "nameSource",
       "parent": "SentryObjCTransactionContext",
       "returnType": "enum SentryObjCTransactionNameSource",
@@ -649,6 +669,12 @@
       "name": "level",
       "parent": "SentryObjCLog",
       "type": "enum SentryObjCLogLevel"
+    },
+    {
+      "kind": "ObjCPropertyDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "type": "enum SentryObjCProfileLifecycle"
     },
     {
       "kind": "ObjCPropertyDecl",

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -96,6 +96,16 @@
   },
   {
     "kind": "EnumConstantDecl",
+    "name": "SentryObjCProfileLifecycleManual",
+    "parent": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "EnumConstantDecl",
+    "name": "SentryObjCProfileLifecycleTrace",
+    "parent": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "EnumConstantDecl",
     "name": "SentryObjCRedactRegionTypeClipBegin",
     "parent": "SentryObjCRedactRegionType"
   },
@@ -303,6 +313,10 @@
   {
     "kind": "EnumDecl",
     "name": "SentryObjCLogLevel"
+  },
+  {
+    "kind": "EnumDecl",
+    "name": "SentryObjCProfileLifecycle"
   },
   {
     "kind": "EnumDecl",
@@ -613,6 +627,12 @@
   {
     "kind": "ObjCInterfaceDecl",
     "name": "SentryObjCPrivateSDKOnly",
+    "super": "NSObject",
+    "has_inner": true
+  },
+  {
+    "kind": "ObjCInterfaceDecl",
+    "name": "SentryObjCProfileOptions",
     "super": "NSObject",
     "has_inner": true
   },
@@ -1396,13 +1416,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "captureNonTerminating:",
-    "parent": "SentryObjCInternalEnvelopeApi",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "category",
     "parent": "SentryObjCBreadcrumb",
     "returnType": "NSString * _Nonnull",
@@ -1511,6 +1524,13 @@
     "name": "configureForm",
     "parent": "SentryObjCUserFeedbackConfiguration",
     "returnType": "void (^ _Nullable)(SentryObjCUserFeedbackFormConfiguration * _Nonnull)",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "configureProfiling",
+    "parent": "SentryObjCOptions",
+    "returnType": "void (^ _Nullable)(SentryObjCProfileOptions * _Nonnull)",
     "instance": true
   },
   {
@@ -3175,6 +3195,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "init",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "instancetype _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "init",
     "parent": "SentryObjCReplayApi",
     "returnType": "instancetype _Nonnull",
     "instance": true
@@ -3968,6 +3995,13 @@
     "name": "level",
     "parent": "SentryObjCLog",
     "returnType": "SentryObjCLogLevel",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "lifecycle",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "SentryObjCProfileLifecycle",
     "instance": true
   },
   {
@@ -4959,6 +4993,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "profileAppStarts",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "profiling",
     "parent": "SentryObjCInternalApi",
     "returnType": "SentryObjCInternalProfilingApi * _Nonnull",
@@ -5401,6 +5442,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "sessionSampleRate",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "float",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "sessionSampleRate",
     "parent": "SentryObjCReplayOptions",
     "returnType": "float",
     "instance": true
@@ -5661,6 +5709,13 @@
     "kind": "ObjCMethodDecl",
     "name": "setConfigureForm:",
     "parent": "SentryObjCUserFeedbackConfiguration",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setConfigureProfiling:",
+    "parent": "SentryObjCOptions",
     "returnType": "void",
     "instance": true
   },
@@ -6506,6 +6561,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setLifecycle:",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setLineNumber:",
     "parent": "SentryObjCFrame",
     "returnType": "void",
@@ -6947,6 +7009,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setProfileAppStarts:",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setQuality:",
     "parent": "SentryObjCReplayOptions",
     "returnType": "void",
@@ -7131,6 +7200,13 @@
     "kind": "ObjCMethodDecl",
     "name": "setSessionReplay:",
     "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setSessionSampleRate:",
+    "parent": "SentryObjCProfileOptions",
     "returnType": "void",
     "instance": true
   },
@@ -8536,13 +8612,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "updateSessionForDroppedEventNonTerminating:",
-    "parent": "SentryObjCInternalEnvelopeApi",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "url",
     "parent": "SentryObjCRequest",
     "returnType": "NSString * _Nullable",
@@ -9000,6 +9069,12 @@
     "name": "configureForm",
     "parent": "SentryObjCUserFeedbackConfiguration",
     "type": "void (^ _Nullable)(SentryObjCUserFeedbackFormConfiguration * _Nonnull)"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "configureProfiling",
+    "parent": "SentryObjCOptions",
+    "type": "void (^ _Nullable)(SentryObjCProfileOptions * _Nonnull)"
   },
   {
     "kind": "ObjCPropertyDecl",
@@ -9981,6 +10056,12 @@
   },
   {
     "kind": "ObjCPropertyDecl",
+    "name": "lifecycle",
+    "parent": "SentryObjCProfileOptions",
+    "type": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
     "name": "lineNumber",
     "parent": "SentryObjCFrame",
     "type": "NSNumber * _Nullable"
@@ -10533,6 +10614,12 @@
   },
   {
     "kind": "ObjCPropertyDecl",
+    "name": "profileAppStarts",
+    "parent": "SentryObjCProfileOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
     "name": "profiling",
     "parent": "SentryObjCInternalApi",
     "type": "SentryObjCInternalProfilingApi * _Nonnull"
@@ -10824,6 +10911,12 @@
     "name": "sessionReplay",
     "parent": "SentryObjCOptions",
     "type": "SentryObjCReplayOptions * _Nonnull"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "sessionSampleRate",
+    "parent": "SentryObjCProfileOptions",
+    "type": "float"
   },
   {
     "kind": "ObjCPropertyDecl",
@@ -11443,6 +11536,11 @@
     "kind": "TypedefDecl",
     "name": "SentryObjCLogLevel",
     "type": "enum SentryObjCLogLevel"
+  },
+  {
+    "kind": "TypedefDecl",
+    "name": "SentryObjCProfileLifecycle",
+    "type": "enum SentryObjCProfileLifecycle"
   },
   {
     "kind": "TypedefDecl",

--- a/sdk_api_objc.json
+++ b/sdk_api_objc.json
@@ -1416,6 +1416,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "captureNonTerminating:",
+    "parent": "SentryObjCInternalEnvelopeApi",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "category",
     "parent": "SentryObjCBreadcrumb",
     "returnType": "NSString * _Nonnull",
@@ -8608,6 +8615,13 @@
     "name": "unmaskedViewClasses",
     "parent": "SentryObjCReplayOptions",
     "returnType": "NSArray<Class> * _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "updateSessionForDroppedEventNonTerminating:",
+    "parent": "SentryObjCInternalEnvelopeApi",
+    "returnType": "void",
     "instance": true
   },
   {

--- a/sdk_api_objc_v10.diff.json
+++ b/sdk_api_objc_v10.diff.json
@@ -178,6 +178,13 @@
     },
     {
       "kind": "ObjCMethodDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "returnType": "SentryObjCProfileLifecycle",
+      "instance": true
+    },
+    {
+      "kind": "ObjCMethodDecl",
       "name": "mode",
       "parent": "SentryObjCDataCollectionKeyValueCollectionBehavior",
       "returnType": "SentryObjCDataCollectionKeyValueCollectionMode",
@@ -315,6 +322,12 @@
       "name": "level",
       "parent": "SentryObjCLog",
       "type": "SentryObjCLogLevel"
+    },
+    {
+      "kind": "ObjCPropertyDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "type": "SentryObjCProfileLifecycle"
     },
     {
       "kind": "ObjCPropertyDecl",
@@ -628,6 +641,13 @@
     },
     {
       "kind": "ObjCMethodDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "returnType": "enum SentryObjCProfileLifecycle",
+      "instance": true
+    },
+    {
+      "kind": "ObjCMethodDecl",
       "name": "mode",
       "parent": "SentryObjCDataCollectionKeyValueCollectionBehavior",
       "returnType": "enum SentryObjCDataCollectionKeyValueCollectionMode",
@@ -779,6 +799,12 @@
       "name": "level",
       "parent": "SentryObjCLog",
       "type": "enum SentryObjCLogLevel"
+    },
+    {
+      "kind": "ObjCPropertyDecl",
+      "name": "lifecycle",
+      "parent": "SentryObjCProfileOptions",
+      "type": "enum SentryObjCProfileLifecycle"
     },
     {
       "kind": "ObjCPropertyDecl",

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -136,6 +136,16 @@
   },
   {
     "kind": "EnumConstantDecl",
+    "name": "SentryObjCProfileLifecycleManual",
+    "parent": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "EnumConstantDecl",
+    "name": "SentryObjCProfileLifecycleTrace",
+    "parent": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "EnumConstantDecl",
     "name": "SentryObjCRedactRegionTypeClipBegin",
     "parent": "SentryObjCRedactRegionType"
   },
@@ -351,6 +361,10 @@
   {
     "kind": "EnumDecl",
     "name": "SentryObjCLogLevel"
+  },
+  {
+    "kind": "EnumDecl",
+    "name": "SentryObjCProfileLifecycle"
   },
   {
     "kind": "EnumDecl",
@@ -679,6 +693,12 @@
   {
     "kind": "ObjCInterfaceDecl",
     "name": "SentryObjCPrivateSDKOnly",
+    "super": "NSObject",
+    "has_inner": true
+  },
+  {
+    "kind": "ObjCInterfaceDecl",
+    "name": "SentryObjCProfileOptions",
     "super": "NSObject",
     "has_inner": true
   },
@@ -1482,13 +1502,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "captureNonTerminating:",
-    "parent": "SentryObjCInternalEnvelopeApi",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "category",
     "parent": "SentryObjCBreadcrumb",
     "returnType": "NSString * _Nonnull",
@@ -1597,6 +1610,13 @@
     "name": "configureForm",
     "parent": "SentryObjCUserFeedbackConfiguration",
     "returnType": "void (^ _Nullable)(SentryObjCUserFeedbackFormConfiguration * _Nonnull)",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "configureProfiling",
+    "parent": "SentryObjCOptions",
+    "returnType": "void (^ _Nullable)(SentryObjCProfileOptions * _Nonnull)",
     "instance": true
   },
   {
@@ -3268,6 +3288,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "init",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "instancetype _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "init",
     "parent": "SentryObjCReplayApi",
     "returnType": "instancetype _Nonnull",
     "instance": true
@@ -4075,6 +4102,13 @@
     "name": "level",
     "parent": "SentryObjCLog",
     "returnType": "SentryObjCLogLevel",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "lifecycle",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "SentryObjCProfileLifecycle",
     "instance": true
   },
   {
@@ -5080,6 +5114,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "profileAppStarts",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "BOOL",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "profiling",
     "parent": "SentryObjCInternalApi",
     "returnType": "SentryObjCInternalProfilingApi * _Nonnull",
@@ -5522,6 +5563,13 @@
   {
     "kind": "ObjCMethodDecl",
     "name": "sessionSampleRate",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "float",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "sessionSampleRate",
     "parent": "SentryObjCReplayOptions",
     "returnType": "float",
     "instance": true
@@ -5789,6 +5837,13 @@
     "kind": "ObjCMethodDecl",
     "name": "setConfigureForm:",
     "parent": "SentryObjCUserFeedbackConfiguration",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setConfigureProfiling:",
+    "parent": "SentryObjCOptions",
     "returnType": "void",
     "instance": true
   },
@@ -6620,6 +6675,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setLifecycle:",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setLineNumber:",
     "parent": "SentryObjCFrame",
     "returnType": "void",
@@ -7054,6 +7116,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "setProfileAppStarts:",
+    "parent": "SentryObjCProfileOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "setQuality:",
     "parent": "SentryObjCReplayOptions",
     "returnType": "void",
@@ -7245,6 +7314,13 @@
     "kind": "ObjCMethodDecl",
     "name": "setSessionReplay:",
     "parent": "SentryObjCOptions",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "setSessionSampleRate:",
+    "parent": "SentryObjCProfileOptions",
     "returnType": "void",
     "instance": true
   },
@@ -8664,13 +8740,6 @@
   },
   {
     "kind": "ObjCMethodDecl",
-    "name": "updateSessionForDroppedEventNonTerminating:",
-    "parent": "SentryObjCInternalEnvelopeApi",
-    "returnType": "void",
-    "instance": true
-  },
-  {
-    "kind": "ObjCMethodDecl",
     "name": "url",
     "parent": "SentryObjCRequest",
     "returnType": "NSString * _Nullable",
@@ -9148,6 +9217,12 @@
     "name": "configureForm",
     "parent": "SentryObjCUserFeedbackConfiguration",
     "type": "void (^ _Nullable)(SentryObjCUserFeedbackFormConfiguration * _Nonnull)"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "configureProfiling",
+    "parent": "SentryObjCOptions",
+    "type": "void (^ _Nullable)(SentryObjCProfileOptions * _Nonnull)"
   },
   {
     "kind": "ObjCPropertyDecl",
@@ -10111,6 +10186,12 @@
   },
   {
     "kind": "ObjCPropertyDecl",
+    "name": "lifecycle",
+    "parent": "SentryObjCProfileOptions",
+    "type": "SentryObjCProfileLifecycle"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
     "name": "lineNumber",
     "parent": "SentryObjCFrame",
     "type": "NSNumber * _Nullable"
@@ -10663,6 +10744,12 @@
   },
   {
     "kind": "ObjCPropertyDecl",
+    "name": "profileAppStarts",
+    "parent": "SentryObjCProfileOptions",
+    "type": "BOOL"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
     "name": "profiling",
     "parent": "SentryObjCInternalApi",
     "type": "SentryObjCInternalProfilingApi * _Nonnull"
@@ -10960,6 +11047,12 @@
     "name": "sessionReplay",
     "parent": "SentryObjCOptions",
     "type": "SentryObjCReplayOptions * _Nonnull"
+  },
+  {
+    "kind": "ObjCPropertyDecl",
+    "name": "sessionSampleRate",
+    "parent": "SentryObjCProfileOptions",
+    "type": "float"
   },
   {
     "kind": "ObjCPropertyDecl",
@@ -11607,6 +11700,11 @@
     "kind": "TypedefDecl",
     "name": "SentryObjCLogLevel",
     "type": "enum SentryObjCLogLevel"
+  },
+  {
+    "kind": "TypedefDecl",
+    "name": "SentryObjCProfileLifecycle",
+    "type": "enum SentryObjCProfileLifecycle"
   },
   {
     "kind": "TypedefDecl",

--- a/sdk_api_objc_v10.json
+++ b/sdk_api_objc_v10.json
@@ -1502,6 +1502,13 @@
   },
   {
     "kind": "ObjCMethodDecl",
+    "name": "captureNonTerminating:",
+    "parent": "SentryObjCInternalEnvelopeApi",
+    "returnType": "void",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
     "name": "category",
     "parent": "SentryObjCBreadcrumb",
     "returnType": "NSString * _Nonnull",
@@ -8736,6 +8743,13 @@
     "name": "unmaskedViewClasses",
     "parent": "SentryObjCReplayOptions",
     "returnType": "NSArray<Class> * _Nonnull",
+    "instance": true
+  },
+  {
+    "kind": "ObjCMethodDecl",
+    "name": "updateSessionForDroppedEventNonTerminating:",
+    "parent": "SentryObjCInternalEnvelopeApi",
+    "returnType": "void",
     "instance": true
   },
   {


### PR DESCRIPTION
## :scroll: Description

Expose continuous profiling configuration on the Objective-C wrapper.

- Add `SentryObjCProfileOptions` and `SentryObjCProfileLifecycle`.
- Wire `SentryObjCOptions.configureProfiling` through to `Options`.
- Publish the new headers on `SentryObjC` and `SentryObjCV10`.
- Drop empty `MODULEMAP_FILE` overrides so Xcode generates a module map that includes them.

Extracted from #8881 so the public ObjC profiling API can land independently of the sample V10 migration. #8881 will stack on this PR.

## :bulb: Motivation and Context

The iOS-ObjectiveC sample lost explicit continuous profiling setup when it moved to `SentryObjCSDK`, because `SentryObjCOptions` had no `configureProfiling` API. That is a public wrapper gap, not sample-only work.

## :green_heart: How did you test it?

- Public API snapshots updated (`sdk_api_objc.json`, `sdk_api_objc_v10.json`, and diffs)
- Sample usage remains in #8881

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).