### PR TITLE
fix(scope): Correlate captures with bound spans

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -555,13 +555,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                                               withScope:(SentryScope *)scope
                                            currentScope:(nullable SentryScope *)currentScope
 {
+    id<SentrySpan> currentScopeSpan = currentScope.span;
     id<SentrySpan> span;
     if ([event isKindOfClass:[SentryTransaction class]]) {
         span = [(SentryTransaction *)event trace];
     } else {
         // Even envelopes without transactions can contain the trace state, allowing Sentry to
         // eventually sample attachments belonging to a transaction.
-        span = currentScope.span ?: scope.span;
+        span = currentScopeSpan ?: scope.span;
     }
 
     SentryTracer *tracer = [SentryTracer getTracer:span];
@@ -570,7 +571,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     if (event.error || event.exceptions.count > 0) {
-        return [[SentryTraceContext alloc] initWithTraceId:scope.propagationContext.traceId
+        SentryId *traceId = currentScopeSpan.traceId ?: scope.propagationContext.traceId;
+        return [[SentryTraceContext alloc] initWithTraceId:traceId
                                                    options:self.options
                                                   replayId:scope.replayId];
     }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -422,7 +422,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    SentryTraceContext *traceContext = [self getTraceStateWithEvent:transaction withScope:scope];
+    SentryTraceContext *traceContext = [self getTraceStateWithEvent:transaction
+                                                          withScope:scope
+                                                       currentScope:nil];
 
     [self.transportAdapter storeEvent:preparedEvent traceContext:traceContext];
 }
@@ -551,6 +553,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (nullable SentryTraceContext *)getTraceStateWithEvent:(SentryEvent *)event
                                               withScope:(SentryScope *)scope
+                                           currentScope:(nullable SentryScope *)currentScope
 {
     id<SentrySpan> span;
     if ([event isKindOfClass:[SentryTransaction class]]) {
@@ -558,7 +561,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     } else {
         // Even envelopes without transactions can contain the trace state, allowing Sentry to
         // eventually sample attachments belonging to a transaction.
-        span = scope.span;
+        span = currentScope.span ?: scope.span;
     }
 
     SentryTracer *tracer = [SentryTracer getTracer:span];
@@ -636,7 +639,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return SentryId.empty;
     }
 
-    SentryTraceContext *traceContext = [self getTraceStateWithEvent:event withScope:scope];
+    SentryTraceContext *traceContext =
+        [self getTraceStateWithEvent:event
+                           withScope:scope
+                        currentScope:isFatalEvent ? nil : [self.currentScopeStorage scope]];
 
     NSArray<SentryAttachment *> *attachments = [self processAttachmentsForEvent:preparedEvent
                                                                     attachments:hint.attachments];
@@ -676,7 +682,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         scope.replayId = replay[@"replay_id"];
     }
 
-    SentryTraceContext *traceContext = [self getTraceStateWithEvent:event withScope:scope];
+    SentryTraceContext *traceContext =
+        [self getTraceStateWithEvent:event
+                           withScope:scope
+                        currentScope:event.isFatalEvent ? nil : [self.currentScopeStorage scope]];
 
     if (session == nil) {
         [self.transportAdapter sendEvent:event traceContext:traceContext attachments:attachments];
@@ -820,7 +829,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    SentryTraceContext *traceContext = [self getTraceStateWithEvent:preparedEvent withScope:scope];
+    SentryTraceContext *traceContext = [self getTraceStateWithEvent:preparedEvent
+                                                          withScope:scope
+                                                       currentScope:currentScope];
 
     NSMutableArray<SentryAttachment *> *allAttachments = [NSMutableArray array];
     [allAttachments addObjectsFromArray:scope.attachments];

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -697,22 +697,6 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
         event.level = level;
     }
 
-    id<SentrySpan> span;
-
-    if (self.span != nil) {
-        @synchronized(_spanLock) {
-            span = self.span;
-        }
-
-        // Span could be nil as we do the first check outside the synchronize
-        if (span != nil) {
-            if (![event.type isEqualToString:SentryEnvelopeItemTypes.transaction] &&
-                [span isKindOfClass:[SentryTracer class]]) {
-                event.transaction = [[(SentryTracer *)span transactionContext] name];
-            }
-        }
-    }
-
     NSMutableDictionary *newContext = [self context].mutableCopy;
     BOOL isRegularEvent
         = event.type == nil || [event.type isEqualToString:SentryEnvelopeItemTypes.event];
@@ -727,9 +711,9 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
                                       intoDictionary:newContext];
     }
 
-    newContext[@"trace"] = [self buildTraceContext:span];
-
     event.context = newContext;
+    // The span getter acquires _spanLock, so this read needs no outer lock.
+    [self applySpan:self.span toEvent:SENTRY_UNWRAP_NULLABLE(SentryEvent, event)];
     return event;
 }
 
@@ -811,6 +795,25 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
         }
 
         event.context = mergedContext;
+    }
+
+    id<SentrySpan> span = self.span;
+    if (span != nil && !event.isFatalEvent
+        && ![event.type isEqualToString:SentryEnvelopeItemTypes.transaction]) {
+        [self applySpan:span toEvent:event];
+    }
+}
+
+- (void)applySpan:(nullable id<SentrySpan>)span toEvent:(SentryEvent *)event
+{
+    NSMutableDictionary *context =
+        [NSMutableDictionary dictionaryWithDictionary:event.context ?: @{}];
+    context[@"trace"] = [self buildTraceContext:span];
+    event.context = context;
+
+    SentryTracer *tracer = [SentryTracer getTracer:span];
+    if (tracer != nil && ![event.type isEqualToString:SentryEnvelopeItemTypes.transaction]) {
+        event.transaction = tracer.transactionContext.name;
     }
 }
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -807,7 +807,7 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
 - (void)applySpan:(nullable id<SentrySpan>)span toEvent:(SentryEvent *)event
 {
     NSMutableDictionary *context =
-        [NSMutableDictionary dictionaryWithDictionary:event.context ?: @{}];
+        [NSMutableDictionary dictionaryWithDictionary:event.context ?: @{ }];
     context[@"trace"] = [self buildTraceContext:span];
     event.context = context;
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -808,12 +808,21 @@ static NSString *const kSentryScopeSpanStatusSerializationKey = @"status";
 {
     NSMutableDictionary *context =
         [NSMutableDictionary dictionaryWithDictionary:event.context ?: @{ }];
+    NSString *previousTraceId = context[@"trace"][@"trace_id"];
     context[@"trace"] = [self buildTraceContext:span];
     event.context = context;
 
+    if ([event.type isEqualToString:SentryEnvelopeItemTypes.transaction]) {
+        return;
+    }
+
     SentryTracer *tracer = [SentryTracer getTracer:span];
-    if (tracer != nil && ![event.type isEqualToString:SentryEnvelopeItemTypes.transaction]) {
+    if (tracer != nil) {
         event.transaction = tracer.transactionContext.name;
+    } else if (span != nil && previousTraceId != nil
+        && ![previousTraceId isEqual:context[@"trace"][@"trace_id"]]) {
+        // A name from another trace must not survive when the new span has no tracer.
+        event.transaction = nil;
     }
 }
 

--- a/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
+++ b/Sources/Swift/Integrations/Metrics/SentryMetricsIntegration.swift
@@ -57,8 +57,8 @@ final class SentryMetricsIntegration<Dependencies: SentryMetricsIntegrationDepen
         }
 
         var mutableMetric = metric
-        // Custom attribute precedence: caller > current scope > global scope. Trace correlation,
-        // user, and the other reserved attributes come from the global scope only.
+        // Custom attribute precedence: caller > current scope > global scope. User and the
+        // other reserved attributes come from the global scope only.
         scope.addAttributesToItem(&mutableMetric, metadata: self.scopeMetaData, currentScope: currentScope)
 
         if let beforeSendMetric = beforeSendMetric {

--- a/Sources/Swift/Tools/TelemetryScopeApplier/SentryLogScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/SentryLogScopeApplier.swift
@@ -7,8 +7,8 @@ import Foundation
 @objc
 public protocol SentryLogScopeApplier {
     /// Applies the scope to the log. Custom attribute precedence: log > current scope > global
-    /// scope. Trace correlation, user, and the other reserved attributes always come from
-    /// `scope`, so the thread-local current scope can't clobber the hub scope's active span.
+    /// scope. The current scope's span takes precedence for trace correlation. User and the
+    /// other reserved attributes come from `scope`.
     func applyScope(_ scope: Scope, currentScope: Scope?, toLog log: SentryLog) -> SentryLog
 }
 

--- a/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
+++ b/Sources/Swift/Tools/TelemetryScopeApplier/TelemetryScopeApplier.swift
@@ -43,10 +43,8 @@ extension TelemetryScopeApplier {
         addUserAttributes(to: &attributes, metadata: metadata)
         addReplayAttributes(to: &attributes)
         // Custom attributes never override existing keys, so applying the thread-local current
-        // scope before the global scope yields: item > current scope > global scope. Only custom
-        // attributes are taken from the current scope; trace correlation, user, replay, and the
-        // other reserved attributes above always come from `self` (the global scope), so the
-        // current scope can't clobber the active span.
+        // scope before the global scope yields: item > current scope > global scope. User,
+        // replay, and the other reserved attributes above still come from the global scope.
         currentScope?.addScopeAttributes(to: &attributes)
         addScopeAttributes(to: &attributes)
         addDefaultUserIdIfNeeded(to: &attributes, metadata: metadata)
@@ -63,8 +61,9 @@ extension TelemetryScopeApplier {
         // See also:
         // - https://develop.sentry.dev/sdk/telemetry/logs/#log-envelope-item-payload
         // - https://develop.sentry.dev/sdk/telemetry/logs/#tracing
-        item.traceId = span?.traceId ?? propagationContextTraceId
-        item.spanId = span?.spanId
+        let effectiveSpan = currentScope?.span ?? span
+        item.traceId = effectiveSpan?.traceId ?? propagationContextTraceId
+        item.spanId = effectiveSpan?.spanId
     }
 
     private func addDefaultAttributes(to attributes: inout [String: SentryAttributeContent], metadata: any TelemetryScopeMetadata) {

--- a/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
+++ b/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
@@ -277,6 +277,38 @@ final class SentryWithCurrentScopeIntegrationTests: XCTestCase {
         XCTAssertEqual(envelopeTrace.traceId, span.traceId)
     }
 
+    func testWithCurrentScope_whenSpanHasNoTracer_shouldNotInheritUnrelatedTransactionName() throws {
+        // -- Arrange --
+        let transaction = SentryTracer(transactionContext: TransactionContext(name: "hub transaction", operation: "test"), hub: nil)
+        SentrySDKInternal.currentHub().scope.span = transaction
+        let context = SpanContext(operation: "test")
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        let span = SentrySpanInternal(context: context, framesTracker: nil)
+        #else
+        let span = SentrySpanInternal(context: context)
+        #endif
+        defer {
+            span.finish()
+            transaction.finish()
+        }
+        let currentScope = SentrySDK.internal.scope.createScope()
+        currentScope.span = span
+        XCTAssertNil(span.tracer)
+        XCTAssertNotEqual(span.traceId, transaction.traceId)
+
+        // -- Act --
+        SentrySDK.internal.scope.withCurrentScope(currentScope) {
+            SentrySDK.capture(event: Event())
+        }
+
+        // -- Assert --
+        let captured = try XCTUnwrap(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
+        let trace = try XCTUnwrap(captured.event.context?["trace"])
+        XCTAssertEqual(trace["trace_id"] as? String, span.traceId.sentryIdString)
+        XCTAssertEqual(trace["span_id"] as? String, span.spanId.sentrySpanIdString)
+        XCTAssertNil(captured.event.transaction)
+    }
+
     func testWithCurrentScope_whenChildSpanIsBound_shouldCorrelateLog() throws {
         // -- Arrange --
         var capturedLog: SentryLog?

--- a/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
+++ b/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
@@ -215,6 +215,129 @@ final class SentryWithCurrentScopeIntegrationTests: XCTestCase {
         XCTAssertEqual(capturedLog?.attributes["log_tag"]?.value as? String, "log-scoped")
     }
 
+    func testWithCurrentScope_whenChildSpanIsBound_shouldCorrelateEventAndEnvelope() throws {
+        // -- Arrange --
+        let context = TransactionContext(name: "local transaction", operation: "test", sampled: .yes, sampleRate: 1, sampleRand: 0.5)
+        let transaction = SentryTracer(transactionContext: context, hub: nil)
+        let child = transaction.startChild(operation: "test.child")
+        defer {
+            child.finish()
+            transaction.finish()
+        }
+        let currentScope = SentrySDK.internal.scope.createScope()
+        currentScope.span = child
+        currentScope.setTag(value: "current", key: "scope")
+        let globalScope = SentrySDKInternal.currentHub().scope
+        XCTAssertNil(globalScope.span)
+        XCTAssertNotEqual(child.traceId, globalScope.propagationContextTraceId)
+        XCTAssertNotEqual(child.spanId, transaction.spanId)
+
+        // -- Act --
+        SentrySDK.internal.scope.withCurrentScope(currentScope) {
+            SentrySDK.capture(event: Event())
+        }
+
+        // -- Assert --
+        let captured = try XCTUnwrap(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
+        XCTAssertEqual(captured.event.tags?["scope"], "current")
+        let trace = try XCTUnwrap(captured.event.context?["trace"])
+        XCTAssertEqual(trace["trace_id"] as? String, child.traceId.sentryIdString)
+        XCTAssertEqual(trace["span_id"] as? String, child.spanId.sentrySpanIdString)
+        let envelopeTrace = try XCTUnwrap(captured.traceContext)
+        XCTAssertEqual(envelopeTrace.traceId, child.traceId)
+        XCTAssertEqual(envelopeTrace.sampled, "true")
+        XCTAssertEqual(envelopeTrace.sampleRate, "1.000000")
+    }
+
+    func testWithCurrentScope_whenChildSpanIsBound_shouldCorrelateLog() throws {
+        // -- Arrange --
+        var capturedLog: SentryLog?
+        #if !SDK_V10
+        fixture.options.enableLogs = true
+        #endif // !SDK_V10
+        fixture.options.beforeSendLog = { log in
+            capturedLog = log
+            return log
+        }
+        let client = try fixture.getSut()
+        let hub = SentryHubInternal(
+            client: client,
+            andScope: Scope(),
+            activeCrashReporterState: TestSentryCrashReporterState(),
+            andDispatchQueue: SentryDispatchQueueWrapper()
+        )
+        SentrySDKInternal.setCurrentHub(hub)
+        let transaction = SentryTracer(transactionContext: TransactionContext(name: "local transaction", operation: "test"), hub: nil)
+        let child = transaction.startChild(operation: "test.child")
+        defer {
+            child.finish()
+            transaction.finish()
+        }
+        let currentScope = SentrySDK.internal.scope.createScope()
+        currentScope.span = child
+        currentScope.setAttribute(value: "current", key: "scope")
+        XCTAssertNil(hub.scope.span)
+        XCTAssertNotEqual(child.traceId, hub.scope.propagationContextTraceId)
+        XCTAssertNotEqual(child.spanId, transaction.spanId)
+
+        // -- Act --
+        SentrySDK.internal.scope.withCurrentScope(currentScope) {
+            SentrySDK.logger.info("scoped log")
+        }
+
+        // -- Assert --
+        let log = try XCTUnwrap(capturedLog)
+        XCTAssertEqual(log.body, "scoped log")
+        XCTAssertEqual(log.attributes["scope"]?.value as? String, "current")
+        XCTAssertEqual(log.traceId, child.traceId)
+        XCTAssertEqual(log.spanId, child.spanId)
+    }
+
+    func testWithCurrentScope_whenChildSpanIsBound_shouldCorrelateMetrics() throws {
+        // -- Arrange --
+        var capturedMetrics: [SentryMetric] = []
+        fixture.options.beforeSendMetric = { metric in
+            capturedMetrics.append(metric)
+            return metric
+        }
+        let hub = SentrySDKInternal.currentHub()
+        let integration = try XCTUnwrap(
+            SentryMetricsIntegration<SentryDependencyContainer>(
+                with: fixture.options,
+                dependencies: SentryDependencyContainer.sharedInstance()
+            ) as Any as? SentryIntegrationProtocol
+        )
+        hub.addInstalledIntegration(integration, name: SentryMetricsIntegration<SentryDependencyContainer>.name)
+        let transaction = SentryTracer(transactionContext: TransactionContext(name: "local transaction", operation: "test"), hub: nil)
+        let child = transaction.startChild(operation: "test.child")
+        defer {
+            child.finish()
+            transaction.finish()
+        }
+        let currentScope = SentrySDK.internal.scope.createScope()
+        currentScope.span = child
+        currentScope.setAttribute(value: "current", key: "scope")
+        XCTAssertNil(hub.scope.span)
+        XCTAssertNotEqual(child.traceId, hub.scope.propagationContextTraceId)
+        XCTAssertNotEqual(child.spanId, transaction.spanId)
+
+        // -- Act --
+        SentrySDK.internal.scope.withCurrentScope(currentScope) {
+            SentrySDK.metrics.count(key: "scoped.counter", value: 1)
+            SentrySDK.metrics.gauge(key: "scoped.gauge", value: 2)
+            SentrySDK.metrics.distribution(key: "scoped.distribution", value: 3)
+        }
+
+        // -- Assert --
+        XCTAssertEqual(capturedMetrics.map(\.name), ["scoped.counter", "scoped.gauge", "scoped.distribution"])
+        XCTAssertEqual(capturedMetrics.map(\.value), [.counter(1), .gauge(2), .distribution(3)])
+        for metric in capturedMetrics {
+            XCTAssertEqual(metric.attributes["scope"], .string("current"), metric.name)
+            XCTAssertEqual(metric.traceId, child.traceId, metric.name)
+            XCTAssertEqual(metric.spanId, child.spanId, metric.name)
+        }
+    }
+
     // MARK: - Helpers
 
     private func lastSentEvent() -> Event? {

--- a/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
+++ b/Tests/SentryTests/SentryWithCurrentScopeIntegrationTests.swift
@@ -249,6 +249,34 @@ final class SentryWithCurrentScopeIntegrationTests: XCTestCase {
         XCTAssertEqual(envelopeTrace.sampleRate, "1.000000")
     }
 
+    func testWithCurrentScope_whenSpanHasNoTracer_shouldCorrelateErrorEnvelope() throws {
+        // -- Arrange --
+        let context = SpanContext(operation: "test")
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        let span = SentrySpanInternal(context: context, framesTracker: nil)
+        #else
+        let span = SentrySpanInternal(context: context)
+        #endif
+        defer { span.finish() }
+        let currentScope = SentrySDK.internal.scope.createScope()
+        currentScope.span = span
+        XCTAssertNil(span.tracer)
+        XCTAssertNotEqual(span.traceId, SentrySDKInternal.currentHub().scope.propagationContextTraceId)
+
+        // -- Act --
+        SentrySDK.internal.scope.withCurrentScope(currentScope) {
+            SentrySDK.capture(error: NSError(domain: "test", code: 1))
+        }
+
+        // -- Assert --
+        let captured = try XCTUnwrap(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
+        let trace = try XCTUnwrap(captured.event.context?["trace"])
+        XCTAssertEqual(trace["trace_id"] as? String, span.traceId.sentryIdString)
+        XCTAssertEqual(trace["span_id"] as? String, span.spanId.sentrySpanIdString)
+        let envelopeTrace = try XCTUnwrap(captured.traceContext)
+        XCTAssertEqual(envelopeTrace.traceId, span.traceId)
+    }
+
     func testWithCurrentScope_whenChildSpanIsBound_shouldCorrelateLog() throws {
         // -- Arrange --
         var capturedLog: SentryLog?

--- a/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
+++ b/Tests/SentryTests/TelemetryScopeApplier/TelemetryScopeApplierTests.swift
@@ -582,13 +582,12 @@ final class TelemetryScopeApplierTests: XCTestCase {
         XCTAssertEqual(item.attributesDict["sentry.sdk.name"], .string(SentryMeta.sdkName))
     }
 
-    func testApplyToItem_withCurrentScope_shouldUseTraceCorrelationFromGlobalScope() {
+    func testApplyToItem_whenBothScopesHaveSpans_shouldUseCurrentScopeSpan() {
         // -- Arrange --
-        let globalTraceId = SentryId()
-        let currentTraceId = SentryId()
-        let span = TestSpan(spanId: SentryId())
-        let scope = TestScope(propagationContextTraceId: globalTraceId)
-        let currentScope = TestScope(propagationContextTraceId: currentTraceId, span: span)
+        let globalSpan = TestSpan(spanId: SentryId())
+        let currentSpan = TestSpan(spanId: SentryId())
+        let scope = TestScope(propagationContextTraceId: SentryId(), span: globalSpan)
+        let currentScope = TestScope(propagationContextTraceId: SentryId(), span: currentSpan)
         let metadata = createTestMetadata()
         var item = createTestItem()
 
@@ -596,10 +595,8 @@ final class TelemetryScopeApplierTests: XCTestCase {
         scope.addAttributesToItem(&item, metadata: metadata, currentScope: currentScope)
 
         // -- Assert --
-        // The current scope contributes custom attributes only; trace correlation must come
-        // from the global scope so the current scope can't clobber the active span.
-        XCTAssertEqual(item.traceId, globalTraceId)
-        XCTAssertNil(item.spanId)
+        XCTAssertEqual(item.traceId, currentSpan.traceId)
+        XCTAssertEqual(item.spanId, currentSpan.spanId)
     }
 
     // MARK: - Default User ID Tests


### PR DESCRIPTION
## :scroll: Description

Correlate events, feedback, logs, and metrics with the current scope’s bound span, including transaction names and envelope trace metadata. Preserve the span’s trace ID in error envelopes when no owning transaction is available.

## :bulb: Motivation and Context

Godot’s span support binds active spans to Cocoa’s current scope, but captured telemetry does not inherit them. This provides the upstream Cocoa fix needed for Godot’s macOS and iOS integration.

- Refs getsentry/sentry-godot#926
- Refs getsentry/sentry-godot#925
- Refs getsentry/sentry-godot#921

## :green_heart: How did you test it?

Added regression tests for scoped event and envelope correlation, logs, metrics, and error envelopes without an owning transaction. Updated the existing telemetry test to expect the current scope’s span.

iOS and macOS builds, static analysis, and focused macOS tests passed. 

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [ ] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

#skip-changelog