### PR TITLE
fix(samples): set CFBundlePackageType for App Clip

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -443,6 +443,7 @@ run_build_for_prs: &run_build_for_prs
 run_testflight_for_prs: &run_testflight_for_prs
   - ".github/workflows/testflight.yml"
   - ".github/file-filters.yml"
+  - "Samples/iOS-Swift/**"
 
   # Scripts & actions
   - "scripts/ci-select-xcode.sh"

--- a/Samples/iOS-Swift/iOS-Swift.yml
+++ b/Samples/iOS-Swift/iOS-Swift.yml
@@ -212,6 +212,7 @@ targets:
     info:
       path: AppClip/Configurations/Info.plist
       properties:
+        CFBundlePackageType: APPL
         CFBundleDisplayName: iOS-Swift
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)


### PR DESCRIPTION
## Description

XcodeGen does not infer `CFBundlePackageType` as `APPL` for
`application.on-demand-install-capable` targets. The App Store requires
this value, so TestFlight uploads fail with error 90183:

> Invalid Bundle OS Type code. The CFBundlePackageType value in the
> io.sentry.sample.iOS-Swift.Clip app bundle's Info.plist file must be
> one of the following Bundle OS Type codes: [APPL].

This was introduced in d0d338a51 which moved Info.plist generation into
XcodeGen. The fix explicitly sets `CFBundlePackageType: APPL` in the
App Clip's info properties.

#skip-changelog

## Test plan

- [ ] TestFlight upload job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #8999