### PR TITLE
feat: inject trace headers at task creation

### DIFF
--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -22,6 +22,12 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
         return;
     }
 
+    // When the trace header is already present it was injected at task-creation time
+    // (see addTraceHeaderFieldsToMutableRequest:...). Skip mutating the live task entirely.
+    if ([request valueForHTTPHeaderField:SENTRY_TRACE_HEADER] != nil) {
+        return;
+    }
+
     if (![SentryTracePropagation isTargetMatch:SENTRY_UNWRAP_NULLABLE(NSURL, request.URL)
                                    withTargets:tracePropagationTargets ?: @[]]) {
         SENTRY_LOG_DEBUG(
@@ -51,6 +57,34 @@ static NSString *const SENTRY_TRACEPARENT = @"traceparent";
             = (void *)[sessionTask methodForSelector:setCurrentRequestSelector];
         func(sessionTask, setCurrentRequestSelector, newRequest);
     }
+}
+
++ (void)addTraceHeaderFieldsToMutableRequest:(NSMutableURLRequest *)request
+                                     baggage:(nullable SentryBaggage *)baggage
+                                 traceHeader:(SentryTraceHeader *)traceHeader
+                        propagateTraceparent:(BOOL)propagateTraceparent
+                     tracePropagationTargets:(NSArray *_Nullable)tracePropagationTargets
+{
+    if (![SentryTracePropagation isTargetMatch:SENTRY_UNWRAP_NULLABLE(NSURL, request.URL)
+                                   withTargets:tracePropagationTargets ?: @[]]) {
+        SENTRY_LOG_DEBUG(
+            @"Not adding trace_id and baggage headers for %@", request.URL.absoluteString);
+        return;
+    }
+
+    NSString *baggageHeader = @"";
+    if (baggage != nil) {
+        NSString *_Nullable rawHeader = [request valueForHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
+        NSDictionary *originalBaggage = [SentryBaggageSerialization decode:rawHeader ?: @""];
+        if (originalBaggage[@"sentry-trace_id"] == nil) {
+            baggageHeader = [baggage toHTTPHeaderWithOriginalBaggage:originalBaggage];
+        }
+    }
+
+    [SentryTracePropagation addHeaderFieldsToRequest:request
+                                         traceHeader:traceHeader
+                                       baggageHeader:baggageHeader
+                                propagateTraceparent:propagateTraceparent];
 }
 
 + (void)addHeaderFieldsToRequest:(NSMutableURLRequest *)request

--- a/Sources/Sentry/include/SentryTracePropagation.h
+++ b/Sources/Sentry/include/SentryTracePropagation.h
@@ -13,6 +13,17 @@ NS_ASSUME_NONNULL_BEGIN
     tracePropagationTargets:(NSArray *_Nullable)tracePropagationTargets
                   toRequest:(NSURLSessionTask *)sessionTask;
 
+/// Injects the trace headers into a mutable request that has not been handed to a task yet.
+///
+/// Unlike @c addBaggageHeader:...toRequest: this never touches a live @c NSURLSessionTask, so it is
+/// safe to call at task-creation time. The caller owns @c request and must not have created a task
+/// from it yet.
++ (void)addTraceHeaderFieldsToMutableRequest:(NSMutableURLRequest *)request
+                                     baggage:(nullable SentryBaggage *)baggage
+                                 traceHeader:(SentryTraceHeader *)traceHeader
+                        propagateTraceparent:(BOOL)propagateTraceparent
+                     tracePropagationTargets:(NSArray *_Nullable)tracePropagationTargets;
+
 + (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets;
 
 @end

--- a/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
+++ b/Sources/Swift/Integrations/Performance/Network/SentryNetworkTrackingIntegration.swift
@@ -4,9 +4,9 @@ import Foundation
 private enum SentryNetworkTrackingSwizzleKeys {
     static let resume = SentryTypedSwizzle.Key()
     static let state = SentryTypedSwizzle.Key()
+    static let dataTaskWithRequest = SentryTypedSwizzle.Key()
 
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
-    static let dataTaskWithRequest = SentryTypedSwizzle.Key()
     static let dataTaskWithURL = SentryTypedSwizzle.Key()
 #endif
 }
@@ -52,9 +52,12 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
         SentryNetworkTrackerProxy.shared.setTarget(networkTracker)
         Self.swizzleURLSessionTasks()
 
+        // Inject trace-propagation headers at task-creation time so we don't mutate the live task's
+        // currentRequest on resume. Applies to request-based data tasks on all platforms.
+        Self.swizzleDataTaskWithRequest()
+
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
         if options.sessionReplay.networkDetailHasUrls {
-            Self.swizzleDataTaskWithRequestForResponseCapture()
             Self.swizzleDataTaskWithURLForResponseCapture()
         }
 #endif
@@ -114,14 +117,18 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
         }
     }
 
-#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
-    private static func swizzleDataTaskWithRequestForResponseCapture() {
+    private static func swizzleDataTaskWithRequest() {
         SentryTypedSwizzle.instanceMethod(
             in: URLSession.self,
             method: .urlSessionDataTaskWithRequest(URLSession.self),
             mode: .oncePerClassAndSuperclasses,
             key: SentryNetworkTrackingSwizzleKeys.dataTaskWithRequest
         ) { _, request, completionHandler, original in
+            // Inject trace-propagation headers before the task is created. Falls back to the
+            // unchanged request when there is no target, so this is safe for every request.
+            let request = SentryNetworkTrackerProxy.shared.target?.injectTraceHeaders(intoRequest: request) ?? request
+
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
             var task: URLSessionDataTask?
             var wrappedHandler: SentryDataTaskCompletionHandler?
             if let completionHandler {
@@ -140,9 +147,13 @@ final class SentryNetworkTrackingIntegration<Dependencies: NetworkTrackerProvide
             let originalTask = original(request, wrappedHandler)
             task = originalTask
             return originalTask
+#else
+            return original(request, completionHandler)
+#endif
         }
     }
 
+#if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
     private static func swizzleDataTaskWithURLForResponseCapture() {
         SentryTypedSwizzle.instanceMethod(
             in: URLSession.self,

--- a/Sources/Swift/Networking/SentryNetworkTracker.swift
+++ b/Sources/Swift/Networking/SentryNetworkTracker.swift
@@ -16,6 +16,7 @@ protocol SentryNetworkTrackerProtocol: AnyObject {
 
     func urlSessionTaskResume(_ sessionTask: URLSessionTask)
     func urlSessionTask(_ sessionTask: URLSessionTask, setState newState: URLSessionTask.State)
+    func injectTraceHeaders(intoRequest request: URLRequest) -> URLRequest
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
     func captureResponseDetails(_ data: Data, response: URLResponse, request requestURL: URL, task: URLSessionTask)
 #endif
@@ -756,6 +757,52 @@ final class SentryDefaultNetworkTracker<Dependencies: SentryDefaultNetworkTracke
         }
 
         return urlHost == apiHost && url.path.contains(apiURL.path)
+    }
+
+    /// Injects trace-propagation headers into a request at task-creation time.
+    ///
+    /// This is the creation-time counterpart to the resume-time injection below. It mutates the
+    /// caller's request value before any task exists, so it never calls `setCurrentRequest:` on a
+    /// live task. Headers reflect the current scope's trace context (the active span's trace header
+    /// when there is a tracer, otherwise the propagation context). Requests to Sentry's own backend
+    /// and requests that do not match `tracePropagationTargets` are left unchanged.
+    func injectTraceHeaders(intoRequest request: URLRequest) -> URLRequest {
+        guard let options = hub.currentOptions, let url = request.url else {
+            return request
+        }
+        if isSentryRequestOnStateChange(url, options: options) {
+            return request
+        }
+
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            return request
+        }
+
+        let scope = hub.scope
+        if let span = scope.span, let tracer = SentryTracer.getTracer(span) {
+            SentryTracePropagation.addTraceHeaderFields(
+                toMutableRequest: mutableRequest,
+                baggage: tracer.traceContext?.toBaggage(),
+                traceHeader: span.toTraceHeader(),
+                propagateTraceparent: options.enablePropagateTraceparent,
+                tracePropagationTargets: options.tracePropagationTargets
+            )
+        } else {
+            let baggage = SentryTraceContextSwiftHelper.baggage(
+                traceId: scope.propagationContextTraceId.sentryIdString,
+                options: options,
+                replayId: scope.replayId
+            )
+            SentryTracePropagation.addTraceHeaderFields(
+                toMutableRequest: mutableRequest,
+                baggage: baggage,
+                traceHeader: scope.propagationContextTraceHeader,
+                propagateTraceparent: options.enablePropagateTraceparent,
+                tracePropagationTargets: options.tracePropagationTargets
+            )
+        }
+
+        return mutableRequest as URLRequest
     }
 
     private func addTraceWithoutTransaction(to task: URLSessionTask) {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -161,6 +161,43 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual(1, breadcrumbs?.count)
     }
 
+    /// Creation-time trace-header injection: a request-based data task carries the trace headers on
+    /// its `currentRequest` as soon as it is created, before `resume`, without mutating a live task.
+    func testDataTaskWithRequest_injectsTraceHeadersAtCreation_beforeResume() throws {
+        // -- Arrange --
+        startSDK()
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let request = URLRequest(url: try XCTUnwrap(URL(string: "https://example.com/api")))
+
+        // -- Act --
+        let task = session.dataTask(with: request) { _, _, _ in }
+        defer { task.cancel() }
+
+        // -- Assert --
+        let currentRequest = try XCTUnwrap(task.currentRequest)
+        XCTAssertNotNil(currentRequest.value(forHTTPHeaderField: "sentry-trace"))
+        XCTAssertNotNil(currentRequest.value(forHTTPHeaderField: "baggage"))
+    }
+
+    /// Requests that do not match `tracePropagationTargets` are left untouched at creation time.
+    func testDataTaskWithRequest_whenTargetDoesNotMatch_doesNotInjectTraceHeaders() throws {
+        // -- Arrange --
+        fixture.options.tracePropagationTargets = ["^https://tracing.example.com"]
+        startSDK()
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        let request = URLRequest(url: try XCTUnwrap(URL(string: "https://other.example.com/api")))
+
+        // -- Act --
+        let task = session.dataTask(with: request) { _, _, _ in }
+        defer { task.cancel() }
+
+        // -- Assert --
+        let currentRequest = try XCTUnwrap(task.currentRequest)
+        XCTAssertNil(currentRequest.value(forHTTPHeaderField: "sentry-trace"))
+    }
+
     func testCaptureFailedRequestsDisabled_WhenSwizzlingDisabled() {
         fixture.options.enableSwizzling = false
         fixture.options.enableCaptureFailedRequests = true

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerProxyTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerProxyTests.swift
@@ -104,6 +104,8 @@ private final class TestNetworkTracker: SentryNetworkTrackerProtocol {
 
     func urlSessionTask(_ sessionTask: URLSessionTask, setState newState: URLSessionTask.State) {}
 
+    func injectTraceHeaders(intoRequest request: URLRequest) -> URLRequest { request }
+
 #if (os(iOS) || os(tvOS) || os(visionOS)) && !SENTRY_NO_UI_FRAMEWORK
     func captureResponseDetails(_ data: Data, response: URLResponse, request requestURL: URL, task: URLSessionTask) {}
 #endif


### PR DESCRIPTION
> **Draft / RFC.** Opening this to align on the approach before expanding it. Complementary to #9009 (which fixes the crash defensively); this reduces the live-task mutation that caused it.

## Motivation

Sentry injects trace-propagation headers by mutating the **live** `NSURLSessionTask` on `resume` via the private `setCurrentRequest:`. That live mutation is the root of the crash in #8917 (and the earlier #8650 churn). Looking at how other SDKs handle this:

- **Firebase Performance** never touches a running task — it swizzles the session/task **factory** methods and works through a delegate.
- **PostHog** injects at **task-creation** time via the factory swizzles, with a resume/KVC fallback.
- **Datadog** mutates the live task on resume like we do (and has no lifetime guarding).

The creation-time approach removes the need to mutate a running task for the common case.

## What this does

Injects trace headers into the **request** before the task is created, for request-based data tasks:

- Extends the existing `dataTask(with:completionHandler:)` (request overload) swizzle — installed on all platforms now — to inject headers into the `URLRequest` before calling through to the original. No live task exists yet, so there is no `setCurrentRequest:`.
- `SentryTracePropagation.addTraceHeaderFieldsToMutableRequest:…` is a new pure-request injector (no task).
- Resume-time `addBaggageHeader:…toRequest:` now **short-circuits** when the request already carries the `sentry-trace` header, so creation-injected tasks never hit `setCurrentRequest:`.

## Scope (intentionally narrow for review)

Covered: `URLSession.dataTask(with: URLRequest, completionHandler:)` on all platforms.

Not yet covered — these still fall back to resume-time injection:
- URL-based tasks (`dataTask(with: URL)`) — no request to inject into at the call site.
- Upload/download tasks and the delegate-style (no completion handler) request overload.
- async/await APIs.

## Key design decision to review

At creation time there is no per-request `http.client` network span yet (that is created on `resume`). So the injected header carries the **current scope's** trace context — the active span's trace header when there is a tracer, otherwise the propagation context — exactly what `addTraceWithoutTransaction` already propagates today when there is no transaction.

The trade-off: the downstream service is parented to the active span / transaction rather than the per-request network span. The alternative that preserves per-request-span parenting is to **create the network span at task-creation time** and inject its header — a larger change to the tracking state machine. I'd like a decision on which direction to take before expanding coverage.

## Open questions

- Propagate scope context (this PR) vs. move network-span creation to task creation?
- How to handle URL-based and upload/download tasks — convert to requests, or keep resume-time for those?
- Spec-compliance review of the propagated parent change.
#skip-changelog
