### PR TITLE
ci: pick unpaired watchOS simulators

### DIFF
--- a/scripts/resolve-test-destination.sh
+++ b/scripts/resolve-test-destination.sh
@@ -78,19 +78,38 @@ else
             TEST_DEVICE="Apple TV"
             ;;
         watchOS)
-            # Pick the newest Apple Watch available in the resolved watchOS runtime.
-            # Watch names include parenthetical sizes (e.g. "Apple Watch Ultra 3 (49mm)")
-            # so we strip from the UUID pattern `(XXXX-...) (State)` rather than the
-            # first `(`, which would lose the size.
+            # WatchKit schemes fail to match iPhone-paired watches by
+            # platform=watchOS Simulator,name=... (xcodebuild reports them as
+            # DVTiPhoneSimulator). Prefer unpaired watches from simctl pairs;
+            # fall back to the newest watch in the runtime if every watch is paired.
+            #
+            # OS=latest (the no --os default) is not a simctl runtime id, so
+            # resolve it to the newest watchOS runtime that has devices.
             OS_MM=$(echo "$TEST_OS" | awk -F. '{print $1"."$2}')
-            TEST_DEVICE=$(xcrun simctl list devices available 2>/dev/null \
-                | awk -v platform="watchOS" -v version="$OS_MM" '
-                    $0 ~ "^-- " platform " " version " --" { in_section = 1; next }
-                    in_section { if (/^-- /) exit; print }' \
-                | grep -E "Apple Watch" \
-                | sed -E 's/^[[:space:]]+//; s/ \([A-F0-9-]+\) \([A-Za-z]+\)[[:space:]]*$//' \
-                | sort -V \
-                | tail -n1) || TEST_DEVICE=""
+            devices_json=$(xcrun simctl list devices available -j 2>/dev/null || echo '{"devices":{}}')
+            if [[ ! "$OS_MM" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                OS_MM=$(printf '%s\n' "$devices_json" \
+                    | jq -r '.devices | keys[] | select(test("watchOS-[0-9]+-[0-9]+")) | capture("watchOS-(?<v>[0-9]+-[0-9]+)") | .v' \
+                    | tr '-' '.' \
+                    | sort -V | tail -n1 || true)
+            fi
+            OS_KEY=$(echo "$OS_MM" | tr '.' '-')
+            paired_json=$(xcrun simctl list pairs -j 2>/dev/null \
+                | jq -c '[.pairs[].watch.udid] // []' 2>/dev/null \
+                || echo '[]')
+            TEST_DEVICE=$(printf '%s\n' "$devices_json" \
+                | jq -r --arg key "$OS_KEY" --argjson paired "$paired_json" '
+                    [
+                      .devices
+                      | to_entries[]
+                      | select(.key | endswith("watchOS-" + $key))
+                      | .value[]
+                      | select(.isAvailable != false)
+                      | {name, unpaired: ((.udid as $id | ($paired | index($id)) == null))}
+                    ] as $watches
+                    | ($watches | map(select(.unpaired)) | if length > 0 then . else $watches end)
+                    | .[].name
+                ' 2>/dev/null | sort -V | tail -n1 || true)
             ;;
         visionOS)
             TEST_DEVICE="Apple Vision Pro"


### PR DESCRIPTION
## :scroll: Description

Prefer unpaired Apple Watch simulators when resolving a watchOS test destination.

WatchKit schemes fail to match iPhone-paired watches (Ultra / Series) via `platform=watchOS Simulator,name=...` because xcodebuild reports them as `DVTiPhoneSimulator`. Use `simctl list pairs` to skip those, and resolve `OS=latest` to the newest watchOS runtime that has devices.

Extracted from #8881.

## :bulb: Motivation and Context

CI and `make` default to `OS=latest` or pick the newest watch, which is typically a paired Ultra. That destination specifier then fails for WatchKit sample builds.

## :green_heart: How did you test it?

- `./scripts/resolve-test-destination.sh --platform watchOS` (no `--os`) → unpaired SE on the newest runtime
- `--os 26.5` / `--os 27.0` → `Apple Watch SE 3 (44mm)`
- `--os 11.5` → newest unpaired watch in that runtime

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog