### PR TITLE
fix: Include full SentryObjC DWARF

### DIFF
--- a/.github/workflows/build-sentryobjc-slices.yml
+++ b/.github/workflows/build-sentryobjc-slices.yml
@@ -79,7 +79,7 @@ jobs:
           fi
           ./scripts/build-dynamic-framework-sentryobjc.sh \
             --sdk "$SDK" \
-            --static-lib "XCFrameworkBuildPath/lib/SentryObjC/$SDK/libSentryObjC-Debug.a" \
+            --static-lib "XCFrameworkBuildPath/lib/SentryObjC/$SDK/libSentryObjC.a" \
             --headers "Sources/SentryObjC/Public" \
             --output-dir XCFrameworkBuildPath \
             "${version_args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Classify MetricKit hangs over 500 ms as errors. (#8948)
 - Add hint parameter to public capture methods on `SentrySDK` (#8943)
 - Prevent Session Replay video encoding from reusing pixel buffers retained by AVFoundation. (#8950)
-- Remove invalid debug-map references from `SentryObjC-Static` XCFrameworks to prevent `dsymutil` missing-object warnings. (#8979)
+- Include full DWARF debug information in `SentryObjC-Static` XCFrameworks to prevent `dsymutil` missing-object warnings. (#8987)
 
 ## 9.27.0
 

--- a/scripts/build-static-library-sentryobjc.sh
+++ b/scripts/build-static-library-sentryobjc.sh
@@ -3,8 +3,7 @@
 # Builds a single SentryObjC static library slice via SPM.
 #
 # Archives the SentryObjC SPM scheme for a given SDK and merges its target
-# objects into two libraries: a stripped static distribution and an unstripped
-# intermediate used to generate the dynamic framework dSYM.
+# objects, including their full DWARF debug information, into libSentryObjC.a.
 
 set -euo pipefail
 
@@ -91,52 +90,85 @@ set -o pipefail && NSUnbufferedIO=YES xcodebuild archive \
     -derivedDataPath "$DERIVED_DATA" \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    DEBUG_INFORMATION_FORMAT=dwarf \
+    CLANG_ENABLE_MODULE_DEBUGGING=NO \
+    OTHER_SWIFT_FLAGS="-Xfrontend -no-clang-module-breadcrumbs" \
     CODE_SIGNING_REQUIRED=NO \
     CODE_SIGN_IDENTITY= \
     ENABLE_CODE_COVERAGE=NO \
     2>&1 | tee "$ARCHIVE_DIR/$SDK.log" | xcbeautify --preserve-unbeautified
 end_group
 
-objects=()
-while IFS= read -r -d '' object; do
-    objects+=( "$object" )
-done < <(find "$archive_path/Products" -type f -name "*.o" -print0)
+link_file_list_root="$DERIVED_DATA/Build/Intermediates.noindex/ArchiveIntermediates/$SCHEME/IntermediateBuildFilesPath"
+architectures=()
+while IFS= read -r -d '' link_file_list; do
+    architecture="$(basename "$(dirname "$link_file_list")")"
+    if [ ${#architectures[@]} -eq 0 ] || [[ " ${architectures[*]} " != *" $architecture "* ]]; then
+        architectures+=( "$architecture" )
+    fi
+done < <(find "$link_file_list_root" -type f -name "*.LinkFileList" -print0)
 
-if [ ${#objects[@]} -eq 0 ]; then
-    log_error "No object files found under $archive_path/Products"
+if [ ${#architectures[@]} -eq 0 ]; then
+    log_error "No link file lists found under $link_file_list_root"
     exit 1
 fi
 
 archive_dir="$LIB_DIR/$SDK"
-debug_static_lib="$archive_dir/libSentryObjC-Debug.a"
+thin_archive_dir="$archive_dir/thin-archives"
 static_lib="$archive_dir/libSentryObjC.a"
-stripped_objects_dir="$archive_dir/stripped-objects"
-rm -rf "$stripped_objects_dir"
-mkdir -p "$stripped_objects_dir"
+rm -rf "$thin_archive_dir"
+mkdir -p "$thin_archive_dir"
 
-begin_group "Create static libraries for $SDK"
-log_info "  Objects:      ${#objects[@]} files"
-log_info "  Debug output: $debug_static_lib"
-libtool -static -no_warning_for_no_symbols -o "$debug_static_lib" "${objects[@]}"
+thin_archives=()
+for architecture in "${architectures[@]}"; do
+    object_file_list="$thin_archive_dir/$architecture.filelist"
+    object_dir="$thin_archive_dir/$architecture-objects"
+    : > "$object_file_list"
+    mkdir -p "$object_dir"
 
-stripped_objects=()
-for object in "${objects[@]}"; do
-    if nm -gU "$object" | grep . > /dev/null; then
-        stripped_object="$stripped_objects_dir/${object##*/}"
-        cp "$object" "$stripped_object"
-        strip -S "$stripped_object"
-        stripped_objects+=( "$stripped_object" )
+    object_count=0
+    while IFS= read -r -d '' link_file_list; do
+        target_build_dir="$(dirname "$(dirname "$(dirname "$link_file_list")")")"
+        target_name="$(basename "$target_build_dir" .build)"
+        while IFS= read -r object; do
+            if [ ! -f "$object" ]; then
+                log_error "Object file not found: $object"
+                exit 1
+            fi
+
+            staged_object="$object_dir/$target_name-${object##*/}"
+            if [ -e "$staged_object" ]; then
+                log_error "Duplicate object file name in $target_name: ${object##*/}"
+                exit 1
+            fi
+            cp "$object" "$staged_object"
+            printf '%s\n' "$staged_object" >> "$object_file_list"
+            object_count=$((object_count + 1))
+        done < "$link_file_list"
+    done < <(find "$link_file_list_root" \
+        -path "*/Objects-normal/$architecture/*.LinkFileList" -type f -print0)
+
+    if [ "$object_count" -eq 0 ]; then
+        log_error "No object files found for $architecture"
+        exit 1
     fi
+
+    thin_archive="$thin_archive_dir/libSentryObjC-$architecture.a"
+    begin_group "Create $architecture static library for $SDK"
+    log_info "  Objects: $object_count files"
+    log_info "  Output:  $thin_archive"
+    libtool -static -no_warning_for_no_symbols \
+        -filelist "$object_file_list" \
+        -o "$thin_archive"
+    end_group
+    thin_archives+=( "$thin_archive" )
 done
 
-if [ ${#stripped_objects[@]} -eq 0 ]; then
-    log_error "No object files with global symbols found under $archive_path/Products"
-    exit 1
-fi
-
-log_info "  Static output: $static_lib"
-libtool -static -no_warning_for_no_symbols -o "$static_lib" "${stripped_objects[@]}"
+begin_group "Create universal static library for $SDK"
+log_info "  Architectures: ${architectures[*]}"
+log_info "  Output:        $static_lib"
+lipo -create "${thin_archives[@]}" -output "$static_lib"
 end_group
 
-log_info "Static slice built: $static_lib"
-log_info "Dynamic-linking intermediate built: $debug_static_lib"
+rm -rf "$thin_archive_dir"
+log_info "Static slice with full DWARF built: $static_lib"

--- a/scripts/build-xcframework-sentryobjc.sh
+++ b/scripts/build-xcframework-sentryobjc.sh
@@ -97,7 +97,7 @@ if [ "$VARIANT" = "dynamic" ] || [ "$VARIANT" = "both" ]; then
     for sdk in "${sdk_list[@]}"; do
         "$SCRIPT_DIR/build-dynamic-framework-sentryobjc.sh" \
             --sdk "$sdk" \
-            --static-lib "$OUTPUT_DIR/lib/SentryObjC/$sdk/libSentryObjC-Debug.a" \
+            --static-lib "$OUTPUT_DIR/lib/SentryObjC/$sdk/libSentryObjC.a" \
             --headers "$HEADERS_DIR" \
             --output-dir "$OUTPUT_DIR"
     done

--- a/scripts/validate-xcframework-sentryobjc-static.sh
+++ b/scripts/validate-xcframework-sentryobjc-static.sh
@@ -61,17 +61,20 @@ if [ ${#STATIC_LIBRARIES[@]} -eq 0 ]; then
 fi
 
 for static_library in "${STATIC_LIBRARIES[@]}"; do
-    if ! nm_output="$(nm -ap "$static_library")"; then
-        log_error "Could not inspect static library debug maps: $static_library"
+    if ! nm -ap "$static_library" \
+        | awk '$5 == "OSO" { found = 1 } END { exit found }'; then
+        log_error "Static library contains debug-map references to external object files: $static_library"
         exit 1
     fi
-    if grep ' OSO ' <<< "$nm_output" > /dev/null; then
-        log_error "Static library contains debug-map references to external object files: $static_library"
+
+    if ! xcrun dwarfdump --show-section-sizes "$static_library" \
+        | awk '$1 == "Total" && $2 == "Size:" && $3 > 0 { found = 1 } END { exit !found }'; then
+        log_error "Static library does not contain full DWARF debug information: $static_library"
         exit 1
     fi
 done
 
-log_info "SentryObjC static libraries contain no external debug maps"
+log_info "SentryObjC static libraries contain full DWARF debug information"
 
 if [ "$BUILD_CONSUMER" = false ]; then
     exit 0


### PR DESCRIPTION
## :scroll: Description

Stacks on #8979 and explores the alternative to stripping static debug information.

`SentryObjC-Static` now archives the original per-file objects with full DWARF instead of SwiftPM's merged debug-map objects. Archive members receive target-qualified names, Clang module debugging is disabled, and Swift Clang-module breadcrumbs are omitted so the result does not depend on producer object files or PCM caches.

Dynamic frameworks reuse the same symbol-rich archive to generate their separate dSYMs before the runtime binary is stripped.

## :bulb: Motivation and Context

This measures the distribution cost of retaining complete portable symbols while fixing the `dsymutil` warnings reported in #8966.

| Artifact | Stripped | Full DWARF | Increase |
| --- | ---: | ---: | ---: |
| Raw logical XCFramework | 158.99 MB | 521.79 MB | 362.80 MB, 228.2% |
| Compressed ZIP | 37.99 MB | 138.08 MB | 100.09 MB, 263.4% |

Per-slice static library sizes:

| Slice | Stripped | Full DWARF | Added | Increase |
| --- | ---: | ---: | ---: | ---: |
| iOS device | 10.99 MB | 37.07 MB | 26.08 MB | 237.3% |
| iOS simulator | 21.04 MB | 72.74 MB | 51.70 MB | 245.8% |
| Mac Catalyst | 22.95 MB | 74.23 MB | 51.28 MB | 223.4% |
| macOS | 16.74 MB | 53.74 MB | 37.00 MB | 221.0% |
| tvOS device | 9.56 MB | 31.09 MB | 21.53 MB | 225.2% |
| tvOS simulator | 18.30 MB | 60.92 MB | 42.62 MB | 232.9% |
| watchOS device | 14.46 MB | 47.19 MB | 32.73 MB | 226.3% |
| watchOS simulator | 14.30 MB | 47.66 MB | 33.36 MB | 233.2% |
| visionOS device | 9.68 MB | 31.99 MB | 22.32 MB | 230.6% |
| visionOS simulator | 18.62 MB | 62.80 MB | 44.18 MB | 237.3% |

The compressed release artifact is 3.63 times larger with full DWARF.

Static libraries cannot ship a final reusable dSYM because addresses are assigned when the consumer links the application. This approach therefore embeds portable DWARF in every static object. Dynamic frameworks have fixed addresses and UUIDs, so they continue to ship symbols in a separate dSYM while keeping the runtime framework stripped.

## :green_heart: How did you test it?

- `make build-xcframework-sentryobjc-static FOR_AGENTS=true`
- Built all ten Apple platform slices and compressed the XCFramework.
- Built the macOS Objective-C CMake consumer with warnings treated as errors.
- Repeated consumer dSYM generation with producer DerivedData hidden.
- Built the macOS dynamic framework and verified its dSYM contains `SentryObjCSDK`.
- `make format`
- `make analyze`
- ShellCheck and Actionlint

Unit tests were not run because this changes release artifact scripts rather than SDK runtime behavior.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

