### PR TITLE
feat(samples): Add hints support to sample app

### DIFF
--- a/Samples/SentrySampleShared/Sources/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/Sources/SentrySampleShared/SentrySDKWrapper.swift
@@ -169,9 +169,10 @@ public struct SentrySDKWrapper {
             options.sampleRate = NSNumber(value: sampleRate)
         }
         options.attachAllThreads = SentrySDKOverrides.Events.attachAllThreads.boolValue
-        options.beforeSend = {
+        options.beforeSendWithHint = { event, hint in
             guard !SentrySDKOverrides.Events.rejectAll.boolValue else { return nil }
-            return $0
+            Self.logHint(hint, callback: "beforeSendWithHint")
+            return event
         }
         options.beforeSendSpan = { span in
             guard !SentrySDKOverrides.Spans.rejectAll.boolValue else { return nil }
@@ -302,10 +303,9 @@ public struct SentrySDKWrapper {
         options.enableSpotlight = SentrySDKOverrides.Spotlight.enable.boolValue
     #endif // targetEnvironment(simulator)
 
-        options.beforeBreadcrumb = { breadcrumb in
-            //Raising notifications when a new breadcrumb is created in order to use this information
-            //to validate whether proper breadcrumb are being created in the right places.
+        options.beforeBreadcrumbWithHint = { breadcrumb, hint in
             NotificationCenter.default.post(name: .init("io.sentry.newbreadcrumb"), object: breadcrumb)
+            Self.logHint(hint, callback: "beforeBreadcrumbWithHint")
             return breadcrumb
         }
 
@@ -455,6 +455,21 @@ public struct SentrySDKWrapper {
         return rawValue
             .replacingOccurrences(of: "--io.sentry.", with: "")
             .replacingOccurrences(of: ".", with: "_")
+    }
+
+    static func logHint(_ hint: Hint, callback: String) {
+        if let error = hint.originalError {
+            print("[Sentry] [\(callback)] originalError: \(error)")
+        }
+        if let exception = hint.originalException {
+            print("[Sentry] [\(callback)] originalException: \(exception)")
+        }
+        if !hint.attachments.isEmpty {
+            print("[Sentry] [\(callback)] attachments: \(hint.attachments.count)")
+        }
+        if let source = hint.hintValue(forKey: "source") {
+            print("[Sentry] [\(callback)] source: \(source)")
+        }
     }
 }
 

--- a/Samples/iOS-Swift/App/Resources/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/App/Resources/Base.lproj/Main.storyboard
@@ -994,8 +994,16 @@
                                                             <action selector="captureErrorInSwiftAsync:" destination="QmU-DD-itF" eventType="touchUpInside" id="a1s-yn-act"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hNt-4w-qR7" userLabel="Capture Error With Hint">
                                                         <rect key="frame" x="0.0" y="56" width="196.66666666666666" height="28"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                        <state key="normal" title="Capture Error With Hint"/>
+                                                        <connections>
+                                                            <action selector="captureErrorWithHint:" destination="QmU-DD-itF" eventType="touchUpInside" id="hNt-4w-act"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
+                                                        <rect key="frame" x="0.0" y="84" width="196.66666666666666" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Capture NSException"/>
                                                         <connections>

--- a/Samples/iOS-Swift/App/Sources/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/App/Sources/ErrorsViewController.swift
@@ -86,6 +86,23 @@ class ErrorsViewController: UIViewController {
         }
     }
 
+    @IBAction func captureErrorWithHint(_ sender: UIButton) {
+        highlightButton(sender)
+        let hint = Hint()
+        hint.setHintValue("ErrorsViewController", forKey: "source")
+        hint.setHintValue(["button": "captureErrorWithHint"], forKey: "context")
+        hint.attachments = [
+            Attachment(data: Data("hint log entry".utf8), filename: "hint.txt")
+        ]
+        do {
+            try RandomErrorGenerator.generate()
+        } catch {
+            SentrySDK.capture(error: error, hint: hint) { scope in
+                scope.setTag(value: "true", key: "hasHint")
+            }
+        }
+    }
+
     @IBAction func captureErrorInSwiftAsync(_ sender: UIButton) {
         highlightButton(sender)
         Task {


### PR DESCRIPTION
## Summary
- Replace `beforeSend`/`beforeBreadcrumb` with `beforeSendWithHint`/`beforeBreadcrumbWithHint` in `SentrySDKWrapper` to demonstrate hint inspection in callbacks
- Add a "Capture Error With Hint" button to the iOS-Swift sample's Errors tab that creates a `Hint` with custom key-value data and a text attachment
- Extract shared hint logging into a `logHint` helper

Closes COCOA-1899

#skip-changelog

## Test plan
- [ ] Build iOS-Swift sample app
- [ ] Tap "Capture Error With Hint" and verify the error is captured with hint metadata logged
- [ ] Verify `beforeSendWithHint` logs originalError, attachment count, and custom source key
- [ ] Verify `beforeBreadcrumbWithHint` logs hint values when present