### PR TITLE
fix(samples): align switch-v10 with SDK_V10

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -396,6 +396,10 @@ run_v10_for_prs: &run_v10_for_prs
   - "scripts/ci-utils.sh"
   - "scripts/sentry-xcodebuild.sh"
   - "scripts/verify-v10-sentrycrash-*.sh"
+  - "scripts/generate-sample-v10.sh"
+  - "scripts/set-xcodegen-package-traits.sh"
+  - "scripts/set-xcodegen-compiler-flags.sh"
+  - "scripts/swap-xcodegen-product-name.sh"
 
   # Project files
   - "Sentry.xcodeproj/**"

--- a/Makefile
+++ b/Makefile
@@ -737,7 +737,7 @@ V10_SDK_FLAGS = GCC_PREPROCESSOR_DEFINITIONS='$$(inherited) SDK_V10=1' SWIFT_ACT
 ## Build the iOS-Swift sample app with the V10 trait
 .PHONY: build-sample-v10-iOS-Swift
 build-sample-v10-iOS-Swift:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/iOS-Swift/iOS-Swift.yml
+	scripts/generate-sample-v10.sh --spec Samples/iOS-Swift/iOS-Swift.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme iOS-Swift \
@@ -749,7 +749,7 @@ build-sample-v10-iOS-Swift:
 ## Build the iOS-SwiftUI sample app with the V10 trait
 .PHONY: build-sample-v10-iOS-SwiftUI
 build-sample-v10-iOS-SwiftUI:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/iOS-SwiftUI/iOS-SwiftUI.yml
+	scripts/generate-sample-v10.sh --spec Samples/iOS-SwiftUI/iOS-SwiftUI.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme iOS-SwiftUI \
@@ -761,7 +761,7 @@ build-sample-v10-iOS-SwiftUI:
 ## Build the iOS-ObjectiveC sample app with the V10 trait
 .PHONY: build-sample-v10-iOS-ObjectiveC
 build-sample-v10-iOS-ObjectiveC:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/iOS-ObjectiveC/iOS-ObjectiveC.yml
+	scripts/generate-sample-v10.sh --spec Samples/iOS-ObjectiveC/iOS-ObjectiveC.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme iOS-ObjectiveC \
@@ -773,7 +773,7 @@ build-sample-v10-iOS-ObjectiveC:
 ## Build the iOS-ObjectiveCpp-NoModules sample app with the V10 trait
 .PHONY: build-sample-v10-iOS-ObjectiveCpp-NoModules
 build-sample-v10-iOS-ObjectiveCpp-NoModules:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/iOS-ObjectiveCpp-NoModules/iOS-ObjectiveCpp-NoModules.yml
+	scripts/generate-sample-v10.sh --spec Samples/iOS-ObjectiveCpp-NoModules/iOS-ObjectiveCpp-NoModules.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme iOS-ObjectiveCpp-NoModules \
@@ -786,7 +786,7 @@ build-sample-v10-iOS-ObjectiveCpp-NoModules:
 ## Build the SPM sample app with the V10 trait
 .PHONY: build-sample-v10-SPM
 build-sample-v10-SPM:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/SPM/SPM.yml
+	scripts/generate-sample-v10.sh --spec Samples/SPM/SPM.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme SPM \
@@ -797,7 +797,7 @@ build-sample-v10-SPM:
 ## Build the DistributionSample app with the V10 trait
 .PHONY: build-sample-v10-DistributionSample
 build-sample-v10-DistributionSample:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/DistributionSample/DistributionSample.yml
+	scripts/generate-sample-v10.sh --spec Samples/DistributionSample/DistributionSample.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme DistributionSample \
@@ -808,7 +808,7 @@ build-sample-v10-DistributionSample:
 ## Build the macOS-Swift sample app with the V10 trait
 .PHONY: build-sample-v10-macOS-Swift
 build-sample-v10-macOS-Swift:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/macOS-Swift/macOS-Swift.yml
+	scripts/generate-sample-v10.sh --spec Samples/macOS-Swift/macOS-Swift.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme macOS-Swift \
@@ -819,7 +819,7 @@ build-sample-v10-macOS-Swift:
 ## Build the macOS-SwiftUI sample app with the V10 trait
 .PHONY: build-sample-v10-macOS-SwiftUI
 build-sample-v10-macOS-SwiftUI:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/macOS-SwiftUI/macOS-SwiftUI.yml
+	scripts/generate-sample-v10.sh --spec Samples/macOS-SwiftUI/macOS-SwiftUI.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme macOS-SwiftUI \
@@ -830,7 +830,7 @@ build-sample-v10-macOS-SwiftUI:
 ## Build the tvOS-Swift sample app with the V10 trait
 .PHONY: build-sample-v10-tvOS-Swift
 build-sample-v10-tvOS-Swift:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/tvOS-Swift/tvOS-Swift.yml
+	scripts/generate-sample-v10.sh --spec Samples/tvOS-Swift/tvOS-Swift.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme tvOS-Swift \
@@ -842,7 +842,7 @@ build-sample-v10-tvOS-Swift:
 ## Build the visionOS-Swift sample app with the V10 trait
 .PHONY: build-sample-v10-visionOS-Swift
 build-sample-v10-visionOS-Swift:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/visionOS-Swift/visionOS-Swift.yml
+	scripts/generate-sample-v10.sh --spec Samples/visionOS-Swift/visionOS-Swift.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme visionOS-Swift \
@@ -854,7 +854,7 @@ build-sample-v10-visionOS-Swift:
 ## Build the watchOS-Swift sample app with the V10 trait
 .PHONY: build-sample-v10-watchOS-Swift
 build-sample-v10-watchOS-Swift:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate --spec Samples/watchOS-Swift/watchOS-Swift.yml
+	scripts/generate-sample-v10.sh --spec Samples/watchOS-Swift/watchOS-Swift.yml
 	set -o pipefail && xcodebuild \
 		-workspace Sentry.xcworkspace \
 		-scheme 'watchOS-Swift WatchKit App' \
@@ -1831,12 +1831,15 @@ xcode: xcode-ci
 
 ## Switch sample Xcode projects to SDK V10 mode
 #
-# Copies each sample XcodeGen YAML, adds the V10 package trait and app-target
-# SDK_V10 compiler flags with yq, and regenerates the Xcode project from that
-# copy. Committed YAML is left unchanged. Skips binary and NoUIFramework samples.
+# Copies each sample XcodeGen YAML, sets the V10 package trait and app-target
+# SDK_V10 compiler flags, rewrites SentrySPM product refs to Sentry, and
+# regenerates the Xcode project from that copy. Committed YAML is left
+# unchanged. Skips binary and NoUIFramework samples. Opens the workspace with
+# SDK_V10=1 so SwiftPM exports the source-built product as Sentry.
 .PHONY: switch-v10
 switch-v10:
-	scripts/set-xcodegen-package-traits.sh --trait V10 --generate
+	scripts/generate-sample-v10.sh --product SentrySPM --with Sentry
+	SDK_V10=1 xed Sentry.xcworkspace
 
 ## Switch sample Xcode projects back to default (non-V10) mode
 #

--- a/Samples/SentrySampleShared/Package.swift
+++ b/Samples/SentrySampleShared/Package.swift
@@ -1,6 +1,17 @@
 // swift-tools-version: 6.1
 
+import Foundation
 import PackageDescription
+
+func envFlag(_ name: String) -> Bool {
+    getenv(name).map { String(cString: $0) == "1" } ?? false
+}
+
+let enableV10 = envFlag("SDK_V10")
+
+// When SDK_V10 is set in the environment, Sentry exports the compile-from-source product
+// as "Sentry" rather than "SentrySPM". Mirror that selection here.
+let sentryProductName = enableV10 ? "Sentry" : "SentrySPM"
 
 let package = Package(
     name: "SentrySampleShared",
@@ -33,7 +44,7 @@ let package = Package(
         .target(
             name: "SentrySampleShared",
             dependencies: [
-                .product(name: "SentrySPM", package: "Sentry"),
+                .product(name: sentryProductName, package: "Sentry"),
                 .product(name: "SentryObjC", package: "Sentry")
             ],
             path: "Sources/SentrySampleShared",

--- a/scripts/generate-sample-v10.sh
+++ b/scripts/generate-sample-v10.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+set -euo pipefail
+
+# Disable SC1091 because it won't work with pre-commit
+# shellcheck source=./scripts/ci-utils.sh disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SAMPLES_DIR="$REPO_ROOT/Samples"
+
+SPECS=()
+PRODUCT=""
+WITH=""
+
+# Binary XCFramework samples cannot enable V10. macOS-CLI-Xcode uses the
+# NoUIFramework trait and must not pick up V10 from a bulk generate.
+SKIP_SPECS=(
+    "macOS-CLI-Xcode.yml"
+    "iOS-ObjectiveC-Dynamic.yml"
+    "iOS-ObjectiveC-Static.yml"
+)
+
+usage() {
+    log_notice "Usage: $(basename "$0")"
+    log_notice "  -s, --spec <path>        XcodeGen YAML spec (repeatable; all eligible"
+    log_notice "                           Samples/ specs when omitted)"
+    log_notice "  -p, --product <name>     Product name to replace in the generate copy"
+    log_notice "  -w, --with <name>        Replacement product name (required with --product)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--spec)    SPECS+=("$2"); shift 2 ;;
+        -p|--product) PRODUCT="$2";  shift 2 ;;
+        -w|--with)    WITH="$2";     shift 2 ;;
+        *)            usage ;;
+    esac
+done
+
+if [[ -n "$PRODUCT" && -z "$WITH" ]]; then
+    log_error "--with is required when --product is set"
+    usage
+fi
+
+if [[ -z "$PRODUCT" && -n "$WITH" ]]; then
+    log_error "--product is required when --with is set"
+    usage
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+    log_error "yq is required (brew install yq)"
+    exit 1
+fi
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+    log_error "xcodegen is required"
+    exit 1
+fi
+
+should_skip() {
+    local basename
+    basename="$(basename "$1")"
+    local skip
+    for skip in "${SKIP_SPECS[@]}"; do
+        if [[ "$basename" == "$skip" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+has_local_packages() {
+    yq -e '.packages | to_entries | map(select(.value | has("path"))) | length > 0' "$1" >/dev/null 2>&1
+}
+
+resolve_spec() {
+    local spec="$1"
+    if [[ -f "$spec" ]]; then
+        echo "$spec"
+        return 0
+    fi
+    if [[ -f "$REPO_ROOT/$spec" ]]; then
+        echo "$REPO_ROOT/$spec"
+        return 0
+    fi
+    log_error "Spec not found: $spec"
+    return 1
+}
+
+collect_specs() {
+    local spec
+    while IFS= read -r -d '' spec; do
+        if should_skip "$spec"; then
+            continue
+        fi
+        if ! has_local_packages "$spec"; then
+            continue
+        fi
+        printf '%s\0' "$spec"
+    done < <(find "$SAMPLES_DIR" -name '*.yml' ! -path '*/Shared/*' -print0)
+}
+
+gather_specs() {
+    local resolved=()
+    local spec
+    if [[ ${#SPECS[@]} -gt 0 ]]; then
+        for spec in "${SPECS[@]}"; do
+            resolved+=("$(resolve_spec "$spec")")
+        done
+        SPECS=("${resolved[@]}")
+        return 0
+    fi
+    SPECS=()
+    while IFS= read -r -d '' spec; do
+        SPECS+=("$spec")
+    done < <(collect_specs)
+}
+
+patch_and_generate() {
+    local spec="$1"
+    local dir base tmp
+    dir="$(dirname "$spec")"
+    base="$(basename "$spec" .yml)"
+    tmp="$dir/${base}.v10.yml"
+
+    (
+        trap 'rm -f "$tmp"' EXIT
+        cp "$spec" "$tmp"
+        "$SCRIPT_DIR/set-xcodegen-package-traits.sh" --spec "$tmp" --trait V10
+        "$SCRIPT_DIR/set-xcodegen-compiler-flags.sh" \
+            --spec "$tmp" \
+            --swift-condition SDK_V10 \
+            --c-define SDK_V10=1
+        if [[ -n "$PRODUCT" ]]; then
+            "$SCRIPT_DIR/swap-xcodegen-product-name.sh" \
+                --spec "$tmp" \
+                --product "$PRODUCT" \
+                --with "$WITH"
+        fi
+        begin_group "generate V10: $spec"
+        xcodegen --spec "$tmp"
+        log_info "  Generated"
+        end_group
+    )
+}
+
+gather_specs
+
+if [[ ${#SPECS[@]} -eq 0 ]]; then
+    log_warning "No XcodeGen specs with local packages found under Samples/"
+    exit 0
+fi
+
+for spec in "${SPECS[@]}"; do
+    patch_and_generate "$spec"
+done
+
+log_info "Done: generated ${#SPECS[@]} V10 project(s)"
+if [[ -n "$PRODUCT" ]]; then
+    log_notice "Product refs rewritten from '$PRODUCT' to '$WITH'. Open Xcode with SDK_V10=1."
+fi

--- a/scripts/set-xcodegen-compiler-flags.sh
+++ b/scripts/set-xcodegen-compiler-flags.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+# Disable SC1091 because it won't work with pre-commit
+# shellcheck source=./scripts/ci-utils.sh disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
+
+SPEC=""
+SWIFT_CONDITIONS=()
+C_DEFINES=()
+
+usage() {
+    log_notice "Usage: $(basename "$0")"
+    log_notice "  -s, --spec <path>              XcodeGen YAML spec (required)"
+    log_notice "  -S, --swift-condition <name>   SWIFT_ACTIVE_COMPILATION_CONDITIONS flag"
+    log_notice "                                 (repeatable)"
+    log_notice "  -D, --c-define <name[=value]>  GCC_PREPROCESSOR_DEFINITIONS flag"
+    log_notice "                                 (repeatable)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--spec)             SPEC="$2";                shift 2 ;;
+        -S|--swift-condition)  SWIFT_CONDITIONS+=("$2"); shift 2 ;;
+        -D|--c-define)         C_DEFINES+=("$2");        shift 2 ;;
+        *)                     usage ;;
+    esac
+done
+
+if [[ -z "$SPEC" ]]; then
+    log_error "--spec is required"
+    usage
+fi
+
+if [[ ${#SWIFT_CONDITIONS[@]} -eq 0 && ${#C_DEFINES[@]} -eq 0 ]]; then
+    log_error "--swift-condition or --c-define is required"
+    usage
+fi
+
+if [[ ! -f "$SPEC" ]]; then
+    log_error "Spec not found: $SPEC"
+    exit 1
+fi
+
+for flag in "${SWIFT_CONDITIONS[@]}"; do
+    if [[ ! "$flag" =~ ^[A-Za-z0-9_]+$ ]]; then
+        log_error "Invalid Swift condition '$flag'"
+        exit 1
+    fi
+done
+
+for flag in "${C_DEFINES[@]}"; do
+    if [[ ! "$flag" =~ ^[A-Za-z0-9_.=]+$ ]]; then
+        log_error "Invalid C define '$flag'"
+        exit 1
+    fi
+done
+
+if ! command -v yq >/dev/null 2>&1; then
+    log_error "yq is required (brew install yq)"
+    exit 1
+fi
+
+# $(inherited) must stay literal for Xcode; do not let the shell expand it.
+# shellcheck disable=SC2016
+inherited='$(inherited)'
+
+if [[ ${#SWIFT_CONDITIONS[@]} -gt 0 ]]; then
+    SWIFT_VALUE="$inherited"
+    for flag in "${SWIFT_CONDITIONS[@]}"; do
+        SWIFT_VALUE+=" $flag"
+    done
+    SWIFT_VALUE="$SWIFT_VALUE" yq -i \
+        '.targets[] |= (.settings.base.SWIFT_ACTIVE_COMPILATION_CONDITIONS = strenv(SWIFT_VALUE))' \
+        "$SPEC"
+fi
+
+if [[ ${#C_DEFINES[@]} -gt 0 ]]; then
+    C_VALUE="$inherited"
+    for flag in "${C_DEFINES[@]}"; do
+        C_VALUE+=" $flag"
+    done
+    C_VALUE="$C_VALUE" yq -i \
+        '.targets[] |= (.settings.base.GCC_PREPROCESSOR_DEFINITIONS = strenv(C_VALUE))' \
+        "$SPEC"
+fi

--- a/scripts/set-xcodegen-package-traits.sh
+++ b/scripts/set-xcodegen-package-traits.sh
@@ -5,207 +5,54 @@ set -euo pipefail
 # shellcheck source=./scripts/ci-utils.sh disable=SC1091
 source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
 
-TRAIT=""
-MODE=""
 SPEC=""
-GENERATE=false
-
-# Binary XCFramework samples cannot enable V10. macOS-CLI-Xcode uses the
-# NoUIFramework trait and must not pick up V10 from a bulk generate.
-SKIP_SPECS=(
-    "macOS-CLI-Xcode.yml"
-    "iOS-ObjectiveC-Dynamic.yml"
-    "iOS-ObjectiveC-Static.yml"
-)
+TRAITS=()
 
 usage() {
     log_notice "Usage: $(basename "$0")"
-    log_notice "  -t, --trait <name>      Package trait to add or remove (required)"
-    log_notice "  -m, --mode <add|remove> Add or remove the trait on YAML specs"
-    log_notice "  -s, --spec <path>       XcodeGen YAML spec (all Samples/ specs when omitted)"
-    log_notice "  -g, --generate          Copy each spec, add the trait, run xcodegen,"
-    log_notice "                          then delete the copy so committed YAML is unchanged."
-    log_notice "                          For V10, also define SDK_V10 on every app target"
+    log_notice "  -s, --spec <path>     XcodeGen YAML spec (required)"
+    log_notice "  -t, --trait <name>    Package trait to set on local path packages"
+    log_notice "                        (repeatable, required)"
     exit 1
 }
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -t|--trait)     TRAIT="$2";     shift 2 ;;
-        -m|--mode)      MODE="$2";      shift 2 ;;
-        -s|--spec)      SPEC="$2";      shift 2 ;;
-        -g|--generate)  GENERATE=true;  shift ;;
-        *)              usage ;;
+        -s|--spec)  SPEC="$2";      shift 2 ;;
+        -t|--trait) TRAITS+=("$2"); shift 2 ;;
+        *)          usage ;;
     esac
 done
 
-if [[ -z "$TRAIT" ]]; then
+if [[ -z "$SPEC" ]]; then
+    log_error "--spec is required"
+    usage
+fi
+
+if [[ ${#TRAITS[@]} -eq 0 ]]; then
     log_error "--trait is required"
     usage
 fi
 
-if [[ ! "$TRAIT" =~ ^[A-Za-z0-9_]+$ ]]; then
-    log_error "Invalid trait name '$TRAIT'"
+if [[ ! -f "$SPEC" ]]; then
+    log_error "Spec not found: $SPEC"
     exit 1
 fi
 
-if $GENERATE; then
-    MODE="add"
-fi
-
-if [[ -z "$MODE" ]]; then
-    log_error "--mode is required unless --generate is set"
-    usage
-fi
-
-if [[ "$MODE" != "add" && "$MODE" != "remove" ]]; then
-    log_error "--mode must be 'add' or 'remove'"
-    usage
-fi
+for trait in "${TRAITS[@]}"; do
+    if [[ ! "$trait" =~ ^[A-Za-z0-9_]+$ ]]; then
+        log_error "Invalid trait name '$trait'"
+        exit 1
+    fi
+done
 
 if ! command -v yq >/dev/null 2>&1; then
     log_error "yq is required (brew install yq)"
     exit 1
 fi
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SAMPLES_DIR="$REPO_ROOT/Samples"
-
-should_skip() {
-    local basename
-    basename="$(basename "$1")"
-    local skip
-    for skip in "${SKIP_SPECS[@]}"; do
-        if [[ "$basename" == "$skip" ]]; then
-            return 0
-        fi
-    done
-    return 1
-}
-
-has_local_packages() {
-    yq -e '.packages | to_entries | map(select(.value | has("path"))) | length > 0' "$1" >/dev/null 2>&1
-}
-
-resolve_spec() {
-    local spec="$1"
-    if [[ -f "$spec" ]]; then
-        echo "$spec"
-        return 0
-    fi
-    if [[ -f "$REPO_ROOT/$spec" ]]; then
-        echo "$REPO_ROOT/$spec"
-        return 0
-    fi
-    log_error "Spec not found: $spec"
-    return 1
-}
-
-add_trait() {
-    yq -i \
-        "(.packages[] | select(has(\"path\"))).traits |= ((. // []) + [\"${TRAIT}\"] | unique)" \
-        "$1"
-}
-
-# Package traits compile Sentry and SentrySampleShared with SDK_V10. App,
-# extension, and UI-test targets still need the flag on their own settings so
-# #if SDK_V10 in sample source matches the linked SDK after switch-v10.
-add_sdk_v10_flags() {
-    # $(inherited) must stay literal for Xcode; do not let the shell expand it.
-    # shellcheck disable=SC2016
-    yq -i '
-        .targets[] |= (
-            .settings.base.SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SDK_V10" |
-            .settings.base.GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) SDK_V10=1"
-        )
-    ' "$1"
-}
-
-remove_trait() {
-    yq -i \
-        "(.packages[] | select(has(\"path\"))).traits |= ((. // []) - [\"${TRAIT}\"]) | del(.packages[].traits | select(length == 0))" \
-        "$1"
-}
-
-patch_spec() {
-    if [[ "$MODE" == "add" ]]; then
-        add_trait "$1"
-    else
-        remove_trait "$1"
-    fi
-}
-
-collect_specs() {
-    local spec
-    while IFS= read -r -d '' spec; do
-        if should_skip "$spec"; then
-            continue
-        fi
-        if ! has_local_packages "$spec"; then
-            continue
-        fi
-        printf '%s\0' "$spec"
-    done < <(find "$SAMPLES_DIR" -name '*.yml' ! -path '*/Shared/*' -print0)
-}
-
-gather_specs() {
-    SPECS=()
-    if [[ -n "$SPEC" ]]; then
-        SPECS=("$(resolve_spec "$SPEC")")
-        return 0
-    fi
-    while IFS= read -r -d '' spec; do
-        SPECS+=("$spec")
-    done < <(collect_specs)
-}
-
-generate_from_spec() {
-    local spec="$1"
-    local dir base tmp
-    dir="$(dirname "$spec")"
-    base="$(basename "$spec" .yml)"
-    tmp="$dir/${base}.v10.yml"
-
-    rm -f "$tmp"
-    trap 'rm -f "'"$tmp"'"' EXIT
-    cp "$spec" "$tmp"
-    add_trait "$tmp"
-    if [[ "$TRAIT" == "V10" ]]; then
-        add_sdk_v10_flags "$tmp"
-    fi
-    begin_group "generate with trait '$TRAIT': $spec"
-    xcodegen --spec "$tmp"
-    log_info "  Generated"
-    end_group
-    rm -f "$tmp"
-    trap - EXIT
-}
-
-gather_specs
-
-if [[ ${#SPECS[@]} -eq 0 ]]; then
-    log_warning "No XcodeGen specs with local packages found under Samples/"
-    exit 0
-fi
-
-if $GENERATE; then
-    local_spec=""
-    for local_spec in "${SPECS[@]}"; do
-        generate_from_spec "$local_spec"
-    done
-    log_info "Done: generated ${#SPECS[@]} project(s) with trait '$TRAIT'"
-    exit 0
-fi
-
-for spec in "${SPECS[@]}"; do
-    begin_group "$MODE trait '$TRAIT' in $(basename "$(dirname "$spec")")"
-    patch_spec "$spec"
-    log_info "  Updated $spec"
-    end_group
+for trait in "${TRAITS[@]}"; do
+    TRAIT="$trait" yq -i \
+        '(.packages[] | select(has("path"))).traits |= ((. // []) + [strenv(TRAIT)] | unique)' \
+        "$SPEC"
 done
-
-action="added"
-if [[ "$MODE" == "remove" ]]; then
-    action="removed"
-fi
-log_info "Done: trait '$TRAIT' $action in ${#SPECS[@]} spec(s)"

--- a/scripts/swap-xcodegen-product-name.sh
+++ b/scripts/swap-xcodegen-product-name.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+# Disable SC1091 because it won't work with pre-commit
+# shellcheck source=./scripts/ci-utils.sh disable=SC1091
+source "$(cd "$(dirname "$0")" && pwd)/ci-utils.sh"
+
+SPEC=""
+PRODUCT=""
+WITH=""
+
+usage() {
+    log_notice "Usage: $(basename "$0")"
+    log_notice "  -s, --spec <path>        XcodeGen YAML spec (required)"
+    log_notice "  -p, --product <name>     Product name to replace (required)"
+    log_notice "  -w, --with <name>        Replacement product name (required)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -s|--spec)    SPEC="$2";    shift 2 ;;
+        -p|--product) PRODUCT="$2"; shift 2 ;;
+        -w|--with)    WITH="$2";    shift 2 ;;
+        *)            usage ;;
+    esac
+done
+
+if [[ -z "$SPEC" ]]; then
+    log_error "--spec is required"
+    usage
+fi
+
+if [[ -z "$PRODUCT" ]]; then
+    log_error "--product is required"
+    usage
+fi
+
+if [[ -z "$WITH" ]]; then
+    log_error "--with is required"
+    usage
+fi
+
+if [[ ! -f "$SPEC" ]]; then
+    log_error "Spec not found: $SPEC"
+    exit 1
+fi
+
+if [[ ! "$PRODUCT" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+    log_error "Invalid product name '$PRODUCT'"
+    exit 1
+fi
+
+if [[ ! "$WITH" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+    log_error "Invalid product name '$WITH'"
+    exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+    log_error "yq is required (brew install yq)"
+    exit 1
+fi
+
+# Rewrite both XcodeGen forms:
+#   product: <name>
+#   products: [<name>, ...]
+FROM="$PRODUCT" TO="$WITH" yq -i '
+    (.targets[].dependencies[] | select(.product == strenv(FROM))).product = strenv(TO) |
+    (.targets[].dependencies[] | select(has("products")).products[] | select(. == strenv(FROM))) = strenv(TO)
+' "$SPEC"


### PR DESCRIPTION
## Summary

`SDK_V10=1` makes SwiftPM export the source-built product as `Sentry` instead of `SentrySPM`. Sample XcodeGen specs still referenced `SentrySPM`, so opening Xcode with that environment failed package resolution.

Split the XcodeGen helpers into focused, reusable scripts:

- `set-xcodegen-package-traits.sh` — set package traits on a spec
- `swap-xcodegen-product-name.sh` — rename a product dependency
- `set-xcodegen-compiler-flags.sh` — set Swift/C compiler flags
- `generate-sample-v10.sh` — copy, patch, and generate a V10 project

`make switch-v10` now rewrites `SentrySPM` → `Sentry` and opens the workspace with `SDK_V10=1 xed Sentry.xcworkspace`. CI `build-sample-v10-*` still generates without the product swap so the V10 trait path keeps linking `SentrySPM`. `SentrySampleShared` selects the product name from `SDK_V10`.

#skip-changelog

Closes #8995