### PR TITLE
fix: Isolate macOS sample plist updates

### DIFF
--- a/Samples/macOS-Swift/macOS-Swift.yml
+++ b/Samples/macOS-Swift/macOS-Swift.yml
@@ -65,13 +65,9 @@ targets:
       Release: App/Configurations/macOS-Swift.xcconfig
       Test: App/Configurations/macOS-Swift.xcconfig
       TestCI: App/Configurations/macOS-Swift.xcconfig
-    postCompileScripts:
-      - script: ../Shared/inject-git-info.sh
-        name: Inject Git Information into Info.plist
-        basedOnDependencyAnalysis: false
     postBuildScripts:
-      - script: ../Shared/reset-git-info.sh
-        name: Reset Git Fields in Info.plist
+      - script: INFOPLIST_FILE="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" ../Shared/inject-git-info.sh
+        name: Inject Git Information into Info.plist
         basedOnDependencyAnalysis: false
   macOS-Swift-UITests:
     type: bundle.ui-testing
@@ -147,13 +143,9 @@ targets:
       Release: App/Configurations/macOS-Swift-Other.xcconfig
       Test: App/Configurations/macOS-Swift-Other.xcconfig
       TestCI: App/Configurations/macOS-Swift-Other.xcconfig
-    postCompileScripts:
-      - script: ../Shared/inject-git-info.sh
-        name: Inject Git Information into Info.plist
-        basedOnDependencyAnalysis: false
     postBuildScripts:
-      - script: ../Shared/reset-git-info.sh
-        name: Reset Git Fields in Info.plist
+      - script: INFOPLIST_FILE="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" ../Shared/inject-git-info.sh
+        name: Inject Git Information into Info.plist
         basedOnDependencyAnalysis: false
   macOS-Swift-Sandboxed:
     type: application
@@ -195,13 +187,9 @@ targets:
       Release: App/Configurations/macOS-Swift-Sandboxed.xcconfig
       Test: App/Configurations/macOS-Swift-Sandboxed.xcconfig
       TestCI: App/Configurations/macOS-Swift-Sandboxed.xcconfig
-    postCompileScripts:
-      - script: ../Shared/inject-git-info.sh
-        name: Inject Git Information into Info.plist
-        basedOnDependencyAnalysis: false
     postBuildScripts:
-      - script: ../Shared/reset-git-info.sh
-        name: Reset Git Fields in Info.plist
+      - script: INFOPLIST_FILE="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" ../Shared/inject-git-info.sh
+        name: Inject Git Information into Info.plist
         basedOnDependencyAnalysis: false
   macOS-Swift-Sandboxed-Other:
     type: application
@@ -243,13 +231,9 @@ targets:
       Release: App/Configurations/macOS-Swift-Sandboxed-Other.xcconfig
       Test: App/Configurations/macOS-Swift-Sandboxed-Other.xcconfig
       TestCI: App/Configurations/macOS-Swift-Sandboxed-Other.xcconfig
-    postCompileScripts:
-      - script: ../Shared/inject-git-info.sh
-        name: Inject Git Information into Info.plist
-        basedOnDependencyAnalysis: false
     postBuildScripts:
-      - script: ../Shared/reset-git-info.sh
-        name: Reset Git Fields in Info.plist
+      - script: INFOPLIST_FILE="${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" ../Shared/inject-git-info.sh
+        name: Inject Git Information into Info.plist
         basedOnDependencyAnalysis: false
 schemes:
   macOS-Swift:


### PR DESCRIPTION
Inject Git metadata into each macOS sample app's processed bundle plist instead of mutating the shared checked-in source plist. This keeps the four UI-test app dependencies safe to build in parallel and removes the now-unnecessary reset phases.

Before the change, all four build phases wrote `App/Configurations/Info.plist`. After the change, each phase writes its own `${TARGET_BUILD_DIR}/${INFOPLIST_PATH}` before code signing. This follows up on the macOS UI build failure investigated in #8931.

**Verification**

- Built the unchanged UI-test dependency graph and inspected all four app plists.
- Built the changed dependency graph and confirmed each app received the expected Git fields while the source plist retained its placeholders.
- Verified all four app bundle signatures with `codesign --verify --deep --strict`.
- `make test-sample-macOS-Swift-ui`
- `make format`
- `make analyze`

#skip-changelog
