### PR TITLE
fix: limit feedback message length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@
 ### Internal
 
 - Fix `SentrySDK.internal.replay.replayId` returning nil for buffered replays (#8976)
+- Mark the fabricated `mach` and `signal` crash mechanisms as `synthetic` so an Apple crash groups with the identical crash reported by the other Sentry SDKs, and so a mach-caught and a signal-caught report of the same bug no longer split into two issues (#8919)
+- Set `mechanism.handled` to `false` on crash reports that carry no mach context, which previously left it unset (#8919)
+- Prevent managed user feedback from submitting messages longer than 4096 Unicode scalars, and show the limit in the feedback form. (#8973)
 
 ## 9.27.0
 

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -229,14 +229,18 @@ extension SentryUserFeedbackFormController: SentryUserFeedbackFormViewModelDeleg
                 }
             }
 
-            guard case let SentryUserFeedbackFormViewModel.InputError.validationError(missing, _) = error,
-                let errorDescription = error.errorDescription else {
+            guard let errorDescription = error.errorDescription else {
                 SentrySDKLog.warning("Unexpected error type.")
                 presentAlert(message: config.formConfig.unexpectedErrorText, errorCode: 2, info: [NSLocalizedDescriptionKey: "Client error: ."])
                 return
             }
 
-            presentAlert(message: errorDescription, errorCode: 1, info: ["missing_fields": missing, NSLocalizedDescriptionKey: "The user did not complete the feedback form."])
+            switch error {
+            case .validationError(let missing, _):
+                presentAlert(message: errorDescription, errorCode: 1, info: ["missing_fields": missing, NSLocalizedDescriptionKey: "The user did not complete the feedback form."])
+            case .messageTooLong:
+                presentAlert(message: errorDescription, errorCode: 1, info: [NSLocalizedDescriptionKey: errorDescription])
+            }
         }
     }
 
@@ -313,6 +317,7 @@ extension SentryUserFeedbackFormController: UITextViewDelegate {
     /// Updates validation state when the feedback message changes.
     public func textViewDidChange(_ textView: UITextView) {
         viewModel.messageTextViewPlaceholder.isHidden = textView.text != ""
+        viewModel.updateMessageCharacterCount()
         viewModel.updateSubmitButtonAccessibilityHint()
     }
 }

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
@@ -13,6 +13,8 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
 
 @objcMembers
 @_spi(Private) public class SentryUserFeedbackFormViewModel: NSObject {
+    static let maxMessageLength = 4_096
+
     let config: SentryUserFeedbackConfiguration
     unowned let controller: SentryUserFeedbackFormController
     weak var delegate: SentryUserFeedbackFormViewModelDelegate?
@@ -126,6 +128,16 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
         textView.accessibilityIdentifier = "io.sentry.feedback.form.message"
         return textView
     }()
+
+    lazy var messageCharacterCountLabel = {
+        let label = UILabel(frame: .zero)
+        label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.adjustsFontForContentSizeCategory = true
+        label.textAlignment = .right
+        label.accessibilityIdentifier = "io.sentry.feedback.form.message-character-count"
+        updateMessageCharacterCount(label: label)
+        return label
+    }()
     
     lazy var screenshotImageView = {
         let iv = UIImageView()
@@ -227,6 +239,7 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
         
         let messageAndScreenshotStack = UIStackView(arrangedSubviews: [
             self.messageTextView,
+            self.messageCharacterCountLabel,
             self.addScreenshotButton,
             self.removeScreenshotStack
         ])
@@ -399,6 +412,17 @@ extension SentryUserFeedbackFormViewModel {
         case .failure(let error): submitButton.accessibilityHint = error.errorDescription
         }
     }
+
+    func updateMessageCharacterCount() {
+        updateMessageCharacterCount(label: messageCharacterCountLabel)
+    }
+
+    private func updateMessageCharacterCount(label: UILabel) {
+        let count = messageTextView.text.unicodeScalars.count
+        label.text = "\(count) / \(Self.maxMessageLength)"
+        label.accessibilityLabel = "\(count) of \(Self.maxMessageLength) characters used"
+        label.textColor = count > Self.maxMessageLength ? config.theme.errorColor : config.theme.foreground
+    }
     
     func themeElements() {
         [fullNameTextField, emailTextField].forEach {
@@ -499,7 +523,9 @@ extension SentryUserFeedbackFormViewModel {
         }
         
         // include the message they'll submit
+        var messageLength = 0
         if let message = messageTextView.textOrNil {
+            messageLength = message.unicodeScalars.count
             hint.append("with message: \(message)")
         } else {
             missing.append(config.formConfig.messageLabel.lowercased())
@@ -510,17 +536,24 @@ extension SentryUserFeedbackFormViewModel {
             let result = SentryUserFeedbackFormValidation.failure(InputError.validationError(missingFields: missing, localizedError: localizedError))
             return result
         }
+
+        guard messageLength <= Self.maxMessageLength else {
+            return .failure(.messageTooLong(maximumLength: Self.maxMessageLength))
+        }
         
         return SentryUserFeedbackFormValidation.success(hint.joined(separator: " ").appending("."))
     }
     
     enum InputError: LocalizedError {
         case validationError(missingFields: [String], localizedError: String)
+        case messageTooLong(maximumLength: Int)
         
         var description: String {
             switch self {
             case .validationError(_, let localizedError):
                 return localizedError
+            case .messageTooLong(let maximumLength):
+                return "The description must not exceed \(maximumLength) characters."
             }
         }
         

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
@@ -136,6 +136,7 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .right
         label.accessibilityIdentifier = "io.sentry.feedback.form.message-character-count"
+        label.accessibilityTraits.insert(.updatesFrequently)
         updateMessageCharacterCount(label: label)
         return label
     }()

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormViewModel.swift
@@ -13,6 +13,7 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
 
 @objcMembers
 @_spi(Private) public class SentryUserFeedbackFormViewModel: NSObject {
+    // The backend uses Python code-point length, which matches Swift Unicode scalars.
     static let maxMessageLength = 4_096
 
     let config: SentryUserFeedbackConfiguration
@@ -131,7 +132,7 @@ protocol SentryUserFeedbackFormViewModelDelegate: NSObjectProtocol {
 
     lazy var messageCharacterCountLabel = {
         let label = UILabel(frame: .zero)
-        label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.font = config.theme.scaledFont(style: .caption1)
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .right
         label.accessibilityIdentifier = "io.sentry.feedback.form.message-character-count"
@@ -418,7 +419,7 @@ extension SentryUserFeedbackFormViewModel {
     }
 
     private func updateMessageCharacterCount(label: UILabel) {
-        let count = messageTextView.text.unicodeScalars.count
+        let count = messageTextView.text?.unicodeScalars.count ?? 0
         label.text = "\(count) / \(Self.maxMessageLength)"
         label.accessibilityLabel = "\(count) of \(Self.maxMessageLength) characters used"
         label.textColor = count > Self.maxMessageLength ? config.theme.errorColor : config.theme.foreground

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -548,6 +548,7 @@ class SentryFeedbackTests: XCTestCase {
         // -- Assert --
         XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.text, "2 / 4096")
         XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.accessibilityLabel, "2 of 4096 characters used")
+        XCTAssertTrue(sut.viewModel.messageCharacterCountLabel.accessibilityTraits.contains(.updatesFrequently))
         XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.textColor, config.theme.foreground)
     }
 

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -456,6 +456,107 @@ class SentryFeedbackTests: XCTestCase {
         XCTAssertEqual(attachments[2].contentType, "video/mp4")
     }
 
+    func testValidate_whenMessageExceedsMaximumLength_shouldReturnSpecificError() throws {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "a", count: 4_097)
+
+        // -- Act --
+        let result = sut.viewModel.validate()
+
+        // -- Assert --
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected an over-limit message to fail validation.")
+        }
+        XCTAssertEqual(error.errorDescription, "The description must not exceed 4096 characters.")
+    }
+
+    func testValidate_whenMessageIsAtMaximumLength_shouldSucceed() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "a", count: 4_096)
+
+        // -- Act --
+        let result = sut.viewModel.validate()
+
+        // -- Assert --
+        guard case .success = result else {
+            return XCTFail("Expected a message at the limit to validate.")
+        }
+    }
+
+    func testValidate_whenRequiredFieldsAreMissingAndMessageIsTooLong_shouldReportMissingFields() throws {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        config.formConfig.isNameRequired = true
+        config.formConfig.isEmailRequired = true
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "a", count: 4_097)
+
+        // -- Act --
+        let result = sut.viewModel.validate()
+
+        // -- Assert --
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected missing required fields to fail validation.")
+        }
+        XCTAssertEqual(error.errorDescription, "You must provide all required information before submitting. Please check the following fields: name and email.")
+    }
+
+    func testMessageCharacterCount_whenTextChanges_shouldCountUnicodeScalars() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = "e\u{301}"
+
+        // -- Act --
+        sut.textViewDidChange(sut.viewModel.messageTextView)
+
+        // -- Assert --
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.text, "2 / 4096")
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.accessibilityLabel, "2 of 4096 characters used")
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.textColor, config.theme.foreground)
+    }
+
+    func testMessageCharacterCount_whenMessageExceedsMaximumLength_shouldUseErrorColor() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "a", count: 4_097)
+
+        // -- Act --
+        sut.textViewDidChange(sut.viewModel.messageTextView)
+
+        // -- Assert --
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.text, "4097 / 4096")
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.textColor, config.theme.errorColor)
+    }
+
+#if !targetEnvironment(macCatalyst)
+    func testSubmitFeedback_whenMessageExceedsMaximumLength_shouldPresentSpecificError() throws {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        config.animations = false
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "a", count: 4_097)
+        let window = UIWindow(windowScene: Self.mockWindowScene)
+        window.rootViewController = sut
+        window.makeKeyAndVisible()
+        addTeardownBlock { [window] in
+            window.isHidden = true
+        }
+
+        // -- Act --
+        sut.submitFeedback()
+
+        // -- Assert --
+        let alert = try XCTUnwrap(sut.presentedViewController as? UIAlertController)
+        XCTAssertEqual(alert.message, "The description must not exceed 4096 characters.")
+    }
+#endif
+
     private let inputCombinations: [FeedbackTestCase] = [
         // base case: don't require name or email, don't input a name or email, don't input a message or screenshot
         (config: (requiresName: false, requiresEmail: false, nameInput: nil, emailInput: nil, messageInput: nil, includeScreenshot: false), shouldValidate: false, expectedSubmitButtonAccessibilityHint: "You must provide all required information before submitting. Please check the following field: description."),

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -487,6 +487,37 @@ class SentryFeedbackTests: XCTestCase {
         }
     }
 
+    func testValidate_whenDecomposedMessageIsAtMaximumScalarLength_shouldSucceed() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "e\u{301}", count: 2_048)
+
+        // -- Act --
+        let result = sut.viewModel.validate()
+
+        // -- Assert --
+        guard case .success = result else {
+            return XCTFail("Expected 4096 Unicode scalars to validate.")
+        }
+    }
+
+    func testValidate_whenDecomposedMessageExceedsMaximumScalarLength_shouldFail() throws {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = String(repeating: "e\u{301}", count: 2_048) + "a"
+
+        // -- Act --
+        let result = sut.viewModel.validate()
+
+        // -- Assert --
+        guard case .failure(let error) = result else {
+            return XCTFail("Expected 4097 Unicode scalars to fail validation.")
+        }
+        XCTAssertEqual(error.errorDescription, "The description must not exceed 4096 characters.")
+    }
+
     func testValidate_whenRequiredFieldsAreMissingAndMessageIsTooLong_shouldReportMissingFields() throws {
         // -- Arrange --
         let config = SentryUserFeedbackConfiguration()
@@ -532,6 +563,31 @@ class SentryFeedbackTests: XCTestCase {
         // -- Assert --
         XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.text, "4097 / 4096")
         XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.textColor, config.theme.errorColor)
+    }
+
+    func testMessageCharacterCount_whenTextIsNil_shouldShowZero() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+        sut.viewModel.messageTextView.text = nil
+
+        // -- Act --
+        sut.viewModel.updateMessageCharacterCount()
+
+        // -- Assert --
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.text, "0 / 4096")
+    }
+
+    func testMessageCharacterCount_whenFontFamilyConfigured_shouldUseThemeFont() {
+        // -- Arrange --
+        let config = SentryUserFeedbackConfiguration()
+        config.theme.fontFamily = "Helvetica"
+
+        // -- Act --
+        let sut = SentryUserFeedbackFormController(preparedConfig: config, screenshot: nil)
+
+        // -- Assert --
+        XCTAssertEqual(sut.viewModel.messageCharacterCountLabel.font.familyName, "Helvetica")
     }
 
 #if !targetEnvironment(macCatalyst)


### PR DESCRIPTION
## :scroll: Description

- Limit managed user-feedback messages to 4096 Unicode scalars, matching the backend's Python code-point validation.
- Show an accessible live character counter below the message field.
- Highlight the counter and present a specific validation error when the limit is exceeded.

## :bulb: Motivation and Context

The Sentry backend rejects feedback messages longer than 4096 code points. The iOS managed feedback form currently allows those messages to be submitted without warning, so feedback can be dropped after the user finishes the form.

Unicode-scalar counting intentionally matches backend `len(message)` behavior for precomposed and decomposed input.

Fixes #4680

## :green_heart: How did you test it?

```sh
./scripts/sentry-xcodebuild.sh \
  --platform iOS \
  --command test \
  --configuration Test \
  --ref fix/feedback-message-limit \
  --destination 'platform=iOS Simulator,id=50ED21A6-2279-4432-B0F0-09E8928CC1EE' \
  --only-testing 'SentryTests/SentryFeedbackTests'
```

Result: 38 tests passed with 0 failures on iOS 26.2. Coverage includes exact 4096/4097 Unicode-scalar boundaries for decomposed input, nil UIKit text handling, missing-required-field precedence, theme font customization, counter accessibility, and submit-error presentation. A sabotage run using Swift grapheme-cluster counting made the 4097-scalar decomposed regression test fail, then pass after restoring Unicode-scalar counting.

```sh
make format
make lint
make analyze
make build-ios FOR_AGENTS=true \
  IOS_SIMULATOR_OS=26.2 \
  IOS_DEVICE_NAME='Sentry OSS iPhone 17 Pro'
```

All commands passed. The destination overrides are required because this machine does not have the repository-default iOS 18.4 runtime.

## :pencil: Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] If I added a new public API, I also added it to the SentryObjC wrapper.


Demo:

https://github.com/user-attachments/assets/567a10bc-429c-49bc-a9dd-311bd1e7f91b


