### PR TITLE
fix: Inherit parentSampleRate and parentSampleRand when the parent decided sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Store the binary image cache in zero-fill memory to reduce the SDK binary size. (#9003)
+- Inherit `parentSampleRate` and `parentSampleRand` when a transaction continues a trace whose parent already made the sampling decision, so the propagated dynamic sampling context keeps the trace's `sample_rate` and `sample_rand`. (#9014)
 
 ## 9.28.0
 

--- a/Sources/Sentry/SentrySampling.m
+++ b/Sources/Sentry/SentrySampling.m
@@ -71,10 +71,18 @@ sentry_sampleTrace(SentrySamplingContext *context, SentryOptions *_Nullable opti
 
     // check the _parent_ transaction's sampling decision, if any
     if (context.transactionContext.parentSampled != kSentrySampleDecisionUndecided) {
-        return
-            [[SentrySamplerDecision alloc] initWithDecision:context.transactionContext.parentSampled
-                                              forSampleRate:context.transactionContext.sampleRate
-                                             withSampleRand:context.transactionContext.sampleRand];
+        // The decision is inherited from the parent, so the sample rate and random value the head
+        // of the trace froze into its dynamic sampling context must be inherited with it. They end
+        // up in this transaction's outgoing baggage, and Relay relies on `sample_rand` being the
+        // same across the whole trace to reach a consistent keep-or-drop decision.
+        SentryTransactionContext *transactionContext = context.transactionContext;
+        NSNumber *_Nullable sampleRate
+            = transactionContext.parentSampleRate ?: transactionContext.sampleRate;
+        NSNumber *_Nullable sampleRand
+            = transactionContext.parentSampleRand ?: transactionContext.sampleRand;
+        return [[SentrySamplerDecision alloc] initWithDecision:transactionContext.parentSampled
+                                                 forSampleRate:sampleRate
+                                                withSampleRand:sampleRand];
     }
 
     return _sentry_calcSampleFromNumericalRate(options.tracesSampleRate);

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -471,6 +471,100 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(context?.sampleRate, 0.51)
     }
     
+    func testStartTransaction_whenParentSampledWithParentSampleRateAndRand_shouldInheritParentSampleRateAndRand() throws {
+        // -- Arrange --
+        let transactionContext = TransactionContext(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation,
+            trace: SentryId(),
+            spanId: SpanId(),
+            parentSpanId: SpanId(),
+            parentSampled: .yes,
+            parentSampleRate: 0.25,
+            parentSampleRand: 0.1234
+        )
+
+        // -- Act --
+        let span = fixture.getSut().startTransaction(transactionContext: transactionContext)
+
+        // -- Assert --
+        let tracer = try XCTUnwrap(span as? SentryTracer)
+        XCTAssertEqual(tracer.sampled, .yes)
+        XCTAssertEqual(tracer.transactionContext.sampleRate, 0.25)
+        XCTAssertEqual(tracer.transactionContext.sampleRand, 0.1234)
+    }
+
+    func testStartTransaction_whenParentNotSampledWithParentSampleRateAndRand_shouldInheritParentSampleRateAndRand() throws {
+        // -- Arrange --
+        let transactionContext = TransactionContext(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation,
+            trace: SentryId(),
+            spanId: SpanId(),
+            parentSpanId: SpanId(),
+            parentSampled: .no,
+            parentSampleRate: 0.25,
+            parentSampleRand: 0.9876
+        )
+
+        // -- Act --
+        let span = fixture.getSut().startTransaction(transactionContext: transactionContext)
+
+        // -- Assert --
+        let tracer = try XCTUnwrap(span as? SentryTracer)
+        XCTAssertEqual(tracer.sampled, .no)
+        XCTAssertEqual(tracer.transactionContext.sampleRate, 0.25)
+        XCTAssertEqual(tracer.transactionContext.sampleRand, 0.9876)
+    }
+
+    func testStartTransaction_whenParentSampledWithoutParentSampleRateAndRand_shouldUseContextSampleRateAndRand() throws {
+        // -- Arrange --
+        let transactionContext = TransactionContext(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation,
+            trace: SentryId(),
+            spanId: SpanId(),
+            parentSpanId: SpanId(),
+            parentSampled: .yes,
+            parentSampleRate: nil,
+            parentSampleRand: nil
+        )
+        transactionContext.sampleRate = 0.5
+        transactionContext.sampleRand = 0.75
+
+        // -- Act --
+        let span = fixture.getSut().startTransaction(transactionContext: transactionContext)
+
+        // -- Assert --
+        let tracer = try XCTUnwrap(span as? SentryTracer)
+        XCTAssertEqual(tracer.sampled, .yes)
+        XCTAssertEqual(tracer.transactionContext.sampleRate, 0.5)
+        XCTAssertEqual(tracer.transactionContext.sampleRand, 0.75)
+    }
+
+    func testStartTransaction_whenParentSampledWithParentSampleRateAndRand_shouldPropagateThemInTraceContext() throws {
+        // -- Arrange --
+        let transactionContext = TransactionContext(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation,
+            trace: SentryId(),
+            spanId: SpanId(),
+            parentSpanId: SpanId(),
+            parentSampled: .yes,
+            parentSampleRate: 0.25,
+            parentSampleRand: 0.1234
+        )
+        let tracer = try XCTUnwrap(fixture.getSut().startTransaction(transactionContext: transactionContext) as? SentryTracer)
+
+        // -- Act --
+        let traceContext = try XCTUnwrap(TraceContext(tracer: tracer, scope: Scope(), options: fixture.options))
+
+        // -- Assert --
+        XCTAssertEqual(traceContext.sampled, "true")
+        XCTAssertEqual(traceContext.sampleRate, "0.250000")
+        XCTAssertEqual(traceContext.sampleRand, "0.123400")
+    }
+
     func testStartTransactionNotSamplingUsingSampleRate() {
         assertSampler(expected: .no) { options in
             options.tracesSampleRate = 0.49


### PR DESCRIPTION
## :scroll: Description

`SentryTransactionContext` accepts `parentSampleRate` and `parentSampleRand` (added in #4751), but `sentry_sampleTrace` never reads them. In the parent-decided branch it reports the context's own `sampleRate` and `sampleRand`, which the trace-header initializer leaves `nil`. A transaction that continues a trace from incoming `sentry-trace` and `baggage` headers therefore ends up with a trace context without `sample_rate` and `sample_rand`, and `SentryTraceContext` omits them from the outgoing baggage.

This change makes the parent-decided branch inherit `parentSampleRate` and `parentSampleRand`, falling back to the context's own `sampleRate` and `sampleRand` when the parent values are not set, which preserves the existing behaviour for callers that set those directly.

## :bulb: Motivation and Context

The [dynamic sampling context spec](https://develop.sentry.dev/sdk/telemetry/traces/dynamic-sampling-context/#unified-propagation-mechanism) requires a received DSC to be treated as frozen and propagated unchanged, and the [propagated random value](https://develop.sentry.dev/sdk/telemetry/traces/#propagated-random-value) section requires `sample_rand` to be the same across a trace so Relay reaches one consistent keep-or-drop decision. Today a Cocoa transaction that continues a trace drops both values, so Relay can sample that transaction independently of the rest of the trace.

Our use case is a desktop app where a web view (JavaScript SDK) starts the trace and the native macOS host continues it for the requests it handles. The only workaround is to also set `sampleRate` and `sampleRand` on the context by hand, which relies on the sampler not reading the parent fields.

## :green_heart: How did you test it?

- Added four tests to `SentryHubTests`. The two `shouldInheritParentSampleRateAndRand` tests and `shouldPropagateThemInTraceContext` fail on `main` with `nil` for both values and pass with this change. The `shouldUseContextSampleRateAndRand` test covers the fallback.
- `make test-macos FOR_AGENTS=true ONLY_TESTING=SentryTests/SentryHubTests`: 122 tests, 0 failures.
- `clang-format` reports no changes for `SentrySampling.m`; `make analyze` run on the change.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).
