### PR TITLE
test: Stabilize concurrent hub captures

### DIFF
--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -922,7 +922,10 @@ class SentryHubTests: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 5.0)
+        // This verifies session synchronization, not capture performance. CPU-constrained visionOS
+        // runners have exceeded five seconds, so use a generous timeout that still detects a
+        // deadlock before the overall test runner timeout.
+        wait(for: [expectation], timeout: 30.0)
 
         // Assert
         let session = try XCTUnwrap(sut.session)
@@ -950,7 +953,10 @@ class SentryHubTests: XCTestCase {
             }
         }
 
-        wait(for: [expectation], timeout: 5.0)
+        // This verifies session synchronization, not capture performance. CPU-constrained visionOS
+        // runners have exceeded five seconds, so use a generous timeout that still detects a
+        // deadlock before the overall test runner timeout.
+        wait(for: [expectation], timeout: 30.0)
 
         // Assert
         let session = try XCTUnwrap(sut.session)


### PR DESCRIPTION
Give the parallel error and exception capture tests enough time to complete on CPU-constrained visionOS runners. The tests still execute 100 concurrent captures and retain a finite deadline for detecting deadlocks.

This follows up on the V10 visionOS timeout observed while validating #8931. Comments clarify that the 30-second timeout is a deadlock safeguard rather than a capture-performance assertion.

**Testing**

- 20 macOS iterations of both concurrency tests, 40/40 passed
- `make test-macos-v10 FOR_AGENTS=true ONLY_TESTING=SentryTestsV10/SentryHubTests/testCaptureMultipleExceptionsInParallel_IncrementsSessionCount,SentryTestsV10/SentryHubTests/testCaptureMultipleErrorsInParallel_IncrementsSessionCount`
- `make test-visionos-v10 FOR_AGENTS=true ONLY_TESTING=SentryTestsV10/SentryHubTests/testCaptureMultipleExceptionsInParallel_IncrementsSessionCount,SentryTestsV10/SentryHubTests/testCaptureMultipleErrorsInParallel_IncrementsSessionCount`
- `make format`
- `make analyze`

#skip-changelog
