### PR TITLE
fix: Resolve the application state at didFinishLaunching when the SDK starts before UIApplication exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Resolve the application state at `UIApplicationDidFinishLaunchingNotification` when the SDK starts before `UIApplication` exists, such as from a SwiftUI `App.init`. A process launched in the background (for example for HealthKit background delivery) was treated as active for its whole lifetime, which let the app hang tracker report fatal app hangs with an idle main thread (#8988)
 - Prevent relevant view controller traversal from recursively loading parent views and invoking `viewDidLoad` twice when tracing is enabled. (#8941)
 - Classify MetricKit hangs over 500 ms as errors. (#8948)
 - Add hint parameter to public capture methods on `SentrySDK` (#8943)

--- a/Sources/Swift/Helper/ThreadSafeApplication.swift
+++ b/Sources/Swift/Helper/ThreadSafeApplication.swift
@@ -17,23 +17,38 @@ final class SentryAlwaysForegroundApplicationStateProvider: NSObject, SentryAppl
 #if !os(macOS) && !os(watchOS) && !SENTRY_NO_UI_FRAMEWORK
 @objc @_spi(Private) public final class SentryThreadsafeApplication: NSObject, SentryApplicationStateProvider {
     private let notificationCenter: SentryNSNotificationCenterWrapper
+    private let applicationProvider: () -> SentryApplication?
     
-    init(applicationProvider: () -> SentryApplication?, notificationCenter: SentryNSNotificationCenterWrapper) {
+    init(applicationProvider: @escaping () -> SentryApplication?, notificationCenter: SentryNSNotificationCenterWrapper) {
         self.notificationCenter = notificationCenter
-        // This matches the ObjC behavior which did not initialize the state when the UIApplication was null
-        // so it kept a default value of 0 which happens to be defined to be `active`.
+        self.applicationProvider = applicationProvider
         // Acquiring the lock is not necessary here since the instance has not been initialized yet.
+        let applicationIsAvailable: Bool
         if let application = applicationProvider() {
             self.state = SentryMutex(application.unsafeApplicationState)
+            applicationIsAvailable = true
         } else {
-            SentrySDKLog.warning("Application is null in SentryThreadsafeApplication")
+            // The SDK can start before UIApplication exists, for example from a SwiftUI `App.init`,
+            // which runs before `UIApplicationMain`. This matches the ObjC behavior which did not
+            // initialize the state when the UIApplication was null so it kept a default value of 0
+            // which happens to be defined to be `active`. That default is only correct for a
+            // foreground launch: a process the system launches in the background, for example for
+            // HealthKit background delivery or a background URLSession, never posts
+            // `didBecomeActive` or `didEnterBackground`, so nothing would ever correct it and the
+            // SDK would treat the whole background lifetime as foreground. The real state is read
+            // once UIApplication is up, at `didFinishLaunchingNotification`.
+            SentrySDKLog.warning("Application is null in SentryThreadsafeApplication. Assuming active until UIApplicationDidFinishLaunchingNotification.")
             self.state = SentryMutex(.active)
+            applicationIsAvailable = false
         }
         super.init()
 
         notificationCenter.addObserver(self, selector: #selector(didEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        if !applicationIsAvailable {
+            notificationCenter.addObserver(self, selector: #selector(didFinishLaunching), name: UIApplication.didFinishLaunchingNotification, object: nil)
+        }
     }
     
     deinit {
@@ -67,6 +82,20 @@ final class SentryAlwaysForegroundApplicationStateProvider: NSObject, SentryAppl
     @objc
     private func didBecomeActive() {
         state.withLock { $0 = .active }
+    }
+
+    /// Only observed when the application was not available at init. The notification is posted on
+    /// the main thread, where reading `unsafeApplicationState` is safe, and it precedes every other
+    /// lifecycle notification, so resolving here cannot overwrite a state a later notification set.
+    @objc
+    private func didFinishLaunching() {
+        notificationCenter.removeObserver(self, name: UIApplication.didFinishLaunchingNotification, object: nil)
+        guard let application = applicationProvider() else {
+            SentrySDKLog.warning("Application is still null in SentryThreadsafeApplication after launch. Keeping the active default.")
+            return
+        }
+        let launchState = application.unsafeApplicationState
+        state.withLock { $0 = launchState }
     }
 }
 #endif

--- a/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
+++ b/Tests/SentryTests/SentryThreadsafeApplicationTests.swift
@@ -48,5 +48,73 @@ final class SentryThreadsafeApplicationTests: XCTestCase {
         XCTAssertTrue(sut.isApplicationInForeground)
         XCTAssertFalse(sut.isActive)
     }
+
+    func testApplicationNilAtInit_shouldAssumeActiveUntilLaunch() {
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let sut = SentryThreadsafeApplication(applicationProvider: { nil }, notificationCenter: notificationCenterWrapper)
+
+        XCTAssertEqual(.active, sut.applicationState)
+        XCTAssertTrue(sut.isActive)
+        XCTAssertTrue(sut.isApplicationInForeground)
+    }
+
+    func testApplicationNilAtInit_shouldResolveStateAtDidFinishLaunching() {
+        // A background launch: the SDK started before UIApplication existed (SwiftUI App.init), and
+        // the system launched the process in the background, so no lifecycle notification follows.
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let application = TestSentryUIApplication()
+        application.unsafeApplicationState = .background
+        var applicationAvailable = false
+        let sut = SentryThreadsafeApplication(applicationProvider: { applicationAvailable ? application : nil }, notificationCenter: notificationCenterWrapper)
+        XCTAssertTrue(sut.isApplicationInForeground)
+
+        applicationAvailable = true
+        notificationCenterWrapper.post(Notification(name: UIApplication.didFinishLaunchingNotification))
+
+        XCTAssertEqual(.background, sut.applicationState)
+        XCTAssertFalse(sut.isApplicationInForeground)
+        XCTAssertFalse(sut.isActive)
+    }
+
+    func testApplicationNilAtInit_foregroundLaunch_shouldFollowLifecycleAfterLaunch() {
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let application = TestSentryUIApplication()
+        application.unsafeApplicationState = .inactive
+        var applicationAvailable = false
+        let sut = SentryThreadsafeApplication(applicationProvider: { applicationAvailable ? application : nil }, notificationCenter: notificationCenterWrapper)
+
+        applicationAvailable = true
+        notificationCenterWrapper.post(Notification(name: UIApplication.didFinishLaunchingNotification))
+        XCTAssertEqual(.inactive, sut.applicationState)
+        XCTAssertTrue(sut.isApplicationInForeground)
+        XCTAssertFalse(sut.isActive)
+
+        notificationCenterWrapper.post(Notification(name: UIApplication.didBecomeActiveNotification))
+        XCTAssertEqual(.active, sut.applicationState)
+        XCTAssertTrue(sut.isActive)
+    }
+
+    func testApplicationAvailableAtInit_shouldIgnoreDidFinishLaunching() {
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let application = TestSentryUIApplication()
+        application.unsafeApplicationState = .inactive
+        let sut = SentryThreadsafeApplication(applicationProvider: { application }, notificationCenter: notificationCenterWrapper)
+
+        application.unsafeApplicationState = .background
+        notificationCenterWrapper.post(Notification(name: UIApplication.didFinishLaunchingNotification))
+
+        XCTAssertEqual(.inactive, sut.applicationState)
+        XCTAssertTrue(sut.isApplicationInForeground)
+    }
+
+    func testApplicationNilAtInitAndAtLaunch_shouldKeepActiveDefault() {
+        let notificationCenterWrapper = TestNSNotificationCenterWrapper()
+        let sut = SentryThreadsafeApplication(applicationProvider: { nil }, notificationCenter: notificationCenterWrapper)
+
+        notificationCenterWrapper.post(Notification(name: UIApplication.didFinishLaunchingNotification))
+
+        XCTAssertEqual(.active, sut.applicationState)
+        XCTAssertTrue(sut.isApplicationInForeground)
+    }
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

`SentryThreadsafeApplication` defaults to `.active` when `UIApplication` is not available at init. That is the case whenever the SDK is started from a SwiftUI `App.init`, which runs before `UIApplicationMain`. From then on only `didBecomeActive` / `willEnterForeground` / `didEnterBackground` update the state, and none of them is posted to a process the system launches **in the background** (HealthKit background delivery, background `URLSession`, location, BGTask). So for such a process the SDK believes it is active and in the foreground for its whole lifetime.

The consequence we hit (sentry-cocoa 9.20.0, iOS 26.6.1, SwiftUI app, `SentrySDK.start` in `App.init`): HealthKit launched the app in the background after a workout was written to Health. `SentryANRTrackerV2` kept running because `isApplicationInForeground` was true, and `SentryHangTrackingIntegration.anrDetected` passed its `.active` guard. After the process was suspended and resumed, the delayed-frames tracker reported one ongoing frame longer than the timeout, so a **"App Hang Fully Blocked"** event was stored with a main thread that was idle in the run loop (`__CFRunLoopRun → __CFRunLoopServiceMachPort → mach_msg2_trap`), with 100 breadcrumbs and not a single `app.lifecycle` / UI / touch crumb. The process was later reclaimed in the background and the next launch sent it as **"Fatal App Hang Fully Blocked: The user or the OS watchdog terminated your app…"**.

## :bulb: Motivation and Context

This PR keeps the `.active` default (a foreground launch is by far the common case and nothing else is known at that point) but, when the application was nil at init, observes `UIApplicationDidFinishLaunchingNotification` once and takes the real `applicationState` from it. That notification is posted on the main thread and precedes every other lifecycle notification, so it cannot overwrite a state a later notification set.

Behaviour change worth calling out: a SwiftUI app that starts the SDK in `App.init` now reads `.inactive` between `didFinishLaunching` and `didBecomeActive` on a foreground launch, which is exactly what a UIKit app starting the SDK from `application(_:didFinishLaunchingWithOptions:)` already sees today.

Two related observations that I did **not** change, in case you want follow-ups:

- `SentryANRTrackerV2` only discounts an oversleep when `deltaFromNowToSleepDeadline >= timeoutInterval`, i.e. a suspension of at least `2 × timeout − sleepInterval` (5.4 s at a 3 s timeout). A suspension between roughly `timeout` and that bound passes the guard, and the ongoing frame then reads as fully blocking.
- `captureStoredAppHangEvent` escalates every stored hang to fatal unless the last launch crashed; the previous `SentryAppState` (`isActive`, `wasTerminated`) that `SentryWatchdogTerminationLogic` consults is not looked at. I left it alone since "the user terminated the app during a hang" is documented as intentionally fatal.

## :green_heart: How did you test it?

New unit tests in `SentryThreadsafeApplicationTests` (nil application at init: stays active until launch; resolves `.background` at `didFinishLaunching`; foreground launch resolves `.inactive` then follows `didBecomeActive`; application available at init ignores `didFinishLaunching`; still-nil at launch keeps the default). Existing tests in that file unchanged and green. Ran `SentryTests/SentryThreadsafeApplicationTests` on the iOS Simulator locally.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
