### PR TITLE
fix(tests): use raster image in replay disk tests

### DIFF
--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -452,7 +452,11 @@ class SentryOnDemandReplayTests: XCTestCase {
         let imagePath = outputPath
             .appendingPathComponent("\(start.timeIntervalSinceReferenceDate)")
             .appendingPathExtension("png")
-        try UIImage.add.pngData()?.write(to: imagePath)
+        let imageData = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).pngData { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+        try imageData.write(to: imagePath)
 
         sut.frames = [
             SentryReplayFrame(imagePath: imagePath.path, time: start, screenName: nil, image: nil)
@@ -495,7 +499,11 @@ class SentryOnDemandReplayTests: XCTestCase {
         let imagePath = outputPath
             .appendingPathComponent("\(start.timeIntervalSinceReferenceDate)")
             .appendingPathExtension("png")
-        try UIImage.add.pngData()?.write(to: imagePath)
+        let imageData = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).pngData { ctx in
+            UIColor.red.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+        try imageData.write(to: imagePath)
 
         // -- Act --
         let sut = SentryOnDemandReplay(


### PR DESCRIPTION
## Summary
- Replace `UIImage.add.pngData()?.write(to:)` with `UIGraphicsImageRenderer` in two replay tests
- `UIImage.add` is an SF Symbol whose `pngData()` can intermittently return nil on CI simulators (no rendering context), and the optional chain silently skips the file write
- This caused `testCreateVideo_whenOnlyDiskFramesAvailable_shouldFallBackToDisk` to fail flakily because the disk image was never written

## Test plan
- [x] `make build-ios FOR_AGENTS=true` passes
- [ ] Verify the previously flaky test passes reliably on CI

#skip-changelog

Closes #8991