### PR TITLE
fix: clear replayId when Session Replay stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Store the binary image cache in zero-fill memory to reduce the SDK binary size. (#9003)
+- Clear the scope's `replayId` when Session Replay is stopped manually, so events captured after `stop()` are no longer linked to a replay that is no longer recording (#9017)
 
 ## 9.28.0
 

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayIntegration.swift
@@ -364,7 +364,13 @@ public class SentrySessionReplayIntegration: NSObject, SwiftIntegration, SentryS
         sessionReplay?.pause()
         touchTracker?.disable()
         removeBackgroundForegroundObservers()
+        // Clear the replay first because the replay ID getter falls back to it when the scope ID is nil.
+        // Reversing this order could briefly return the ID of the replay that just stopped.
         sessionReplay = nil
+        // Clear the scope's replayId so events captured after a manual stop() are not associated with a
+        // replay that is no longer recording. This mirrors sessionReplayEnded(), which is only reached on
+        // the maximum-duration teardown path and never for a manual stop().
+        SentrySDKInternal.currentHub().configureScope { scope in scope.replayId = nil }
     }
 
     // MARK: - API Exposed to ObjC

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -1318,6 +1318,33 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertNil(sut.sessionReplay)
     }
 
+    func testReplayIdAndSessionReplayCleared_whenStopped() throws {
+        // -- Arrange --
+        startSDK(sessionSampleRate: 1, errorSampleRate: 0)
+        let sut = try getSut()
+
+        var replayId: String?
+        SentrySDKInternal.currentHub().configureScope { scope in
+            replayId = scope.replayId
+        }
+        XCTAssertNotNil(replayId)
+
+        // -- Act --
+        sut.stop()
+
+        // -- Assert --
+        // The scope's replayId is the value serialized as `replay_id` onto captured events, so
+        // clearing it ensures events captured after stop() are not linked to the stopped replay.
+        var serializedReplayId: Any?
+        SentrySDKInternal.currentHub().configureScope { scope in
+            replayId = scope.replayId
+            serializedReplayId = scope.serialize()["replay_id"]
+        }
+        XCTAssertNil(replayId)
+        XCTAssertNil(serializedReplayId)
+        XCTAssertNil(sut.sessionReplay)
+    }
+
     func testSessionReplayEnded_whenReplayIdIsCleared_shouldClearSessionReplayFirst() throws {
         // -- Arrange --
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)


### PR DESCRIPTION
## :scroll: Description

Manually stopping Session Replay via `stop()` halts recording but never clears `scope.replayId`. As a result, error events captured after a manual `stop()` still carry the stopped replay's `replay_id`, associating them with a replay that is no longer recording.

A manual `stop()` funnels through `stopCurrentReplay()`, which never reached the code that clears the scope. This change clears `scope.replayId` in `stopCurrentReplay()` as part of teardown, mirroring `sessionReplayEnded()` (the maximum-duration teardown path), which already does this. The ordering matches `sessionReplayEnded()` too — clear `sessionReplay` first, since the replay ID getter falls back to it when the scope ID is nil. The two teardown paths are independent (neither calls the other), so there is no double-clear.

## :bulb: Motivation and Context

Fixes #9016

## :green_heart: How did you test it?

Added tests, manual testing with RN

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] If I added a new public API, I also added it to the [SentryObjC wrapper](../develop-docs/SENTRY-OBJC.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)